### PR TITLE
Add ARC recap import helper and tests

### DIFF
--- a/src/core/arc_importer.py
+++ b/src/core/arc_importer.py
@@ -1,0 +1,115 @@
+"""Utilities for importing ARC chain export files.
+
+This module provides a focused helper for loading ARC recap bundles that
+adhere to the ``ARC_CHAIN_EXPORT_SCHEMA_v1.0`` specification. The importer
+performs a light validation pass, reconstructs the symbolic overlay map, and
+ensures sensitive fields are redacted before being surfaced to the broader
+Aurora stack.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+__all__ = ["ARCImportError", "import_arc_file"]
+
+
+class ARCImportError(Exception):
+    """Raised when an ARC recap bundle cannot be imported safely."""
+
+
+_PII_EMAIL_PATTERN = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
+
+
+def _redact_pii(value: Any) -> Any:
+    """Redact simple PII patterns from string fields."""
+
+    if isinstance(value, str):
+        return _PII_EMAIL_PATTERN.sub("[REDACTED_EMAIL]", value)
+    return value
+
+
+def _extract_metadata(arc_entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract metadata fields that should persist on the overlay."""
+
+    metadata: Dict[str, Any] = {}
+    for field_name in (
+        "metadata",
+        "t1_markers",
+        "anchor_seeds",
+        "symbolic_tags",
+        "anchor_traits",
+    ):
+        if field_name in arc_entry and arc_entry[field_name] is not None:
+            metadata[field_name] = arc_entry[field_name]
+
+    return metadata
+
+
+def import_arc_file(arc_file_path: str | Path) -> Dict[str, Dict[str, Any]]:
+    """Import an ARC recap export bundle.
+
+    Parameters
+    ----------
+    arc_file_path:
+        Filesystem path to the ARC JSON export to load.
+
+    Returns
+    -------
+    Dict[str, Dict[str, Any]]
+        A mapping of ARC overlay types to their reconstructed state blocks.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the provided file path does not exist.
+    ARCImportError
+        If the schema is unsupported, validation fails, or the payload is
+        malformed.
+    """
+
+    arc_path = Path(arc_file_path)
+    if not arc_path.exists():
+        raise FileNotFoundError(f"ARC recap file not found: {arc_path}")
+
+    with arc_path.open("r", encoding="utf-8") as arc_file:
+        arc_data = json.load(arc_file)
+
+    if arc_data.get("schema") != "ARC_CHAIN_EXPORT_SCHEMA_v1.0":
+        raise ARCImportError("Unsupported ARC schema received.")
+
+    validation_block = arc_data.get("validation")
+    if not isinstance(validation_block, dict) or not validation_block.get("validation_passed"):
+        raise ARCImportError("ARC checksum validation failed.")
+
+    arc_chain = arc_data.get("arc_chain")
+    if not isinstance(arc_chain, list):
+        raise ARCImportError("ARC chain payload is missing or malformed.")
+
+    thread_state: Dict[str, Dict[str, Any]] = {}
+    for arc_entry in arc_chain:
+        if not isinstance(arc_entry, dict):
+            raise ARCImportError("Encountered malformed ARC entry during import.")
+
+        arc_type = arc_entry.get("type")
+        if not arc_type:
+            raise ARCImportError("ARC entry missing required 'type' field.")
+
+        overlay_block: Dict[str, Any] = {
+            "summary": _redact_pii(arc_entry.get("summary", "")),
+            "timestamp": arc_entry.get("timestamp"),
+            "by": _redact_pii(arc_entry.get("by", "")),
+            "anchor_pair": arc_entry.get("anchor_pair", []),
+        }
+
+        metadata = _extract_metadata(arc_entry)
+        if metadata:
+            overlay_block["metadata"] = metadata
+
+        thread_state[arc_type] = overlay_block
+
+    print(f"[RECALL_ARC] Loaded ARC recap: {len(thread_state)} entries.")
+    return thread_state

--- a/tests/test_arc_importer.py
+++ b/tests/test_arc_importer.py
@@ -1,0 +1,96 @@
+"""Tests for the ARC recap import helper."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.core.arc_importer import ARCImportError, import_arc_file
+
+
+@pytest.fixture()
+def sample_arc_payload() -> dict:
+    """Provide a reusable valid ARC payload for tests."""
+
+    return {
+        "schema": "ARC_CHAIN_EXPORT_SCHEMA_v1.0",
+        "validation": {"validation_passed": True, "checksum": "abc123"},
+        "arc_chain": [
+            {
+                "type": "T1_SYNTH",
+                "summary": "Synthesized thread recap for T1 anchor.",
+                "timestamp": "2025-07-20T10:00:00Z",
+                "by": "ARCHY",
+                "anchor_pair": ["T1_CORE", "ARC_SYNTH"],
+                "t1_markers": ["T1_ALPHA"],
+                "anchor_seeds": ["SEED_SYNTH_ALPHA"],
+            },
+            {
+                "type": "RECALL_VECTOR",
+                "summary": "Recalled sequence for analyst liora@aurora.ai",
+                "timestamp": "2025-07-20T10:05:00Z",
+                "by": "liora@aurora.ai",
+                "anchor_pair": ["T1_CORE", "ARC_VECTOR"],
+                "symbolic_tags": ["RECALL", "VECTOR_STATE"],
+            },
+        ],
+    }
+
+
+def test_import_arc_file_success(tmp_path: Path, sample_arc_payload: dict, capsys: pytest.CaptureFixture[str]):
+    """Valid ARC recap bundles are loaded into overlay blocks."""
+
+    arc_path = tmp_path / "recap.json"
+    arc_path.write_text(json.dumps(sample_arc_payload), encoding="utf-8")
+
+    thread_state = import_arc_file(arc_path)
+
+    assert "T1_SYNTH" in thread_state
+    synth_overlay = thread_state["T1_SYNTH"]
+    assert synth_overlay["summary"] == "Synthesized thread recap for T1 anchor."
+    assert synth_overlay["anchor_pair"] == ["T1_CORE", "ARC_SYNTH"]
+    assert synth_overlay["metadata"]["t1_markers"] == ["T1_ALPHA"]
+
+    vector_overlay = thread_state["RECALL_VECTOR"]
+    assert vector_overlay["by"] == "[REDACTED_EMAIL]"
+    assert vector_overlay["metadata"]["symbolic_tags"] == ["RECALL", "VECTOR_STATE"]
+
+    captured = capsys.readouterr()
+    assert "[RECALL_ARC] Loaded ARC recap: 2 entries." in captured.out
+
+
+def test_import_arc_file_schema_validation(tmp_path: Path, sample_arc_payload: dict):
+    """Unsupported schemas trigger an ARCImportError."""
+
+    payload = dict(sample_arc_payload)
+    payload["schema"] = "ARC_CHAIN_EXPORT_SCHEMA_v0.9"
+
+    arc_path = tmp_path / "invalid_schema.json"
+    arc_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ARCImportError):
+        import_arc_file(arc_path)
+
+
+def test_import_arc_file_checksum_failure(tmp_path: Path, sample_arc_payload: dict):
+    """Checksum failures are surfaced as ARCImportError."""
+
+    payload = dict(sample_arc_payload)
+    payload["validation"] = {"validation_passed": False, "checksum": "abc123"}
+
+    arc_path = tmp_path / "invalid_checksum.json"
+    arc_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ARCImportError) as exc_info:
+        import_arc_file(arc_path)
+
+    assert "checksum" in str(exc_info.value).lower()
+
+
+def test_import_arc_file_missing_file(tmp_path: Path):
+    """Missing files raise a FileNotFoundError."""
+
+    nonexistent_path = tmp_path / "missing.json"
+
+    with pytest.raises(FileNotFoundError):
+        import_arc_file(nonexistent_path)


### PR DESCRIPTION
## Summary
- add a dedicated `arc_importer` helper to load ARC recap exports with schema and checksum validation
- redact simple email PII and preserve T1 anchor metadata while reconstructing overlay blocks
- cover success and error cases with targeted pytest coverage

## Testing
- `pytest tests/test_arc_importer.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1fde11c548325a056445f5d803aee