### PR TITLE
Add denial auditing for living computation events

### DIFF
--- a/src/api/living_computation_example.py
+++ b/src/api/living_computation_example.py
@@ -100,6 +100,16 @@ async def analyze_with_living_computation(request: AnalysisRequest):
     # 2. ETHICAL EVALUATION (Simplified - full Triplex Handshake in production)
     # In production: Axiomera (L3) → HALO (L2) → Human (L1)
     if event.risk_score > 0.8:
+        event_system.abort_event(
+            event_id=event.event_id,
+            reason="High-risk operation requires explicit Command authorization",
+            audit_metadata={
+                "risk_score": event.risk_score,
+                "trigger": "living_computation_high_risk_gate",
+                "user_context": request.user_context,
+                "t1_anchor": event.t1_anchor,
+            }
+        )
         raise HTTPException(
             status_code=403,
             detail="High-risk operation requires explicit Command authorization"

--- a/src/core/event_system.py
+++ b/src/core/event_system.py
@@ -296,12 +296,41 @@ class EventSystem:
         # Move to timeline (persistent history)
         self.timeline.append(event)
         del self.active_events[event_id]
-        
+
         # Advance spatial-relational boundary (SRB)
         self.srb_state = int(hashlib.sha256(
             f"{self.srb_state}||{event.symbolic_hash}".encode()
         ).hexdigest()[:8], 16) % 10000
-    
+
+    def abort_event(
+        self,
+        event_id: str,
+        reason: str,
+        audit_metadata: Optional[Dict[str, Any]] = None
+    ):
+        """Abort an in-flight event while preserving an audit trail."""
+
+        if event_id not in self.active_events:
+            raise ValueError(f"Event {event_id} not found in active events")
+
+        event = self.active_events[event_id]
+        event.result = {
+            "status": "denied",
+            "reason": reason,
+            "audit": audit_metadata or {},
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        event.memory_references = []
+        event.pattern_connections = []
+        event.collaboration_network = {}
+
+        self.timeline.append(event)
+        del self.active_events[event_id]
+
+        self.srb_state = int(hashlib.sha256(
+            f"{self.srb_state}||{event.symbolic_hash}||denied".encode()
+        ).hexdigest()[:8], 16) % 10000
+
     def get_event_history(
         self,
         entity: Optional[str] = None,

--- a/tests/test_living_computation_example.py
+++ b/tests/test_living_computation_example.py
@@ -1,0 +1,50 @@
+"""Tests for the living computation example API."""
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.living_computation_example import (
+    AnalysisRequest,
+    analyze_with_living_computation,
+)
+from src.core.event_system import get_event_system
+
+
+@pytest.fixture
+def anyio_backend():
+    """Limit AnyIO to the asyncio backend for deterministic testing."""
+
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_high_risk_request_aborts_event(monkeypatch):
+    """Ensure high-risk requests leave no active events and record denial."""
+
+    event_system = get_event_system()
+    event_system.timeline.clear()
+    event_system.active_events.clear()
+
+    original_create_event = event_system.create_event
+
+    def _high_risk_event(*args, **kwargs):
+        event = original_create_event(*args, **kwargs)
+        event.risk_score = 0.95
+        return event
+
+    monkeypatch.setattr(event_system, "create_event", _high_risk_event)
+
+    request = AnalysisRequest(data={"payload": "sensitive"}, user_context="QA")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await analyze_with_living_computation(request)
+
+    assert exc_info.value.status_code == 403
+    assert event_system.active_events == {}
+    assert event_system.timeline, "Denied event should be recorded in the timeline"
+    denied_event = event_system.timeline[-1]
+    assert denied_event.result["status"] == "denied"
+    assert denied_event.result["audit"]["risk_score"] == pytest.approx(0.95)
+
+    event_system.timeline.clear()
+


### PR DESCRIPTION
## Summary
- add an abort_event helper that records denial outcomes while removing active entries from the event system
- update the living computation analysis endpoint to call the denial helper when high-risk requests are blocked
- cover the high-risk denial path with a regression test that ensures no active events remain after rejection

## Testing
- pytest tests/test_living_computation_example.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691868f48b948325bcc0ae365d534f70)