### PR TITLE
Enforce CSRF verification on AI management routes

### DIFF
--- a/docs/AI_INTEGRATION_UPGRADE_v1.1.0.md
+++ b/docs/AI_INTEGRATION_UPGRADE_v1.1.0.md
@@ -112,6 +112,9 @@ GPT-4o → Claude 3.5 Sonnet → GPT-5 → Claude 4.5 Opus
 
 All endpoints under `/ai/` prefix with CSRF protection:
 
+> **Authentication header:** Each request must include `Authorization: Bearer <CSRF token>`.
+> Tokens are minted via the shared security middleware (`src/middleware/fastapi_security.py`).
+
 ### Status & Discovery
 
 - `GET /ai/status` - Overall AI system status

--- a/src/api/ai_management_routes.py
+++ b/src/api/ai_management_routes.py
@@ -9,8 +9,11 @@ import logging
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
+
+from src.middleware.fastapi_security import security as shared_security
+from src.middleware.fastapi_security import verify_csrf_token
 
 try:
     from modules.ai_core import AIModel, claude_hub, gpt5_hub, unified_ai
@@ -22,7 +25,7 @@ except ImportError:
     unified_ai = None
 
 # Security
-security = HTTPBearer()
+security = shared_security
 
 # Router
 router = APIRouter(prefix="/ai", tags=["AI Model Management"])
@@ -69,6 +72,7 @@ async def get_ai_status(token: HTTPAuthorizationCredentials = Depends(security))
     """
     Get comprehensive AI integration status including model availability
     """
+    verify_csrf_token(token)
     if not unified_ai:
         raise HTTPException(status_code=503, detail="AI integration not available")
 
@@ -95,6 +99,7 @@ async def get_model_capabilities(
     """
     Get detailed capabilities for a specific AI model
     """
+    verify_csrf_token(token)
     if not unified_ai or not AIModel:
         raise HTTPException(status_code=503, detail="AI integration not available")
 
@@ -146,6 +151,8 @@ async def select_model(
     
     This sets the default model preference but maintains fallback chains
     """
+    verify_csrf_token(token)
+
     if not unified_ai or not AIModel:
         raise HTTPException(status_code=503, detail="AI integration not available")
 
@@ -190,6 +197,7 @@ async def enable_claude_45(token: HTTPAuthorizationCredentials = Depends(securit
     """
     Enable Claude 4.5 Opus when it becomes available
     """
+    verify_csrf_token(token)
     if not claude_hub:
         raise HTTPException(status_code=503, detail="Claude integration not available")
 
@@ -214,11 +222,12 @@ async def enable_claude_45(token: HTTPAuthorizationCredentials = Depends(securit
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post(\"/enable-gpt5\", summary=\"Enable GPT-5\")
+@router.post("/enable-gpt5", summary="Enable GPT-5")
 async def enable_gpt5(token: HTTPAuthorizationCredentials = Depends(security)):
     """
     Enable GPT-5 when it becomes available
     """
+    verify_csrf_token(token)
     if not gpt5_hub:
         raise HTTPException(status_code=503, detail="GPT integration not available")
 
@@ -248,6 +257,7 @@ async def enable_gpt5_codex(token: HTTPAuthorizationCredentials = Depends(securi
     """
     Enable GPT-5 Codex when it becomes available
     """
+    verify_csrf_token(token)
     if not gpt5_hub:
         raise HTTPException(status_code=503, detail="GPT integration not available")
 
@@ -277,6 +287,7 @@ async def list_available_models(token: HTTPAuthorizationCredentials = Depends(se
     """
     Get list of currently available AI models with basic info
     """
+    verify_csrf_token(token)
     if not unified_ai or not AIModel:
         raise HTTPException(status_code=503, detail="AI integration not available")
 

--- a/tests/test_ai_management_security.py
+++ b/tests/test_ai_management_security.py
@@ -1,0 +1,78 @@
+"""Regression tests for AI management CSRF enforcement."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api import ai_management_routes
+from src.middleware.fastapi_security import generate_csrf_token
+
+
+@pytest.fixture(autouse=True)
+def stub_ai_core(monkeypatch):
+    """Provide deterministic AI core stubs for route handlers."""
+
+    class _DummyHub:
+        def get_global_status(self):
+            return {"online": True}
+
+    class _DummyUnifiedAI:
+        def get_available_models(self):
+            return [SimpleNamespace(value="test-model")]
+
+        def get_model_capabilities(self, model):
+            return SimpleNamespace(
+                provider=SimpleNamespace(value="aurora"),
+                context_window=8192,
+                max_output_tokens=4096,
+                supports_function_calling=True,
+                supports_vision=False,
+                supports_code_execution=False,
+                reasoning_strength=9.0,
+                code_generation_strength=8.5,
+                mathematical_strength=8.0,
+                latency_avg_ms=120,
+                cost_per_1k_tokens=0.02,
+                available=True,
+            )
+
+    monkeypatch.setattr(ai_management_routes, "claude_hub", _DummyHub())
+    monkeypatch.setattr(ai_management_routes, "gpt5_hub", _DummyHub())
+    monkeypatch.setattr(ai_management_routes, "unified_ai", _DummyUnifiedAI())
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    """Return a FastAPI test client wired with the AI router."""
+
+    app = FastAPI()
+    app.include_router(ai_management_routes.router)
+    return TestClient(app)
+
+
+def test_ai_routes_reject_invalid_token(client):
+    """Ensure AI routes deny requests with malformed bearer tokens."""
+
+    response = client.get(
+        "/ai/status",
+        headers={"Authorization": "Bearer invalid-token"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_ai_routes_accept_valid_token(client):
+    """Ensure valid CSRF tokens allow handlers to execute."""
+
+    token = generate_csrf_token("test-session")
+
+    response = client.get(
+        "/ai/status",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_models"] == 1


### PR DESCRIPTION
## Summary
- use the shared CSRF verifier in `ai_management_routes` and invoke it for every endpoint before business logic runs
- add regression tests that confirm invalid bearer tokens are rejected while valid tokens reach the handler
- document the required Authorization header for `/ai` endpoints in the AI integration guide

## Testing
- CSRF_SECRET_KEY=test-secret pytest tests/test_ai_management_security.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691868e5c96883258b23e8a4b15fc6ca)