### PR TITLE
Fix dev container build path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "Aurora Reflective Autonomy DevContainer",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "context": ".."
   },
   "postCreateCommand": "pip install -r requirements.txt || true; npm install",
   "customizations": {

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "aurora-cloudbank",
   "build": {
     "dockerfile": ".devcontainer/Dockerfile",
-    "context": ".."
+    "context": "."
   },
   "postCreateCommand": "pip install -r requirements.txt || true && npm install",
   "customizations": {


### PR DESCRIPTION
## Summary
- use repository root for devcontainer build context
- specify build context for `.devcontainer/devcontainer.json`

## Testing
- `bash scripts/validate-cicd.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860f5bca08c8325a8fe5fc9de8b86f4