### PR TITLE
Potential fix for code scanning alert no. 148: Bad HTML filtering regexp

### DIFF
--- a/middleware/aurora-security-middleware.js
+++ b/middleware/aurora-security-middleware.js
@@ -5,6 +5,7 @@
 
 const rateLimit = require('express-rate-limit');
 const helmet = require('helmet');
+const sanitizeHtml = require('sanitize-html');
 
 class AuroraSecurityMiddleware {
   constructor(app) {
@@ -163,21 +164,13 @@ class AuroraSecurityMiddleware {
    */
   sanitizeInput(input) {
     if (typeof input !== 'string') return input;
-
-    // Remove potential XSS and dangerous protocols
-    const dangerousProtocol = 'java' + 'script:'; // Split to avoid security scanner detection
-    let sanitized = input
-      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-      .replace(new RegExp(dangerousProtocol, 'gi'), 'blocked:')
-      .replace(/vbscript:/gi, 'blocked:')
-      .replace(/data:text\/html/gi, 'blocked:');
-    // Remove all event handler attributes (on*)
-    let prev;
-    do {
-      prev = sanitized;
-      sanitized = sanitized.replace(/on\w+\s*=/gi, '');
-    } while (sanitized !== prev);
-    return sanitized;
+    // Use sanitize-html to remove all HTML tags and dangerous protocols
+    return sanitizeHtml(input, {
+      allowedTags: [],
+      allowedAttributes: {},
+      // Disallow all protocols that could be dangerous. Remove href/src attributes.
+      allowedSchemes: [],
+    });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "express-rate-limit": "^8.0.1",
     "helmet": "^7.1.0",
     "socket.io": "^4.7.0",
-    "ws": "^8.13.0"
+    "ws": "^8.13.0",
+    "sanitize-html": "^2.17.0"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
Potential fix for [https://github.com/AUo959/aurora-cloudbank-symbolic/security/code-scanning/148](https://github.com/AUo959/aurora-cloudbank-symbolic/security/code-scanning/148)

The best way to fix this problem is to use a well-tested, community-maintained HTML sanitization library such as `sanitize-html` or `DOMPurify` (for frontend, but here `sanitize-html` is appropriate for backend Node.js code). These libraries correctly handle malformed HTML and provide robust XSS prevention, rather than relying on brittle or incomplete regular expressions. The function `sanitizeInput` should be updated to use the library instead of the faulty regular expression.

To implement this, in `middleware/aurora-security-middleware.js`, we should:
- Add the necessary import/require statement for `sanitize-html`.
- Refactor the `sanitizeInput` method (line 164 onwards) to use `sanitizeHtml` instead of custom, unsafe regular expressions for `<script>` removal and inline handler stripping.
- There is no need to chain multiple regex-based cleanups anymore, as `sanitize-html` can be configured to drop all unwanted tags and attributes. As a default, we can configure it to allow no tags and no attributes for the strongest security, which effectively strips all HTML, not just script tags and handlers.

No other changes to logic or parameters elsewhere in the file are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
