### PR TITLE
fix(vercel): build and serve static site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
     "version": 2,
-    "buildCommand": "npm ci && npm run build",
-    "outputDirectory": "out",
+    "buildCommand": "npm run build:web:prod",
+    "outputDirectory": "build",
     "framework": null,
     "installCommand": "npm ci",
     "devCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Vercel deploy was failing because the configuration expected an out/ directory and ran npm run build, which does not produce a static site output for this repo.

## Change
- Set Vercel buildCommand to run the repo’s web build pipeline (npm run build:web:prod).
- Set Vercel outputDirectory to build (matches scripts/build-web.js output).

## Scope
- Only vercel.json.

## Local sanity check
- Ran: node scripts/build-web.js (creates build/ successfully)
