### PR TITLE
Convert API bridge server to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "npm run test:node && npm run test:web",
-    "test:node": "node --test tests/node",
+    "test:node": "node --test tests/node/*.test.js",
     "test:web": "node --test tests/web",
     "test:unit": "npm run test:node",
     "test:integration": "npm run test:web",

--- a/src/bridge/api_bridge_server.js
+++ b/src/bridge/api_bridge_server.js
@@ -3,18 +3,22 @@
  * Emergency deployment for Agent Constellation communication
  */
 
-const http = require('http');
-const AgentSynchronizer = require('../system/agent_synchronizer');
+import http from 'http';
+import { AgentSynchronizer } from '../system/agent_synchronizer.js';
 
 class ApiBridgeServer {
-  constructor(port = 3838) {
+  constructor(port = 3838, synchronizer = new AgentSynchronizer()) {
     this.port = port;
     this.server = null;
-    this.synchronizer = new AgentSynchronizer();
+    this.synchronizer = synchronizer;
     this.status = 'INITIALIZING';
   }
 
   start() {
+    if (this.server) {
+      return this.server;
+    }
+
     this.server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'application/json');
       res.setHeader('Access-Control-Allow-Origin', '*');
@@ -35,6 +39,8 @@ class ApiBridgeServer {
       this.status = 'OPERATIONAL';
       process.stdout.write(`🌐 [API_BRIDGE] Server running on port ${this.port}\n`);
     });
+
+    return this.server;
   }
 
   async handleAgentStatus(req, res) {
@@ -73,15 +79,16 @@ class ApiBridgeServer {
   stop() {
     if (this.server) {
       this.server.close();
+      this.server = null;
       this.status = 'STOPPED';
     }
   }
 }
 
-module.exports = ApiBridgeServer;
+export default ApiBridgeServer;
 
 // Emergency deployment
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   const bridge = new ApiBridgeServer();
   bridge.start();
 

--- a/tests/node/api_bridge_server.test.js
+++ b/tests/node/api_bridge_server.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+
+import ApiBridgeServer from '../../src/bridge/api_bridge_server.js';
+
+test('ApiBridgeServer starts and stops cleanly', async t => {
+  const synchronizerStub = {
+    getStatus: () => ({ status: 'STUBBED' }),
+    getDriftReport: async () => ({ drift: 'none' }),
+    synchronizeAllLayers: async () => ({ success: true })
+  };
+
+  const bridge = new ApiBridgeServer(0, synchronizerStub);
+  t.after(() => bridge.stop());
+
+  const server = bridge.start();
+  await once(server, 'listening');
+
+  assert.equal(bridge.status, 'OPERATIONAL');
+
+  const address = server.address();
+  assert.ok(address && typeof address.port === 'number' && address.port > 0);
+});


### PR DESCRIPTION
## Summary
- migrate the API bridge server to native ESM with a default export and updated emergency entrypoint guard
- allow synchronizer injection, avoid duplicate server starts, and return the server handle for callers
- update the Node test script and add a smoke test that instantiates the API bridge server under Node 20+

## Testing
- npm run test:node

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187471178483258bda38851e2e6fa3)