### PR TITLE
Add drop-in thread context tagging agent v2

### DIFF
--- a/scripts/drop_in_thread_agent_v2.py
+++ b/scripts/drop_in_thread_agent_v2.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Drop-In Thread Context Tagging Agent v2.0
+
+This script classifies thread content using the existing reflective autonomy
+classification engine and returns a context dictionary. The output includes
+an alias (same as the folder) and optionally a live context directive.
+"""
+
+import argparse
+import json
+
+from modules.reflective_autonomy.threadcore_tagging import (
+    tag_thread_context as base_tag_thread_context,
+    PROJECT_CATEGORIES,
+)
+
+# Live context directive presented when include_directive is True
+LIVE_CONTEXT_DIRECTIVE = """
+\u26a0\ufe0f LIVE CONTEXT MODE ACTIVE
+
+You are being asked to evaluate the actual content of the thread.
+Return a true classification – not an example or template output.
+
+\u2705 Return based on real content
+\u2705 DO NOT simulate or placeholder output
+\u2705 This is used for routing, sealing, or archive classification
+""".strip()
+
+# Default alias mapping uses the category names directly
+ALIAS_MAP = {category: category for category in PROJECT_CATEGORIES.keys()}
+ALIAS_MAP.setdefault("Unsorted", "Unsorted")
+
+
+def tag_thread_context(content: str, include_directive: bool = True) -> dict:
+    """Classify thread content and return tagging info with alias."""
+    base_result = base_tag_thread_context(content)
+
+    alias = ALIAS_MAP.get(base_result["primary_folder"], base_result["primary_folder"])
+
+    result = {
+        "alias": alias,
+        "folder": base_result["primary_folder"],
+        "priority": base_result["priority"],
+        "reason": base_result["reason"],
+    }
+
+    if include_directive:
+        result["directive"] = LIVE_CONTEXT_DIRECTIVE
+
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Drop-In Thread Context Tagging Agent v2.0"
+    )
+    parser.add_argument("input_file", help="Path to text file to classify")
+    parser.add_argument(
+        "--no-directive",
+        action="store_true",
+        help="Omit the live context directive from output",
+    )
+    args = parser.parse_args()
+
+    with open(args.input_file, "r", encoding="utf-8") as fh:
+        content = fh.read()
+
+    result = tag_thread_context(content, include_directive=not args.no_directive)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_drop_in_thread_agent_v2.py
+++ b/tests/test_drop_in_thread_agent_v2.py
@@ -1,0 +1,23 @@
+from scripts.drop_in_thread_agent_v2 import tag_thread_context
+
+
+def test_alias_and_folder_high_priority():
+    text = "Threadcore symbolic anchor drift vector reflect seal"
+    result = tag_thread_context(text)
+    assert result["alias"] == "SymbolicOps"
+    assert result["folder"] == "SymbolicOps"
+    assert result["priority"] == "high"
+    assert "directive" in result
+
+
+def test_unsorted_low_priority():
+    result = tag_thread_context("")
+    assert result["alias"] == "Unsorted"
+    assert result["folder"] == "Unsorted"
+    assert result["priority"] == "low"
+
+
+def test_no_directive_flag():
+    text = "Commit to the github repo"
+    result = tag_thread_context(text, include_directive=False)
+    assert "directive" not in result


### PR DESCRIPTION
## Summary
- add `drop_in_thread_agent_v2.py` script to classify thread content using existing tagging logic
- include live context directive and alias handling
- add tests for the new tagging agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b494b83e883258b997ef8e496c397