### PR TITLE
Align collaboration mesh agent constructor with mesh defaults

### DIFF
--- a/src/core/mesh_agent.js
+++ b/src/core/mesh_agent.js
@@ -431,12 +431,47 @@ class MeshAgent {
 // Add collaboration chamber specific methods to MeshAgent class
 class CollaborationMeshAgent extends MeshAgent {
   constructor(agentId, config = {}) {
-    super();
-    this.agentId = agentId;
-    this.config = { ...MESH_CONFIG, ...config };
+    const mergedConfig = { ...MESH_CONFIG, ...config };
+
+    mergedConfig.activationPhrases = {
+      ...MESH_CONFIG.activationPhrases,
+      ...(config.activationPhrases || {})
+    };
+
+    mergedConfig.relayApiEndpoints = {
+      ...MESH_CONFIG.relayApiEndpoints,
+      ...(config.relayApiEndpoints || {})
+    };
+
+    const canonicalAgent = Array.isArray(mergedConfig.agents)
+      ? mergedConfig.agents.find(agent => agent.id === agentId)
+      : undefined;
+
+    const resolvedAgentId = typeof agentId === 'string' && agentId.trim().length > 0
+      ? agentId.trim()
+      : (typeof config.agentId === 'string' && config.agentId.trim().length > 0
+        ? config.agentId.trim()
+        : 'AURORA_COLLAB_AGENT');
+
+    const derivedRole = config.role
+      || (canonicalAgent && canonicalAgent.role)
+      || 'Collaborative Mesh Agent';
+
+    const derivedEndpoint = config.apiEndpoint
+      || (mergedConfig.relayApiEndpoints && mergedConfig.relayApiEndpoints[resolvedAgentId])
+      || `/api/relay/${resolvedAgentId.toLowerCase()}`;
+
+    const derivedActivationPhrase = config.activationPhrase
+      || (mergedConfig.activationPhrases && mergedConfig.activationPhrases[resolvedAgentId])
+      || `ORION_${resolvedAgentId}_RELAY_ACTIVATE//`;
+
+    super(resolvedAgentId, derivedRole, derivedEndpoint, derivedActivationPhrase);
+
+    this.agentId = this.id;
+    this.config = mergedConfig;
     this.messageHistory = [];
     this.collaborationState = 'active';
-    this.specialization = this.getAgentSpecialization(agentId);
+    this.specialization = this.getAgentSpecialization(this.agentId);
   }
 
   getAgentSpecialization(agentId) {
@@ -668,7 +703,7 @@ class CollaborationMeshAgent extends MeshAgent {
 
   async activateAgent(agentId) {
     // Create and return agent instance
-    const agent = new CollaborationMeshAgent(agentId);
+    const agent = new CollaborationMeshAgent(agentId, this.config);
     await agent.initializeFederation();
     return agent;
   }

--- a/tests/node/mesh/collaboration_mesh_agent.test.js
+++ b/tests/node/mesh/collaboration_mesh_agent.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadCommonJsModule } from '../utils/cjs-loader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function createLoggerStubs() {
+  const systemEntries = [];
+  const bridgeEntries = [];
+  const ethicsEntries = [];
+
+  return {
+    stubs: {
+      systemLogger: {
+        info: (message, metadata = {}) => {
+          systemEntries.push({ level: 'info', message, metadata });
+        },
+        error: (message, metadata = {}) => {
+          systemEntries.push({ level: 'error', message, metadata });
+        }
+      },
+      bridgeLogger: {
+        bridge: (message, metadata = {}) => {
+          bridgeEntries.push({ level: 'bridge', message, metadata });
+        }
+      },
+      ethicsLogger: {
+        ethics: (message, metadata = {}) => {
+          ethicsEntries.push({ level: 'ethics', message, metadata });
+        }
+      }
+    },
+    systemEntries,
+    bridgeEntries,
+    ethicsEntries
+  };
+}
+
+function loadMeshAgentsWithStubs() {
+  const loggerStubs = createLoggerStubs();
+  const modulePath = path.join(__dirname, '..', '..', '..', 'src', 'core', 'mesh_agent.js');
+  const meshModule = loadCommonJsModule(modulePath, {
+    requireMap: new Map([
+      [
+        '../utils/aurora_logger.js',
+        {
+          systemLogger: loggerStubs.stubs.systemLogger,
+          bridgeLogger: loggerStubs.stubs.bridgeLogger,
+          ethicsLogger: loggerStubs.stubs.ethicsLogger
+        }
+      ]
+    ])
+  });
+
+  return { ...meshModule, loggerStubs };
+}
+
+test('CollaborationMeshAgent messages use the agent id as the sender', async () => {
+  const { CollaborationMeshAgent } = loadMeshAgentsWithStubs();
+  const agent = new CollaborationMeshAgent('ARCHY');
+
+  const message = await agent.sendMessage('OPPY', 'Testing vector routing');
+
+  assert.equal(agent.id, 'ARCHY');
+  assert.equal(agent.agentId, 'ARCHY');
+  assert.equal(message.from, 'ARCHY');
+});
+
+test('CollaborationMeshAgent handshake logs include the resolved agent id', async () => {
+  const { CollaborationMeshAgent, loggerStubs } = loadMeshAgentsWithStubs();
+  const agent = new CollaborationMeshAgent('ARCHY');
+
+  await agent.handshake();
+
+  const handshakeLog = loggerStubs.systemEntries.find(entry =>
+    entry.message.includes('Starting handshake sequence')
+  );
+
+  assert.ok(handshakeLog, 'Expected handshake log entry to be recorded');
+  assert.ok(
+    handshakeLog.message.includes('ARCHY'),
+    'Handshake log should reference the resolved agent id'
+  );
+});


### PR DESCRIPTION
## Summary
- ensure CollaborationMeshAgent derives role, endpoint, and activation phrase from the mesh configuration before calling the base constructor
- keep collaboration agent identifiers synchronized and share configuration when spawning additional agents
- add node test coverage verifying message sender ids and handshake logs reflect the active collaboration agent

## Testing
- node --test tests/node/**/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186c5fe10083258214ff8f62f6dded)