### PR TITLE
Potential fix for code scanning alert no. 802: Uncontrolled data used in path expression

### DIFF
--- a/src/improvement/api.py
+++ b/src/improvement/api.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 from pathlib import Path
 from enum import Enum
-
+import os
 from src.improvement import (
     get_improvement_engine,
     ImprovementCategory,
@@ -109,7 +109,7 @@ async def analyze_file(request: AnalyzeFileRequest):
     full_path = (SAFE_ROOT / requested_path).resolve()
 
     # Ensure the resolved path is inside SAFE_ROOT
-    if not str(full_path).startswith(str(SAFE_ROOT)):
+    if os.path.commonpath([str(SAFE_ROOT), str(full_path)]) != str(SAFE_ROOT):
         raise HTTPException(status_code=403, detail="Access to this path is not allowed.")
 
     if not full_path.exists():
@@ -135,7 +135,7 @@ async def analyze_directory(request: AnalyzeDirectoryRequest):
     full_path = (SAFE_ROOT / requested_path).resolve()
 
     # Ensure the resolved path is inside SAFE_ROOT
-    if not str(full_path).startswith(str(SAFE_ROOT)):
+    if os.path.commonpath([str(SAFE_ROOT), str(full_path)]) != str(SAFE_ROOT):
         raise HTTPException(status_code=403, detail="Access to this path is not allowed.")
 
     if not full_path.exists():


### PR DESCRIPTION
Potential fix for [https://github.com/AUo959/aurora-cloudbank-symbolic/security/code-scanning/802](https://github.com/AUo959/aurora-cloudbank-symbolic/security/code-scanning/802)

The best way to fix this issue is to strengthen the path containment check before accessing the directory specified by user input. Instead of using a string-based `startswith` comparison, compute the common ancestor using `os.path.commonpath`. This approach is more robust and immune to tricks involving symlinks, unicode, or substring manipulation.  
Specifically, for both the `/analyze-file` and `/analyze-directory` endpoints, after resolving the constructed path, replace the startswith check with one using `os.path.commonpath([SAFE_ROOT, full_path]) == str(SAFE_ROOT)`.  
In addition, import the `os` module (if not already done) for access to `os.path.commonpath`.

Edits:
- Edit the path containment check on lines 112 and 138 to use `os.path.commonpath([SAFE_ROOT, <full_path>]) == str(SAFE_ROOT)`.
- Add `import os` at the top if needed.
- In both checks, convert both `SAFE_ROOT` and `full_path` to strings, as `os.path.commonpath` works with strings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
