### PR TITLE
Fix L2 integration route decorators and add tests

### DIFF
--- a/src/servers/l2_integration_server.py
+++ b/src/servers/l2_integration_server.py
@@ -248,7 +248,8 @@ async def health_check():
 
 # Aurora Custom GPT Integration Endpoints
 if AURORA_CUSTOM_GPT_AVAILABLE:
-    @app.post(  # verify_csrf inside"/api/aurora/command")
+    # CSRF token verification occurs inside the handler
+    @app.post("/api/aurora/command")
     async def aurora_custom_gpt_command(request_data: dict, token: HTTPAuthorizationCredentials = Depends(security)):
         """Receive command from Aurora Custom GPT and route to command node with CSRF validation."""
         verify_csrf_token(token)
@@ -303,7 +304,8 @@ if AURORA_CUSTOM_GPT_AVAILABLE:
             logger.error("Aurora status request failed: %s", str(str(e))[:100])
             raise HTTPException(status_code=500, detail="Aurora status retrieval failed")
 
-    @app.post(  # verify_csrf inside"/api/aurora/initialize")
+    # CSRF token verification occurs inside the handler
+    @app.post("/api/aurora/initialize")
     async def initialize_aurora_integration(token: HTTPAuthorizationCredentials = Depends(security)):
         """Initialize Aurora Custom GPT integration with CSRF validation."""
         verify_csrf_token(token)
@@ -343,7 +345,8 @@ else:
 
 # L2 Meta-Agent Bridge Endpoints
 
-@app.post(  # verify_csrf inside"/api/bridge/gpt/connect/{agent_id}")
+# CSRF token verification occurs inside the handler
+@app.post("/api/bridge/gpt/connect/{agent_id}")
 async def connect_custom_gpt(
     agent_id: str,
     request_data: Dict[str, Any],
@@ -417,7 +420,8 @@ async def connect_custom_gpt(
         logger.error("Custom GPT connection failed for %s: %s", str(agent_id)[:100], str(str(e))[:100])
         raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
 
-@app.post(  # verify_csrf inside"/api/bridge/gpt/message/{agent_id}")
+# CSRF token verification occurs inside the handler
+@app.post("/api/bridge/gpt/message/{agent_id}")
 async def relay_message(
     agent_id: str,
     request_data: Dict[str, Any],
@@ -496,7 +500,8 @@ async def get_agent_status(agent_id: str):
         logger.error("Agent status retrieval failed for %s: %s", str(agent_id)[:100], str(str(e))[:100])
         raise HTTPException(status_code=500, detail=f"Status retrieval failed: {str(e)}")
 
-@app.post(  # verify_csrf inside"/api/bridge/gpt/heartbeat/{agent_id}")
+# CSRF token verification occurs inside the handler
+@app.post("/api/bridge/gpt/heartbeat/{agent_id}")
 async def update_heartbeat(agent_id: str, token: HTTPAuthorizationCredentials = Depends(security)):
     """Update agent heartbeat timestamp with CSRF validation."""
     verify_csrf_token(token)
@@ -525,7 +530,8 @@ async def update_heartbeat(agent_id: str, token: HTTPAuthorizationCredentials = 
         logger.error("Heartbeat update failed for %s: %s", str(agent_id)[:100], str(str(e))[:100])
         raise HTTPException(status_code=500, detail=f"Heartbeat update failed: {str(e)}")
 
-@app.post(  # verify_csrf inside"/api/bridge/gpt/disconnect/{agent_id}")
+# CSRF token verification occurs inside the handler
+@app.post("/api/bridge/gpt/disconnect/{agent_id}")
 async def disconnect_agent(agent_id: str, token: HTTPAuthorizationCredentials = Depends(security)):
     """Disconnect an agent from the constellation with CSRF validation."""
     verify_csrf_token(token)

--- a/tests/test_l2_integration_server_routes.py
+++ b/tests/test_l2_integration_server_routes.py
@@ -1,0 +1,77 @@
+"""Tests for L2 integration server route registration."""
+
+import sys
+import types
+
+import pytest
+from fastapi.routing import APIRoute
+
+
+@pytest.fixture(autouse=True)
+def stub_chatgpt_agent_mode(monkeypatch):
+    """Provide a lightweight stub for the chatgpt_agent_mode integration if missing."""
+
+    module_name = "src.integrations.chatgpt_agent_mode"
+
+    class _StubBridge:
+        """Minimal async-compatible stub for auroraCustomGptBridge."""
+
+        def __init__(self):
+            self.integrationActive = True
+
+        async def initializeCommandNodeIntegration(self):
+            self.integrationActive = True
+            return {"success": True}
+
+        async def routeCommandFromCustomGpt(self, command, context):
+            return {"success": True, "command": command, "context": context}
+
+        def getIntegrationStatus(self):
+            return {"active": True}
+
+        async def getConstellationStatus(self):
+            return {"success": True, "constellation": []}
+
+    try:
+        module = __import__(module_name, fromlist=["AURORA_CUSTOM_GPT", "auroraCustomGptBridge"])
+    except ImportError:
+        stub_module = types.ModuleType(module_name)
+        stub_module.AURORA_CUSTOM_GPT = object()
+        stub_module.auroraCustomGptBridge = _StubBridge()
+        monkeypatch.setitem(sys.modules, module_name, stub_module)
+        try:
+            yield
+        finally:
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+    else:
+        if not hasattr(module, "AURORA_CUSTOM_GPT"):
+            monkeypatch.setattr(module, "AURORA_CUSTOM_GPT", object(), raising=False)
+        if not hasattr(module, "auroraCustomGptBridge"):
+            monkeypatch.setattr(module, "auroraCustomGptBridge", _StubBridge(), raising=False)
+        yield
+
+
+def _get_route(app, path: str, method: str):
+    """Return the FastAPI route matching the given path and HTTP method."""
+    for route in app.routes:
+        if isinstance(route, APIRoute) and route.path == path and method.upper() in route.methods:
+            return route
+    return None
+
+
+def test_l2_integration_server_registers_expected_routes():
+    """Ensure critical L2 integration routes are registered on the FastAPI app."""
+    from src.servers.l2_integration_server import app
+
+    expected_routes = [
+        ("/api/aurora/command", "POST"),
+        ("/api/aurora/initialize", "POST"),
+        ("/api/bridge/gpt/connect/{agent_id}", "POST"),
+        ("/api/bridge/gpt/message/{agent_id}", "POST"),
+        ("/api/bridge/gpt/heartbeat/{agent_id}", "POST"),
+        ("/api/bridge/gpt/disconnect/{agent_id}", "POST"),
+    ]
+
+    for path, method in expected_routes:
+        route = _get_route(app, path, method)
+        assert route is not None, f"Route {method} {path} is not registered on the app"


### PR DESCRIPTION
## Summary
- update the L2 integration server decorators so each endpoint declares its route path directly
- clarify inline CSRF verification comments for the adjusted route handlers
- add a FastAPI route registration test with a lightweight chatgpt_agent_mode stub to ensure the endpoints remain available

## Testing
- python -m compileall src/servers/l2_integration_server.py
- pytest tests/test_l2_integration_server_routes.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691874742b648325879e72261e0d6a37)