### PR TITLE
Redact mesh activation secrets from logs

### DIFF
--- a/operations/symbolic_mesh/security_notes.md
+++ b/operations/symbolic_mesh/security_notes.md
@@ -1,0 +1,7 @@
+# Mesh Security Notes
+
+## Sanitized Activation Logging
+
+- **Activation confirmation:** Mesh agents now emit activation telemetry that omits the raw activation phrase. The bridge logger receives only a boolean `hasActivationPhrase` flag and a short SHA-256 hash preview.
+- **Operator validation:** During activation reviews, confirm that the bridge log payload includes the `activation.activationHashPreview` field. Compare the preview with the expected hash reference in your secured runbook instead of the plaintext phrase.
+- **Secret handling:** Because the activation phrase is never serialized to logs, operators must rely on secured key management procedures for full phrase retrieval. Any discrepancy between the preview hash and the expected reference should trigger an immediate incident review.

--- a/src/core/mesh_agent.js
+++ b/src/core/mesh_agent.js
@@ -7,6 +7,8 @@
  * activation control, and threadcore monitoring.
  */
 
+const crypto = require('crypto');
+
 const { systemLogger, bridgeLogger, ethicsLogger } = require('../utils/aurora_logger.js');
 
 // Core Mesh Configuration
@@ -250,12 +252,37 @@ class MeshAgent {
     this.status = 'LIVE';
     this.meshConnected = true;
 
+    const activationLogMetadata = this.getActivationLogMetadata();
+
     bridgeLogger.bridge(`🌟 [MESH] Agent ${this.id} now live in constellation`, {
       status: this.status,
       role: this.role,
       constellation: MESH_CONFIG.constellation,
-      activationPhrase: this.activationPhrase
+      activation: activationLogMetadata
     });
+  }
+
+  /**
+   * Produce sanitized activation logging metadata.
+   * Returns only non-sensitive confirmation data.
+   */
+  getActivationLogMetadata() {
+    if (!this.activationPhrase) {
+      return {
+        hasActivationPhrase: false
+      };
+    }
+
+    const activationHash = crypto
+      .createHash('sha256')
+      .update(this.activationPhrase)
+      .digest('hex');
+
+    return {
+      hasActivationPhrase: true,
+      hashAlgorithm: 'sha256',
+      activationHashPreview: activationHash.slice(0, 16)
+    };
   }
 
   /**

--- a/tests/node/mesh_agent.test.js
+++ b/tests/node/mesh_agent.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadCommonJsModule } from './utils/cjs-loader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test('MeshAgent#setLive logs sanitized activation metadata', async () => {
+  const bridgeEvents = [];
+
+  const stubBridgeLogger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    bridge: (message, metadata = {}) => {
+      bridgeEvents.push({ message, metadata });
+    }
+  };
+
+  const stubSystemLogger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {}
+  };
+
+  const stubEthicsLogger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {}
+  };
+
+  const { MeshAgent } = loadCommonJsModule(
+    path.join(__dirname, '..', '..', 'src', 'core', 'mesh_agent.js'),
+    {
+      requireMap: new Map([
+        [
+          '../utils/aurora_logger.js',
+          {
+            systemLogger: stubSystemLogger,
+            bridgeLogger: stubBridgeLogger,
+            ethicsLogger: stubEthicsLogger
+          }
+        ]
+      ])
+    }
+  );
+
+  const activationSecret = 'ORION_TEST_AGENT_ACTIVATE//';
+
+  const agent = new MeshAgent(
+    'TEST_MESH_AGENT',
+    'Test Mesh Role',
+    '/api/mesh/test',
+    activationSecret
+  );
+
+  bridgeEvents.length = 0;
+
+  await agent.setLive();
+
+  assert.equal(agent.status, 'LIVE');
+  assert.equal(agent.meshConnected, true);
+  assert.ok(bridgeEvents.length > 0, 'bridge logger should be invoked');
+
+  const { metadata } = bridgeEvents[bridgeEvents.length - 1];
+  const serializedMetadata = JSON.stringify(metadata);
+
+  assert.ok(!serializedMetadata.includes(activationSecret), 'activation phrase leaked to logs');
+  assert.strictEqual(metadata.activationPhrase, undefined);
+  assert.ok(metadata.activation, 'sanitized activation metadata missing');
+  assert.strictEqual(metadata.activation.hasActivationPhrase, true);
+  assert.ok(typeof metadata.activation.activationHashPreview === 'string');
+  assert.notStrictEqual(metadata.activation.activationHashPreview, activationSecret);
+  assert.ok(metadata.activation.activationHashPreview.length > 0);
+});


### PR DESCRIPTION
## Summary
- hash and redact mesh agent activation phrases before logging bridge telemetry
- add a helper that returns sanitized activation metadata and cover it with a node-level unit test
- document the sanitized activation logging workflow for operators in the mesh security notes

## Testing
- node --test tests/node/*.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186c33ab608325a21042f8bcbd6060)