### PR TITLE
Add ARC chain import utility with validation

### DIFF
--- a/src/aurora/core/__init__.py
+++ b/src/aurora/core/__init__.py
@@ -1,0 +1,5 @@
+"""Aurora core exports."""
+
+from .arc_importer import ArcImportError, import_arc_file
+
+__all__ = ["ArcImportError", "import_arc_file"]

--- a/src/aurora/core/arc_importer.py
+++ b/src/aurora/core/arc_importer.py
@@ -1,0 +1,106 @@
+"""ARC chain import utilities for Aurora CloudBank.
+
+This module focuses on reconstructing thread state overlays from archived
+ARC (Aurora Recall Chain) exports. The implementation respects the existing
+symbolic metadata conventions by preserving anchor pairs and author
+identifiers while ensuring the payload passes integrity validation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+SUPPORTED_ARC_SCHEMA = "ARC_CHAIN_EXPORT_SCHEMA_v1.0"
+
+
+class ArcImportError(RuntimeError):
+    """Raised when an ARC chain export cannot be processed."""
+
+
+def _load_arc_payload(arc_file_path: Path) -> Dict[str, Any]:
+    """Load and decode the ARC JSON payload.
+
+    Args:
+        arc_file_path: Path to the ARC export file.
+
+    Returns:
+        Parsed ARC payload as a dictionary.
+
+    Raises:
+        ArcImportError: If the payload cannot be decoded.
+    """
+
+    try:
+        with arc_file_path.open("r", encoding="utf-8") as arc_file:
+            return json.load(arc_file)
+    except json.JSONDecodeError as exc:  # pragma: no cover - explicit branch in tests
+        raise ArcImportError(f"ARC payload at '{arc_file_path}' is not valid JSON.") from exc
+
+
+def _validate_arc_payload(payload: Dict[str, Any]) -> None:
+    """Validate the ARC payload header and checksum metadata."""
+
+    if payload.get("schema") != SUPPORTED_ARC_SCHEMA:
+        raise ArcImportError(
+            "Unsupported ARC schema received. "
+            f"Expected '{SUPPORTED_ARC_SCHEMA}' but received '{payload.get('schema')}'."
+        )
+
+    validation_block = payload.get("validation")
+    if not isinstance(validation_block, dict) or not validation_block.get("validation_passed"):
+        raise ArcImportError("ARC checksum validation failed.")
+
+    if "arc_chain" not in payload or not isinstance(payload["arc_chain"], list):
+        raise ArcImportError("ARC payload is missing the 'arc_chain' sequence.")
+
+
+def _extract_arc_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract and validate a single ARC overlay entry."""
+
+    required_fields = {"type", "summary", "timestamp", "by", "anchor_pair"}
+    missing_fields = sorted(required_fields - entry.keys())
+    if missing_fields:
+        raise ArcImportError("ARC entry missing required fields: " + ", ".join(missing_fields))
+
+    arc_type = entry.get("type")
+    if not isinstance(arc_type, str) or not arc_type.strip():
+        raise ArcImportError("ARC entry contains an invalid 'type' identifier.")
+
+    return {
+        "type": arc_type,
+        "summary": entry["summary"],
+        "timestamp": entry["timestamp"],
+        "by": entry["by"],
+        "anchor_pair": entry["anchor_pair"],
+    }
+
+
+def import_arc_file(arc_file_path: str | Path) -> Dict[str, Dict[str, Any]]:
+    """Import an ARC chain export and reconstruct the thread state overlays."""
+
+    arc_path = Path(arc_file_path)
+    if not arc_path.exists():
+        raise FileNotFoundError(f"ARC file '{arc_path}' does not exist.")
+    if not arc_path.is_file():
+        raise ArcImportError(f"ARC path '{arc_path}' must be a file.")
+
+    payload = _load_arc_payload(arc_path)
+    _validate_arc_payload(payload)
+
+    thread_state: Dict[str, Dict[str, Any]] = {}
+    for entry in payload.get("arc_chain", []):
+        if not isinstance(entry, dict):
+            raise ArcImportError("ARC chain entries must be JSON objects.")
+
+        overlay = _extract_arc_entry(entry)
+        thread_state[overlay["type"]] = {
+            "summary": overlay["summary"],
+            "timestamp": overlay["timestamp"],
+            "by": overlay["by"],
+            "anchor_pair": overlay["anchor_pair"],
+        }
+
+    print(f"[RECALL_ARC] Loaded ARC recap: {len(thread_state)} entries.")
+    return thread_state

--- a/tests/test_arc_importer.py
+++ b/tests/test_arc_importer.py
@@ -1,0 +1,105 @@
+"""Tests for the ARC chain import utility."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.aurora.core.arc_importer import ArcImportError, import_arc_file
+
+
+def _write_arc_file(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _base_payload() -> dict:
+    return {
+        "schema": "ARC_CHAIN_EXPORT_SCHEMA_v1.0",
+        "validation": {"validation_passed": True},
+        "arc_chain": [],
+    }
+
+
+def test_import_arc_file_success(tmp_path, capsys):
+    payload = _base_payload()
+    payload["arc_chain"] = [
+        {
+            "type": "T1-SEED",
+            "summary": "Initialized anchor threads",
+            "timestamp": "2025-07-20T18:26:00Z",
+            "by": "Aurora-Core",
+            "anchor_pair": ["seed://T1", "anchor://root"],
+        },
+        {
+            "type": "T2-RECALL",
+            "summary": "Recalled symbolic overlays",
+            "timestamp": "2025-07-20T18:27:00Z",
+            "by": "Aurora-Core",
+            "anchor_pair": ["recall://T2", "anchor://overlay"],
+        },
+    ]
+
+    arc_file = _write_arc_file(tmp_path / "arc.json", payload)
+
+    thread_state = import_arc_file(arc_file)
+
+    assert thread_state == {
+        "T1-SEED": {
+            "summary": "Initialized anchor threads",
+            "timestamp": "2025-07-20T18:26:00Z",
+            "by": "Aurora-Core",
+            "anchor_pair": ["seed://T1", "anchor://root"],
+        },
+        "T2-RECALL": {
+            "summary": "Recalled symbolic overlays",
+            "timestamp": "2025-07-20T18:27:00Z",
+            "by": "Aurora-Core",
+            "anchor_pair": ["recall://T2", "anchor://overlay"],
+        },
+    }
+
+    captured = capsys.readouterr()
+    assert "[RECALL_ARC] Loaded ARC recap: 2 entries." in captured.out
+
+
+def test_import_arc_file_schema_validation(tmp_path):
+    payload = _base_payload()
+    payload["schema"] = "ARC_CHAIN_EXPORT_SCHEMA_v0.9"
+
+    arc_file = _write_arc_file(tmp_path / "arc-invalid-schema.json", payload)
+
+    with pytest.raises(ArcImportError):
+        import_arc_file(arc_file)
+
+
+def test_import_arc_file_missing_required_fields(tmp_path):
+    payload = _base_payload()
+    payload["arc_chain"] = [
+        {
+            "type": "T3-SUMMARY",
+            "summary": "Missing anchor pair",
+            "timestamp": "2025-07-20T18:28:00Z",
+            "by": "Aurora-Core",
+            # anchor_pair intentionally omitted
+        }
+    ]
+
+    arc_file = _write_arc_file(tmp_path / "arc-missing-fields.json", payload)
+
+    with pytest.raises(ArcImportError) as exc_info:
+        import_arc_file(arc_file)
+
+    assert "missing required fields" in str(exc_info.value)
+
+
+def test_import_arc_file_failed_checksum(tmp_path):
+    payload = _base_payload()
+    payload["validation"] = {"validation_passed": False}
+
+    arc_file = _write_arc_file(tmp_path / "arc-failed-checksum.json", payload)
+
+    with pytest.raises(ArcImportError):
+        import_arc_file(arc_file)


### PR DESCRIPTION
## Summary
- implement ARC chain import utility that validates schema, checksum metadata, and overlay fields before reconstructing thread state
- expose the import helper through the Aurora core package for downstream integrations
- add pytest coverage for successful imports and validation failure scenarios

## Testing
- pytest tests/test_arc_importer.py

------
https://chatgpt.com/codex/tasks/task_e_68d1fde11c548325a056445f5d803aee