### PR TITLE
Add visualization stack documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
 # Documentation Index
 
 Welcome to the Aurora Reflective Autonomy System documentation. Use this index to navigate system guides, architecture, and usage examples.
+
+- [System Architecture](architecture.md)
+- [Visualization Stack and Integration Plan](visualization_stack.md)

--- a/docs/visualization_stack.md
+++ b/docs/visualization_stack.md
@@ -1,0 +1,41 @@
+# Visualization Stack and Integration Plan
+
+This document outlines the recommended toolchain for rendering Aurora's simulations. The goal is to provide real‑time 3D visuals, physics, audio, and smooth communication with the Python and Node.js services already present in this repository.
+
+## 1. Graphics and Rendering
+- **Game Engine**: Use **Godot 4** (MIT License). It offers 3D/2D rendering, a built‑in editor and Python‑like scripting with GDScript. The engine includes Bullet physics and an audio server.
+- **Modeling and Assets**: Create or edit models in **Blender** and export them as `glTF` or `FBX`. These open formats keep the assets portable.
+- **Cross‑Platform Builds**: Godot exports to desktop, web, and mobile using Vulkan and WebGL.
+
+## 2. Physics and Simulation
+- Rely on Godot's built‑in Bullet physics for 3D or the Box2D‑style engine for 2D.
+- Keep your simulation logic separate from the engine so core algorithms remain independent from the rendering layer.
+
+## 3. Audio
+- Godot provides positional audio and mixing out of the box. For advanced features you may integrate libraries such as FMOD or OpenAL later.
+
+## 4. Service Integration
+- Keep simulation data generation within the existing Python modules under `modules/reflective_autonomy`.
+- Expose state updates via REST or WebSocket endpoints in `aurora_gui_cloudhub_fastapi.py` or the Node.js command node.
+- In Godot, write scripts to poll these endpoints or listen for WebSocket events, then update the game world accordingly.
+
+## 5. Development Workflow
+- Continue using `docker-compose` to orchestrate services. Add a container for the game engine when needed to maintain a reproducible setup.
+- Track large assets with **Git LFS** so models and textures live alongside the code base.
+- Create GitHub Actions workflows to build or package the game project and run any headless tests.
+
+## 6. Initial Prototype
+- Start a small Godot project that loads a simple scene and connects to the FastAPI endpoints.
+- Define a concise JSON format for simulation state. Keep this independent from the engine so other tools can reuse it.
+- Add Blender export scripts to convert models to the engine format and save them in version control.
+
+## 7. Documentation and Testing
+- Document the API endpoints used by the engine. Store architecture diagrams and instructions in `docs/`.
+- Expand unit tests for your Python modules and Node.js services. Later, include integration tests that launch the game in headless mode.
+
+## 8. Optional Extensions
+- Plan for multiplayer using WebSocket or UDP networking if needed.
+- Godot's experimental VR/AR support allows immersive scenarios in the future.
+- Reuse the existing telemetry system to log simulation events and user interactions for analysis.
+
+By following this approach, you gain a flexible visualization layer that remains fully open source and integrates cleanly with the existing code. The MIT‑licensed stack keeps Aurora’s tooling consistent while allowing room to adopt more advanced engines if requirements change.


### PR DESCRIPTION
## Summary
- document the proposed real-time visualization stack
- link to the new plan from the documentation index

## Testing
- `pre-commit run --files docs/visualization_stack.md docs/index.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4c9c02508325844ed55194f61f44