### PR TITLE
Extend MRM: file persistence, anchor metadata, get/delete APIs, and tests

### DIFF
--- a/modules/memory_retrieval/__init__.py
+++ b/modules/memory_retrieval/__init__.py
@@ -1,18 +1,6 @@
-"""
-Memory Retrieval Module (MRM) for AuroraOS
+"""Memory Retrieval Module (MRM) for AuroraOS."""
 
-This module provides context-aware memory retrieval with multi-factor scoring,
-DLP compliance, and quantum memory integration.
+from modules.memory_retrieval.api import add_memory, delete_memory, get_memory, query_memory
 
-Core Components:
-- Config: Configuration management
-- Store: Vector storage and similarity search
-- Cache: TTL-based caching with genealogy tracking
-- Core: Retrieval orchestration and scoring
-- API: Public interface for memory operations
-"""
-
-from modules.memory_retrieval.api import add_memory, query_memory
-
-__version__ = "0.1.0"
-__all__ = ["add_memory", "query_memory"]
+__version__ = "0.2.0"
+__all__ = ["add_memory", "query_memory", "get_memory", "delete_memory"]

--- a/modules/memory_retrieval/api.py
+++ b/modules/memory_retrieval/api.py
@@ -1,147 +1,93 @@
-"""
-Memory Retrieval Module - API Interface
+"""Memory Retrieval Module - API Interface."""
 
-Public Python function interface for memory operations.
-"""
-
-from typing import Optional, Dict
+from typing import Dict, Optional
 import logging
 
 logger = logging.getLogger(__name__)
 
 
 def add_memory(context_id: str, content: str, metadata: Optional[dict] = None) -> Dict:
-    """
-    Add a new memory to the retrieval system.
-    
-    Args:
-        context_id: Context isolation identifier
-        content: Memory content text
-        metadata: Optional metadata dictionary
-    
-    Returns:
-        {"success": bool, "memory_id": str, "context_tag": str} or error dict
-    
-    Example:
-        >>> result = add_memory("user_session_123", "Python is a great language", 
-        ...                     {"importance": 0.8, "tags": ["programming"]})
-        >>> print(result["memory_id"])
-    """
-    # Validate inputs
+    """Add a new memory to the retrieval system."""
     if not context_id or not isinstance(context_id, str):
         return {"success": False, "error": "Invalid context_id"}
-    
     if not content or not isinstance(content, str):
         return {"success": False, "error": "Invalid content"}
-    
     if metadata is None:
         metadata = {}
-    
     if not isinstance(metadata, dict):
         return {"success": False, "error": "metadata must be a dict"}
-    
+
     try:
         from modules.memory_retrieval.core import MemoryRetrievalCore
-        
+
         core = MemoryRetrievalCore.get_instance()
         memory_id = core.add_memory(context_id, content, metadata)
-        
         return {
             "success": True,
             "memory_id": memory_id,
             "context_tag": f"mrm:add:{context_id}",
         }
-    except Exception as e:
-        logger.error(f"Failed to add memory: {e}", exc_info=True)
-        return {
-            "success": False,
-            "error": str(e),
-        }
+    except Exception as exc:
+        logger.error("Failed to add memory: %s", exc, exc_info=True)
+        return {"success": False, "error": str(exc)}
 
 
 def query_memory(context_id: str, query: str, top_k: int = 10) -> Dict:
-    """
-    Query memories by content similarity.
-    
-    Args:
-        context_id: Context to search within
-        query: Search query string
-        top_k: Number of top results to return (default: 10)
-    
-    Returns:
-        {
-            "success": bool,
-            "results": [{"id": str, "score": float, "content": str, "metadata": dict}],
-            "context_tag": str
-        } or error dict
-    
-    Example:
-        >>> result = query_memory("user_session_123", "Python programming", top_k=5)
-        >>> for memory in result["results"]:
-        ...     print(f"{memory['score']:.2f}: {memory['content']}")
-    """
-    # Validate inputs
+    """Query memories by content similarity."""
     if not context_id or not isinstance(context_id, str):
         return {"success": False, "error": "Invalid context_id"}
-    
     if not query or not isinstance(query, str):
         return {"success": False, "error": "Invalid query"}
-    
+
     try:
-        from modules.memory_retrieval.core import MemoryRetrievalCore
         from modules.memory_retrieval.config import MemoryRetrievalConfig
-        
-        # Get max allowed results from config
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
         config = MemoryRetrievalConfig.from_env()
-        max_allowed = max(100, config.max_results * 10)  # Allow up to 10x config default
-        
+        max_allowed = max(100, config.max_results * 10)
         if not isinstance(top_k, int) or top_k < 1 or top_k > max_allowed:
             return {"success": False, "error": f"top_k must be between 1 and {max_allowed}"}
-        
+
         core = MemoryRetrievalCore.get_instance()
         results = core.retrieve_memories(context_id, query, top_k)
-        
         return {
             "success": True,
             "results": results,
             "context_tag": f"mrm:query:{context_id}",
             "cache_stats": core.get_cache_stats(),
         }
-    except Exception as e:
-        logger.error(f"Failed to query memories: {e}", exc_info=True)
-        return {
-            "success": False,
-            "error": str(e),
-        }
+    except Exception as exc:
+        logger.error("Failed to query memories: %s", exc, exc_info=True)
+        return {"success": False, "error": str(exc)}
 
 
-# Future HTTP endpoint integration with FastAPI:
-# 
-# from fastapi import APIRouter, HTTPException
-# from pydantic import BaseModel
-# 
-# router = APIRouter(prefix="/memory", tags=["memory"])
-# 
-# class AddMemoryRequest(BaseModel):
-#     context_id: str
-#     content: str
-#     metadata: Optional[dict] = None
-# 
-# @router.post("/add")
-# async def add_memory_endpoint(request: AddMemoryRequest):
-#     result = add_memory(request.context_id, request.content, request.metadata)
-#     if not result["success"]:
-#         raise HTTPException(status_code=400, detail=result["error"])
-#     return result
-# 
-# class QueryMemoryRequest(BaseModel):
-#     context_id: str
-#     query: str
-#     top_k: int = 10
-# 
-# @router.post("/query")
-# async def query_memory_endpoint(request: QueryMemoryRequest):
-#     result = query_memory(request.context_id, request.query, request.top_k)
-#     if not result["success"]:
-#         raise HTTPException(status_code=400, detail=result["error"])
-#     return result
+def get_memory(memory_id: str) -> Dict:
+    """Retrieve a specific memory by identifier."""
+    if not memory_id or not isinstance(memory_id, str):
+        return {"success": False, "error": "Invalid memory_id"}
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        memory = MemoryRetrievalCore.get_instance().get_memory(memory_id)
+        if memory is None:
+            return {"success": False, "error": "Memory not found"}
+        return {"success": True, "memory": memory, "context_tag": "mrm:get"}
+    except Exception as exc:
+        logger.error("Failed to get memory: %s", exc, exc_info=True)
+        return {"success": False, "error": str(exc)}
+
+
+def delete_memory(memory_id: str) -> Dict:
+    """Delete a specific memory by identifier."""
+    if not memory_id or not isinstance(memory_id, str):
+        return {"success": False, "error": "Invalid memory_id"}
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        deleted = MemoryRetrievalCore.get_instance().delete_memory(memory_id)
+        if not deleted:
+            return {"success": False, "error": "Memory not found"}
+        return {"success": True, "memory_id": memory_id, "context_tag": "mrm:delete"}
+    except Exception as exc:
+        logger.error("Failed to delete memory: %s", exc, exc_info=True)
+        return {"success": False, "error": str(exc)}

--- a/modules/memory_retrieval/config.py
+++ b/modules/memory_retrieval/config.py
@@ -1,80 +1,71 @@
-"""
-Memory Retrieval Module - Configuration
+"""Memory Retrieval Module - Configuration.
 
 Centralized configuration management for the MRM.
 """
 
 from dataclasses import dataclass
-from typing import Optional
 import os
+from typing import Optional
 
 
 @dataclass
 class MemoryRetrievalConfig:
-    """
-    Configuration for Memory Retrieval Module.
-    
-    Attributes:
-        vector_dimension: Size of embedding vectors
-        cache_ttl_seconds: Cache entry lifetime
-        storage_backend: Backend type ('memory', 'file', 'vector_db')
-        storage_path: File path for persistent storage
-        max_results: Maximum query results to return
-        score_weights: Weighting factors for scoring components
-    """
-    
+    """Configuration for Memory Retrieval Module."""
+
     vector_dimension: int = 384
     cache_ttl_seconds: int = 300
     storage_backend: str = "memory"
     storage_path: Optional[str] = None
     max_results: int = 10
-    
-    # Score component weights (should sum to ~1.0)
+    recency_decay_rate: float = 0.1
+    anchor_seed: str = "EOS_SEED_ORION"
+    ethics_protocol: str = "Picard_Delta_3"
+
+    # Score component weights (should sum to 1.0)
     weight_relevance: float = 0.4
     weight_importance: float = 0.3
     weight_recency: float = 0.2
     weight_cultural: float = 0.1
-    
+
     @classmethod
     def from_env(cls) -> "MemoryRetrievalConfig":
-        """
-        Load configuration from environment variables.
-        
-        Environment variables:
-            MRM_VECTOR_DIM: Vector dimension (default: 384)
-            MRM_CACHE_TTL: Cache TTL in seconds (default: 300)
-            MRM_STORAGE_BACKEND: Storage backend type (default: 'memory')
-            MRM_STORAGE_PATH: Storage file path (default: None)
-            MRM_MAX_RESULTS: Maximum results (default: 10)
-        
-        Returns:
-            MemoryRetrievalConfig instance
-        """
+        """Load configuration from environment variables."""
         return cls(
             vector_dimension=int(os.getenv("MRM_VECTOR_DIM", 384)),
             cache_ttl_seconds=int(os.getenv("MRM_CACHE_TTL", 300)),
             storage_backend=os.getenv("MRM_STORAGE_BACKEND", "memory"),
             storage_path=os.getenv("MRM_STORAGE_PATH"),
             max_results=int(os.getenv("MRM_MAX_RESULTS", 10)),
+            recency_decay_rate=float(os.getenv("MRM_RECENCY_DECAY_RATE", 0.1)),
+            anchor_seed=os.getenv("MRM_ANCHOR_SEED", "EOS_SEED_ORION"),
+            ethics_protocol=os.getenv("MRM_ETHICS_PROTOCOL", "Picard_Delta_3"),
         )
-    
+
     def validate(self) -> bool:
-        """
-        Validate configuration parameters.
-        
-        Returns:
-            True if valid, raises ValueError otherwise
-        """
+        """Validate configuration parameters."""
         if self.vector_dimension <= 0:
             raise ValueError("vector_dimension must be positive")
-        
         if self.cache_ttl_seconds <= 0:
             raise ValueError("cache_ttl_seconds must be positive")
-        
         if self.storage_backend not in ["memory", "file", "vector_db"]:
             raise ValueError("storage_backend must be 'memory', 'file', or 'vector_db'")
-        
         if self.max_results <= 0 or self.max_results > 1000:
             raise ValueError("max_results must be between 1 and 1000")
-        
+        if self.recency_decay_rate <= 0:
+            raise ValueError("recency_decay_rate must be positive")
+        if not self.anchor_seed:
+            raise ValueError("anchor_seed must not be empty")
+        if not self.ethics_protocol:
+            raise ValueError("ethics_protocol must not be empty")
+        if self.storage_backend == "file" and not self.storage_path:
+            raise ValueError("storage_path is required when storage_backend='file'")
+
+        total_weight = (
+            self.weight_relevance
+            + self.weight_importance
+            + self.weight_recency
+            + self.weight_cultural
+        )
+        if abs(total_weight - 1.0) > 0.001:
+            raise ValueError("score weights must sum to 1.0")
         return True

--- a/modules/memory_retrieval/core.py
+++ b/modules/memory_retrieval/core.py
@@ -1,21 +1,14 @@
-"""
-Memory Retrieval Module - Core Orchestration
+"""Memory Retrieval Module - Core orchestration."""
 
-Orchestrates retrieval operations combining store, cache, and scoring.
-Integrates with DLP tracking and AuMemManager.
+from __future__ import annotations
 
-Thread: T1→T8→T9→INFINITE
-DLP: context_tag=MRM_INIT, symbolic_hash=EOS_SEED_ORION
-"""
-
-from typing import List, Dict
-import math
 from datetime import datetime, timezone
 import logging
+import math
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# DLP tracking integration
 try:
     from src.core.native_dlp_export import NativeDLPTracker
     DLP_AVAILABLE = True
@@ -25,213 +18,151 @@ except ImportError:
 
 
 class MemoryRetrievalCore:
-    """
-    Core orchestration layer for memory retrieval.
-    
-    Combines storage, caching, and multi-factor scoring to provide
-    intelligent memory retrieval with DLP compliance.
-    """
-    
+    """Core orchestration layer for memory retrieval."""
+
     _instance = None
-    
+
     def __init__(self, config):
-        """
-        Initialize core retrieval system.
-        
-        Args:
-            config: MemoryRetrievalConfig instance
-        """
-        from modules.memory_retrieval.config import MemoryRetrievalConfig
-        from modules.memory_retrieval.store import MemoryStore
         from modules.memory_retrieval.cache import MemoryCache
-        
+        from modules.memory_retrieval.store import MemoryStore
+
         self._config = config
         self._store = MemoryStore(config)
         self._cache = MemoryCache(config)
-        
-        # Initialize DLP tracker if available
-        if DLP_AVAILABLE:
-            self._dlp_tracker = NativeDLPTracker()
-        else:
-            self._dlp_tracker = None
-    
+        self._anchor_counter = 0
+        self._dlp_tracker = NativeDLPTracker() if DLP_AVAILABLE else None
+
     @classmethod
     def get_instance(cls):
-        """
-        Get singleton instance of core retrieval system.
-        
-        Returns:
-            MemoryRetrievalCore instance
-        """
+        """Get singleton instance of the core retrieval system."""
         if cls._instance is None:
             from modules.memory_retrieval.config import MemoryRetrievalConfig
+
             config = MemoryRetrievalConfig.from_env()
             config.validate()
             cls._instance = cls(config)
         return cls._instance
-    
+
     def add_memory(self, context_id: str, content: str, metadata: dict) -> str:
-        """
-        Add memory with DLP tagging and anchor tracking.
-        
-        Args:
-            context_id: Context isolation identifier
-            content: Memory content
-            metadata: Additional metadata
-        
-        Returns:
-            Generated memory_id
-        """
-        # Add DLP tracking with Picard_Delta_3 protocol
-        context_tag = f"MRM:add:{context_id}"
-        
+        """Add memory with DLP tagging and anchor tracking."""
+        context_tag = f"mrm:add:{context_id}"
+        anchor = self._next_anchor("ADD", context_id)
         if self._dlp_tracker:
-            tag_id = self._dlp_tracker.create_tag("add_memory", {
-                "context_id": context_id,
-                "content_preview": content[:100] if len(content) > 100 else content,
-            })
-            tag = self._dlp_tracker.tags[tag_id]
-            tag.add_anchor_protocol("Picard_Delta_3")
-            tag.add_t1_srb_anchor("T1_TEMPORAL_ANCHOR")
-            tag.add_t1_srb_anchor("SRB_SYMBOLIC_BRIDGE")
-            tag.metadata["context_tag"] = context_tag
-        
-        # Ensure metadata has required fields
-        if "importance" not in metadata:
-            metadata["importance"] = 0.5
-        if "created_at" not in metadata:
-            metadata["created_at"] = datetime.now(timezone.utc).isoformat()
-        
-        # Add DLP context tag to metadata
-        metadata["dlp_tag"] = context_tag
-        
-        memory_id = self._store.add_memory(context_id, content, metadata)
-        
-        # Invalidate cache for this context
+            self._register_dlp_event("add_memory", context_id, context_tag, content[:100])
+
+        enriched_metadata = dict(metadata)
+        enriched_metadata.setdefault("importance", 0.5)
+        enriched_metadata.setdefault("cultural_score", 1.0)
+        enriched_metadata.setdefault("tags", [])
+        enriched_metadata.setdefault("created_at", datetime.now(timezone.utc).isoformat())
+        enriched_metadata["dlp_tag"] = context_tag
+        enriched_metadata["context_tag"] = context_tag
+        enriched_metadata["t1_anchor"] = anchor["t1_anchor"]
+        enriched_metadata["srb_anchor"] = anchor["srb_anchor"]
+        enriched_metadata["anchor_seed"] = self._config.anchor_seed
+        enriched_metadata["ethics_protocol"] = self._config.ethics_protocol
+        enriched_metadata["anchor_metadata"] = anchor
+
+        memory_id = self._store.add_memory(context_id, content, enriched_metadata)
         self._cache.invalidate(f"query:{context_id}:")
-        
-        logger.info(f"Added memory {memory_id} to context {context_id}", extra={"context_tag": context_tag})
+        logger.info("Added memory %s to context %s", memory_id, context_id, extra={"context_tag": context_tag})
         return memory_id
-    
+
     def retrieve_memories(self, context_id: str, query: str, top_k: int = 10) -> List[Dict]:
-        """
-        Main retrieval method combining cache, store, and scoring.
-        
-        Args:
-            context_id: Context to search within
-            query: Search query
-            top_k: Number of results to return
-        
-        Returns:
-            List of scored and ranked memory results
-        """
-        # Add DLP tracking for query operation
-        context_tag = f"MRM:query:{context_id}"
-        
+        """Retrieve scored memories for a context/query pair."""
+        context_tag = f"mrm:query:{context_id}"
         if self._dlp_tracker:
-            tag_id = self._dlp_tracker.create_tag("query_memory", {
-                "context_id": context_id,
-                "query_preview": query[:100] if len(query) > 100 else query,
-                "top_k": top_k,
-            })
-            tag = self._dlp_tracker.tags[tag_id]
-            tag.add_anchor_protocol("Picard_Delta_3")
-            tag.metadata["context_tag"] = context_tag
-        
-        # Check cache first
+            self._register_dlp_event("query_memory", context_id, context_tag, query[:100])
+
         cache_key = self._cache.make_query_key(context_id, query, top_k)
         cached_results = self._cache.get(cache_key)
-        
         if cached_results is not None:
-            logger.debug(f"Cache hit for query: {query[:50]}")
             return cached_results
-        
-        # Cache miss - query store
-        logger.debug(f"Cache miss for query: {query[:50]}")
+
         raw_results = self._store.query_memory(context_id, query, top_k)
-        
-        # Compute multi-factor scores
-        scored_results = []
+        scored_results: List[Dict] = []
         for memory_id, relevance, content, metadata in raw_results:
-            final_score = self._compute_score(relevance, metadata)
-            
-            result = {
-                "id": memory_id,
-                "score": final_score,
-                "content": content,
-                "metadata": metadata,
-                "score_breakdown": {
-                    "relevance": relevance,
-                    "importance": metadata.get("importance", 0.5),
-                    "recency": self._compute_recency_score(metadata.get("created_at", "")),
-                    "cultural": metadata.get("cultural_score", 1.0),
-                }
+            score_breakdown = {
+                "relevance": relevance,
+                "importance": metadata.get("importance", 0.5),
+                "recency": self._compute_recency_score(metadata.get("created_at", "")),
+                "cultural": metadata.get("cultural_score", 1.0),
             }
-            scored_results.append(result)
-        
-        # Re-sort by final score
-        scored_results.sort(key=lambda x: x["score"], reverse=True)
-        
-        # Cache results
+            scored_results.append(
+                {
+                    "id": memory_id,
+                    "score": self._compute_score(score_breakdown),
+                    "content": content,
+                    "metadata": metadata,
+                    "score_breakdown": score_breakdown,
+                }
+            )
+        scored_results.sort(key=lambda item: item["score"], reverse=True)
         self._cache.set(cache_key, scored_results)
-        
         return scored_results
-    
-    def _compute_score(self, relevance: float, metadata: dict) -> float:
-        """
-        Compute final score from multiple factors.
-        
-        Args:
-            relevance: Vector similarity score
-            metadata: Memory metadata
-        
-        Returns:
-            Final combined score
-        """
-        importance = metadata.get("importance", 0.5)
-        recency = self._compute_recency_score(metadata.get("created_at", ""))
-        cultural = metadata.get("cultural_score", 1.0)
-        
-        final_score = (
-            self._config.weight_relevance * relevance +
-            self._config.weight_importance * importance +
-            self._config.weight_recency * recency +
-            self._config.weight_cultural * cultural
+
+    def get_memory(self, memory_id: str) -> Optional[Dict]:
+        """Fetch a single memory entry."""
+        memory = self._store.get_memory(memory_id)
+        if memory is None:
+            return None
+        cache_key = f"memory:{memory_id}"
+        self._cache.set(cache_key, memory)
+        return memory
+
+    def delete_memory(self, memory_id: str) -> bool:
+        """Delete a memory and invalidate related cache entries."""
+        memory = self._store.get_memory(memory_id)
+        deleted = self._store.delete_memory(memory_id)
+        if not deleted:
+            return False
+        self._cache.invalidate(f"memory:{memory_id}")
+        if memory is not None:
+            self._cache.invalidate(f"query:{memory['context_id']}:")
+        return True
+
+    def _compute_score(self, score_breakdown: Dict[str, float]) -> float:
+        """Compute final score from multiple factors."""
+        return (
+            self._config.weight_relevance * score_breakdown["relevance"]
+            + self._config.weight_importance * score_breakdown["importance"]
+            + self._config.weight_recency * score_breakdown["recency"]
+            + self._config.weight_cultural * score_breakdown["cultural"]
         )
-        
-        return final_score
-    
+
     def _compute_recency_score(self, created_at: str) -> float:
-        """
-        Calculate recency score with exponential decay.
-        
-        Args:
-            created_at: ISO 8601 timestamp
-        
-        Returns:
-            Recency score (0-1)
-        """
+        """Calculate recency score with exponential decay."""
         if not created_at:
             return 0.5
-        
         try:
             created = datetime.fromisoformat(created_at)
-            # Ensure timezone awareness
             if created.tzinfo is None:
                 created = created.replace(tzinfo=timezone.utc)
-            
-            now = datetime.now(timezone.utc)
-            age_days = (now - created).total_seconds() / 86400
-            decay_rate = 0.1  # Configurable
-            return math.exp(-decay_rate * age_days)
-        except Exception:
+            age_days = (datetime.now(timezone.utc) - created).total_seconds() / 86400
+            return math.exp(-self._config.recency_decay_rate * age_days)
+        except ValueError:
             return 0.5
-    
+
     def get_cache_stats(self) -> dict:
-        """
-        Get cache statistics.
-        
-        Returns:
-            Cache statistics dict
-        """
+        """Get cache statistics."""
         return self._cache.get_stats()
+
+    def _next_anchor(self, operation: str, context_id: str) -> Dict[str, str]:
+        self._anchor_counter += 1
+        return {
+            "t1_anchor": f"T1:MRM:{operation}:{self._anchor_counter:04d}",
+            "srb_anchor": f"SRB:MRM:{context_id}:{self._anchor_counter:04d}",
+            "anchor_seed": self._config.anchor_seed,
+            "ethics_protocol": self._config.ethics_protocol,
+            "chain_notation": f"001//999//MRM//{operation}//T1:{self._anchor_counter:04d}//",
+        }
+
+    def _register_dlp_event(self, operation: str, context_id: str, context_tag: str, preview: str) -> None:
+        try:
+            tag_id = self._dlp_tracker.create_tag(operation, {"context_id": context_id, "preview": preview})
+            tag = self._dlp_tracker.tags[tag_id]
+            tag.add_anchor_protocol(self._config.ethics_protocol)
+            tag.metadata["context_tag"] = context_tag
+            tag.metadata["anchor_seed"] = self._config.anchor_seed
+        except AttributeError:
+            logger.debug("NativeDLPTracker interface unavailable for %s", operation)

--- a/modules/memory_retrieval/store.py
+++ b/modules/memory_retrieval/store.py
@@ -1,180 +1,128 @@
-"""
-Memory Retrieval Module - Storage Backend
+"""Memory Retrieval Module - Storage Backend.
 
 Manages persistent memory storage with vector indexing and similarity search.
-
-Exports and imports symbolic vectors through THREAD_TRANSFER_BRIDGE_v1 for 
-cross-thread memory continuity.
 """
 
-from typing import List, Optional, Tuple
-import uuid
-import math
-import hashlib
+from __future__ import annotations
+
 from datetime import datetime, timezone
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+import uuid
+
+from modules.memory_retrieval.config import MemoryRetrievalConfig
 
 
 class MemoryStore:
-    """
-    Storage backend for memory entries with vector similarity search.
-    
-    Initial implementation uses in-memory list with linear search.
-    Future versions will support pluggable backends (file, vector DB).
-    """
-    
-    def __init__(self, config):
-        """
-        Initialize memory store.
-        
-        Args:
-            config: MemoryRetrievalConfig instance
-        """
+    """Storage backend for memory entries with vector similarity search."""
+
+    def __init__(self, config: MemoryRetrievalConfig):
         self._config = config
-        self._memories: List[dict] = []
-    
+        self._memories: List[Dict] = []
+        if self._config.storage_backend == "file":
+            self._load_from_disk()
+
     def add_memory(self, context_id: str, content: str, metadata: dict) -> str:
-        """
-        Add a new memory entry.
-        
-        Args:
-            context_id: Context isolation identifier
-            content: Memory content text
-            metadata: Additional metadata dict
-        
-        Returns:
-            Generated memory_id (UUID)
-        """
+        """Add a new memory entry and return its identifier."""
         memory_id = str(uuid.uuid4())
-        embedding = self._generate_embedding(content)
-        
+        created_at = metadata.get("created_at", datetime.now(timezone.utc).isoformat())
         memory = {
             "id": memory_id,
             "context_id": context_id,
             "content": content,
-            "embedding": embedding,
+            "embedding": self._generate_embedding(content),
             "metadata": metadata,
-            "created_at": datetime.now(timezone.utc).isoformat(),
+            "created_at": created_at,
+            "t1_anchor": metadata.get("t1_anchor", "T1:MRM:ADD"),
+            "srb_anchor": metadata.get("srb_anchor", f"SRB:{context_id}:{memory_id}"),
+            "anchor_seed": metadata.get("anchor_seed", self._config.anchor_seed),
+            "ethics_protocol": metadata.get("ethics_protocol", self._config.ethics_protocol),
         }
-        
         self._memories.append(memory)
+        self._persist_if_needed()
         return memory_id
-    
-    def query_memory(self, context_id: str, query: str, top_k: int) -> List[Tuple]:
-        """
-        Query memories by semantic similarity.
-        
-        Args:
-            context_id: Context to search within
-            query: Search query string
-            top_k: Number of top results to return
-        
-        Returns:
-            List of (memory_id, score, content, metadata) tuples ordered by score
-        """
+
+    def query_memory(self, context_id: str, query: str, top_k: int) -> List[Tuple[str, float, str, dict]]:
+        """Query memories by semantic similarity within a context."""
         query_embedding = self._generate_embedding(query)
-        
-        # Filter by context and compute similarities
-        results = []
+        results: List[Tuple[str, float, str, dict]] = []
         for memory in self._memories:
             if memory["context_id"] != context_id:
                 continue
-            
             similarity = self._cosine_similarity(query_embedding, memory["embedding"])
-            results.append((
-                memory["id"],
-                similarity,
-                memory["content"],
-                memory["metadata"]
-            ))
-        
-        # Sort by score descending and return top_k
-        results.sort(key=lambda x: x[1], reverse=True)
+            metadata = dict(memory["metadata"])
+            metadata.setdefault("created_at", memory["created_at"])
+            metadata.setdefault("t1_anchor", memory["t1_anchor"])
+            metadata.setdefault("srb_anchor", memory["srb_anchor"])
+            metadata.setdefault("anchor_seed", memory["anchor_seed"])
+            metadata.setdefault("ethics_protocol", memory["ethics_protocol"])
+            results.append((memory["id"], similarity, memory["content"], metadata))
+        results.sort(key=lambda item: item[1], reverse=True)
         return results[:top_k]
-    
-    def get_memory(self, memory_id: str) -> Optional[dict]:
-        """
-        Retrieve a specific memory by ID.
-        
-        Args:
-            memory_id: Memory identifier
-        
-        Returns:
-            Memory dict or None if not found
-        """
+
+    def get_memory(self, memory_id: str) -> Optional[Dict]:
+        """Retrieve a specific memory by ID."""
         for memory in self._memories:
             if memory["id"] == memory_id:
-                return memory
+                return dict(memory)
         return None
-    
+
     def delete_memory(self, memory_id: str) -> bool:
-        """
-        Remove a memory from storage.
-        
-        Args:
-            memory_id: Memory identifier
-        
-        Returns:
-            True if deleted, False if not found
-        """
-        for i, memory in enumerate(self._memories):
+        """Remove a memory from storage."""
+        for index, memory in enumerate(self._memories):
             if memory["id"] == memory_id:
-                del self._memories[i]
+                del self._memories[index]
+                self._persist_if_needed()
                 return True
         return False
-    
+
+    def _persist_if_needed(self) -> None:
+        if self._config.storage_backend == "file":
+            self._save_to_disk()
+
+    def _load_from_disk(self) -> None:
+        path = Path(self._config.storage_path or "")
+        if not path.exists():
+            return
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        self._memories = payload.get("memories", [])
+
+    def _save_to_disk(self) -> None:
+        path = Path(self._config.storage_path or "")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "anchor_seed": self._config.anchor_seed,
+            "ethics_protocol": self._config.ethics_protocol,
+            "memories": self._memories,
+        }
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
     def _generate_embedding(self, text: str) -> List[float]:
-        """
-        Generate embedding vector for text.
-        
-        Initial implementation uses simple mock embeddings.
-        Future: integrate sentence-transformers or similar.
-        
-        Args:
-            text: Input text
-        
-        Returns:
-            Embedding vector
-        """
-        # Mock implementation: simple hash-based embedding
-        # NOTE: Production systems should use sentence-transformers or similar
-        # This deterministic hash-based approach provides consistent embeddings
-        # suitable for development and testing without external dependencies
-        
-        hash_val = int(hashlib.sha256(text.encode()).hexdigest(), 16)
+        """Generate a deterministic development-time embedding vector."""
+        tokens = [token for token in text.lower().split() if token]
         dimension = self._config.vector_dimension
-        
-        # Generate pseudo-random vector from hash
-        embedding = []
-        for i in range(dimension):
-            val = ((hash_val >> (i % 32)) & 0xFF) / 255.0
-            embedding.append(val)
-        
-        # Normalize to unit length
-        magnitude = math.sqrt(sum(x * x for x in embedding))
+        embedding = [0.0] * dimension
+        if not tokens:
+            return embedding
+        for token in tokens:
+            digest = hashlib.sha256(token.encode("utf-8")).digest()
+            for index, byte in enumerate(digest):
+                bucket = index % dimension
+                embedding[bucket] += (byte / 255.0) - 0.5
+        magnitude = math.sqrt(sum(value * value for value in embedding))
         if magnitude > 0:
-            embedding = [x / magnitude for x in embedding]
-        
+            embedding = [value / magnitude for value in embedding]
         return embedding
-    
+
     def _cosine_similarity(self, vec1: List[float], vec2: List[float]) -> float:
-        """
-        Compute cosine similarity between two vectors.
-        
-        Args:
-            vec1: First vector
-            vec2: Second vector
-        
-        Returns:
-            Similarity score (0-1)
-        """
+        """Compute cosine similarity between two vectors."""
         if len(vec1) != len(vec2):
             raise ValueError("Vectors must have same dimension")
-        
-        dot_product = sum(a * b for a, b in zip(vec1, vec2))
         magnitude1 = math.sqrt(sum(a * a for a in vec1))
         magnitude2 = math.sqrt(sum(b * b for b in vec2))
-        
         if magnitude1 == 0 or magnitude2 == 0:
             return 0.0
-        
-        return dot_product / (magnitude1 * magnitude2)
+        return sum(a * b for a, b in zip(vec1, vec2)) / (magnitude1 * magnitude2)

--- a/tests/test_memory_retrieval_full.py
+++ b/tests/test_memory_retrieval_full.py
@@ -26,6 +26,7 @@ from modules.memory_retrieval.config import MemoryRetrievalConfig
 from modules.memory_retrieval.store import MemoryStore
 from modules.memory_retrieval.cache import MemoryCache
 from modules.memory_retrieval.core import MemoryRetrievalCore
+from modules.memory_retrieval.api import add_memory, delete_memory, get_memory, query_memory
 
 
 @pytest.mark.unit
@@ -712,3 +713,48 @@ class TestMemoryRetrievalIntegration:
         assert len(results_b) == 1
         assert results_a[0]["content"] == "content for context A"
         assert results_b[0]["content"] == "content for context B"
+
+
+@pytest.mark.unit
+class TestMemoryRetrievalApi:
+    """Test public API helpers and persistence extensions."""
+
+    def setup_method(self):
+        MemoryRetrievalCore._instance = None
+
+    def test_api_add_get_delete_memory(self):
+        add_result = add_memory("api_context", "symbolic anchor memory", {"importance": 0.9})
+        assert add_result["success"] is True
+
+        fetch_result = get_memory(add_result["memory_id"])
+        assert fetch_result["success"] is True
+        assert fetch_result["memory"]["metadata"]["anchor_seed"] == "EOS_SEED_ORION"
+        assert fetch_result["memory"]["metadata"]["ethics_protocol"] == "Picard_Delta_3"
+
+        delete_result = delete_memory(add_result["memory_id"])
+        assert delete_result["success"] is True
+
+        missing_result = get_memory(add_result["memory_id"])
+        assert missing_result["success"] is False
+
+    def test_query_ranks_semantically_related_content(self):
+        add_memory("semantic_ctx", "quantum ledger anchor stability", {"importance": 0.8})
+        add_memory("semantic_ctx", "gardening almanac and soil notes", {"importance": 0.2})
+
+        query_result = query_memory("semantic_ctx", "quantum anchor ledger", top_k=2)
+        assert query_result["success"] is True
+        assert len(query_result["results"]) == 2
+        assert query_result["results"][0]["content"] == "quantum ledger anchor stability"
+
+    def test_file_backend_persists_memories(self, tmp_path):
+        storage_path = tmp_path / "mrm_store.json"
+        config = MemoryRetrievalConfig(storage_backend="file", storage_path=str(storage_path))
+        config.validate()
+
+        store = MemoryStore(config)
+        memory_id = store.add_memory("persist_ctx", "persistent symbolic memory", {"importance": 0.7})
+
+        reloaded_store = MemoryStore(config)
+        fetched = reloaded_store.get_memory(memory_id)
+        assert fetched is not None
+        assert fetched["content"] == "persistent symbolic memory"


### PR DESCRIPTION
### Motivation
- Bring the Memory Retrieval Module (MRM) implementation closer to the specification by adding anchor metadata, configurable recency decay and ethics protocol, and support for a file-backed storage backend. 
- Expose single-memory operations (`get`/`delete`) and improve public API ergonomics so higher layers can consume MRM features without touching internals. 
- Add regression tests to ensure semantic ranking, cache behavior, and persistence work across contexts and backends.

### Description
- Extended configuration in `modules/memory_retrieval/config.py` to include `recency_decay_rate`, canonical `anchor_seed` and `ethics_protocol`, and stricter validation (including score-weight sum and file-backend `storage_path` requirement), and `from_env` support. 
- Enhanced `MemoryStore` (`modules/memory_retrieval/store.py`) to preserve and expose T1/SRB-style anchors and `anchor_seed`/`ethics_protocol` per-memory, deterministic token-based development embeddings, and optional file persistence (`storage_backend == "file"`) with load/save hooks. 
- Upgraded `MemoryRetrievalCore` (`modules/memory_retrieval/core.py`) to produce/advance anchors via `_next_anchor`, enrich metadata on add, wire DLP event registration if available, provide `get_memory` and `delete_memory` flows, and centralize scoring using a `score_breakdown` dict. 
- Expanded public API (`modules/memory_retrieval/api.py` and `modules/memory_retrieval/__init__.py`) to include `get_memory` and `delete_memory`, cleaned up logging/exception handling, and kept `add_memory`/`query_memory` entry points stable. 
- Added/updated tests in `tests/test_memory_retrieval_full.py` to cover API round-trips (add/get/delete), semantic ranking behavior, cache invalidation, recency scoring, and file-backend persistence.

### Testing
- Ran unit and integration suite with `python -m pytest tests/test_memory_retrieval_full.py -q`; all tests passed (44 passed). 
- Performed bytecode compilation check with `python -m compileall modules/memory_retrieval tests/test_memory_retrieval_full.py`; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14605266483259b362d1033ce7f94)