### PR TITLE
Support decimal and negative scalars in multivector expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,18 @@ Additionally, use `python scripts/cask_tool.py` to generate CASK reports and cha
 ## MCP-Driven API Endpoints
 
 - `/geometric/product` — Clifford algebra geometric product
+- `/geometric/mult` — Geometric product of two multivector expressions
 - `/quantum/symbolic_vector` — Quantum-inspired symbolic vector generation
 - `/mcp_bridge` — MCP Bridge Core configuration (JSON)
 - `/mcp_bridge/route_command` — Symbolic command routing (MCP-governed, with security/anchor validation)
+
+### Multivector Expression Format
+
+Endpoints like `/geometric/mult` expect each multivector to be provided as a
+whitespace-separated string of tokens. Every token must be either a blade label
+such as `e1`, `e2`, etc., or a numeric scalar. Scalars may include decimals and
+negative values. For example, the expression `"-1.5 e1 e2"` represents the
+multivector `-1.5 + e1 + e2`.
 
 ## Architecture Diagram
 

--- a/aurora_api.py
+++ b/aurora_api.py
@@ -18,19 +18,37 @@ ga = GeometricAlgebra()
 
 
 def parse_multivector(expression: str, blades: dict):
-    """Safely parse a multivector expression."""
+    """Safely parse a multivector expression.
+
+    The expression should contain whitespace-separated tokens where each token is
+    either a blade label (e.g., ``e1``) or a numeric scalar. Scalars may include
+    negative values and decimals.
+    """
+
     allowed_symbols = set(blades.keys())
-    tokens = expression.split()
+    tokens = [t.strip() for t in expression.split()]
     for token in tokens:
-        if token not in allowed_symbols and not token.isnumeric():
+        if not token:
+            raise ValueError("Empty token in expression")
+        try:
+            float(token)
+            is_number = True
+        except ValueError:
+            is_number = False
+        if token not in allowed_symbols and not is_number:
             raise ValueError(f"Invalid token in expression: {token}")
+
     # Construct the multivector using the blades dictionary
     result = None
     for token in tokens:
         if token in blades:
             result = blades[token] if result is None else result + blades[token]
-        elif token.isnumeric():
-            result = float(token) if result is None else result + float(token)
+        else:
+            try:
+                number = float(token)
+            except ValueError:
+                raise ValueError(f"Invalid numeric token in expression: {token}")
+            result = number if result is None else result + number
     return result
 
 class VectorRequest(BaseModel):
@@ -57,6 +75,11 @@ def create_vector(req: VectorRequest):
 
 @app.post("/geometric/mult")
 def geometric_product(req: MultivectorRequest):
+    """Compute the geometric product of two multivector expressions.
+
+    Each expression is a whitespace-separated list of blade labels (e.g., ``e1``)
+    and/or numeric scalars. Scalars may be negative or decimal values.
+    """
     try:
         a = parse_multivector(req.a, ga.blades)
         b = parse_multivector(req.b, ga.blades)

--- a/tests/test_multivector_expression.py
+++ b/tests/test_multivector_expression.py
@@ -1,0 +1,24 @@
+import pytest
+
+from aurora_api import parse_multivector
+from modules.symbolic_core.geometric_algebra import GeometricAlgebra
+
+
+ga = GeometricAlgebra()
+
+
+def test_parse_multivector_accepts_negative_decimal():
+    result = parse_multivector("-1.5 e1", ga.blades)
+    expected = ga.blades["e1"] - 1.5
+    assert str(result) == str(expected)
+
+
+def test_parse_multivector_strips_whitespace():
+    result = parse_multivector("  -2.0   e2  ", ga.blades)
+    expected = ga.blades["e2"] - 2.0
+    assert str(result) == str(expected)
+
+
+def test_parse_multivector_rejects_invalid_token():
+    with pytest.raises(ValueError):
+        parse_multivector("e1;rm", ga.blades)


### PR DESCRIPTION
## Summary
- relax multivector parsing to accept negative and decimal scalars
- sanitize tokens and document whitespace-separated multivector format
- add unit tests for valid and invalid multivector expressions

## Testing
- `pytest tests/test_multivector_expression.py`
- `pytest` *(fails: NameError in cask_tool tests and error in test_gitwiz_functionality.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c790818a548325b5e0a12b9a47d097