### PR TITLE
docs: add basic repository health check report (2026-03-10)

### DIFF
--- a/reports/basic_health_check_2026-03-10.md
+++ b/reports/basic_health_check_2026-03-10.md
@@ -1,0 +1,67 @@
+# Aurora CloudBank Basic Health Check Report
+
+- **T1_MARKER**: `T1_HEALTHCHECK_2026_03_10`
+- **ANCHOR_SEED**: `AURORA_HEALTH_ALPHA_0310`
+- **Repository**: `/workspace/aurora-cloudbank-symbolic`
+- **Run Timestamp (UTC)**: `2026-03-10 12:10:48`
+
+## Commands Executed
+
+1. `make health-check`
+2. `make lint-tools`
+3. `pytest -q`
+4. `npm run -s lint`
+
+## Results Snapshot
+
+### 1) make health-check
+- **Status**: PASS
+- **Output highlights**:
+  - Quick repository health script executed successfully.
+  - Reported branch count: `0`.
+  - Reported status: `EXCELLENT (maintaining gains!)`.
+
+### 2) make lint-tools
+- **Status**: FAIL (environment/dependency gap)
+- **Output highlights**:
+  - `flake8` executable not found in current environment.
+  - Make target exited with error code `127`.
+- **Interpretation**:
+  - Python lint stage cannot run until lint dependencies are installed.
+
+### 3) pytest -q
+- **Status**: FAIL
+- **Output highlights**:
+  - Test discovery started (`1625` items collected).
+  - Interrupted during collection with `18` import errors.
+  - Primary repeated failure pattern: `ImportError: cannot import name 'UTC' from 'datetime'`.
+- **Interpretation**:
+  - Runtime appears to be Python 3.10, while modules importing `datetime.UTC` require Python 3.11+ semantics.
+
+### 4) npm run -s lint
+- **Status**: FAIL
+- **Output highlights**:
+  - ESLint found `20` issues (`5` errors, `15` warnings).
+  - Notable errors include undefined browser globals (`WebSocket`, `setTimeout`, `setInterval`) and undefined `fetch` in tests.
+- **Interpretation**:
+  - JS lint pipeline is wired and running, but current ESLint environment/global configuration (or code assumptions) is inconsistent for some files.
+
+## Basic Health Assessment
+
+- **Overall**: PARTIAL / NEEDS ATTENTION
+- **What is healthy**:
+  - Built-in repository health script is operational and returns an optimistic internal status.
+  - Node lint tooling is installed and executable.
+- **What is blocking CI-grade confidence**:
+  - Missing Python lint dependency (`flake8`) in active environment.
+  - Python test collection breakage due to `datetime.UTC` imports under Python 3.10.
+  - Existing ESLint errors in static web and Node test code.
+
+## Recommended Next Actions
+
+1. **Align Python runtime to 3.11+** for environments running tests, or refactor UTC usage for 3.10 compatibility where required.
+2. **Install Python lint dependencies** (e.g., via project dev requirements) so `make lint-tools` can execute.
+3. **Adjust ESLint globals/env per scope**:
+   - Browser files: enable browser globals.
+   - Node tests using `fetch`: set Node version/globals or polyfill/test env.
+4. Re-run the same four commands after dependency/runtime alignment to confirm clean baseline.


### PR DESCRIPTION
### Motivation
- Provide a compact, timestamped baseline health snapshot for repository tooling and CI triage and record symbolic anchors for traceability.

### Description
- Add `reports/basic_health_check_2026-03-10.md` containing `T1_MARKER` and `ANCHOR_SEED`, the outputs for `make health-check`, `make lint-tools`, `pytest -q`, and `npm run -s lint`, and concise remediation recommendations.

### Testing
- Ran `make health-check` (PASS); `make lint-tools` (FAILED due to missing `flake8`); `pytest -q` (FAILED during collection with repeated `ImportError: cannot import name 'UTC' from 'datetime'`, indicating Python 3.10/3.11 mismatch); and `npm run -s lint` (FAILED with ESLint reporting 5 errors and 15 warnings, including undefined browser globals and `fetch` issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0096d09508325804656e55fc6bf69)