### PR TITLE
Add module integrator and telemetry logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ docker-compose up --build
 - The command node listens on port 3001 by default.
 - Replace the placeholder app in `services/command_node/` with your real Node.js code when ready.
 
+## Orion Backup Sync Utility
+Use `python scripts/orion_backup_sync.py --help` to export and synchronize the staff registry and Orion Station blueprint. Backups are stored in `backups/` and `--rollback` restores the latest snapshot.
+
+## Module Integration Tool
+Use `python scripts/module_integrator.py --help` to merge new modules across branches. The tool validates anchor compliance, logs telemetry to `logs/telemetry.log`, and supports per-module rollback.
+
+
 ## Contributing
 See `CONTRIBUTING.md` for guidelines.
 

--- a/modules/telemetry_logger.py
+++ b/modules/telemetry_logger.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+telemetry_logger.py
+
+Simple telemetry logging system for Orion Constellation modules.
+
+Summary:
+    - Provides logging utilities for integration and backup scripts
+    - Outputs logs to `logs/telemetry.log` for operator dashboard
+
+Integration Notes:
+    - Uses Python's `logging` module
+    - Creates the log directory if missing
+
+// ANCHOR: EOS_SEED_ORION
+// ETHICS: Picard_Delta_3
+"""
+
+import logging
+import os
+
+TELEMETRY_LOG = "logs/telemetry.log"
+
+
+def get_logger(name: str = "telemetry") -> logging.Logger:
+    os.makedirs(os.path.dirname(TELEMETRY_LOG), exist_ok=True)
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.FileHandler(TELEMETRY_LOG)
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,6 @@
 # Scripts Directory
 
 Deployment, bootstrap, and helper scripts for the Aurora Reflective Autonomy System.
+
+- `orion_backup_sync.py` - Backup and synchronize staff registry and Orion Station blueprint.
+- `module_integrator.py` - Automate integration of modules across Command Node and PL branch with telemetry logging.

--- a/scripts/module_integrator.py
+++ b/scripts/module_integrator.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+module_integrator.py
+
+Automate integration of new or updated modules into both the Command Node and PL branch.
+
+Summary:
+    - Validates module anchor compliance and drift neutrality
+    - Synchronizes module directories across branches
+    - Logs integration events for the operator dashboard
+    - Supports rollback of individual modules from backups
+
+Integration Notes:
+    - Expects a `module.yaml` file containing `anchor_seed` in each module
+    - Uses `yaml` and `shutil`; requires `pyyaml`
+    - Telemetry logged to `logs/telemetry.log`
+
+// ANCHOR: EOS_SEED_ORION
+// ETHICS: Picard_Delta_3
+"""
+
+import argparse
+import os
+import shutil
+import yaml
+from datetime import datetime
+
+from modules.telemetry_logger import get_logger
+
+ANCHOR_SEED = "EOS_SEED_ORION"
+logger = get_logger("module_integrator")
+
+
+def load_metadata(path: str) -> dict:
+    meta_path = os.path.join(path, "module.yaml")
+    if not os.path.exists(meta_path):
+        raise FileNotFoundError(f"Missing module.yaml in {path}")
+    with open(meta_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    anchor = data.get("anchor_seed")
+    if anchor != ANCHOR_SEED:
+        raise ValueError(f"Anchor mismatch in {meta_path}: {anchor} != {ANCHOR_SEED}")
+    return data
+
+
+def backup_module(dest: str) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    backup_dir = os.path.join("backups", os.path.basename(dest))
+    os.makedirs(backup_dir, exist_ok=True)
+    archive_name = f"{timestamp}.bak"
+    shutil.make_archive(os.path.join(backup_dir, archive_name), "zip", dest)
+    backup_path = os.path.join(backup_dir, archive_name + ".zip")
+    logger.info("Backup created: %s", backup_path)
+    return backup_path
+
+
+def restore_module(dest: str) -> str:
+    backup_dir = os.path.join("backups", os.path.basename(dest))
+    if not os.path.isdir(backup_dir):
+        raise FileNotFoundError(f"No backups for {dest}")
+    files = sorted(os.listdir(backup_dir))
+    if not files:
+        raise FileNotFoundError(f"No backups for {dest}")
+    latest = files[-1]
+    shutil.rmtree(dest, ignore_errors=True)
+    shutil.unpack_archive(os.path.join(backup_dir, latest), dest)
+    logger.info("Restored %s from %s", dest, latest)
+    return latest
+
+
+def sync_module(src: str, dest: str) -> None:
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest)
+    logger.info("Synchronized %s -> %s", src, dest)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Integrate modules across branches")
+    parser.add_argument("module_path", help="Path to module to integrate")
+    parser.add_argument("--command-node", default="command_node_data/modules",
+                        help="Command node modules directory")
+    parser.add_argument("--pl-branch", default="pl_branch_data/modules",
+                        help="PL branch modules directory")
+    parser.add_argument("--rollback", action="store_true",
+                        help="Rollback latest backup of this module")
+    args = parser.parse_args()
+
+    logger.info("Integration start for %s", args.module_path)
+
+    dests = [
+        os.path.join(args.command_node, os.path.basename(args.module_path)),
+        os.path.join(args.pl_branch, os.path.basename(args.module_path)),
+    ]
+
+    try:
+        if args.rollback:
+            for d in dests:
+                name = restore_module(d)
+                print(f"Restored {d} from {name}")
+            return
+
+        load_metadata(args.module_path)
+        confirm = input("Proceed with module integration? [y/N] ")
+        if confirm.lower() != "y":
+            print("Operation cancelled")
+            return
+
+        for d in dests:
+            if os.path.exists(d):
+                backup_module(d)
+            os.makedirs(os.path.dirname(d), exist_ok=True)
+            sync_module(args.module_path, d)
+            load_metadata(d)
+            print(f"Integrated {args.module_path} -> {d}")
+
+    except Exception as exc:
+        logger.error("Integration failed: %s", exc)
+        print(f"Error: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/orion_backup_sync.py
+++ b/scripts/orion_backup_sync.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+orion_backup_sync.py
+
+Backup and synchronize the staff registry and Orion Station blueprint
+between Command Node and PL branch.
+
+Summary:
+    - Exports and archives registry and blueprint states
+    - Validates EOS_SEED_ORION anchor to enforce zero drift
+    - Supports rollback from timestamped backups
+    - Designed for the ORION Constellation symbolic mesh
+
+Integration Notes:
+    - Requires `pyyaml` for YAML parsing
+    - Stores backups in `backups/` relative to this script
+
+// ANCHOR: EOS_SEED_ORION
+// ETHICS: Picard_Delta_3
+"""
+
+import argparse
+import os
+import shutil
+import yaml
+from datetime import datetime
+
+from modules.telemetry_logger import get_logger
+
+ANCHOR_SEED = "EOS_SEED_ORION"
+BACKUP_DIR = "backups"
+logger = get_logger("orion_backup_sync")
+
+
+def load_yaml(path: str) -> dict:
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"{path} does not exist")
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def validate_anchor(data: dict, path: str) -> None:
+    anchor = data.get("anchor_seed")
+    if anchor != ANCHOR_SEED:
+        raise ValueError(f"Anchor mismatch in {path}: {anchor} != {ANCHOR_SEED}")
+
+
+def backup_file(src: str) -> str:
+    os.makedirs(BACKUP_DIR, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    backup_name = f"{os.path.basename(src)}.{timestamp}.bak"
+    backup_path = os.path.join(BACKUP_DIR, backup_name)
+    shutil.copy2(src, backup_path)
+    logger.info("Backup created for %s -> %s", src, backup_path)
+    return backup_path
+
+
+def sync_file(src: str, dest: str) -> None:
+    shutil.copy2(src, dest)
+    logger.info("Synchronized %s -> %s", src, dest)
+
+
+def rollback_file(dest: str) -> str:
+    if not os.path.isdir(BACKUP_DIR):
+        raise FileNotFoundError("No backups directory found")
+    prefix = os.path.basename(dest)
+    matches = [f for f in os.listdir(BACKUP_DIR) if f.startswith(prefix)]
+    if not matches:
+        raise FileNotFoundError(f"No backups found for {dest}")
+    latest = sorted(matches)[-1]
+    backup_path = os.path.join(BACKUP_DIR, latest)
+    shutil.copy2(backup_path, dest)
+    logger.info("Rolled back %s from %s", dest, backup_path)
+    return backup_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Archive and synchronize Orion staff registry and blueprint")
+    parser.add_argument("--command-node", default="command_node_data",
+                        help="Command node data directory")
+    parser.add_argument("--pl-branch", default="pl_branch_data",
+                        help="PL branch data directory")
+    parser.add_argument("--rollback", choices=["staff", "blueprint", "all"],
+                        help="Rollback target")
+    args = parser.parse_args()
+
+    staff_cmd = os.path.join(args.command_node, "staff_registry.yaml")
+    bp_cmd = os.path.join(args.command_node, "orion_station_blueprint.yaml")
+    staff_pl = os.path.join(args.pl_branch, "staff_registry.yaml")
+    bp_pl = os.path.join(args.pl_branch, "orion_station_blueprint.yaml")
+
+    resources = [
+        (staff_cmd, staff_pl),
+        (bp_cmd, bp_pl),
+    ]
+
+    if args.rollback:
+        targets = resources
+        if args.rollback != "all":
+            mapping = {"staff": resources[0], "blueprint": resources[1]}
+            targets = [mapping[args.rollback]]
+
+        for _, dest in targets:
+            try:
+                restore_path = rollback_file(dest)
+                print(f"Rolled back {dest} from {restore_path}")
+            except Exception as e:
+                print(f"Rollback failed for {dest}: {e}")
+        return
+
+    confirm = input("Proceed with backup and synchronization? [y/N] ")
+    if confirm.lower() != "y":
+        print("Operation cancelled")
+        return
+
+    for src, dest in resources:
+        try:
+            data = load_yaml(src)
+            validate_anchor(data, src)
+        except Exception as e:
+            print(f"Validation failed for {src}: {e}")
+            continue
+
+        if os.path.exists(dest):
+            try:
+                bpath = backup_file(dest)
+                print(f"Backup created: {bpath}")
+            except Exception as e:
+                print(f"Could not backup {dest}: {e}")
+                continue
+        else:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+
+        try:
+            sync_file(src, dest)
+            dest_data = load_yaml(dest)
+            validate_anchor(dest_data, dest)
+            print(f"Synced {src} -> {dest}")
+        except Exception as e:
+            print(f"Error syncing {src} to {dest}: {e}")
+
+    print("Backup and synchronization complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_module_integrator.py
+++ b/tests/test_module_integrator.py
@@ -1,0 +1,4 @@
+from scripts.module_integrator import ANCHOR_SEED
+
+def test_anchor_seed_constant():
+    assert ANCHOR_SEED == "EOS_SEED_ORION"


### PR DESCRIPTION
## Summary
- add `telemetry_logger` module for telemetry
- add `module_integrator.py` to automate module sync across branches
- enhance `orion_backup_sync.py` with telemetry and granular rollback
- document new utilities in `README.md` and `scripts/README.md`
- test anchor constant for module integrator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b23e6df748325893ab8617e763c29