### PR TITLE
Improve AIF hub logging and coverage

### DIFF
--- a/services/aif_hub.py
+++ b/services/aif_hub.py
@@ -1,7 +1,3 @@
-import logging
-
-logger = logging.getLogger(__name__)
-
 import os
 import secrets
 from typing import List
@@ -19,10 +15,16 @@ AIF_TOKEN = os.environ.get("AIF_TOKEN")
 if not AIF_TOKEN or AIF_TOKEN == "change-me":
     # Generate cryptographically secure random token
     AIF_TOKEN = secrets.token_urlsafe(32)
-    logger.warning("No secure AIF_TOKEN provided. Generated random token for this session.")
-    logger.info("Generated AIF_TOKEN: %s", AIF_TOKEN[:8] + "..." + AIF_TOKEN[-4:])  # Only log partial token for security
-    logger.warning("WARNING: Using generated AIF_TOKEN: {AIF_TOKEN}")
-    print("   Set AIF_TOKEN environment variable for production use.")
+    token_stub = AIF_TOKEN[:8] + "..." + AIF_TOKEN[-4:]
+    logger.warning(
+        "No secure AIF_TOKEN provided. Generated random token for this session.",
+        extra={"event": "aif_token_bootstrap"},
+    )
+    logger.info("Generated AIF_TOKEN: %s", token_stub)  # Only log partial token for security
+    logger.warning(
+        "Set AIF_TOKEN environment variable for production use.",
+        extra={"event": "aif_token_bootstrap"},
+    )
 
 
 class ConnectionManager:
@@ -45,9 +47,21 @@ class ConnectionManager:
         for connection in list(self.active_connections):
             if connection is sender:
                 continue
+            client_meta = getattr(connection, "client", None)
             try:
                 await connection.send_text(message)
-            except Exception:
+            except WebSocketDisconnect:
+                logger.info(
+                    "WebSocket disconnected during broadcast; dropping connection",
+                    extra={"client": client_meta, "event": "broadcast_disconnect"},
+                )
+                self.disconnect(connection)
+            except Exception as exc:
+                logger.warning(
+                    "Broadcast send failure; disconnecting client",
+                    extra={"client": client_meta, "event": "broadcast_failure"},
+                    exc_info=exc,
+                )
                 self.disconnect(connection)
 
 

--- a/tests/test_aif_hub.py
+++ b/tests/test_aif_hub.py
@@ -1,22 +1,59 @@
-import os
+"""Tests for AIF hub token bootstrap and broadcast logging."""
+
+import importlib
+import logging
+import sys
+
+import asyncio
 
 import pytest
-from fastapi.testclient import TestClient
-
-os.environ["AIF_TOKEN"] = "test-token"
-
-from services.aif_hub import app  # noqa: E402
+from fastapi import WebSocketDisconnect
 
 
-def test_websocket_broadcast():
-    """Test websocket broadcast functionality."""
-    try:
-        with TestClient(app) as client:
-            with client.websocket_connect("/ws", headers={"Authorization": "Bearer test-token"}) as ws1:
-                with client.websocket_connect("/ws", headers={"Authorization": "Bearer test-token"}) as ws2:
-                    ws1.send_text("anchor")
-                    data = ws2.receive_text()
-                    assert data == "anchor"
-    except Exception as e:
-        # If there's a compatibility issue, skip the test for now
-        pytest.skip(f"WebSocket test skipped due to compatibility issue: {e}")
+class _FailureWebSocket:
+    def __init__(self, name: str, exc: Exception):
+        self.name = name
+        self.exc = exc
+        self.client = (name, 0)
+
+    async def send_text(self, message: str):  # pragma: no cover - exercised via broadcast
+        raise self.exc
+
+
+def test_token_bootstrap_uses_logger(monkeypatch, caplog, capsys):
+    monkeypatch.setenv("AIF_TOKEN", "change-me")
+    sys.modules.pop("services.aif_hub", None)
+
+    with caplog.at_level(logging.INFO):
+        module = importlib.import_module("services.aif_hub")
+
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert any("AIF_TOKEN" in record.getMessage() for record in caplog.records)
+    assert module.AIF_TOKEN
+
+
+def test_broadcast_logs_and_disconnects_on_failure(caplog):
+    sys.modules.pop("services.aif_hub", None)
+    module = importlib.import_module("services.aif_hub")
+
+    failure_connection = _FailureWebSocket("failure", RuntimeError("send-failed"))
+    disconnect_connection = _FailureWebSocket("disconnect", WebSocketDisconnect())
+
+    manager = module.ConnectionManager()
+    manager.active_connections = [failure_connection, disconnect_connection]
+
+    async def _run_broadcast():
+        with caplog.at_level(logging.INFO):
+            await manager.broadcast("payload")
+
+    asyncio.run(_run_broadcast())
+
+    assert failure_connection not in manager.active_connections
+    assert disconnect_connection not in manager.active_connections
+
+    warning_records = [record for record in caplog.records if record.levelno >= logging.WARNING]
+    info_records = [record for record in caplog.records if record.levelno == logging.INFO]
+
+    assert any(getattr(record, "event", "") == "broadcast_failure" for record in warning_records)
+    assert any(getattr(record, "event", "") == "broadcast_disconnect" for record in info_records)


### PR DESCRIPTION
## Summary
- replace console printing in AIF hub token bootstrap with telemetry logger events
- add structured logging and specific handling for broadcast send failures
- introduce tests for token generation logging and broadcast error paths

## Testing
- python -m pytest tests/test_aif_hub.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c6a4aa9e08325bc3aaab336fa5b83)