### PR TITLE
Validate command before ethics check

### DIFF
--- a/auth/ethics_layer.js
+++ b/auth/ethics_layer.js
@@ -1,5 +1,13 @@
 exports.ethicsCheck = function(command) {
   const forbidden = ['blacklist', 'override'];
+  if (
+    !command ||
+    typeof command !== 'object' ||
+    typeof command.name !== 'string' ||
+    command.name.trim() === ''
+  ) {
+    return false;
+  }
   return !forbidden.includes(command.name.toLowerCase());
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aurora-cloudbank-symbolic",
   "version": "0.1.0",
   "scripts": {
-    "test": "AES_KEY_256_HEX=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef node tests/test_crypto.js && node tests/test_pas.js && node tests/test_signal_prioritizer.js && node tests/test_pqn_router.js",
+    "test": "AES_KEY_256_HEX=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef node tests/test_crypto.js && node tests/test_pas.js && node tests/test_signal_prioritizer.js && node tests/test_pqn_router.js && node tests/test_ethics_layer.js",
     "start-command-node": "node src/core/command_node.js",
     "start-api-bridge": "node src/bridge/api_bridge_server.js",
     "start-drift-sync": "node src/system/lattice_sync.js",

--- a/tests/test_ethics_layer.js
+++ b/tests/test_ethics_layer.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { ethicsCheck } = require('../auth/ethics_layer');
+
+assert.strictEqual(ethicsCheck({ name: 'launch' }), true, 'valid command should return true');
+assert.strictEqual(ethicsCheck(), false, 'missing command should return false');
+assert.strictEqual(ethicsCheck({}), false, 'command without name should return false');
+assert.strictEqual(ethicsCheck({ name: 42 }), false, 'command name must be a non-empty string');
+
+console.log('ethics layer tests passed');


### PR DESCRIPTION
## Summary
- Avoid errors by validating `command` and `command.name` before running ethics checks
- Add unit tests for valid, missing, and malformed command inputs
- Include ethics-layer test in npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c789b2ef448325b2d253baac4aa4ea