### PR TITLE
Update IV handling in crypto.js

### DIFF
--- a/crypto.js
+++ b/crypto.js
@@ -1,8 +1,8 @@
 const crypto = require("crypto");
 
-// Key and IV generation; replace with a secure KMS in production.
+// Key generation; replace with a secure KMS in production. The IV will be
+// generated for each encryption call to ensure uniqueness.
 const key = crypto.randomBytes(32); // AES-256 requires 32-byte key
-const iv = crypto.randomBytes(16); // Initialization Vector for CBC mode
 
 /**
  * Encrypts data using AES-256-CBC.
@@ -10,6 +10,8 @@ const iv = crypto.randomBytes(16); // Initialization Vector for CBC mode
  * @returns {object} - The encrypted data and IV.
  */
 function encrypt(data) {
+  // Generate a unique IV for each encryption call
+  const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
   let encrypted = cipher.update(data, "utf-8", "hex");
   encrypted += cipher.final("hex");
@@ -19,7 +21,8 @@ function encrypt(data) {
 /**
  * Decrypts data using AES-256-CBC.
  * @param {string} encryptedData - The encrypted data.
- * @param {string} ivHex - The Initialization Vector in hex format.
+ * @param {string} ivHex - The Initialization Vector in hex format returned by
+ * encrypt().
  * @returns {string} - The decrypted data.
  */
 function decrypt(encryptedData, ivHex) {


### PR DESCRIPTION
## Summary
- generate a fresh IV inside `encrypt`
- expect `decrypt` to receive the IV from `encrypt`
- document IV generation

## Testing
- `node -e "const c=require('./crypto.js'); const r=c.encrypt('hi'); console.log(r); console.log(c.decrypt(r.encryptedData, r.iv));"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2505baf0832594230953b9e4927c