### PR TITLE
Implement PAS monitoring module

### DIFF
--- a/live_threads/diagnostics.json
+++ b/live_threads/diagnostics.json
@@ -1,0 +1,9 @@
+{
+  "symbolicDrift": 0,
+  "lastAnchorSync": 1751183857157,
+  "ethicsFlags": [],
+  "load": 9,
+  "commandCount": 0,
+  "glyphCount": 0,
+  "bundleCount": 0
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aurora-cloudbank-symbolic",
   "version": "0.1.0",
   "scripts": {
-    "test": "node tests/test_crypto.js",
+    "test": "AES_KEY_256_HEX=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef node tests/test_crypto.js && node tests/test_pas.js",
     "start-command-node": "node src/core/command_node.js",
     "start-api-bridge": "node src/bridge/api_bridge_server.js",
     "start-drift-sync": "node src/system/lattice_sync.js",

--- a/seeds/live_threads/diagnostics.json
+++ b/seeds/live_threads/diagnostics.json
@@ -1,0 +1,9 @@
+{
+  "symbolicDrift": 0,
+  "lastAnchorSync": 0,
+  "ethicsFlags": [],
+  "load": 0,
+  "commandCount": 0,
+  "glyphCount": 0,
+  "bundleCount": 0
+}

--- a/src/core/command_node.js
+++ b/src/core/command_node.js
@@ -1,16 +1,29 @@
 // command_node.js – ORION CORE CPU Relay
 // THREADCORE v3.5.1 integration – Symbolic Command Node
 
-const { glyphSync } = require('../lib/glyph_engine');
-const { anchorResolve, ethicsCheck } = require('../auth/ethics_layer');
-const { zipBeaconPing } = require('../lib/zipcomm');
+const { routeGlyph } = require('./glyph_engine');
+const { compressBundle } = require('./zipcomm');
+const { anchorResolve, ethicsCheck } = require('../../auth/ethics_layer');
+const { loadDiagnostics, saveDiagnostics } = require('./diagnostics');
+const { runPASCycle, initializePAS } = require('./parasym_activation');
+
+// Start PAS monitoring when this module is loaded
+initializePAS();
 
 module.exports = {
   executeCommand(command) {
     if (!ethicsCheck(command)) throw new Error('Ethics violation detected');
+    const diag = loadDiagnostics();
+    diag.commandCount = (diag.commandCount || 0) + 1;
+    diag.lastCommandAt = Date.now();
+    diag.load = diag.commandCount - (diag.processedCount || 0);
+    saveDiagnostics(diag);
+
     const anchor = anchorResolve(command.context || "AUTO");
-    glyphSync(anchor);
-    zipBeaconPing("ORION_CORE");
+    routeGlyph(command.name);
+    compressBundle("ORION_CORE");
+
+    runPASCycle();
     return `Command ${command.name} executed with anchor ${anchor}`;
   }
 };

--- a/src/core/diagnostics.js
+++ b/src/core/diagnostics.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const DIAG_PATH = path.join(__dirname, '..', '..', 'live_threads', 'diagnostics.json');
+
+function loadDiagnostics() {
+  if (!fs.existsSync(DIAG_PATH)) {
+    const init = {
+      symbolicDrift: 0,
+      lastAnchorSync: Date.now(),
+      ethicsFlags: [],
+      load: 0,
+      commandCount: 0,
+      glyphCount: 0,
+      bundleCount: 0
+    };
+    fs.writeFileSync(DIAG_PATH, JSON.stringify(init, null, 2));
+    return init;
+  }
+  return JSON.parse(fs.readFileSync(DIAG_PATH, 'utf8'));
+}
+
+function saveDiagnostics(data) {
+  fs.writeFileSync(DIAG_PATH, JSON.stringify(data, null, 2));
+}
+
+module.exports = { DIAG_PATH, loadDiagnostics, saveDiagnostics };

--- a/src/core/ethics_layer.js
+++ b/src/core/ethics_layer.js
@@ -1,10 +1,15 @@
 // ethics_layer.js
 // Enforces ethics protocol: Picard_Delta_3 and validates capsule payloads
 
+const { loadDiagnostics, saveDiagnostics } = require('./diagnostics');
+
 module.exports = {
   validatePayload: (payload) => {
     const protocol = 'Picard_Delta_3';
     console.log(`Validating payload under protocol ${protocol}:`, payload);
+    const diag = loadDiagnostics();
+    diag.ethicsChecks = (diag.ethicsChecks || 0) + 1;
+    saveDiagnostics(diag);
     // Add validation logic here
     return true;
   }

--- a/src/core/glyph_engine.js
+++ b/src/core/glyph_engine.js
@@ -1,10 +1,14 @@
 // glyph_engine.js
 // Manages symbolic glyph routing, parsing, and execution
 
+const { loadDiagnostics, saveDiagnostics } = require('./diagnostics');
+
 module.exports = {
   routeGlyph: (glyph) => {
     console.log('Routing glyph:', glyph);
-    // Add glyph routing logic here
+    const diag = loadDiagnostics();
+    diag.glyphCount = (diag.glyphCount || 0) + 1;
+    saveDiagnostics(diag);
     return `Glyph ${glyph} routed.`;
   }
 };

--- a/src/core/parasym_activation.js
+++ b/src/core/parasym_activation.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const { loadDiagnostics, saveDiagnostics } = require('./diagnostics');
+
+const DRIFT_THRESHOLD = 0.3;
+const MAX_ANCHOR_INTERVAL = 10 * 60 * 1000; // 10 minutes
+const LOAD_THRESHOLD = 5;
+
+function alignAnchors(diag) {
+  console.log('PAS: Aligning anchors');
+  diag.symbolicDrift = 0;
+  diag.lastAnchorSync = Date.now();
+}
+
+function propagateAnchor(diag) {
+  console.log('PAS: Propagating anchor state');
+  diag.lastAnchorSync = Date.now();
+}
+
+function handleEthicsAlert(flags, diag) {
+  console.log('PAS: Handling ethics alerts', flags);
+  diag.ethicsFlags = [];
+}
+
+function throttleIncoming(diag) {
+  console.log('PAS: Throttling incoming workload');
+  diag.load = Math.max(0, diag.load - 1);
+}
+
+function runPASCycle() {
+  const diag = loadDiagnostics();
+  if (diag.symbolicDrift > DRIFT_THRESHOLD) alignAnchors(diag);
+  if (Date.now() - diag.lastAnchorSync > MAX_ANCHOR_INTERVAL) propagateAnchor(diag);
+  if (diag.ethicsFlags && diag.ethicsFlags.length > 0) handleEthicsAlert(diag.ethicsFlags, diag);
+  if (diag.load > LOAD_THRESHOLD) throttleIncoming(diag);
+  saveDiagnostics(diag);
+  fs.appendFileSync(path.join(__dirname, '..', '..', 'live_threads', 'pas.log'),
+    `${new Date().toISOString()} PAS cycle executed\n`);
+}
+
+function initializePAS(interval = 5000) {
+  setInterval(runPASCycle, interval);
+  console.log('PAS initialized with interval', interval);
+}
+
+module.exports = {
+  initializePAS,
+  runPASCycle,
+  DRIFT_THRESHOLD,
+  MAX_ANCHOR_INTERVAL,
+  LOAD_THRESHOLD
+};

--- a/src/core/zipcomm.js
+++ b/src/core/zipcomm.js
@@ -1,10 +1,14 @@
 // zipcomm.js
 // Handles ZIPWIZ compression, encryption, and bundle control
 
+const { loadDiagnostics, saveDiagnostics } = require('./diagnostics');
+
 module.exports = {
   compressBundle: (bundle) => {
     console.log('Compressing bundle:', bundle);
-    // Add compression logic here
+    const diag = loadDiagnostics();
+    diag.bundleCount = (diag.bundleCount || 0) + 1;
+    saveDiagnostics(diag);
     return `Bundle ${bundle} compressed.`;
   }
 };

--- a/tests/test_pas.js
+++ b/tests/test_pas.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { loadDiagnostics, saveDiagnostics } = require('../src/core/diagnostics');
+const { runPASCycle } = require('../src/core/parasym_activation');
+
+let diag = loadDiagnostics();
+diag.symbolicDrift = 0.5;
+diag.lastAnchorSync = Date.now() - (11 * 60 * 1000);
+diag.ethicsFlags = ['violation'];
+diag.load = 10;
+saveDiagnostics(diag);
+
+runPASCycle();
+
+diag = loadDiagnostics();
+assert.ok(diag.symbolicDrift <= 0.5, 'drift should not increase');
+assert.strictEqual(diag.ethicsFlags.length, 0, 'ethics flags should be cleared');
+assert.ok(Date.now() - diag.lastAnchorSync < 1000, 'anchor should be resynced');
+console.log('PAS cycle test passed');


### PR DESCRIPTION
## Summary
- implement Parasympathetic Activation System in `src/core`
- track runtime diagnostics and add helper module
- hook PAS into command node and update glyph engine, zipcomm, and ethics layer
- add diagnostics seed files and PAS unit test
- update test script to set crypto env var

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError for httpx, yaml, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6860f00c80808325a4e717cc4471a025