### PR TITLE
Redact activation phrases from bridge logs

### DIFF
--- a/docs/INCIDENT_RESPONSE_RUNBOOK.md
+++ b/docs/INCIDENT_RESPONSE_RUNBOOK.md
@@ -174,6 +174,10 @@ grep "DENIED" /var/log/aurora/access.log
    - Create tracking issue in GitHub
    - Schedule patch in next sprint
 
+**Activation Phrase Redaction:**
+- Bridge activation failures are now automatically redacted in logs and responses.
+- If any activation phrase appears in telemetry or incident notes, escalate to CSO Chen immediately and purge/redact the artifact.
+
 ---
 
 ### INCIDENT 4: Performance Degradation

--- a/src/api/mesh_api.js
+++ b/src/api/mesh_api.js
@@ -273,7 +273,7 @@ router.post('/agents/:agentId/activate', async (req, res) => {
     bridgeLogger.bridge(`🚀 [MESH_API] Agent ${agentId} activated`, {
       agentId: agentId,
       status: agent.status,
-      activationPhrase: expectedPhrase
+      activationPhraseStatus: 'validated'
     });
 
     res.json({

--- a/src/bridge/enhanced_api_bridge.js
+++ b/src/bridge/enhanced_api_bridge.js
@@ -74,14 +74,15 @@ class EnhancedApiBridge {
       // Validate activation phrase
       const expectedPhrase = this.activationPhrases[agentId];
       if (activationPhrase !== expectedPhrase) {
-        bridgeLogger.error(`Invalid activation phrase for ${agentId}`, {
+        bridgeLogger.error(`Invalid activation attempt for ${agentId}`, {
           agentId,
-          expected: expectedPhrase,
-          received: activationPhrase
+          validation: 'activation_phrase_failed',
+          phraseRedacted: true
         });
         return res.status(401).json({
           error: 'Invalid activation phrase',
-          hint: 'Use ORION_[AGENT]_RELAY_ACTIVATE//'
+          agentId,
+          guidance: 'Activation validation failed. Contact Aurora operations to reauthorize.'
         });
       }
 

--- a/src/core/mesh_agent.js
+++ b/src/core/mesh_agent.js
@@ -254,7 +254,7 @@ class MeshAgent {
       status: this.status,
       role: this.role,
       constellation: MESH_CONFIG.constellation,
-      activationPhrase: this.activationPhrase
+      activationPhraseStatus: 'validated'
     });
   }
 

--- a/tests/node/enhanced_api_bridge.test.js
+++ b/tests/node/enhanced_api_bridge.test.js
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadCommonJsModule } from './utils/cjs-loader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const normalizeMetadata = candidate => {
+  if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+    return candidate;
+  }
+  return {};
+};
+
+const createBridgeLoggerMock = collected => ({
+  bridge(message, fromLayerOrMeta, toLayerMaybe, metadataMaybe) {
+    let metadata = {};
+    if (metadataMaybe && typeof metadataMaybe === 'object') {
+      metadata = metadataMaybe;
+    } else if (fromLayerOrMeta && typeof fromLayerOrMeta === 'object') {
+      metadata = fromLayerOrMeta;
+    }
+    collected.push({ level: 'bridge', message, metadata: normalizeMetadata(metadata) });
+  },
+  error(message, metadata) {
+    collected.push({ level: 'error', message, metadata: normalizeMetadata(metadata) });
+  },
+  info(message, metadata) {
+    collected.push({ level: 'info', message, metadata: normalizeMetadata(metadata) });
+  },
+  warn(message, metadata) {
+    collected.push({ level: 'warn', message, metadata: normalizeMetadata(metadata) });
+  }
+});
+
+const createSystemLoggerMock = () => ({
+  info() {},
+  error() {},
+  warn() {},
+  debug() {}
+});
+
+class StubMeshFederation {
+  constructor() {
+    this.relayMessage = async () => ({ success: true, status: 'mocked', messageId: 'mocked' });
+  }
+
+  getSystemStatus() {
+    return { status: 'mocked' };
+  }
+}
+
+const loadBridgeModule = loggerCalls => {
+  const bridgeLogger = createBridgeLoggerMock(loggerCalls);
+  const systemLogger = createSystemLoggerMock();
+
+  const requireMap = new Map([
+    ['../utils/aurora_logger.js', { systemLogger, bridgeLogger }],
+    [path.resolve(__dirname, '..', '..', 'src', 'utils', 'aurora_logger.js'), { systemLogger, bridgeLogger }],
+    ['../core/mesh_agent.js', { MeshFederation: StubMeshFederation }],
+    [path.resolve(__dirname, '..', '..', 'src', 'core', 'mesh_agent.js'), { MeshFederation: StubMeshFederation }]
+  ]);
+
+  return loadCommonJsModule(
+    path.join(__dirname, '..', '..', 'src', 'bridge', 'enhanced_api_bridge.js'),
+    { requireMap }
+  );
+};
+
+const createResponse = () => {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+};
+
+test('connectCustomGpt redacts activation phrases on invalid attempts', async () => {
+  const loggerCalls = [];
+  const { EnhancedApiBridge } = loadBridgeModule(loggerCalls);
+  const bridge = new EnhancedApiBridge();
+
+  const req = {
+    params: { agentId: 'ARCHY' },
+    body: { activationPhrase: 'INVALID_PHRASE', capabilities: ['telemetry'] }
+  };
+  const res = createResponse();
+
+  await bridge.connectCustomGpt(req, res);
+
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.body.error, 'Invalid activation phrase');
+  assert.equal(res.body.agentId, 'ARCHY');
+  assert.ok(!JSON.stringify(res.body).includes('ORION_ARCHY_RELAY_ACTIVATE//'));
+
+  const serializedLogs = loggerCalls.map(entry => JSON.stringify(entry));
+  for (const record of serializedLogs) {
+    assert.ok(!record.includes('ORION_ARCHY_RELAY_ACTIVATE//'));
+  }
+
+  const errorLog = loggerCalls.find(
+    entry => entry.level === 'error' && entry.message.includes('Invalid activation attempt')
+  );
+  assert.ok(errorLog, 'expected invalid activation attempt to be logged');
+  assert.equal(errorLog.metadata.phraseRedacted, true);
+});


### PR DESCRIPTION
## Summary
- redact activation phrase metadata from the Enhanced API Bridge invalid-activation handler and responses
- remove activation phrase values from related bridge logging paths and update the incident response runbook with the new redaction policy
- add a node-based bridge test to ensure activation phrases never appear in error logs

## Testing
- node --test tests/node/**/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186c48981883258491ef9148a63f29)