### PR TITLE
Combine visualization docs and add merge script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A fully operational, ethics-aligned symbolic governance and self-healing system.
 
+Detailed architecture guides and visualization package information can be found in
+[the documentation index](docs/index.md).
+
 ## Features
 
 - Modular symbolic governance engine
@@ -90,6 +93,10 @@ Use `python scripts/orion_backup_sync.py --help` to export and synchronize the s
 ## Module Integration Tool
 
 Use `python scripts/module_integrator.py --help` to merge new modules across branches. The tool validates anchor compliance, logs telemetry to `logs/telemetry.log`, and supports per-module rollback.
+
+## Package Combination Utility
+
+Use `python scripts/combine_package_versions.py OUTPUT.zip FILE1.zip FILE2.zip ...` to merge multiple archive versions into a single package. This helps consolidate legacy module bundles before deployment.
 
 ## CASK Integration Utilities
 

--- a/docs/combined_visualization_package.md
+++ b/docs/combined_visualization_package.md
@@ -1,0 +1,40 @@
+# Combined Visualization Package
+
+This guide consolidates the previous visualization documents into a single blueprint for deploying Aurora's simulation graphics.
+
+## 1. Goals
+- Provide real-time 3D visuals, physics and audio for Aurora simulations.
+- Maintain tight integration with the existing Python and Node.js services.
+- Offer a scalable and secure workflow that works locally and in the cloud.
+
+## 2. Core Components
+- **Godot 4 Engine** for rendering and physics with scripts written in GDScript or C#.
+- **FastAPI services** (`aurora_gui_cloudhub_fastapi.py`) exposing REST and WebSocket APIs.
+- **Node.js command node** for runtime orchestration and additional WebSocket channels.
+- **Docker Compose** (and optional Kubernetes) to orchestrate these services consistently.
+
+## 3. Asset Pipeline
+- Create assets in **Blender** and export to `glTF`.
+- Store large binaries using **Git LFS**.
+- Maintain a `game/` directory for the Godot project and `game/assets` for models, textures and audio.
+
+## 4. API Integration
+- Define typed JSON schemas (e.g. `SymbolicVector`) for state updates.
+- Use WebSockets for real-time data and REST for configuration or asset metadata.
+- Require authentication tokens when connecting from the engine to backend services.
+
+## 5. Development Workflow
+- Use Docker Compose to run Python services, the Node command node and (optionally) a headless Godot container.
+- GitHub Actions should run unit tests, headless Godot tests and build Docker images.
+- Provide Blender export scripts and Godot export scripts so packaged builds are reproducible.
+
+## 6. Observability
+- Centralize logs from Python, Node.js and Godot using the existing telemetry logger.
+- Add metrics collection via Prometheus and Grafana or an ELK stack.
+
+## 7. Next Steps
+1. Prototype a minimal Godot project that connects to the FastAPI WebSocket.
+2. Expand the API schema and document all endpoints in this repository.
+3. Build a simple demo scene that visualizes a symbolic simulation.
+
+This combined package lays the groundwork for a robust, enterprise-ready visualization stack while remaining fully open source.

--- a/docs/enterprise_visualization_package.md
+++ b/docs/enterprise_visualization_package.md
@@ -1,0 +1,45 @@
+# Enterprise Visualization Package
+
+This guide describes how to evolve the basic visualization stack into an enterprise-grade package suitable for large scale deployments.
+
+## 1. Goals
+- Provide real-time 3D visuals, physics and audio for Aurora simulations.
+- Keep integration with existing Python and Node.js services.
+- Offer a maintainable, scalable and secure workflow for teams.
+
+## 2. Core Components
+- **Godot 4 Engine** for rendering and physics. Script integration is done with GDScript or C#.
+- **FastAPI services** under `aurora_gui_cloudhub_fastapi.py` manage simulation logic and REST/WebSocket APIs.
+- **Node.js command node** coordinates runtime tasks and can expose additional WebSocket endpoints.
+- **Docker Compose** orchestrates all services for consistent local and cloud environments.
+
+## 3. Asset Pipeline
+- Create assets in **Blender** and export them to `glTF`.
+- Store large binaries with **Git LFS** to keep the repository lightweight.
+- Maintain a `game/` directory containing the Godot project and `game/assets` for models, textures and audio.
+
+## 4. API Integration
+- Define typed JSON schemas (e.g., `SymbolicVector`) for state updates.
+- Expose real-time data through WebSocket channels so the Godot client can subscribe to simulation events.
+- Provide REST endpoints for initialization and asset metadata.
+
+## 5. Security and Scalability
+- Use API keys or JWT tokens for authentication between the engine and backend services.
+- Containerize each component and deploy via Kubernetes or similar if horizontal scaling is required.
+- Employ rate limiting and audit logging using the existing telemetry logger.
+
+## 6. Continuous Integration / Deployment
+- Add GitHub Actions workflows that run unit tests, headless Godot tests and build Docker images.
+- Package the Godot project using automated export scripts so artifacts are ready for deployment.
+- Publish versioned Docker images to a registry for staging and production.
+
+## 7. Observability
+- Centralize logs from Python, Node.js and Godot using a monitoring stack (e.g., Prometheus + Grafana or ELK).
+- Record key simulation events with the telemetry logger for later analysis.
+
+## 8. Next Steps
+1. Prototype a minimal Godot project that connects to the FastAPI WebSocket.
+2. Expand the API to cover the full simulation state and user interactions.
+3. Document build and deployment procedures in the repository.
+
+By following this package layout and workflow, the visualization stack becomes robust enough for enterprise scenarios while retaining the open-source flexibility of the Aurora system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,4 +3,6 @@
 Welcome to the Aurora Reflective Autonomy System documentation. Use this index to navigate system guides, architecture, and usage examples.
 
 - [System Architecture](architecture.md)
+- [Combined Visualization Package](combined_visualization_package.md)
 - [Visualization Stack and Integration Plan](visualization_stack.md)
+- [Enterprise Visualization Package](enterprise_visualization_package.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,3 +4,4 @@ Deployment, bootstrap, and helper scripts for the Aurora Reflective Autonomy Sys
 
 - `orion_backup_sync.py` - Backup and synchronize staff registry and Orion Station blueprint.
 - `module_integrator.py` - Automate integration of modules across Command Node and PL branch with telemetry logging.
+- `combine_package_versions.py` - Merge multiple archive versions into a single consolidated package.

--- a/scripts/combine_package_versions.py
+++ b/scripts/combine_package_versions.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Combine multiple module packages into a single archive."""
+
+import argparse
+import os
+import shutil
+import tempfile
+import zipfile
+
+
+def combine(output: str, packages: list[str]) -> str:
+    with tempfile.TemporaryDirectory() as tmp:
+        for pkg in packages:
+            if not zipfile.is_zipfile(pkg):
+                raise ValueError(f"{pkg} is not a valid zip file")
+            with zipfile.ZipFile(pkg) as z:
+                z.extractall(tmp)
+        shutil.make_archive(os.path.splitext(output)[0], "zip", tmp)
+    return os.path.abspath(output)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Merge package zip files")
+    parser.add_argument("output", help="Output combined zip file")
+    parser.add_argument("packages", nargs="+", help="Input package zip files")
+    args = parser.parse_args()
+
+    out_path = combine(args.output, args.packages)
+    print(f"Combined package created at {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- consolidate existing visualization docs into `docs/combined_visualization_package.md`
- link the new combined guide from the docs index
- document a new `combine_package_versions.py` utility and reference it in README
- update scripts README

## Testing
- `pip install -r requirements.txt` *(fails to install numba: Python 3.11 not supported)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_685b45e83618832595c61e4f9891531a