### PR TITLE
Potential fix for code scanning alert no. 763: Overly permissive file permissions

### DIFF
--- a/scripts/aurora_validation_manager.py
+++ b/scripts/aurora_validation_manager.py
@@ -172,7 +172,7 @@ echo "✅ Post-commit validation update complete"
             f.write(hook_content)
 
         # Make executable
-        os.chmod(post_commit_hook, 0o755)
+        os.chmod(post_commit_hook, 0o700)
         print("✅ Created post-commit hook for validation updates")
 
     def cleanup_old_reports(self):


### PR DESCRIPTION
Potential fix for [https://github.com/AUo959/aurora-cloudbank-symbolic/security/code-scanning/763](https://github.com/AUo959/aurora-cloudbank-symbolic/security/code-scanning/763)

To fix this problem, we should restrict the permissions on the `post_commit_hook` file to only allow the owner (the user creating the file) to read, write, and execute it. This prevents group and others on the system from accessing, reading, or executing the script, in line with secure coding guidelines. Specifically, replace `0o755` (owner rwx, group rx, others rx) with `0o700` (owner rwx, group none, others none) in the `os.chmod` call. Only modify the specific line setting permissions, leaving all other logic and functionality unchanged. No additional imports or dependencies are required, as the `os` module provides the required functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
