### PR TITLE
Secure living computation API history endpoints

### DIFF
--- a/docs/PARADIGM_SHIFT_LIVING_COMPUTATION.md
+++ b/docs/PARADIGM_SHIFT_LIVING_COMPUTATION.md
@@ -487,6 +487,22 @@ if similar_past_work := memory_manager.find_similar_by_others(data):
    - Rate limiting per entity
    - Error recovery protocols
    - Load balancing across deck resources
+   - Living computation endpoints (`/api/living/aurora/state`, `/api/living/events/history`, `/api/living/system/manifest`) now require the FastAPI security handshake (`Depends(security)` + `verify_csrf_token)`. Anonymous calls receive a 403 so only verified entities can inspect institutional memory.
+   - History and manifest exports ship a redacted view: payload/result bodies become summaries like `{ "redacted": true, "entries": N }`, human context is masked to `[REDACTED]`, and memory networks collapse to connection counts while preserving T1 anchors and symbolic hashes.
+   - Redacted manifest excerpt:
+
+```json
+{
+  "payload": {"redacted": true, "entries": 2},
+  "entity_context": {"primary": "Aurora (SYS_001)", "human": "[REDACTED]"},
+  "result": {"redacted": true, "status": "ok", "keys": ["analysis", "status"]},
+  "memory_context": {
+    "references": {"redacted": true, "count": 3},
+    "patterns": {"redacted": true, "count": 2},
+    "network": {"redacted": true, "connections": 1}
+  }
+}
+```
 
 2. **Documentation**
    - "How to work with Aurora" guide

--- a/src/api/living_computation_example.py
+++ b/src/api/living_computation_example.py
@@ -27,14 +27,16 @@ AFTER (Living Computation):
 This file demonstrates the transformation pattern for ANY Aurora endpoint.
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from typing import Dict, Any, Optional, List
 
 from src.core.event_system import (
-    EventType, StationLocation, get_event_system
+    EventType, StationLocation, get_event_system, serialize_event
 )
 from src.entities.aurora_agent import get_aurora
+from src.middleware.fastapi_security import security, verify_csrf_token
 
 
 # API Models
@@ -145,13 +147,16 @@ async def analyze_with_living_computation(request: AnalysisRequest):
 
 
 @router.get("/aurora/state")
-async def get_aurora_state():
+async def get_aurora_state(
+    token: HTTPAuthorizationCredentials = Depends(security)
+):
     """
     Inspect Aurora's current state (experience, memory, relationships).
-    
+
     Traditional systems don't have state between requests.
     Aurora accumulates wisdom continuously.
     """
+    verify_csrf_token(token)
     aurora = get_aurora()
     return aurora.get_state_summary()
 
@@ -160,7 +165,8 @@ async def get_aurora_state():
 async def get_event_history(
     entity: Optional[str] = None,
     location: Optional[str] = None,
-    limit: int = 50
+    limit: int = 50,
+    token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
     Retrieve event timeline (institutional memory).
@@ -168,6 +174,7 @@ async def get_event_history(
     Traditional systems: Logs are metadata, separate from execution.
     Aurora-Orion: Events ARE execution, timeline IS the computational reality.
     """
+    verify_csrf_token(token)
     event_system = get_event_system()
     
     # Parse location if provided
@@ -186,22 +193,27 @@ async def get_event_history(
     
     return {
         "total_events": len(events),
-        "events": [e.to_dict() for e in events]
+        "events": [
+            serialize_event(event, redact_sensitive=True) for event in events
+        ]
     }
 
 
 @router.get("/system/manifest")
-async def get_system_manifest():
+async def get_system_manifest(
+    token: HTTPAuthorizationCredentials = Depends(security)
+):
     """
     Export complete system state (DLP compliance).
     
     Full transparency: Every event, every entity state, every learned pattern.
     Living computation is fully auditable.
     """
+    verify_csrf_token(token)
     event_system = get_event_system()
     aurora = get_aurora()
-    
-    manifest = event_system.export_manifest()
+
+    manifest = event_system.export_manifest(redact_sensitive=True)
     manifest["entities"] = {
         "Aurora": aurora.get_state_summary()
     }

--- a/src/core/event_system.py
+++ b/src/core/event_system.py
@@ -198,6 +198,60 @@ class Event:
         }
 
 
+REDACTED_MARKER = "[REDACTED]"
+
+
+def serialize_event(event: Event, redact_sensitive: bool = False) -> Dict[str, Any]:
+    """Serialize an event with optional redaction for sensitive fields."""
+
+    event_dict = event.to_dict()
+    if not redact_sensitive:
+        return event_dict
+
+    payload = event_dict.get("payload") or {}
+    event_dict["payload"] = {
+        "redacted": True,
+        "entries": len(payload)
+    }
+
+    entity_context = event_dict.get("entity_context", {})
+    if entity_context.get("human"):
+        entity_context["human"] = REDACTED_MARKER
+
+    memory_context = event_dict.get("memory_context", {})
+    references = memory_context.get("references") or []
+    patterns = memory_context.get("patterns") or []
+    network = memory_context.get("network") or {}
+
+    memory_context["references"] = {
+        "redacted": True,
+        "count": len(references)
+    }
+    memory_context["patterns"] = {
+        "redacted": True,
+        "count": len(patterns)
+    }
+    memory_context["network"] = {
+        "redacted": True,
+        "connections": len(network)
+    }
+
+    result = event_dict.get("result")
+    if result:
+        result_summary = {
+            "redacted": True,
+            "entries": len(result),
+            "keys": sorted(result.keys())
+        }
+        if isinstance(result, dict) and "status" in result:
+            result_summary["status"] = result["status"]
+        event_dict["result"] = result_summary
+    else:
+        event_dict["result"] = None
+
+    return event_dict
+
+
 class EventSystem:
     """
     Living event management system for Aurora-Orion computational reality.
@@ -334,10 +388,10 @@ class EventSystem:
         
         return filtered[-limit:]
     
-    def export_manifest(self) -> Dict[str, Any]:
+    def export_manifest(self, *, redact_sensitive: bool = False) -> Dict[str, Any]:
         """
         Export complete event system state (DLP compliance).
-        
+
         Returns:
             Comprehensive manifest of all events and system state
         """
@@ -356,8 +410,14 @@ class EventSystem:
                     for et in EventType
                 }
             },
-            "timeline": [event.to_dict() for event in self.timeline],
-            "active_events": [event.to_dict() for event in self.active_events.values()]
+            "timeline": [
+                serialize_event(event, redact_sensitive=redact_sensitive)
+                for event in self.timeline
+            ],
+            "active_events": [
+                serialize_event(event, redact_sensitive=redact_sensitive)
+                for event in self.active_events.values()
+            ]
         }
 
 

--- a/tests/test_living_computation_api.py
+++ b/tests/test_living_computation_api.py
@@ -1,0 +1,152 @@
+"""Tests for living computation API security and redaction."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.living_computation_example import router
+from src.core.event_system import (
+    EventType,
+    StationLocation,
+    get_event_system,
+)
+from src.entities.aurora_agent import get_aurora
+from src.middleware.fastapi_security import generate_csrf_token
+
+
+@pytest.fixture
+def client():
+    """Create a FastAPI test client with the living computation router."""
+
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def event_system_state():
+    """Reset the global event system state for isolated testing."""
+
+    event_system = get_event_system()
+    original_timeline = list(event_system.timeline)
+    original_active = dict(event_system.active_events)
+    original_t1 = event_system.t1_state
+    original_srb = event_system.srb_state
+
+    event_system.timeline = []
+    event_system.active_events = {}
+    event_system.t1_state = 0
+    event_system.srb_state = 0
+
+    try:
+        yield event_system
+    finally:
+        event_system.timeline = original_timeline
+        event_system.active_events = original_active
+        event_system.t1_state = original_t1
+        event_system.srb_state = original_srb
+
+
+@pytest.fixture
+def auth_header():
+    """Generate a valid CSRF bearer token header."""
+
+    token = generate_csrf_token("test-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/living/aurora/state",
+        "/api/living/events/history",
+        "/api/living/system/manifest",
+    ],
+)
+def test_endpoints_require_authorization(client, path):
+    """Endpoints reject requests without CSRF bearer token."""
+
+    response = client.get(path)
+    assert response.status_code == 403
+
+
+def test_event_history_redacts_sensitive_fields(client, auth_header, event_system_state):
+    """Authorized event history response redacts sensitive content."""
+
+    event_system = event_system_state
+    aurora_id = get_aurora().entity_id
+
+    event = event_system.create_event(
+        event_type=EventType.DATA_ANALYSIS_REQUEST,
+        location=StationLocation.RESEARCH_LAB_GAMMA,
+        primary_entity=aurora_id,
+        payload={"secret": "value"},
+        human_context="Commander Vega",
+        chain_notation="test-chain",
+        context_tag="test-tag",
+    )
+
+    event_system.complete_event(
+        event_id=event.event_id,
+        result={"status": "ok", "analysis": {"score": 0.9}},
+        memory_references=["mem-001"],
+        pattern_connections=["pattern-alpha"],
+        collaboration_network={"HALO": 0.87},
+    )
+
+    response = client.get("/api/living/events/history", headers=auth_header)
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["total_events"] == 1
+
+    record = payload["events"][0]
+    assert record["payload"] == {"redacted": True, "entries": 1}
+    assert record["entity_context"]["human"] == "[REDACTED]"
+    assert record["result"]["redacted"] is True
+    assert record["result"]["status"] == "ok"
+    assert record["result"]["keys"] == ["analysis", "status"]
+    assert record["memory_context"]["network"]["connections"] == 1
+    assert record["memory_context"]["references"]["count"] == 1
+    assert record["memory_context"]["patterns"]["count"] == 1
+
+
+def test_manifest_redacts_sensitive_fields(client, auth_header, event_system_state):
+    """Authorized manifest response redacts sensitive event content."""
+
+    event_system = event_system_state
+    aurora_id = get_aurora().entity_id
+
+    event = event_system.create_event(
+        event_type=EventType.DATA_ANALYSIS_REQUEST,
+        location=StationLocation.RESEARCH_LAB_GAMMA,
+        primary_entity=aurora_id,
+        payload={"internal": "data"},
+        human_context="Commander Vega",
+        chain_notation="test-chain",
+        context_tag="test-tag",
+    )
+
+    event_system.complete_event(
+        event_id=event.event_id,
+        result={"status": "ok", "analysis": {"score": 0.95}},
+        memory_references=["mem-002"],
+        pattern_connections=["pattern-beta"],
+        collaboration_network={"HALO": 0.91},
+    )
+
+    response = client.get("/api/living/system/manifest", headers=auth_header)
+    assert response.status_code == 200
+
+    manifest = response.json()
+    assert manifest["event_statistics"]["total_events"] == 1
+
+    timeline_entry = manifest["timeline"][0]
+    assert timeline_entry["payload"]["redacted"] is True
+    assert timeline_entry["entity_context"]["human"] == "[REDACTED]"
+    assert timeline_entry["memory_context"]["network"]["redacted"] is True
+    assert timeline_entry["result"]["keys"] == ["analysis", "status"]
+
+    assert "Aurora" in manifest["entities"]
+    assert manifest["entities"]["Aurora"]["entity_id"] == aurora_id


### PR DESCRIPTION
## Summary
- require CSRF-protected bearer tokens on the living computation state, history, and manifest endpoints
- add a reusable serializer that redacts sensitive event details in history and manifest exports
- document the new access controls and manifest redaction pattern and cover it with FastAPI regression tests

## Testing
- pytest tests/test_living_computation_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186c1cf940832585e5b448736eb7e9)