### PR TITLE
Add ARC export import utility and tests

### DIFF
--- a/src/aurora/utils/__init__.py
+++ b/src/aurora/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for Aurora CloudBank modules."""
+
+from .arc_importer import ARC_EXPORT_SCHEMA, import_arc_file
+
+__all__ = ["ARC_EXPORT_SCHEMA", "import_arc_file"]

--- a/src/aurora/utils/arc_importer.py
+++ b/src/aurora/utils/arc_importer.py
@@ -1,0 +1,108 @@
+"""Utilities for importing Aurora Recall Chain (ARC) export files.
+
+This module provides a small helper for loading ARC chain exports that are
+shared between Aurora CloudBank agents.  The function performs a minimal
+validation pass that mirrors the lightweight verification performed when the
+bundle is generated and reconstructs the symbolic overlay blocks into an
+in-memory thread state dictionary.
+
+The implementation intentionally keeps the structure transparent so that
+callers can inspect the reconstructed anchors (T1 metadata, anchor seeds, and
+other overlay attributes) without additional transformations.  All validation
+errors raise ``ValueError`` to make failure handling explicit for the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+
+ARC_EXPORT_SCHEMA = "ARC_CHAIN_EXPORT_SCHEMA_v1.0"
+
+
+def _ensure_mapping(payload: Mapping[str, Any] | None, error_message: str) -> Mapping[str, Any]:
+    """Validate that ``payload`` is a mapping.
+
+    ``ValueError`` is raised with ``error_message`` if validation fails.  This
+    helper keeps the main loader readable while still providing targeted error
+    messages for diagnostic logs.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise ValueError(error_message)
+    return payload
+
+
+def import_arc_file(arc_file_path: str | Path) -> Dict[str, Dict[str, Any]]:
+    """Load an ARC export and reconstruct the thread state overlays.
+
+    Parameters
+    ----------
+    arc_file_path:
+        Filesystem path to the ARC export JSON file.
+
+    Returns
+    -------
+    dict[str, dict[str, Any]]
+        A mapping keyed by ARC segment type with the associated symbolic
+        overlay metadata (summary, timestamp, author, anchor pair).
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``arc_file_path`` does not exist.
+    ValueError
+        If the file contents do not conform to the ARC export contract.
+    json.JSONDecodeError
+        If the file is not valid JSON.
+    """
+
+    path = Path(arc_file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"ARC file not found: {path}")
+
+    with path.open("r", encoding="utf-8") as file_handle:
+        arc_data = json.load(file_handle)
+
+    schema = arc_data.get("schema")
+    if schema != ARC_EXPORT_SCHEMA:
+        raise ValueError(f"Unsupported ARC schema '{schema}'. Expected '{ARC_EXPORT_SCHEMA}'.")
+
+    validation_block = _ensure_mapping(
+        arc_data.get("validation"),
+        "ARC payload missing validation block.",
+    )
+    if not validation_block.get("validation_passed"):
+        raise ValueError("ARC checksum validation failed.")
+
+    arc_chain = arc_data.get("arc_chain")
+    if not isinstance(arc_chain, list):
+        raise ValueError("ARC chain payload malformed: expected a list of overlay entries.")
+
+    thread_state: Dict[str, Dict[str, Any]] = {}
+    required_fields = ("type", "summary", "timestamp", "by", "anchor_pair")
+    for entry in arc_chain:
+        if not isinstance(entry, dict):
+            raise ValueError("ARC chain entry must be an object.")
+
+        missing_fields = [field for field in required_fields if field not in entry]
+        if missing_fields:
+            raise ValueError(
+                f"ARC chain entry missing required fields: {', '.join(sorted(missing_fields))}."
+            )
+
+        arc_type = entry["type"]
+        thread_state[arc_type] = {
+            "summary": entry["summary"],
+            "timestamp": entry["timestamp"],
+            "by": entry["by"],
+            "anchor_pair": entry["anchor_pair"],
+        }
+
+    print(f"[RECALL_ARC] Loaded ARC recap: {len(thread_state)} entries.")
+    return thread_state
+
+
+__all__ = ["ARC_EXPORT_SCHEMA", "import_arc_file"]

--- a/tests/test_arc_importer.py
+++ b/tests/test_arc_importer.py
@@ -1,0 +1,85 @@
+"""Tests for the ARC import utility."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.aurora.utils.arc_importer import ARC_EXPORT_SCHEMA, import_arc_file
+
+
+def _write_arc_file(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _base_payload() -> dict:
+    return {
+        "schema": ARC_EXPORT_SCHEMA,
+        "validation": {"validation_passed": True},
+        "arc_chain": [
+            {
+                "type": "T1_THREAD_SUMMARY",
+                "summary": "Anchor recap",
+                "timestamp": 1731615123.321,
+                "by": "Aurora-Core",
+                "anchor_pair": ["seed-alpha", "seed-beta"],
+            }
+        ],
+    }
+
+
+def test_import_arc_file_reconstructs_thread_state(tmp_path, capsys):
+    payload = _base_payload()
+    arc_path = _write_arc_file(tmp_path / "thread.arc.json", payload)
+
+    thread_state = import_arc_file(arc_path)
+
+    assert thread_state == {
+        "T1_THREAD_SUMMARY": {
+            "summary": "Anchor recap",
+            "timestamp": 1731615123.321,
+            "by": "Aurora-Core",
+            "anchor_pair": ["seed-alpha", "seed-beta"],
+        }
+    }
+
+    out, err = capsys.readouterr()
+    assert "[RECALL_ARC] Loaded ARC recap: 1 entries." in out
+    assert err == ""
+
+
+def test_import_arc_file_rejects_invalid_schema(tmp_path):
+    payload = _base_payload()
+    payload["schema"] = "OTHER_SCHEMA"
+    arc_path = _write_arc_file(tmp_path / "bad_schema.arc.json", payload)
+
+    with pytest.raises(ValueError, match="Unsupported ARC schema"):
+        import_arc_file(arc_path)
+
+
+def test_import_arc_file_rejects_failed_validation(tmp_path):
+    payload = _base_payload()
+    payload["validation"] = {"validation_passed": False}
+    arc_path = _write_arc_file(tmp_path / "invalid_validation.arc.json", payload)
+
+    with pytest.raises(ValueError, match="ARC checksum validation failed"):
+        import_arc_file(arc_path)
+
+
+def test_import_arc_file_requires_arc_chain_list(tmp_path):
+    payload = _base_payload()
+    payload["arc_chain"] = "not-a-list"
+    arc_path = _write_arc_file(tmp_path / "invalid_chain.arc.json", payload)
+
+    with pytest.raises(ValueError, match="ARC chain payload malformed"):
+        import_arc_file(arc_path)
+
+
+def test_import_arc_file_missing_entry_fields(tmp_path):
+    payload = _base_payload()
+    payload["arc_chain"][0].pop("summary")
+    arc_path = _write_arc_file(tmp_path / "missing_fields.arc.json", payload)
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        import_arc_file(arc_path)


### PR DESCRIPTION
## Summary
- add a dedicated `import_arc_file` helper for reconstructing ARC export overlays
- expose the loader via the Aurora utils package and retain schema constants
- cover expected success and failure scenarios with focused pytest cases

## Testing
- `pytest tests/test_arc_importer.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1fde11c548325a056445f5d803aee