### PR TITLE
Add encryption round-trip test

### DIFF
--- a/crypto_refactored.js
+++ b/crypto_refactored.js
@@ -47,9 +47,7 @@ if (require.main === module) {
             console.error('Decryption failed:', err.message);
         }
     } else {
-        console.log('Usage:
-  node crypto.js encrypt "your text"
-  node crypto.js decrypt <encryptedData> <iv>');
+        console.log('Usage:\n  node crypto_refactored.js encrypt "your text"\n  node crypto_refactored.js decrypt <encryptedData> <iv>');
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "aurora-cloudbank-symbolic",
+  "version": "0.1.0",
+  "scripts": {
+    "test": "node tests/test_crypto.js"
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,17 @@
 # Tests Directory
 
 Unit and integration tests for the Aurora Reflective Autonomy System. Add test files as the project grows.
+
+
+## Running the Node crypto test
+Run the encryption round-trip test with:
+
+```bash
+node tests/test_crypto.js
+```
+
+If you have `npm` available, you can also run:
+
+```bash
+npm test --silent
+```

--- a/tests/test_crypto.js
+++ b/tests/test_crypto.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { encrypt, decrypt } = require('../crypto_refactored');
+
+const plaintext = 'Encryption test string';
+const { encryptedData, iv } = encrypt(plaintext);
+const decrypted = decrypt(encryptedData, iv);
+
+assert.strictEqual(decrypted, plaintext, 'decrypted text should match original');
+console.log('Encryption round-trip successful');


### PR DESCRIPTION
## Summary
- fix CLI usage string for `crypto_refactored.js`
- document using `npm test` in test README
- add encryption round-trip test

## Testing
- `node tests/test_crypto.js`
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b25112fe88325a8ae0e1b417a6d6d