### PR TITLE
Implement Aurora Interlink Fabric prototype

### DIFF
--- a/README-symbolic.md
+++ b/README-symbolic.md
@@ -64,6 +64,22 @@ Docker Compose mounts symbolic memory for GUI view:
 - Context persistence across GPT sessions
 - Shared symbolic memory federation across constellations
 
+## 🌐 Aurora Interlink Fabric
+
+The **Aurora Interlink Fabric (AIF)** is a lightweight WebSocket hub enabling
+live synchronization of memory anchors between running Aurora instances. Each
+client authenticates with a shared token and publishes anchor updates that the
+hub broadcasts to all connected nodes. This keeps conversations and symbolic
+state consistent across devices and chat platforms.
+
+- Service entry point: `services/aif_hub.py`
+- FastAPI GUI endpoint `/ws` provides basic peer broadcast capabilities
+- Tokens are provided via the `AIF_TOKEN` environment variable
+
+This early prototype prioritizes security and transparent logging with the
+existing telemetry system. Future iterations will extend federation features and
+access controls.
+
 ---
 
 ## 📞 Contact

--- a/aurora_gui_cloudhub_fastapi.py
+++ b/aurora_gui_cloudhub_fastapi.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 import uuid
+from typing import List
 import uvicorn
 import logging
 
@@ -11,6 +12,9 @@ app = FastAPI(title="Aurora Cloud GUI – ZIP Wizard Dashboard")
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("aurora_gui_cloudhub")
+
+# Active WebSocket connections for basic broadcast
+connections: List[WebSocket] = []
 
 # Serve static files if needed in the future
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -59,6 +63,24 @@ async def upload_bundle(file: UploadFile = File(...)):
     with open(upload_path, "wb") as buffer:
         buffer.write(data)
     return {"message": "Bundle received", "filename": filename}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    connections.append(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            for conn in list(connections):
+                if conn is websocket:
+                    continue
+                try:
+                    await conn.send_text(data)
+                except WebSocketDisconnect:
+                    connections.remove(conn)
+    except WebSocketDisconnect:
+        connections.remove(websocket)
 
 
 @app.on_event("startup")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@
 pyyaml==6.0.2
 flake8==7.3.0
 pytest==8.4.0
+fastapi==0.97.0
+uvicorn==0.27.1
+httpx==0.27.0

--- a/services/aif_hub.py
+++ b/services/aif_hub.py
@@ -1,0 +1,67 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
+import os
+from typing import List
+
+from modules.telemetry_logger import get_logger
+
+app = FastAPI(title="Aurora Interlink Fabric Hub")
+logger = get_logger("aif_hub")
+
+AIF_TOKEN = os.environ.get("AIF_TOKEN", "change-me")
+
+
+class ConnectionManager:
+    """Manage active WebSocket connections."""
+
+    def __init__(self) -> None:
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: str, sender: WebSocket | None = None) -> None:
+        for connection in list(self.active_connections):
+            if connection is sender:
+                continue
+            try:
+                await connection.send_text(message)
+            except Exception:
+                self.disconnect(connection)
+
+
+manager = ConnectionManager()
+
+
+def _validate_token(websocket: WebSocket) -> None:
+    token = websocket.headers.get("authorization", "")
+    if token.startswith("Bearer "):
+        token = token.split(" ", 1)[1]
+    if token != AIF_TOKEN:
+        logger.warning("Unauthorized WebSocket connection attempt")
+        raise HTTPException(status_code=403, detail="Unauthorized")
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    _validate_token(websocket)
+    await manager.connect(websocket)
+    logger.info("Client connected to AIF hub")
+    try:
+        while True:
+            data = await websocket.receive_text()
+            logger.info("Anchor received: %s", data)
+            await manager.broadcast(data, sender=websocket)
+    except WebSocketDisconnect:
+        logger.info("Client disconnected from AIF hub")
+        manager.disconnect(websocket)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8090)

--- a/tests/test_aif_hub.py
+++ b/tests/test_aif_hub.py
@@ -1,0 +1,15 @@
+import os
+from fastapi.testclient import TestClient
+
+os.environ['AIF_TOKEN'] = 'test-token'
+
+from services.aif_hub import app  # noqa: E402
+
+
+def test_websocket_broadcast():
+    client = TestClient(app)
+    with client.websocket_connect('/ws', headers={'Authorization': 'Bearer test-token'}) as ws1:
+        with client.websocket_connect('/ws', headers={'Authorization': 'Bearer test-token'}) as ws2:
+            ws1.send_text('anchor')
+            data = ws2.receive_text()
+            assert data == 'anchor'


### PR DESCRIPTION
## Summary
- extend FastAPI GUI service with a `/ws` WebSocket broadcast route
- introduce `services/aif_hub.py` as the core of the Aurora Interlink Fabric
- document the new fabric in `README-symbolic.md`
- add a simple test for WebSocket broadcast behaviour
- include FastAPI and dependencies in requirements

## Testing
- `pre-commit run --files README-symbolic.md aurora_gui_cloudhub_fastapi.py services/aif_hub.py tests/test_aif_hub.py requirements.txt`
- `pytest -q`
- `AES_KEY_256_HEX=0000000000000000000000000000000000000000000000000000000000000000 node tests/test_crypto.js`


------
https://chatgpt.com/codex/tasks/task_e_685b87526e888325b80876759e17846b