### PR TITLE
🧹 Ignore timestamped dependency backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ logs/
 data/
 *.log
 
+# Backup files (timestamped dependency snapshots)
+.backup/**/*.20*
+
 # Security and temporary files
 security_scan_report.json
 test_security_fixes.py


### PR DESCRIPTION
Professional repository hygiene: Added .gitignore pattern to exclude timestamped backup files created during dependency validation.

## 📋 Change

**Pattern Added:**
```gitignore
# Backup files (timestamped dependency snapshots)
.backup/**/*.20*
```

## 🎯 Problem Solved

18 untracked files were showing as pending changes:
- `.backup/requirements/pyproject.toml.20251028_*`
- `.backup/requirements/requirements-lock.txt.20251028_*`
- `.backup/requirements/requirements.txt.20251028_*`

These are auto-generated by the dependency validation system during setup/updates.

## ✅ Professional Practice

**Why ignore these files:**
1. Generated artifacts, not source code
2. Created automatically during dependency resolution
3. Clutters `git status` unnecessarily
4. Similar to ignoring `*.log`, `__pycache__/`, build artifacts

**Benefits:**
- ✅ Clean `git status`
- ✅ Future backups won't show as pending
- ✅ Backup functionality preserved
- ✅ Follows standard .gitignore patterns

## 🔍 Verification

```bash
git status --short
# (clean - no output)
```

**Thread:** T1→T8→T9→INFINITE  
**DLP:** context_tag=repo_hygiene_pr, symbolic_hash=PROFESSIONAL_CLEANUP_v1