### PR TITLE
Add ARC chain processing support to developer CLI

### DIFF
--- a/tests/fixtures/arc_chain_sample.json
+++ b/tests/fixtures/arc_chain_sample.json
@@ -1,0 +1,50 @@
+{
+  "schema": "ARC_CHAIN_EXPORT_SCHEMA_v1.0",
+  "exported_at": "2025-09-22T20:35:00Z",
+  "thread_id": "aurora.thread.gumas.v2.4.1",
+  "linked_threads": ["halo.thread.v1", "liora.thread.v2"],
+  "arc_chain": [
+    {
+      "type": "INIT_ARC",
+      "timestamp": "2025-09-21T00:00:00Z",
+      "by": "system",
+      "summary": "Thread initiated for GUMAS continuity enhancements.",
+      "anchor_pair": ["0xINIT", "0x001"],
+      "propagate_to": ["sibling"],
+      "driftlog_delta": null
+    },
+    {
+      "type": "UPLOAD_ARC",
+      "timestamp": "2025-09-21T15:42:10Z",
+      "by": "Emily Roberts",
+      "summary": "Aurora_PATCH_GPT-Editor_T2_v1.0.zip uploaded. Preload snapshot captured.",
+      "anchor_pair": ["0x001", "0x002"],
+      "propagate_to": ["sibling", "parent"],
+      "driftlog_delta": "-0.3%"
+    },
+    {
+      "type": "ETHICS_ARC",
+      "timestamp": "2025-09-21T16:03:44Z",
+      "by": "Prof. Elena Sorensen",
+      "summary": "Symbolic ethics alignment verified (no override).",
+      "anchor_pair": ["0x002", "0x003"],
+      "propagate_to": ["parent"],
+      "driftlog_delta": "Δ0.000"
+    }
+  ],
+  "closure": {
+    "type": "CLOSURE_ARC",
+    "sealed_by": "system",
+    "timestamp": "2025-09-22T18:00:00Z",
+    "summary": "Thread finalized for export.",
+    "archive_ready": true
+  },
+  "signature": "aurora.system.symbolic.v2.4",
+  "validation": {
+    "checksums": {
+      "arc_chain": "SHA256:f97b4cfa...",
+      "linked_manifest": "SHA256:ae32b1fa..."
+    },
+    "validation_passed": true
+  }
+}

--- a/tests/test_arc_chain_processor.py
+++ b/tests/test_arc_chain_processor.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.symbolic.arc_chain_processor import ArcChainProcessor
+
+
+def load_sample() -> Path:
+    return Path(__file__).resolve().parent / "fixtures" / "arc_chain_sample.json"
+
+
+def test_arc_chain_summary_metrics():
+    processor = ArcChainProcessor.from_file(load_sample())
+    summary = processor.build_summary()
+
+    assert summary["schema"] == "ARC_CHAIN_EXPORT_SCHEMA_v1.0"
+    assert summary["thread_id"] == "aurora.thread.gumas.v2.4.1"
+    assert summary["total_events"] == 3
+    assert summary["event_types"]["INIT_ARC"] == 1
+    assert summary["event_types"]["UPLOAD_ARC"] == 1
+    assert summary["event_types"]["ETHICS_ARC"] == 1
+    assert summary["drift_metrics"]["max_delta"] == pytest.approx(0.0)
+    assert summary["drift_metrics"]["max_abs_delta"] == pytest.approx(0.3)
+    assert summary["closure"]["sealed"] is True
+    assert summary["validation_passed"] is True
+    assert "anomalies" not in summary or not summary["anomalies"]
+
+
+def test_arc_chain_enhanced_payload_contains_summary(tmp_path):
+    processor = ArcChainProcessor.from_file(load_sample())
+    enhanced = processor.export_enhanced_payload()
+
+    assert "enhancements" in enhanced
+    assert "summary" in enhanced["enhancements"]
+    summary = enhanced["enhancements"]["summary"]
+    assert summary["total_events"] == 3
+    assert enhanced["enhancements"]["anomalies"] == summary.get("anomalies", [])
+
+    output_path = tmp_path / "enhanced.json"
+    output_path.write_text(json.dumps(enhanced), encoding="utf-8")
+    loaded = json.loads(output_path.read_text(encoding="utf-8"))
+    assert loaded["enhancements"]["summary"]["thread_id"] == "aurora.thread.gumas.v2.4.1"

--- a/tests/test_cli_arc_chain.py
+++ b/tests/test_cli_arc_chain.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CLI = str(Path("tools/cli/aurora_dev_cli.py").resolve())
+PYTHON = sys.executable
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cli_arc_analyze_json_output():
+    sample = Path(__file__).resolve().parent / "fixtures" / "arc_chain_sample.json"
+
+    proc = subprocess.run(
+        [PYTHON, CLI, "arc", "analyze", str(sample), "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert payload["thread_id"] == "aurora.thread.gumas.v2.4.1"
+    assert payload["total_events"] == 3
+    assert payload["validation_passed"] is True
+    assert "drift_metrics" in payload

--- a/tools/cli/aurora_dev_cli.py
+++ b/tools/cli/aurora_dev_cli.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(WORKSPACE_ROOT))
 
 from tools.symbolic.memory_sealer import MemorySealingEngine  # noqa: E402
 from tools.symbolic.anchor_tracker import SymbolicAnchorTracker  # noqa: E402
+from tools.symbolic.arc_chain_processor import ArcChainProcessor  # noqa: E402
 
 
 class AuroraDeveloperCLI:
@@ -62,6 +63,17 @@ class AuroraDeveloperCLI:
             print(f"❌ Unknown anchor command: {args.anchor_cmd}")
             return 1
 
+    def cmd_arc(self, args) -> int:
+        """Handle ARC chain export operations."""
+        if not args.arc_cmd:
+            print("❌ ARC command required (e.g., 'analyze')")
+            return 1
+        if args.arc_cmd == "analyze":
+            return self._arc_analyze(args)
+
+        print(f"❌ Unknown ARC command: {args.arc_cmd}")
+        return 1
+
     def _anchor_track(self, args) -> int:
         """Track symbolic anchors across repository"""
         if not getattr(args, "json", False):
@@ -95,9 +107,7 @@ class AuroraDeveloperCLI:
                 print(json.dumps(payload, separators=(",", ":")))
             else:
                 if args.pattern:
-                    print(
-                        f"Found {total_anchors} anchors matching '{args.pattern}' in {len(found_anchors)} files:"
-                    )
+                    print(f"Found {total_anchors} anchors matching '{args.pattern}' in {len(found_anchors)} files:")
                 else:
                     print(f"Found {total_anchors} anchors in {len(found_anchors)} files:")
 
@@ -209,6 +219,85 @@ class AuroraDeveloperCLI:
             print(f"❌ Error sealing anchor thread: {e}")
             return 1
 
+    def _arc_analyze(self, args) -> int:
+        """Analyze an ARC chain export payload."""
+        if not args.payload:
+            print("❌ ARC payload path required")
+            return 1
+
+        try:
+            processor = ArcChainProcessor.from_file(args.payload)
+            summary = processor.build_summary()
+        except Exception as exc:
+            print(f"❌ Error analyzing ARC chain: {exc}")
+            return 1
+
+        if args.enhanced_out:
+            try:
+                Path(args.enhanced_out).write_text(
+                    json.dumps(processor.export_enhanced_payload(), indent=2),
+                    encoding="utf-8",
+                )
+                if not args.json:
+                    print(f"🗂️ Enhanced payload saved to: {args.enhanced_out}")
+            except Exception as exc:
+                print(f"⚠️  Failed to write enhanced payload: {exc}")
+
+        if args.json:
+            print(json.dumps(summary, separators=(",", ":")))
+            return 0
+
+        print("🧭 ARC Chain Summary")
+        print("=" * 40)
+        print(f"Schema: {summary.get('schema')}")
+        print(f"Thread: {summary.get('thread_id')}")
+        print(f"Events: {summary.get('total_events')} ({len(summary.get('event_types', {}))} types)")
+
+        timeline = summary.get("timeline", {})
+        print(f"Timeline: {timeline.get('start', 'unknown')} → {timeline.get('end', 'unknown')}")
+
+        participants = summary.get("participants", [])
+        if participants:
+            print(f"Participants ({len(participants)}): {', '.join(participants)}")
+
+        targets = summary.get("propagation_targets", [])
+        if targets:
+            print(f"Propagation targets: {', '.join(targets)}")
+
+        drift = summary.get("drift_metrics", {})
+        print(
+            "Drift Δ: max={max_delta:.3f}, min={min_delta:.3f}, |max|={max_abs:.3f}".format(
+                max_delta=drift.get("max_delta", 0.0),
+                min_delta=drift.get("min_delta", 0.0),
+                max_abs=drift.get("max_abs_delta", 0.0),
+            )
+        )
+        if drift.get("requires_attention"):
+            print("⚠️  Drift requires attention (≥1.0% detected)")
+
+        closure = summary.get("closure", {})
+        if closure.get("sealed"):
+            print(f"Closure: sealed by {closure.get('sealed_by')} at {closure.get('timestamp')}")
+            if closure.get("archive_ready"):
+                print("Archive ready: ✅")
+        else:
+            print("Closure: not sealed")
+
+        if summary.get("validation_passed"):
+            print("Validation: ✅")
+        else:
+            print("Validation: ⚠️  Checks pending")
+
+        anomalies = summary.get("anomalies", [])
+        if anomalies:
+            print("Anomalies detected:")
+            for item in anomalies:
+                print(f"  - {item}")
+        else:
+            print("Anomalies: none")
+
+        return 0
+
     def cmd_seal(self, args) -> int:
         """Handle memory sealing commands"""
         if not args.target:
@@ -267,11 +356,7 @@ class AuroraDeveloperCLI:
         try:
             print(f"🔄 Restoring state: {args.anchor_or_seal_id}")
 
-            result = self.memory_sealer.restore_sealed_state(
-                args.anchor_or_seal_id,
-                args.target_path,
-                args.dry
-            )
+            result = self.memory_sealer.restore_sealed_state(args.anchor_or_seal_id, args.target_path, args.dry)
 
             if result["status"] == "dry_run_complete":
                 print("🔍 Dry run - would perform these actions:")
@@ -406,12 +491,16 @@ class AuroraDeveloperCLI:
 
             if lineage1 and lineage2:
                 print("\n🔗 Lineage Comparison:")
-                print(f"  {args.anchor1}: Gen {lineage1.generation}, "
-                      f"{len(lineage1.ancestors)} ancestors, "
-                      f"{len(lineage1.descendants)} descendants")
-                print(f"  {args.anchor2}: Gen {lineage2.generation}, "
-                      f"{len(lineage2.ancestors)} ancestors, "
-                      f"{len(lineage2.descendants)} descendants")
+                print(
+                    f"  {args.anchor1}: Gen {lineage1.generation}, "
+                    f"{len(lineage1.ancestors)} ancestors, "
+                    f"{len(lineage1.descendants)} descendants"
+                )
+                print(
+                    f"  {args.anchor2}: Gen {lineage2.generation}, "
+                    f"{len(lineage2.ancestors)} ancestors, "
+                    f"{len(lineage2.descendants)} descendants"
+                )
 
                 # Find common ancestors
                 common_ancestors = set(lineage1.ancestors) & set(lineage2.ancestors)
@@ -468,7 +557,7 @@ class AuroraDeveloperCLI:
                     "lineages_mapped": len(lineages),
                     "drift": {k: len(v) for k, v in drift_issues.items()},
                     "repo": str(self.repo_path),
-                    "timestamp": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+                    "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                     "version": self.version,
                 }
                 print(json.dumps(payload, separators=(",", ":")))
@@ -508,6 +597,7 @@ Examples:
     aurora-cli anchor track --ext .md --json          # Track anchors in markdown, JSON output
     aurora-cli anchor track --pattern INFRA --since 2025-09-01
     aurora-cli anchor resolve T70_DOC_REORG           # Resolve specific anchor
+    aurora-cli arc analyze exports/arc.json --json    # Analyze ARC chain export
     aurora-cli seal tools/symbolic --verify           # Seal and verify directory
     aurora-cli restore T70_SEAL_123 --dry             # Dry run restore
     aurora-cli manifest --target T71_INFRA            # Generate manifest for T71
@@ -515,7 +605,7 @@ Examples:
     aurora-cli diff T70_DOC_REORG T71_INFRA           # Compare two anchors
     aurora-cli status                                 # Show system status
     aurora-cli status --json --since 2025-09-15       # Machine-readable status since a date
-"""
+""",
     )
 
     parser.add_argument("--version", action="version", version="Aurora CLI 1.0.0")
@@ -526,6 +616,18 @@ Examples:
     # Anchor tracking commands
     anchor_parser = subparsers.add_parser("anchor", help="Anchor tracking operations")
     anchor_subparsers = anchor_parser.add_subparsers(dest="anchor_cmd")
+
+    # ARC chain commands
+    arc_parser = subparsers.add_parser("arc", help="ARC chain export analysis")
+    arc_subparsers = arc_parser.add_subparsers(dest="arc_cmd")
+
+    analyze_parser = arc_subparsers.add_parser("analyze", help="Analyze ARC chain export")
+    analyze_parser.add_argument("payload", help="Path to ARC chain export JSON")
+    analyze_parser.add_argument("--json", action="store_true", help="Emit JSON output for machine parsing")
+    analyze_parser.add_argument(
+        "--enhanced-out",
+        help="Write enhanced payload (original + summary) to this file",
+    )
 
     # anchor track
     track_parser = anchor_subparsers.add_parser("track", help="Track symbolic anchors")
@@ -614,6 +716,8 @@ def main():
     # Route commands to appropriate handlers
     if args.command == "anchor":
         return cli.cmd_anchor(args)
+    elif args.command == "arc":
+        return cli.cmd_arc(args)
     elif args.command == "seal":
         return cli.cmd_seal(args)
     elif args.command == "restore":

--- a/tools/symbolic/__init__.py
+++ b/tools/symbolic/__init__.py
@@ -2,5 +2,15 @@
 Symbolic Infrastructure Tools - T71 Genesis
 """
 
+from .anchor_tracker import SymbolicAnchorTracker
+from .arc_chain_processor import ArcChainProcessor
+from .manifest_generator import ManifestGenerator
+from .memory_sealer import MemorySealingEngine
+
 __version__ = "1.0.0"
-__all__ = ["SymbolicAnchorTracker", "MemorySealingEngine", "ManifestGenerator"]
+__all__ = [
+    "SymbolicAnchorTracker",
+    "MemorySealingEngine",
+    "ManifestGenerator",
+    "ArcChainProcessor",
+]

--- a/tools/symbolic/arc_chain_processor.py
+++ b/tools/symbolic/arc_chain_processor.py
@@ -1,0 +1,219 @@
+"""Utilities for analyzing ARC chain export payloads."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """Parse ISO 8601 timestamps with optional trailing Z into aware datetimes."""
+    if not value:
+        raise ValueError("timestamp value is required")
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_drift(value: Optional[str]) -> Optional[float]:
+    """Convert drift strings like '-0.3%' or 'Δ0.000' into floats."""
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace("Δ", "")
+    if cleaned.endswith("%"):
+        cleaned = cleaned[:-1]
+    cleaned = cleaned.replace("+", "")
+    cleaned = cleaned.replace("%", "")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+@dataclass(eq=True)
+class ArcEvent:
+    """Single ARC chain event."""
+
+    event_type: str
+    timestamp: datetime
+    author: str
+    summary: str
+    anchor_pair: Tuple[Optional[str], Optional[str]]
+    propagate_to: Sequence[str]
+    drift_delta: Optional[float]
+    raw: Dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ArcEvent":
+        anchor_pair: Iterable[Optional[str]] = data.get("anchor_pair") or (None, None)
+        if isinstance(anchor_pair, (list, tuple)):
+            values: List[Optional[str]] = list(anchor_pair)[:2]
+            while len(values) < 2:
+                values.append(None)
+            anchor_tuple = (values[0], values[1])
+        else:
+            anchor_tuple = (None, None)
+
+        return cls(
+            event_type=data.get("type", "UNKNOWN"),
+            timestamp=_parse_timestamp(data["timestamp"]),
+            author=data.get("by", "unknown"),
+            summary=data.get("summary", ""),
+            anchor_pair=anchor_tuple,
+            propagate_to=tuple(data.get("propagate_to", [])),
+            drift_delta=_parse_drift(data.get("driftlog_delta")),
+            raw=data,
+        )
+
+
+@dataclass(eq=True)
+class ArcClosure:
+    """Closure metadata for ARC chains."""
+
+    sealed_by: str
+    timestamp: datetime
+    summary: str
+    archive_ready: bool
+    raw: Dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ArcClosure":
+        return cls(
+            sealed_by=data.get("sealed_by", "unknown"),
+            timestamp=_parse_timestamp(data["timestamp"]),
+            summary=data.get("summary", ""),
+            archive_ready=bool(data.get("archive_ready", False)),
+            raw=data,
+        )
+
+
+class ArcChainProcessor:
+    """Parser and analyzer for ARC chain export payloads."""
+
+    EXPECTED_SCHEMA_PREFIX = "ARC_CHAIN_EXPORT_SCHEMA"
+
+    def __init__(self, payload: Dict[str, Any], events: List[ArcEvent], closure: Optional[ArcClosure]):
+        self.payload = payload
+        self.events = events
+        self.closure = closure
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ArcChainProcessor":
+        schema = data.get("schema", "")
+        if not schema.startswith(cls.EXPECTED_SCHEMA_PREFIX):
+            raise ValueError(f"Unsupported ARC schema: {schema}")
+
+        arc_chain = data.get("arc_chain", [])
+        events = [ArcEvent.from_dict(item) for item in arc_chain]
+        closure = ArcClosure.from_dict(data["closure"]) if data.get("closure") else None
+        return cls(data, events, closure)
+
+    @classmethod
+    def from_file(cls, file_path: Path | str) -> "ArcChainProcessor":
+        path = Path(file_path)
+        content = json.loads(path.read_text(encoding="utf-8"))
+        return cls.from_dict(content)
+
+    def detect_anomalies(self) -> List[str]:
+        anomalies: List[str] = []
+        if not self.events:
+            anomalies.append("no_events_present")
+            return anomalies
+
+        sorted_events = sorted(self.events, key=lambda event: event.timestamp)
+        if sorted_events != self.events:
+            anomalies.append("timeline_out_of_order")
+
+        for event in self.events:
+            if not event.anchor_pair[0] or not event.anchor_pair[1]:
+                anomalies.append(f"missing_anchor_pair::{event.event_type}")
+            if not event.propagate_to:
+                anomalies.append(f"missing_propagation_targets::{event.event_type}")
+        return anomalies
+
+    def build_summary(self) -> Dict[str, Any]:
+        now = datetime.now(timezone.utc).isoformat()
+        event_counts: Dict[str, int] = {}
+        participants: List[str] = []
+        propagation_targets: List[str] = []
+        anchor_pairs: List[Tuple[Optional[str], Optional[str]]] = []
+        drift_values: List[float] = []
+
+        for event in self.events:
+            event_counts[event.event_type] = event_counts.get(event.event_type, 0) + 1
+            participants.append(event.author)
+            propagation_targets.extend(event.propagate_to)
+            anchor_pairs.append(event.anchor_pair)
+            if event.drift_delta is not None:
+                drift_values.append(event.drift_delta)
+
+        unique_participants = sorted({p for p in participants if p})
+        unique_targets = sorted({t for t in propagation_targets if t})
+        unique_anchors = sorted({anchor for pair in anchor_pairs for anchor in pair if anchor})
+
+        drift_metrics = {
+            "max_delta": max(drift_values) if drift_values else 0.0,
+            "min_delta": min(drift_values) if drift_values else 0.0,
+            "max_abs_delta": max((abs(value) for value in drift_values), default=0.0),
+            "requires_attention": any(abs(value) >= 1.0 for value in drift_values),
+        }
+
+        timeline_start = self.events[0].timestamp if self.events else None
+        timeline_end = self.events[-1].timestamp if self.events else None
+
+        closure_summary: Dict[str, Any]
+        if self.closure:
+            closure_summary = {
+                "sealed": True,
+                "sealed_by": self.closure.sealed_by,
+                "timestamp": self.closure.timestamp.isoformat(),
+                "summary": self.closure.summary,
+                "archive_ready": self.closure.archive_ready,
+            }
+        else:
+            closure_summary = {"sealed": False}
+
+        validation = self.payload.get("validation", {})
+        summary = {
+            "schema": self.payload.get("schema"),
+            "thread_id": self.payload.get("thread_id"),
+            "linked_threads": self.payload.get("linked_threads", []),
+            "total_events": len(self.events),
+            "event_types": event_counts,
+            "participants": unique_participants,
+            "propagation_targets": unique_targets,
+            "anchor_pairs": unique_anchors,
+            "timeline": {
+                "start": timeline_start.isoformat() if timeline_start else None,
+                "end": timeline_end.isoformat() if timeline_end else None,
+            },
+            "drift_metrics": drift_metrics,
+            "closure": closure_summary,
+            "validation_passed": bool(validation.get("validation_passed")),
+            "signature": self.payload.get("signature"),
+            "analysis_generated_at": now,
+        }
+
+        anomalies = self.detect_anomalies()
+        if anomalies:
+            summary["anomalies"] = anomalies
+
+        return summary
+
+    def export_enhanced_payload(self) -> Dict[str, Any]:
+        enhanced = dict(self.payload)
+        enhanced.setdefault("enhancements", {})
+        summary = self.build_summary()
+        enhanced["enhancements"]["summary"] = summary
+        enhanced["enhancements"]["anomalies"] = summary.get("anomalies", [])
+        enhanced["enhancements"]["generated_at"] = datetime.now(timezone.utc).isoformat()
+        return enhanced


### PR DESCRIPTION
## Summary
- add an `ArcChainProcessor` utility that normalizes ARC chain exports, derives drift metrics, and produces enhanced payloads for downstream tooling
- integrate a new `arc analyze` command into the Aurora developer CLI to surface ARC summaries in human-readable or JSON form and optionally persist enhanced exports
- provide a reusable ARC chain fixture alongside focused processor and CLI tests to guard the new workflows

## Testing
- pytest tests/test_arc_chain_processor.py tests/test_cli_arc_chain.py

------
https://chatgpt.com/codex/tasks/task_e_68d1fd981734832589588638fcad76c7