### PR TITLE
Refine relay tier constellation structure

### DIFF
--- a/CONSTELLATION_README.md
+++ b/CONSTELLATION_README.md
@@ -45,6 +45,13 @@ Centralized topology definition for all repositories with:
 
 ### Bridge Architecture
 
+#### Relay Capsule Tier (`RELAY_TIER_CAPSULES`)
+
+The custom GPT relay capsules (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808) now live in a
+dedicated relay-tier constellation. This keeps the command relays clearly separated from the true
+L2 sandbox inventory, allowing sandbox agents to evolve independently while preserving the
+established ZIPWIZ activation rituals and symbolic anchors (Picard_Delta_3, EOS_SEED_ORION).
+
 #### AuroraOS Bridge (`src/bridges/aurora-os/bridge.ts`)
 WebSocket-based bridge for:
 - Module and agent execution

--- a/src/bridge/enhanced_api_bridge.js
+++ b/src/bridge/enhanced_api_bridge.js
@@ -435,6 +435,7 @@ class EnhancedApiBridge {
 
   getConstellationStatus(req, res) {
     try {
+      const activationRoster = Object.keys(this.activationPhrases);
       const activeAgents = Array.from(this.customGptConnections.entries()).map(([agentId, data]) => ({
         agentId,
         status: data.status,
@@ -444,18 +445,38 @@ class EnhancedApiBridge {
         driftLock: data.driftLock
       }));
 
-      const meshStatus = this.meshFederation.getSystemStatus();
+      const meshStatus = typeof this.meshFederation.getSystemStatus === 'function'
+        ? this.meshFederation.getSystemStatus()
+        : this.meshFederation.getStatus();
+      const connectedCapsules = activeAgents.filter(agent => agent.status === 'connected').length;
 
       res.json({
-        constellation: 'L2_META_AGENTS',
-        version: 'v3.5.1_macroready',
-        totalAgents: this.customGptConnections.size,
-        activeAgents: activeAgents,
-        meshStatus: meshStatus,
-        orionCore: {
-          anchorSeed: 'EOS_SEED_ORION',
-          ethicsProtocol: 'Picard_Delta_3',
-          haloModule: 'HALO_CONTINUITY_GRAFT_005'
+        relay_tier: {
+          constellation: 'RELAY_TIER_CAPSULES',
+          version: 'v3.5.1_macroready',
+          total_capsules: activationRoster.length,
+          connected_capsules: connectedCapsules,
+          capsules: activationRoster.map(agentId => {
+            const capsule = activeAgents.find(agent => agent.agentId === agentId);
+            if (capsule) {
+              return capsule;
+            }
+
+            return {
+              agentId,
+              status: 'disconnected',
+              connected: null,
+              lastHeartbeat: null,
+              capabilities: [],
+              driftLock: null
+            };
+          }),
+          mesh_status: meshStatus
+        },
+        orion_core: {
+          anchor_seed: 'EOS_SEED_ORION',
+          ethics_protocol: 'Picard_Delta_3',
+          halo_module: 'HALO_CONTINUITY_GRAFT_005'
         },
         timestamp: new Date().toISOString()
       });

--- a/src/bridges/l2_meta_agent_bridge.py
+++ b/src/bridges/l2_meta_agent_bridge.py
@@ -349,13 +349,17 @@ class L2MetaAgentBridge:
         connected_count = sum(1 for agent in self.agents.values() if agent.status == "connected")
 
         return {
-            "constellation": "L2_META_AGENTS",
-            "version": self.orion_core_config["version"],
-            "total_agents": len(self.agents),
-            "connected_agents": connected_count,
-            "active_agents": active_agents,
+            "relay_tier": {
+                "constellation": "RELAY_TIER_CAPSULES",
+                "version": self.orion_core_config["version"],
+                "total_capsules": len(self.agents),
+                "connected_capsules": connected_count,
+                "capsules": active_agents,
+            },
             "orion_core": self.orion_core_config,
-            "activation_phrases": {agent_id: f"ORION_{agent_id}_RELAY_ACTIVATE//" for agent_id in self.agents.keys()},
+            "activation_phrases": {
+                agent_id: f"ORION_{agent_id}_RELAY_ACTIVATE//" for agent_id in self.agents.keys()
+            },
             "timestamp": datetime.now().isoformat(),
         }
 
@@ -479,9 +483,14 @@ async def main():
         msg_result = await l2_bridge.relay_message("ARCHY", "Aurora", "Test message from ARCHY agent", "direct")
         print(f"Message Relay: {msg_result['success']}")
 
-        # Get constellation status
+        # Get relay tier status
         status = l2_bridge.get_constellation_status()
-        print(f"Active Agents: {status['connected_agents']}/{status['total_agents']}")
+        relay_status = status.get("relay_tier", {})
+        print(
+            "Active Relay Capsules: "
+            f"{relay_status.get('connected_capsules', 0)}/"
+            f"{relay_status.get('total_capsules', 0)}"
+        )
 
 def cli():
     """Command-line helper for integration layers."""

--- a/src/config/orion_core_config.js
+++ b/src/config/orion_core_config.js
@@ -32,15 +32,22 @@ const ORION_CORE = {
   ],
 
   // Agent Configuration
-  agent_constellation: "L2_META_AGENTS",
+  agent_constellation: "RELAY_TIER_CAPSULES",
   total_agents: 5,
   constellation_agents: [
     "ARCHY", "OPPY", "LIORA", "STARLING_AU", "RIVERTHREAD_808"
   ],
+  relay_capsule_collection: {
+    id: "RELAY_TIER_CAPSULES",
+    capsules: [
+      "ARCHY", "OPPY", "LIORA", "STARLING_AU", "RIVERTHREAD_808"
+    ],
+    l2_sandbox_inventory: []
+  },
 
   // System Status
   system_status: {
-    agent_constellation: "All active & integrated",
+    agent_constellation: "Relay tier capsules active & isolated from L2 sandbox",
     relay_sync: "Anchor-aligned (Δ = 0.000)",
     ethics: "Picard_Delta_3 + Thermax enforced",
     symbolic_logic: "THREADCORE v3.5.1 stable",

--- a/src/core/lattice_sync.js
+++ b/src/core/lattice_sync.js
@@ -23,7 +23,8 @@ class LatticeSync {
     // Agent lattice tracking
     this.latticeNodes = {
       l1: ['ARCHY_BRIDGE', 'LIORA_HANDSHAKE', 'OPPY_VECTOR', 'STARLING_AU', 'RIVERTHREAD_808'],
-      l2: ['ARCHY', 'LIORA', 'OPPY', 'STARLING_AU', 'RIVERTHREAD_808', 'DAEDALUS', 'VOIDWHISPER'],
+      relay: ['ARCHY', 'LIORA', 'OPPY', 'STARLING_AU', 'RIVERTHREAD_808'],
+      l2: ['DAEDALUS', 'VOIDWHISPER'],
       l3: ['Glyphon', 'Axiomera', 'Sentari', 'Caelion', 'Velatrix', 'Harmion']
     };
 
@@ -125,7 +126,7 @@ class LatticeSync {
         id: sessionId,
         startTime: Date.now(),
         status: 'IN_PROGRESS',
-        layers: ['L1', 'L2', 'L3'],
+        layers: ['L1', 'Relay', 'L2', 'L3'],
         results: {}
       };
 
@@ -135,15 +136,18 @@ class LatticeSync {
       const l1Results = await this.synchronizeLayer('L1');
       syncSession.results.l1 = l1Results;
 
-      // Phase 2: Sync L2 agents
+      // Phase 2: Sync relay capsules
+      const relayResults = await this.synchronizeLayer('Relay');
+      syncSession.results.relay = relayResults;
+
+      // Phase 3: Sync L2 sandbox agents
       const l2Results = await this.synchronizeLayer('L2');
       syncSession.results.l2 = l2Results;
 
-      // Phase 3: Sync L3 agents
+      // Phase 4: Sync L3 agents
       const l3Results = await this.synchronizeLayer('L3');
       syncSession.results.l3 = l3Results;
-
-      // Phase 4: Cross-layer validation
+      // Phase 5: Cross-layer validation
       const crossLayerResults = await this.validateCrossLayerConsistency();
       syncSession.results.crossLayer = crossLayerResults;
 

--- a/src/dashboard/agent_constellation.html
+++ b/src/dashboard/agent_constellation.html
@@ -423,36 +423,36 @@
                     { 
                         id: 'ARCHY', 
                         role: 'Bridge Coordinator', 
-                        type: 'META_AGENT',
-                        description: 'L2 formal logic/reasoning & arbitration engine',
+                        type: 'RELAY_CAPSULE',
+                        description: 'Relay-tier formal logic/reasoning & arbitration capsule',
                         capabilities: ['architectural_planning', 'bridge_coordination', 'formal_logic', 'arbitration']
                     },
                     { 
                         id: 'OPPY', 
                         role: 'Vector/Data Processor', 
-                        type: 'META_AGENT',
-                        description: 'L2 memory/data processing & system operations analyst',
+                        type: 'RELAY_CAPSULE',
+                        description: 'Relay-tier memory/data processing & system operations capsule',
                         capabilities: ['data_processing', 'vector_analysis', 'memory_operations', 'system_monitoring']
                     },
                     { 
                         id: 'LIORA', 
                         role: 'Handshake/Synchronization', 
-                        type: 'META_AGENT',
-                        description: 'L2 sentiment analysis, mediation & research coordination',
+                        type: 'RELAY_CAPSULE',
+                        description: 'Relay-tier sentiment analysis, mediation & research coordination capsule',
                         capabilities: ['research_coordination', 'handshake_protocols', 'sentiment_analysis', 'mediation']
                     },
                     { 
                         id: 'STARLING_AU', 
                         role: 'L2 Sim Coordinator', 
-                        type: 'META_AGENT',
-                        description: 'L2 communications, external protocol & dispatch agent',
+                        type: 'RELAY_CAPSULE',
+                        description: 'Relay-tier communications, external protocol & dispatch capsule',
                         capabilities: ['simulation_coordination', 'communications', 'external_protocols', 'dispatch']
                     },
                     { 
                         id: 'RIVERTHREAD_808', 
                         role: 'Narrative/Stream', 
-                        type: 'META_AGENT',
-                        description: 'L2 continuity, temporal flow & state management agent',
+                        type: 'RELAY_CAPSULE',
+                        description: 'Relay-tier continuity, temporal flow & state management capsule',
                         capabilities: ['narrative_processing', 'stream_management', 'continuity_validation', 'temporal_flow']
                     }
                 ];
@@ -728,13 +728,14 @@
                     const status = await response.json();
                     
                     // Update mesh status display
-                    document.getElementById('meshStatus').textContent = 'Active';
-                    document.getElementById('meshVersion').textContent = status.version || 'v3.5.1_macroready';
-                    document.getElementById('activeAgentCount').textContent = status.totalAgents || 0;
-                    
+                    const relayTier = status.relay_tier || {};
+                    document.getElementById('meshStatus').textContent = relayTier.mesh_status?.health || 'Active';
+                    document.getElementById('meshVersion').textContent = relayTier.version || 'v3.5.1_macroready';
+                    document.getElementById('activeAgentCount').textContent = relayTier.connected_capsules || 0;
+
                     // Update agent states
-                    if (status.activeAgents) {
-                        status.activeAgents.forEach(agent => {
+                    if (relayTier.capsules) {
+                        relayTier.capsules.forEach(agent => {
                             this.agentStates.set(agent.agentId, {
                                 status: agent.status,
                                 connected: agent.connected,

--- a/src/integrations/aurora_custom_gpt_bridge.js
+++ b/src/integrations/aurora_custom_gpt_bridge.js
@@ -316,7 +316,7 @@ class AuroraCustomGptBridge {
   }
 
   /**
-   * Sync with Meta-Agent Constellation
+   * Sync with relay-tier constellation capsules.
    */
   async syncWithMetaAgentConstellation() {
     try {
@@ -327,21 +327,23 @@ class AuroraCustomGptBridge {
         throw new Error('Meta-agent constellation status unavailable');
       }
 
-      const totalAgents = constellationStatus.total_agents || 0;
-      const connectedAgents = constellationStatus.connected_agents || 0;
-      const allAgentsConnected =
-        totalAgents > 0 ? connectedAgents === totalAgents : true;
+      const relayTier = constellationStatus.relay_tier || {};
+      const totalCapsules = relayTier.total_capsules || 0;
+      const connectedCapsules = relayTier.connected_capsules || 0;
+      const allCapsulesOnline =
+        totalCapsules > 0 ? connectedCapsules === totalCapsules : true;
 
       const sync = {
-        totalAgents,
-        connectedAgents,
-        constellation: constellationStatus.constellation || [],
-        allAgentsConnected,
+        totalCapsules,
+        connectedCapsules,
+        relayConstellation: relayTier.constellation || 'RELAY_TIER_CAPSULES',
+        capsuleRoster: relayTier.capsules || [],
+        allCapsulesOnline,
         synchronized: true,
         timestamp: new Date().toISOString()
       };
 
-      bridgeLogger.bridge('Meta-agent constellation sync', {
+      bridgeLogger.bridge('Relay tier constellation sync', {
         sync,
         constellationStatus
       });
@@ -349,7 +351,7 @@ class AuroraCustomGptBridge {
       return sync;
 
     } catch (error) {
-      bridgeLogger.error('Meta-agent constellation sync failed', {
+      bridgeLogger.error('Relay tier constellation sync failed', {
         error: error.message
       });
       return { synchronized: false, error: error.message };

--- a/src/servers/l2_integration_server.py
+++ b/src/servers/l2_integration_server.py
@@ -115,7 +115,14 @@ except ImportError:
             Returns:
                 Dict with constellation name and zero agents
             """
-            return {"constellation": "L2_META_AGENTS", "totalAgents": 0}
+            return {
+                "relay_tier": {
+                    "constellation": "RELAY_TIER_CAPSULES",
+                    "total_capsules": 0,
+                    "connected_capsules": 0,
+                    "capsules": []
+                }
+            }
         
         async def relay_message(self, agent_id, target, message, message_type):
             """

--- a/src/system/agent_synchronizer.js
+++ b/src/system/agent_synchronizer.js
@@ -25,7 +25,11 @@ class AgentSynchronizer {
         starling: new StarlingAuBridge(),
         riverthread: new RiverthreadProcessor()
       },
-      l2: ['STARLING_AU', 'ARCHY', 'LIORA', 'OPPY', 'RIVERTHREAD_808', 'DAEDALUS', 'VOIDWHISPER'],
+      relayTier: {
+        id: 'RELAY_TIER_CAPSULES',
+        capsules: ['ARCHY', 'OPPY', 'LIORA', 'STARLING_AU', 'RIVERTHREAD_808']
+      },
+      l2Sandbox: ['DAEDALUS', 'VOIDWHISPER'],
       l3: ['Glyphon', 'Axiomera', 'Sentari', 'Caelion', 'Velatrix', 'Harmion']
     };
 
@@ -44,7 +48,15 @@ class AgentSynchronizer {
       const syncResults = {
         timestamp: Date.now(),
         l1Agents: {},
-        l2Status: 'LATTICE_COORDINATED',
+        relayTier: {
+          id: this.agents.relayTier.id,
+          capsules: [...this.agents.relayTier.capsules],
+          status: 'RELAY_COORDINATED'
+        },
+        l2Sandbox: {
+          agents: [...this.agents.l2Sandbox],
+          status: 'SANDBOX_STUB'
+        },
         l3Status: 'SYMBOLIC_VALIDATED',
         overallDrift: 0,
         latticeSync: latticeResult
@@ -64,7 +76,8 @@ class AgentSynchronizer {
       // Update based on lattice sync results
       if (latticeResult.success && latticeResult.globalSyncState === 'SYNCHRONIZED') {
         syncResults.syncStatus = 'FULLY_SYNCHRONIZED';
-        syncResults.l2Status = 'SYNCHRONIZED';
+        syncResults.relayTier.status = 'SYNCHRONIZED';
+        syncResults.l2Sandbox.status = 'SANDBOX_READY';
         syncResults.l3Status = 'SYNCHRONIZED';
       }
 
@@ -91,7 +104,8 @@ class AgentSynchronizer {
       status: syncResult.syncStatus,
       agentCount: {
         l1: Object.keys(this.agents.l1).length,
-        l2: this.agents.l2.length,
+        relay: this.agents.relayTier.capsules.length,
+        l2Sandbox: this.agents.l2Sandbox.length,
         l3: this.agents.l3.length
       },
       deployedAgents: syncResult.l1Agents,
@@ -105,7 +119,8 @@ class AgentSynchronizer {
       status: this.status,
       agentCount: {
         l1: Object.keys(this.agents.l1).length,
-        l2: this.agents.l2.length,
+        relay: this.agents.relayTier.capsules.length,
+        l2Sandbox: this.agents.l2Sandbox.length,
         l3: this.agents.l3.length
       },
       lastSync: this.lastSyncTime,

--- a/tests/test_relay_constellation.js
+++ b/tests/test_relay_constellation.js
@@ -1,0 +1,42 @@
+const { describe, test, expect, beforeEach } = require('@jest/globals');
+
+jest.mock('../src/utils/aurora_logger.js', () => ({
+  systemLogger: { info: jest.fn(), error: jest.fn() },
+  bridgeLogger: { bridge: jest.fn(), error: jest.fn(), critical: jest.fn(), warn: jest.fn() },
+  ethicsLogger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+}));
+
+const { EnhancedApiBridge } = require('../src/bridge/enhanced_api_bridge.js');
+
+describe('EnhancedApiBridge relay constellation status', () => {
+  let bridge;
+
+  beforeEach(() => {
+    bridge = new EnhancedApiBridge();
+  });
+
+  test('exposes relay tier naming and capsule roster', () => {
+    const payloadHolder = {};
+
+    bridge.getConstellationStatus({}, {
+      json(payload) {
+        payloadHolder.payload = payload;
+      }
+    });
+
+    const { payload } = payloadHolder;
+    expect(payload).toBeDefined();
+    expect(payload.relay_tier.constellation).toBe('RELAY_TIER_CAPSULES');
+    expect(payload.relay_tier.total_capsules).toBe(5);
+    expect(Array.isArray(payload.relay_tier.capsules)).toBe(true);
+    expect(payload.relay_tier.capsules).toHaveLength(5);
+    const capsuleIds = payload.relay_tier.capsules.map(capsule => capsule.agentId);
+    expect(capsuleIds).toEqual([
+      'ARCHY',
+      'OPPY',
+      'LIORA',
+      'STARLING_AU',
+      'RIVERTHREAD_808'
+    ]);
+  });
+});

--- a/tests/test_relay_constellation.py
+++ b/tests/test_relay_constellation.py
@@ -1,0 +1,41 @@
+"""Regression tests for relay tier constellation status."""
+
+from datetime import datetime
+
+import pytest
+
+from src.bridges.l2_meta_agent_bridge import L2MetaAgentBridge
+
+
+@pytest.fixture()
+def bridge():
+    """Provide a fresh bridge instance for each test."""
+    return L2MetaAgentBridge()
+
+
+def test_relay_constellation_structure(bridge):
+    """Relay tier status should use the relay-specific naming."""
+    status = bridge.get_constellation_status()
+
+    relay_tier = status.get("relay_tier")
+    assert relay_tier is not None
+    assert relay_tier["constellation"] == "RELAY_TIER_CAPSULES"
+    assert relay_tier["total_capsules"] == 5
+    assert relay_tier["connected_capsules"] == 0
+    assert len(relay_tier["capsules"]) == 5
+
+
+def test_relay_capsule_entries_include_metadata(bridge):
+    """Each relay capsule entry should expose descriptive metadata."""
+    status = bridge.get_constellation_status()
+    relay_tier = status["relay_tier"]
+
+    for capsule in relay_tier["capsules"]:
+        assert "agent_id" in capsule
+        assert "status" in capsule
+        assert capsule["status"] in {"connected", "disconnected"}
+        assert "capabilities" in capsule
+        assert isinstance(capsule["capabilities"], list)
+        if capsule.get("connected"):
+            # Connected timestamps must be ISO 8601
+            datetime.fromisoformat(capsule["connected"])  # pragma: no branch


### PR DESCRIPTION
## Summary
- rename the L2 meta-agent constellation payloads to the relay-tier capsule schema across JS and Python bridges
- update orchestration configs and synchronizers to track relay capsules separately from the future L2 sandbox
- add relay-tier regression tests and documentation clarifying the new boundary terminology

## Testing
- npx jest tests/test_relay_constellation.js
- pytest tests/test_relay_constellation.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918745cca508325acdc031df7921524)