### PR TITLE
Ensure Node.js 20 available in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# Base image with Node.js 20
+FROM mcr.microsoft.com/devcontainers/javascript-node:20
+
+# Install Python 3 and pip for the backend
+RUN apt-get update \
+    && apt-get install -y python3 python3-pip \
+    && apt-get clean
+
+# Ensure node and npm are in the PATH for all shells and users
+RUN ln -sf $(which node) /usr/local/bin/node \
+    && ln -sf $(which npm) /usr/local/bin/npm \
+    && echo 'export PATH=/usr/local/bin:$PATH' > /etc/profile.d/node.sh
+
+USER node
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,9 @@
 {
   "name": "Aurora Reflective Autonomy DevContainer",
-  "image": "mcr.microsoft.com/devcontainers/python:3.11",
-  "features": {},
-  "postCreateCommand": "pip install -r requirements.txt || true",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "pip install -r requirements.txt || true && npm install",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -12,6 +13,7 @@
         "eamodio.gitlens",
         "redhat.vscode-yaml",
         "yzhang.markdown-all-in-one",
+        "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "editorconfig.editorconfig",
         "ms-azuretools.vscode-docker",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postCreateCommand": "pip install -r requirements.txt || true && npm install",
+  "postCreateCommand": "pip install -r requirements.txt || true; npm install",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ graph TD
 
 See `CONTRIBUTING.md` for guidelines.
 
+## Dev Container Troubleshooting
+
+Node.js 20 is installed via the dev container Dockerfile and `npm install` runs automatically after creation.
+If `node` or `npm` are not found, ensure your shell loads `/etc/profile.d/node.sh` or add `/usr/local/bin` to your `PATH`. Rebuild the container if packages were installed with the wrong user.
+
 ## License
 
 See `LICENSE` for terms.

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,10 +1,13 @@
 {
   "name": "aurora-cloudbank",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
-  "postCreateCommand": "npm install",
+  "build": {
+    "dockerfile": ".devcontainer/Dockerfile"
+  },
+  "postCreateCommand": "pip install -r requirements.txt || true && npm install",
   "customizations": {
     "vscode": {
       "extensions": [
+        "ms-python.python",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode"
       ]

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": ".devcontainer/Dockerfile"
   },
-  "postCreateCommand": "pip install -r requirements.txt || true && npm install",
+  "postCreateCommand": "pip install -r requirements.txt || true; npm install",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
- add Dockerfile installing Node.js 20 and Python
- build devcontainer from this Dockerfile for both configs
- run `pip install` and `npm install` automatically
- document troubleshooting tips for `node` and `npm`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685cedb802888325b8b66e835f266ff0