### PR TITLE
Add CASK integration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Use `python scripts/orion_backup_sync.py --help` to export and synchronize the s
 ## Module Integration Tool
 Use `python scripts/module_integrator.py --help` to merge new modules across branches. The tool validates anchor compliance, logs telemetry to `logs/telemetry.log`, and supports per-module rollback.
 
+## CASK Integration Utilities
+The repository distributes reference datasets for the Culturally Aware Simulation Knowledge (CASK) system in `CASK_Assets.zip`. A small CLI helper is available for exploring these assets:
+
+```bash
+python scripts/cask_integration.py summary
+python scripts/cask_integration.py chart --output my_chart.png
+```
+
+This tool loads the CSV tables directly from the zip archive and can generate a simplified architecture diagram.
+
 
 ## Contributing
 See `CONTRIBUTING.md` for guidelines.

--- a/modules/cask_tool.py
+++ b/modules/cask_tool.py
@@ -31,19 +31,19 @@ def _open_asset(name: str) -> str:
 def load_specifications() -> pd.DataFrame:
     """Load the CASK technical specifications table."""
     data = _open_asset("cask_technical_specifications.csv")
-    return pd.read_csv(pd.compat.StringIO(data))
+    return pd.read_csv(StringIO(data))
 
 
 def load_risk_assessment() -> pd.DataFrame:
     """Load the CASK risk assessment table."""
     data = _open_asset("cask_risk_assessment.csv")
-    return pd.read_csv(pd.compat.StringIO(data))
+    return pd.read_csv(StringIO(data))
 
 
 def load_vs_sota() -> pd.DataFrame:
     """Load the comparison against state of the art table."""
     data = _open_asset("cask_vs_sota_comparison.csv")
-    return pd.read_csv(pd.compat.StringIO(data))
+    return pd.read_csv(StringIO(data))
 
 
 def generate_architecture_chart(output: str = "cask_architecture.png") -> str:

--- a/modules/cask_tool.py
+++ b/modules/cask_tool.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Utilities for interacting with the CASK reference assets.
+
+This module loads data from ``CASK_Assets.zip`` and provides helper
+functions to parse the included CSV files as pandas ``DataFrame``
+objects. It can also generate a simplified architecture chart for
+quick visualization.
+"""
+
+from __future__ import annotations
+
+import os
+import zipfile
+from io import TextIOWrapper
+from typing import IO
+
+import pandas as pd
+
+ASSET_ZIP = "CASK_Assets.zip"
+
+
+def _open_asset(name: str) -> IO[str]:
+    """Return a text stream for ``name`` within ``ASSET_ZIP``."""
+    if not os.path.exists(ASSET_ZIP):
+        raise FileNotFoundError(f"{ASSET_ZIP} not found")
+    with zipfile.ZipFile(ASSET_ZIP) as zf:
+        return TextIOWrapper(zf.open(name), encoding="utf-8")
+
+
+def load_specifications() -> pd.DataFrame:
+    """Load the CASK technical specifications table."""
+    with _open_asset("cask_technical_specifications.csv") as f:
+        return pd.read_csv(f)
+
+
+def load_risk_assessment() -> pd.DataFrame:
+    """Load the CASK risk assessment table."""
+    with _open_asset("cask_risk_assessment.csv") as f:
+        return pd.read_csv(f)
+
+
+def load_vs_sota() -> pd.DataFrame:
+    """Load the comparison against state of the art table."""
+    with _open_asset("cask_vs_sota_comparison.csv") as f:
+        return pd.read_csv(f)
+
+
+def generate_architecture_chart(output: str = "cask_architecture.png") -> str:
+    """Generate a simple architecture diagram and return the output path."""
+    import plotly.graph_objects as go
+
+    fig = go.Figure()
+    colors = {
+        "knowledge": "#1FB8CD",
+        "processing": "#FFC185",
+        "validation": "#5D878F",
+    }
+    components = [
+        (1, 5, "Global DB", colors["knowledge"]),
+        (3, 5, "Ethics Index", colors["knowledge"]),
+        (5, 5, "Cultural Framework", colors["knowledge"]),
+        (1, 3, "SVCC", colors["processing"]),
+        (3, 3, "GPT Layer", colors["processing"]),
+        (5, 3, "Agent Sim", colors["processing"]),
+        (2, 1, "Ethics Validator", colors["validation"]),
+        (4, 1, "ORION Runtime", colors["validation"]),
+    ]
+    for x, y, text, color in components:
+        fig.add_shape(
+            type="rect",
+            x0=x - 0.4,
+            y0=y - 0.4,
+            x1=x + 0.4,
+            y1=y + 0.4,
+            fillcolor=color,
+            line=dict(color="black", width=2),
+        )
+        fig.add_annotation(x=x, y=y, text=text, showarrow=False)
+
+    fig.update_xaxes(visible=False)
+    fig.update_yaxes(visible=False)
+    fig.update_layout(
+        plot_bgcolor="white",
+        paper_bgcolor="white",
+        width=800,
+        height=400,
+        title="CASK Architecture (simplified)",
+    )
+    fig.write_image(output)
+    return output

--- a/modules/cask_tool.py
+++ b/modules/cask_tool.py
@@ -66,10 +66,10 @@ def generate_architecture_chart(output: str = "cask_architecture.png") -> str:
     for x, y, text, color in components:
         fig.add_shape(
             type="rect",
-            x0=x - 0.4,
-            y0=y - 0.4,
-            x1=x + 0.4,
-            y1=y + 0.4,
+            x0=x - RECTANGLE_PADDING,
+            y0=y - RECTANGLE_PADDING,
+            x1=x + RECTANGLE_PADDING,
+            y1=y + RECTANGLE_PADDING,
             fillcolor=color,
             line=dict(color="black", width=2),
         )

--- a/modules/cask_tool.py
+++ b/modules/cask_tool.py
@@ -19,30 +19,31 @@ import pandas as pd
 ASSET_ZIP = "CASK_Assets.zip"
 
 
-def _open_asset(name: str) -> IO[str]:
-    """Return a text stream for ``name`` within ``ASSET_ZIP``."""
+def _open_asset(name: str) -> str:
+    """Return the contents of ``name`` within ``ASSET_ZIP`` as a string."""
     if not os.path.exists(ASSET_ZIP):
         raise FileNotFoundError(f"{ASSET_ZIP} not found")
     with zipfile.ZipFile(ASSET_ZIP) as zf:
-        return TextIOWrapper(zf.open(name), encoding="utf-8")
+        with zf.open(name) as file:
+            return file.read().decode("utf-8")
 
 
 def load_specifications() -> pd.DataFrame:
     """Load the CASK technical specifications table."""
-    with _open_asset("cask_technical_specifications.csv") as f:
-        return pd.read_csv(f)
+    data = _open_asset("cask_technical_specifications.csv")
+    return pd.read_csv(pd.compat.StringIO(data))
 
 
 def load_risk_assessment() -> pd.DataFrame:
     """Load the CASK risk assessment table."""
-    with _open_asset("cask_risk_assessment.csv") as f:
-        return pd.read_csv(f)
+    data = _open_asset("cask_risk_assessment.csv")
+    return pd.read_csv(pd.compat.StringIO(data))
 
 
 def load_vs_sota() -> pd.DataFrame:
     """Load the comparison against state of the art table."""
-    with _open_asset("cask_vs_sota_comparison.csv") as f:
-        return pd.read_csv(f)
+    data = _open_asset("cask_vs_sota_comparison.csv")
+    return pd.read_csv(pd.compat.StringIO(data))
 
 
 def generate_architecture_chart(output: str = "cask_architecture.png") -> str:

--- a/modules/cask_tool.py
+++ b/modules/cask_tool.py
@@ -11,9 +11,6 @@ from __future__ import annotations
 
 import os
 import zipfile
-from io import TextIOWrapper
-from typing import IO
-
 import pandas as pd
 
 ASSET_ZIP = "CASK_Assets.zip"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@
 pyyaml==6.0.2
 flake8==7.3.0
 pytest==8.4.0
+pandas==2.2.2
+plotly==5.22.0
+kaleido==0.2.1

--- a/scripts/cask_integration.py
+++ b/scripts/cask_integration.py
@@ -27,7 +27,7 @@ def cmd_chart(path: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Interact with CASK assets")
-    sub = parser.add_subparsers(dest="command")
+    sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("summary", help="Print dataset summaries")
     chart_p = sub.add_parser("chart", help="Generate architecture chart")

--- a/scripts/cask_integration.py
+++ b/scripts/cask_integration.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Command line interface for working with CASK assets."""
+
+import argparse
+
+from modules.cask_tool import (
+    load_specifications,
+    load_risk_assessment,
+    load_vs_sota,
+    generate_architecture_chart,
+)
+
+
+def cmd_summary() -> None:
+    specs = load_specifications()
+    risks = load_risk_assessment()
+    comp = load_vs_sota()
+    print("Specifications rows:", len(specs))
+    print("Risk assessment rows:", len(risks))
+    print("Comparison rows:", len(comp))
+
+
+def cmd_chart(path: str) -> None:
+    out = generate_architecture_chart(path)
+    print(f"Chart written to {out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with CASK assets")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("summary", help="Print dataset summaries")
+    chart_p = sub.add_parser("chart", help="Generate architecture chart")
+    chart_p.add_argument("--output", default="cask_architecture.png")
+
+    args = parser.parse_args()
+
+    if args.command == "summary":
+        cmd_summary()
+    elif args.command == "chart":
+        cmd_chart(args.output)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cask_tool.py
+++ b/tests/test_cask_tool.py
@@ -1,0 +1,31 @@
+from modules.cask_tool import (
+    load_specifications,
+    load_risk_assessment,
+    load_vs_sota,
+    generate_architecture_chart,
+)
+
+
+def test_load_specifications():
+    df = load_specifications()
+    assert not df.empty
+    assert "Component" in df.columns
+
+
+def test_load_risk_assessment():
+    df = load_risk_assessment()
+    assert not df.empty
+    assert "Risk_Category" in df.columns
+
+
+def test_load_vs_sota():
+    df = load_vs_sota()
+    assert not df.empty
+    assert "Technical_Domain" in df.columns
+
+
+def test_generate_architecture_chart(tmp_path):
+    out = tmp_path / "chart.png"
+    path = generate_architecture_chart(str(out))
+    assert out.exists()
+    assert path == str(out)


### PR DESCRIPTION
## Summary
- include a `cask_tool` module for working with the CASK dataset
- provide a small CLI wrapper under `scripts/`
- document usage in the README
- add pandas/plotly/kaleido to requirements
- test CASK utilities

## Testing
- `npm test --silent`
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_685b86999b388325a6f85cbf2669ba31