### PR TITLE
Mask mesh activation phrases in logs

### DIFF
--- a/src/api/mesh_api.js
+++ b/src/api/mesh_api.js
@@ -4,6 +4,7 @@
  */
 
 const express = require('express');
+const crypto = require('crypto');
 const { MESH_CONFIG, MeshFederation } = require('../core/mesh_agent.js');
 const { systemLogger, bridgeLogger } = require('../utils/aurora_logger.js');
 
@@ -270,10 +271,18 @@ router.post('/agents/:agentId/activate', async (req, res) => {
       await agent.handshake();
     }
 
+    const activationDigest = crypto
+      .createHash('sha256')
+      .update(expectedPhrase)
+      .digest('hex');
+
     bridgeLogger.bridge(`🚀 [MESH_API] Agent ${agentId} activated`, {
       agentId: agentId,
       status: agent.status,
-      activationPhrase: expectedPhrase
+      activationVerification: {
+        method: 'sha256',
+        digest: activationDigest
+      }
     });
 
     res.json({

--- a/tests/node/mesh_api_activation.test.js
+++ b/tests/node/mesh_api_activation.test.js
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express from 'express';
+
+import { loadCommonJsModule } from './utils/cjs-loader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test('mesh activation logging redacts activation phrases', async () => {
+  const bridgeEvents = [];
+  const stubBridgeLogger = {
+    bridge(message, metadata) {
+      bridgeEvents.push({ message, metadata });
+    }
+  };
+
+  const stubSystemLogger = {
+    info() {},
+    error() {}
+  };
+
+  class MockAgent {
+    constructor(id) {
+      this.id = id;
+      this.status = 'LIVE';
+      this.role = 'Sentinel';
+      this.ethicsStatus = 'Nominal';
+      this.driftLevel = 0;
+      this.lastSync = Date.now();
+      this.meshConnected = true;
+      this.apiEndpoint = 'mock://endpoint';
+      this.sessionId = 'session-anchor';
+    }
+
+    async handshake() {
+      this.status = 'LIVE';
+    }
+  }
+
+  class MockMeshFederation {
+    constructor() {
+      this.status = 'ACTIVE';
+      this.agents = new Map([[
+        'agent-7',
+        new MockAgent('agent-7')
+      ]]);
+    }
+
+    async initializeMesh() {
+      return this;
+    }
+
+    getStatus() {
+      return {
+        meshStatus: this.status,
+        agentCount: this.agents.size
+      };
+    }
+  }
+
+  const meshModule = loadCommonJsModule(
+    path.join(__dirname, '..', '..', 'src', 'api', 'mesh_api.js'),
+    {
+      requireMap: new Map([
+        [
+          '../core/mesh_agent.js',
+          {
+            MESH_CONFIG: {
+              activationPhrases: { 'agent-7': 'super-secret-phrase' },
+              relayApiEndpoints: [],
+              version: '1.0.0-test',
+              anchorSeed: 'T1-anchor',
+              ethicsProtocol: 'Picard_Delta_3',
+              constellation: [],
+              commProtocol: 'quantum-mesh'
+            },
+            MeshFederation: MockMeshFederation
+          }
+        ],
+        [
+          '../utils/aurora_logger.js',
+          {
+            systemLogger: stubSystemLogger,
+            bridgeLogger: stubBridgeLogger
+          }
+        ]
+      ])
+    }
+  );
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/mesh', meshModule.router);
+
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/mesh/agents/agent-7/activate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ activationPhrase: 'super-secret-phrase' })
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(body.agent?.activated, true);
+    assert.ok(bridgeEvents.length >= 1, 'bridge logger should capture activation event');
+
+    const activationEvent = bridgeEvents.at(-1);
+    const serializedMetadata = JSON.stringify(activationEvent.metadata);
+    assert.ok(!serializedMetadata.includes('super-secret-phrase'), 'metadata should not leak the raw activation phrase');
+    assert.ok(activationEvent.metadata.activationVerification, 'activation verification metadata is present');
+    assert.equal(activationEvent.metadata.activationVerification.method, 'sha256');
+    assert.match(activationEvent.metadata.activationVerification.digest, /^[0-9a-f]{64}$/i);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- hash the mesh activation phrase before emitting activation success logs to avoid leaking the raw secret
- annotate activation logs with sha256 verification metadata while leaving the HTTP response unchanged
- add a node-based integration test that exercises the activation route and confirms the logger output omits the clear-text phrase

## Testing
- node --test tests/node/mesh_api_activation.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691868ec5fb083258600c995198617d5)