### PR TITLE
Fix CI validation to use canonical test path

### DIFF
--- a/tests/test_t71_tools.py
+++ b/tests/test_t71_tools.py
@@ -3,18 +3,17 @@
 Basic test for T71 Symbolic Infrastructure tools
 """
 
+from pathlib import Path
 import sys
 import traceback
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
 
 from tools.symbolic.anchor_tracker import SymbolicAnchorTracker
 from tools.symbolic.memory_sealer import MemorySealingEngine
 from tools.cli.aurora_dev_cli import AuroraDeveloperCLI
 from tools.symbolic.manifest_generator import ManifestGenerator
-
-# Add tools to path
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
 
 
 def test_anchor_tracker():
@@ -43,13 +42,24 @@ def test_memory_sealer():
     # Test sealing this test file
     test_file = Path(__file__)
     seal = sealer.seal_file(test_file)
+    seal_path = sealer.seals_dir / f"{seal.seal_id}.json"
+    backup_path = sealer.seals_dir / f"{seal.seal_id}_backup.zip"
 
-    assert seal.seal_id is not None, "Should generate seal ID"
-    assert seal.sha256_hash is not None, "Should generate hash"
+    try:
+        assert seal.seal_id is not None, "Should generate seal ID"
+        assert seal.sha256_hash is not None, "Should generate hash"
 
-    # Test verification
-    verification = sealer.verify_seal(seal.seal_id)
-    assert verification["status"] == "valid", f"Seal should be valid: {verification}"
+        # Test verification
+        verification = sealer.verify_seal(seal.seal_id)
+        assert verification["status"] == "valid", f"Seal should be valid: {verification}"
+    finally:
+        if seal_path.exists():
+            seal_path.unlink()
+
+        if backup_path.exists():
+            backup_path.unlink()
+
+        sealer.seals.pop(seal.seal_id, None)
 
     print("✅ Memory Sealer tests passed")
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -52,7 +52,7 @@ The wizard will guide you through:
 pip install pytest black flake8 isort
 
 # Test installation
-python test_t71_tools.py
+python tests/test_t71_tools.py
 ```
 
 ### Basic Usage
@@ -266,7 +266,7 @@ Current implementation status (as of 2025-07-20):
 
 Run the comprehensive test suite:
 ```bash
-python test_t71_tools.py
+python tests/test_t71_tools.py
 ```
 
 Validates:

--- a/tools/integration/ci_helpers.py
+++ b/tools/integration/ci_helpers.py
@@ -148,7 +148,7 @@ jobs:
 
     - name: Run T71 Infrastructure Tests
       run: |
-        python test_t71_tools.py
+        python tests/test_t71_tools.py
 
     - name: Validate Symbolic Anchors
       run: |
@@ -271,8 +271,9 @@ jobs:
 
         try:
             # Run the T71 test suite
+            test_path = self.repo_path / "tests" / "test_t71_tools.py"
             process = subprocess.run(
-                ["python", "test_t71_tools.py"], capture_output=True, text=True, cwd=self.repo_path
+                ["python", str(test_path)], capture_output=True, text=True, cwd=self.repo_path
             )
 
             if process.returncode == 0:
@@ -373,8 +374,9 @@ jobs:
 
         try:
             # Run basic functionality test
+            test_path = self.repo_path / "tests" / "test_t71_tools.py"
             process = subprocess.run(
-                ["python", "test_t71_tools.py"], capture_output=True, text=True, cwd=self.repo_path
+                ["python", str(test_path)], capture_output=True, text=True, cwd=self.repo_path
             )
 
             if process.returncode == 0:


### PR DESCRIPTION
## Summary
- update CI helper to invoke the maintained T71 tool test suite from tests/test_t71_tools.py
- refresh documentation references to the canonical test location
- harden the T71 tool test harness by fixing sys.path setup and cleaning up generated seals

## Testing
- python tests/test_t71_tools.py
- python tools/integration/ci_helpers.py validate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c64d8213483258334ab00200ed9b8)