### PR TITLE
Add ARC chain enhancer utility and tests

### DIFF
--- a/tests/test_arc_chain_enhancer.py
+++ b/tests/test_arc_chain_enhancer.py
@@ -1,0 +1,89 @@
+"""Tests for the ARC Chain Enhancer utility."""
+
+from datetime import datetime
+
+import pytest
+
+from tools.symbolic.arc_chain_enhancer import ARCChainEnhancer, ARCValidationError
+
+
+@pytest.fixture
+def sample_arc_payload() -> dict:
+    return {
+        "schema": "ARC_CHAIN_EXPORT_SCHEMA_v1.0",
+        "exported_at": "2025-09-22T20:35:00Z",
+        "thread_id": "aurora.thread.gumas.v2.4.1",
+        "arc_chain": [
+            {
+                "type": "INIT_ARC",
+                "timestamp": "2025-09-21T00:00:00Z",
+                "by": "system",
+                "summary": "Thread initiated for GUMAS continuity enhancements.",
+                "anchor_pair": ["0xINIT", "0x001"],
+                "propagate_to": ["sibling"],
+                "driftlog_delta": None,
+            },
+            {
+                "type": "UPLOAD_ARC",
+                "timestamp": "2025-09-21T15:42:10Z",
+                "by": "Emily Roberts",
+                "summary": "Aurora_PATCH_GPT-Editor_T2_v1.0.zip uploaded. Preload snapshot captured.",
+                "anchor_pair": ["0x001", "0x002"],
+                "propagate_to": ["sibling", "parent"],
+                "driftlog_delta": "-0.3%",
+            },
+            {
+                "type": "ETHICS_ARC",
+                "timestamp": "2025-09-21T16:03:44Z",
+                "by": "Prof. Elena Sorensen",
+                "summary": "Symbolic ethics alignment verified (no override).",
+                "anchor_pair": ["0x002", "0x003"],
+                "propagate_to": ["parent"],
+                "driftlog_delta": "Δ0.000",
+            },
+        ],
+        "closure": {
+            "type": "CLOSURE_ARC",
+            "sealed_by": "system",
+            "timestamp": "2025-09-22T18:00:00Z",
+            "summary": "Thread finalized for export.",
+            "archive_ready": True,
+        },
+    }
+
+
+def test_enhancement_summary(sample_arc_payload):
+    enhancer = ARCChainEnhancer(sample_arc_payload)
+    summary = enhancer.enhancement_summary()
+
+    assert summary["schema"] == "ARC_CHAIN_EXPORT_SCHEMA_v1.0"
+    assert summary["thread_id"] == "aurora.thread.gumas.v2.4.1"
+    assert summary["chain_length"] == 3
+    assert summary["arc_types"]["UPLOAD_ARC"] == 1
+    assert summary["propagation"]["targets"]["parent"] == 2
+    assert summary["anchor_integrity"]["initial_pair"] == ("0xINIT", "0x001")
+    assert summary["driftlog"]["entries_with_drift"] == 2
+    assert summary["closure"]["sealed"] is True
+
+    exported_at = datetime.fromisoformat(summary["exported_at"])
+    assert exported_at.year == 2025
+
+
+def test_enhanced_payload_contains_anchor_metadata(sample_arc_payload):
+    enhancer = ARCChainEnhancer(sample_arc_payload)
+    payload = enhancer.enhanced_payload()
+
+    assert "arc_enhancement" in payload
+    enhancement_block = payload["arc_enhancement"]
+
+    assert enhancement_block["t1_anchor_seed"] == ARCChainEnhancer.T1_ANCHOR_SEED
+    assert enhancement_block["srb_bridge"] == ARCChainEnhancer.SRB_BRIDGE_ANCHOR
+    assert enhancement_block["summary"]["chain_length"] == 3
+
+
+def test_validation_error_on_missing_root_key(sample_arc_payload):
+    invalid_payload = {**sample_arc_payload}
+    invalid_payload.pop("arc_chain")
+
+    with pytest.raises(ARCValidationError):
+        ARCChainEnhancer(invalid_payload)

--- a/tools/symbolic/__init__.py
+++ b/tools/symbolic/__init__.py
@@ -3,4 +3,14 @@ Symbolic Infrastructure Tools - T71 Genesis
 """
 
 __version__ = "1.0.0"
-__all__ = ["SymbolicAnchorTracker", "MemorySealingEngine", "ManifestGenerator"]
+
+from .arc_chain_enhancer import ARCChainEnhancer, ARCEntry, ARCValidationError
+
+__all__ = [
+    "SymbolicAnchorTracker",
+    "MemorySealingEngine",
+    "ManifestGenerator",
+    "ARCChainEnhancer",
+    "ARCEntry",
+    "ARCValidationError",
+]

--- a/tools/symbolic/arc_chain_enhancer.py
+++ b/tools/symbolic/arc_chain_enhancer.py
@@ -1,0 +1,238 @@
+"""ARC Chain Enhancer
+=====================
+
+Utility helpers for processing Aurora Record Chain (ARC) exports.
+
+The enhancer focuses on light-weight validation and summary generation
+so that ARC payloads can be integrated with the existing symbolic
+infrastructure without mutating canonical constants (e.g. Picard_Delta_3
+or ORION bridge settings). The implementation keeps transparency in
+processing steps and surfaces the derived metrics explicitly in the
+returned metadata block.
+
+This module intentionally avoids external dependencies in order to
+remain compatible with the constrained execution environments used by
+Aurora CloudBank.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+import copy
+
+
+class ARCValidationError(ValueError):
+    """Raised when an ARC export payload fails validation."""
+
+
+def _parse_iso_timestamp(value: str) -> datetime:
+    """Parse ISO-8601 timestamps while accepting ``Z`` suffix values."""
+
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _parse_drift_delta(value: Optional[str]) -> Optional[float]:
+    """Convert drift delta strings into numeric values.
+
+    Supports values expressed with percentage symbols (``-0.3%``) or with
+    the ``Δ`` prefix (``Δ0.000``). If the string cannot be parsed the
+    function falls back to ``None`` so that calling code can decide how to
+    handle missing information.
+    """
+
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    cleaned = cleaned.replace("Δ", "").replace("delta", "").replace("%", "")
+
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class ARCEntry:
+    """Single record inside an ARC chain."""
+
+    arc_type: str
+    timestamp: datetime
+    author: str
+    summary: str
+    anchor_pair: Tuple[str, str]
+    propagate_to: Tuple[str, ...]
+    driftlog_delta: Optional[float]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ARCEntry":
+        """Create an :class:`ARCEntry` from raw dictionary data."""
+
+        required_fields = ["type", "timestamp", "by", "summary", "anchor_pair", "propagate_to"]
+        missing = [field for field in required_fields if field not in data]
+        if missing:
+            raise ARCValidationError(f"Missing required fields in ARC entry: {missing}")
+
+        anchor_pair = data["anchor_pair"]
+        if not isinstance(anchor_pair, (list, tuple)) or len(anchor_pair) != 2:
+            raise ARCValidationError("anchor_pair must be a 2-element list or tuple")
+
+        propagate_to = data.get("propagate_to", [])
+        if not isinstance(propagate_to, Iterable):
+            raise ARCValidationError("propagate_to must be an iterable")
+
+        timestamp = _parse_iso_timestamp(str(data["timestamp"]))
+        drift_delta = _parse_drift_delta(data.get("driftlog_delta"))
+
+        return cls(
+            arc_type=str(data["type"]),
+            timestamp=timestamp,
+            author=str(data["by"]),
+            summary=str(data["summary"]),
+            anchor_pair=(str(anchor_pair[0]), str(anchor_pair[1])),
+            propagate_to=tuple(str(target) for target in propagate_to),
+            driftlog_delta=drift_delta,
+        )
+
+
+class ARCChainEnhancer:
+    """Enhance and summarise ARC export payloads."""
+
+    T1_ANCHOR_SEED = "T1_ARC_CHAIN_ENHANCER"
+    SRB_BRIDGE_ANCHOR = "SRB_ARC_CHAIN_BRIDGE"
+
+    def __init__(self, arc_payload: Dict[str, Any]):
+        self._raw_payload = copy.deepcopy(arc_payload)
+        self.schema = ""
+        self.exported_at: Optional[datetime] = None
+        self.thread_id = ""
+        self.entries: List[ARCEntry] = []
+        self.closure: Dict[str, Any] = {}
+        self._validate_and_parse()
+
+    def _validate_and_parse(self) -> None:
+        """Validate root keys and parse ARC entries."""
+
+        required_root_keys = ["schema", "exported_at", "thread_id", "arc_chain"]
+        missing = [key for key in required_root_keys if key not in self._raw_payload]
+        if missing:
+            raise ARCValidationError(f"Missing required ARC root keys: {missing}")
+
+        self.schema = str(self._raw_payload["schema"])
+        self.exported_at = _parse_iso_timestamp(str(self._raw_payload["exported_at"]))
+        self.thread_id = str(self._raw_payload["thread_id"])
+
+        arc_chain = self._raw_payload.get("arc_chain", [])
+        if not isinstance(arc_chain, list):
+            raise ARCValidationError("arc_chain must be a list of entries")
+
+        self.entries = [ARCEntry.from_dict(entry) for entry in arc_chain]
+
+        closure = self._raw_payload.get("closure", {})
+        if closure:
+            if not isinstance(closure, dict):
+                raise ARCValidationError("closure must be a dictionary when provided")
+            self.closure = closure
+
+    # ------------------------------------------------------------------
+    # Derived metrics
+    # ------------------------------------------------------------------
+    def _count_arc_types(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for entry in self.entries:
+            counts[entry.arc_type] = counts.get(entry.arc_type, 0) + 1
+        return counts
+
+    def _collect_participants(self) -> List[str]:
+        return sorted({entry.author for entry in self.entries})
+
+    def _collect_propagation_targets(self) -> Dict[str, int]:
+        targets: Dict[str, int] = {}
+        for entry in self.entries:
+            for target in entry.propagate_to:
+                targets[target] = targets.get(target, 0) + 1
+        return targets
+
+    def _collect_anchor_pairs(self) -> List[Tuple[str, str]]:
+        unique_pairs = {entry.anchor_pair for entry in self.entries}
+        return sorted(unique_pairs)
+
+    def _compute_drift_metrics(self) -> Dict[str, Any]:
+        deltas = [entry.driftlog_delta for entry in self.entries if entry.driftlog_delta is not None]
+        if not deltas:
+            return {
+                "entries_with_drift": 0,
+                "net_change": 0.0,
+                "max_abs_change": 0.0,
+                "has_drift": False,
+            }
+
+        net_change = sum(deltas)
+        max_abs_change = max(abs(delta) for delta in deltas)
+
+        return {
+            "entries_with_drift": len(deltas),
+            "net_change": round(net_change, 6),
+            "max_abs_change": round(max_abs_change, 6),
+            "has_drift": any(delta != 0.0 for delta in deltas),
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def enhancement_summary(self) -> Dict[str, Any]:
+        """Return the derived metrics for the ARC chain."""
+
+        propagation_targets = self._collect_propagation_targets()
+
+        return {
+            "schema": self.schema,
+            "thread_id": self.thread_id,
+            "exported_at": self.exported_at.isoformat() if self.exported_at else None,
+            "chain_length": len(self.entries),
+            "arc_types": self._count_arc_types(),
+            "participants": self._collect_participants(),
+            "propagation": {
+                "targets": propagation_targets,
+                "total_targets": sum(propagation_targets.values()),
+            },
+            "anchor_integrity": {
+                "unique_pairs": self._collect_anchor_pairs(),
+                "initial_pair": self.entries[0].anchor_pair if self.entries else None,
+                "terminal_pair": self.entries[-1].anchor_pair if self.entries else None,
+                "t1_anchor_seed": self.T1_ANCHOR_SEED,
+                "srb_bridge": self.SRB_BRIDGE_ANCHOR,
+            },
+            "driftlog": self._compute_drift_metrics(),
+            "closure": {
+                "sealed": bool(self.closure),
+                "sealed_by": self.closure.get("sealed_by") if self.closure else None,
+                "archive_ready": bool(self.closure.get("archive_ready")) if self.closure else False,
+                "summary": self.closure.get("summary") if self.closure else None,
+            },
+        }
+
+    def enhanced_payload(self) -> Dict[str, Any]:
+        """Return the payload augmented with an ``arc_enhancement`` block."""
+
+        payload_copy = copy.deepcopy(self._raw_payload)
+        payload_copy["arc_enhancement"] = {
+            "t1_anchor_seed": self.T1_ANCHOR_SEED,
+            "srb_bridge": self.SRB_BRIDGE_ANCHOR,
+            "summary": self.enhancement_summary(),
+        }
+        return payload_copy
+
+
+__all__ = ["ARCChainEnhancer", "ARCEntry", "ARCValidationError"]
+


### PR DESCRIPTION
## Summary
- add an ARC chain enhancer utility that validates exports and derives propagation, anchor, and drift metrics
- expose the enhancer through the symbolic tools package for downstream consumers
- add pytest coverage to confirm enhancement output and schema validation behaviour

## Testing
- pytest tests/test_arc_chain_enhancer.py

------
https://chatgpt.com/codex/tasks/task_e_68d1fd981734832589588638fcad76c7