### PR TITLE
docs(aurora): register Iran War 2026 package and knowledge-index integration notes

### DIFF
--- a/docs/qgia-iran-war-2026-package-registration.md
+++ b/docs/qgia-iran-war-2026-package-registration.md
@@ -1,0 +1,159 @@
+# QGIA Iran War 2026 — Constellation Package Registration
+
+## Purpose
+
+This document registers the Iran War 2026 documentation package with CONSTELLATION-PRIME (aurora-cloudbank-symbolic) and provides knowledge-index integration notes, cross-repo node manifests, and event-contract references.
+
+---
+
+## Package Node Registration
+
+| Field | Value |
+|---|---|
+| Package ID | `qgia.iran-war-2026` |
+| Package type | Theater assessment bundle |
+| Primary repo | `qgia-knowledge-library` |
+| Path | `regions/middle-east/iran/iran-war-2026/` |
+| Schema repo | `qgia-knowledge-spine` |
+| Schema path | `frameworks/`, `schemas/`, `methods/` |
+| Runtime repo | `Orion-Station-QGIA` |
+| Runtime path | `docs/runtime-ingestion-iran-war-2026.md` |
+| Baseline date | 2026-04-19T00:00:00Z |
+| Status | Active — kinetic conflict in progress |
+
+---
+
+## Cross-Repo Node Manifest
+
+```json
+{
+  "node_id": "qgia.iran-war-2026",
+  "node_type": "theater_assessment_bundle",
+  "status": "active",
+  "baseline_timestamp": "2026-04-19T00:00:00Z",
+  "repos": {
+    "schema": {
+      "repo": "qgia-knowledge-spine",
+      "paths": [
+        "frameworks/iran-war-scenario-taxonomy.md",
+        "schemas/actor-card-schema.md",
+        "schemas/probability-ledger-schema.md",
+        "methods/iran-regime-dirichlet-template.md"
+      ]
+    },
+    "corpus": {
+      "repo": "qgia-knowledge-library",
+      "paths": [
+        "regions/middle-east/iran/iran-war-2026/README.md",
+        "regions/middle-east/iran/iran-war-2026/baseline-ledger.md",
+        "regions/middle-east/iran/iran-war-2026/actor-cards.md",
+        "regions/middle-east/iran/iran-war-2026/scenario-catalog.md"
+      ]
+    },
+    "runtime": {
+      "repo": "Orion-Station-QGIA",
+      "paths": [
+        "docs/runtime-ingestion-iran-war-2026.md",
+        "docs/config-contracts.md"
+      ]
+    }
+  },
+  "upstream_links": [
+    "qgia.spine",
+    "qgia.corpus"
+  ],
+  "downstream_consumers": [
+    "qgia.space-node",
+    "qgia.orion-runtime"
+  ]
+}
+```
+
+---
+
+## Knowledge-Index Integration Notes
+
+### Index Entry Requirements
+
+When updating `.aurora/knowledge-index.json`, the Iran War 2026 package should be indexed with the following metadata:
+
+```json
+{
+  "id": "qgia.iran-war-2026",
+  "title": "Iran War 2026 Theater Assessment Bundle",
+  "theater": "Middle East / Iran",
+  "type": "theater_assessment",
+  "status": "active",
+  "baseline": "2026-04-19T00:00:00Z",
+  "documents": [
+    { "id": "iran-war-scenario-taxonomy", "repo": "qgia-knowledge-spine", "type": "framework" },
+    { "id": "actor-card-schema", "repo": "qgia-knowledge-spine", "type": "schema" },
+    { "id": "probability-ledger-schema", "repo": "qgia-knowledge-spine", "type": "schema" },
+    { "id": "iran-regime-dirichlet-template", "repo": "qgia-knowledge-spine", "type": "method" },
+    { "id": "iran-war-2026-readme", "repo": "qgia-knowledge-library", "type": "theater_readme" },
+    { "id": "iran-war-2026-baseline-ledger", "repo": "qgia-knowledge-library", "type": "ledger" },
+    { "id": "iran-war-2026-actor-cards", "repo": "qgia-knowledge-library", "type": "actor_cards" },
+    { "id": "iran-war-2026-scenario-catalog", "repo": "qgia-knowledge-library", "type": "scenario_catalog" }
+  ],
+  "key_scenarios": [
+    "IRN_WAR_PROTRACTED_AIR_CAMPAIGN_60_180D",
+    "IRN_WAR_REGION_WIDE_CONFLICT_GE_6_STATES",
+    "IRN_REGIME_H1_HARDLINE_SURVIVAL",
+    "IRN_WAR_HORMUZ_CLOSURE_GE_60D",
+    "IRN_WAR_NUCLEAR_DECISION_WITHIN_12M"
+  ]
+}
+```
+
+### Auto-Index Trigger
+
+Once both `qgia-knowledge-spine` PR #2 and `qgia-knowledge-library` PR #3 are merged, the auto-index pipeline should be triggered to:
+1. Pull updated manifests from both repos
+2. Register the `qgia.iran-war-2026` node in `.aurora/knowledge-index.json`
+3. Emit a `KNOWLEDGE_NODE_REGISTERED` event to downstream consumers
+4. Notify `qgia.space-node` and `qgia.orion-runtime` of the new package availability
+
+---
+
+## Event Contracts
+
+### `KNOWLEDGE_NODE_REGISTERED`
+
+```json
+{
+  "event_type": "KNOWLEDGE_NODE_REGISTERED",
+  "node_id": "qgia.iran-war-2026",
+  "timestamp": "<merge_timestamp>",
+  "triggering_repos": ["qgia-knowledge-spine", "qgia-knowledge-library"],
+  "consumers": ["qgia.space-node", "qgia.orion-runtime"]
+}
+```
+
+### `LEDGER_BASELINE_COMMITTED`
+
+```json
+{
+  "event_type": "LEDGER_BASELINE_COMMITTED",
+  "package_id": "qgia.iran-war-2026",
+  "timestamp": "2026-04-19T00:00:00Z",
+  "scenario_count": 9,
+  "tier_1_count": 5,
+  "tier_2_count": 4,
+  "composite_confidence": 0.74
+}
+```
+
+---
+
+## Maintenance
+
+- Registration document should be updated when package structure changes materially.
+- Knowledge-index entries must be updated when new theater documents are added.
+- Event contracts should be versioned alongside the schema repo.
+
+| Field | Value |
+|---|---|
+| Version | 0.1.0 |
+| Status | Draft |
+| Owner | CONSTELLATION-PRIME / aurora-cloudbank-symbolic |
+| Review cycle | On package structural change |

--- a/docs/qgia-iran-war-2026-package-registration.md
+++ b/docs/qgia-iran-war-2026-package-registration.md
@@ -59,12 +59,12 @@ This document registers the Iran War 2026 documentation package with CONSTELLATI
     }
   },
   "upstream_links": [
-    "qgia.spine",
-    "qgia.corpus"
+    "QGIA-SPINE",
+    "QGIA-CORPUS"
   ],
   "downstream_consumers": [
-    "qgia.space-node",
-    "qgia.orion-runtime"
+    "CONSTELLATION-PRIME",
+    "AURORA-RUNTIME"
   ]
 }
 ```
@@ -75,32 +75,84 @@ This document registers the Iran War 2026 documentation package with CONSTELLATI
 
 ### Index Entry Requirements
 
-When updating `.aurora/knowledge-index.json`, the Iran War 2026 package should be indexed with the following metadata:
+When updating `.aurora/knowledge-index.json`, represent the Iran War 2026 package through schema-compliant `documents[]` entries in the source repo's top-level knowledge index. Package-level metadata such as status, baseline date, key scenarios, and dependency state belongs in this registration document or a dedicated package manifest unless `constellation-contracts/schemas/knowledge-index.schema.json` is extended.
+
+Example `qgia-knowledge-spine/.aurora/knowledge-index.json` structure:
 
 ```json
 {
-  "id": "qgia.iran-war-2026",
-  "title": "Iran War 2026 Theater Assessment Bundle",
-  "theater": "Middle East / Iran",
-  "type": "theater_assessment",
-  "status": "active",
-  "baseline": "2026-04-19T00:00:00Z",
+  "version": "1.0.0",
+  "source_repo": "qgia-knowledge-spine",
+  "generated_at": "2026-04-19T00:00:00Z",
   "documents": [
-    { "id": "iran-war-scenario-taxonomy", "repo": "qgia-knowledge-spine", "type": "framework" },
-    { "id": "actor-card-schema", "repo": "qgia-knowledge-spine", "type": "schema" },
-    { "id": "probability-ledger-schema", "repo": "qgia-knowledge-spine", "type": "schema" },
-    { "id": "iran-regime-dirichlet-template", "repo": "qgia-knowledge-spine", "type": "method" },
-    { "id": "iran-war-2026-readme", "repo": "qgia-knowledge-library", "type": "theater_readme" },
-    { "id": "iran-war-2026-baseline-ledger", "repo": "qgia-knowledge-library", "type": "ledger" },
-    { "id": "iran-war-2026-actor-cards", "repo": "qgia-knowledge-library", "type": "actor_cards" },
-    { "id": "iran-war-2026-scenario-catalog", "repo": "qgia-knowledge-library", "type": "scenario_catalog" }
-  ],
-  "key_scenarios": [
-    "IRN_WAR_PROTRACTED_AIR_CAMPAIGN_60_180D",
-    "IRN_WAR_REGION_WIDE_CONFLICT_GE_6_STATES",
-    "IRN_REGIME_H1_HARDLINE_SURVIVAL",
-    "IRN_WAR_HORMUZ_CLOSURE_GE_60D",
-    "IRN_WAR_NUCLEAR_DECISION_WITHIN_12M"
+    {
+      "id": "iran-war-scenario-taxonomy",
+      "title": "Iran War Scenario Taxonomy",
+      "domain": "framework",
+      "path": "frameworks/iran-war-scenario-taxonomy.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    },
+    {
+      "id": "actor-card-schema",
+      "title": "Actor Card Schema",
+      "domain": "schema",
+      "path": "schemas/actor-card-schema.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    },
+    {
+      "id": "probability-ledger-schema",
+      "title": "Probability Ledger Schema",
+      "domain": "schema",
+      "path": "schemas/probability-ledger-schema.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    },
+    {
+      "id": "iran-regime-dirichlet-template",
+      "title": "Iran Regime Dirichlet Template",
+      "domain": "method",
+      "path": "methods/iran-regime-dirichlet-template.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    }
+  ]
+}
+```
+
+Example `qgia-knowledge-library/.aurora/knowledge-index.json` structure:
+
+```json
+{
+  "version": "1.0.0",
+  "source_repo": "qgia-knowledge-library",
+  "generated_at": "2026-04-19T00:00:00Z",
+  "documents": [
+    {
+      "id": "iran-war-2026-readme",
+      "title": "Iran War 2026 Package README",
+      "domain": "theater_readme",
+      "path": "regions/middle-east/iran/iran-war-2026/README.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    },
+    {
+      "id": "iran-war-2026-baseline-ledger",
+      "title": "Iran War 2026 Baseline Ledger",
+      "domain": "ledger",
+      "path": "regions/middle-east/iran/iran-war-2026/baseline-ledger.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    },
+    {
+      "id": "iran-war-2026-actor-cards",
+      "title": "Iran War 2026 Actor Cards",
+      "domain": "actor_cards",
+      "path": "regions/middle-east/iran/iran-war-2026/actor-cards.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    },
+    {
+      "id": "iran-war-2026-scenario-catalog",
+      "title": "Iran War 2026 Scenario Catalog",
+      "domain": "scenario_catalog",
+      "path": "regions/middle-east/iran/iran-war-2026/scenario-catalog.md",
+      "checksum": "REPLACE_WITH_ACTUAL_SHA256"
+    }
   ]
 }
 ```
@@ -109,37 +161,51 @@ When updating `.aurora/knowledge-index.json`, the Iran War 2026 package should b
 
 Once both `qgia-knowledge-spine` PR #2 and `qgia-knowledge-library` PR #3 are merged, the auto-index pipeline should be triggered to:
 1. Pull updated manifests from both repos
-2. Register the `qgia.iran-war-2026` node in `.aurora/knowledge-index.json`
-3. Emit a `KNOWLEDGE_NODE_REGISTERED` event to downstream consumers
-4. Notify `qgia.space-node` and `qgia.orion-runtime` of the new package availability
+2. Regenerate and validate the schema-compliant `.aurora/knowledge-index.json` files
+3. Emit `qgia.knowledge.updated` events from `QGIA-SPINE` and `QGIA-CORPUS`
+4. Notify `CONSTELLATION-PRIME` and `AURORA-RUNTIME` of the new package availability through the event payload
 
 ---
 
 ## Event Contracts
 
-### `KNOWLEDGE_NODE_REGISTERED`
+### Package schema registration
 
 ```json
 {
-  "event_type": "KNOWLEDGE_NODE_REGISTERED",
-  "node_id": "qgia.iran-war-2026",
-  "timestamp": "<merge_timestamp>",
-  "triggering_repos": ["qgia-knowledge-spine", "qgia-knowledge-library"],
-  "consumers": ["qgia.space-node", "qgia.orion-runtime"]
+  "event_type": "qgia.knowledge.updated",
+  "source_node": "QGIA-SPINE",
+  "timestamp": "2026-04-19T00:00:00Z",
+  "payload": {
+    "action": "package_schema_registered",
+    "package_id": "qgia.iran-war-2026",
+    "triggering_repos": ["qgia-knowledge-spine", "qgia-knowledge-library"],
+    "documents": [
+      "frameworks/iran-war-scenario-taxonomy.md",
+      "schemas/actor-card-schema.md",
+      "schemas/probability-ledger-schema.md",
+      "methods/iran-regime-dirichlet-template.md"
+    ],
+    "consumers": ["CONSTELLATION-PRIME", "AURORA-RUNTIME"]
+  }
 }
 ```
 
-### `LEDGER_BASELINE_COMMITTED`
+### Ledger baseline committed
 
 ```json
 {
-  "event_type": "LEDGER_BASELINE_COMMITTED",
-  "package_id": "qgia.iran-war-2026",
+  "event_type": "qgia.knowledge.updated",
+  "source_node": "QGIA-CORPUS",
   "timestamp": "2026-04-19T00:00:00Z",
-  "scenario_count": 9,
-  "tier_1_count": 5,
-  "tier_2_count": 4,
-  "composite_confidence": 0.74
+  "payload": {
+    "action": "ledger_baseline_committed",
+    "package_id": "qgia.iran-war-2026",
+    "scenario_count": 9,
+    "tier_1_count": 5,
+    "tier_2_count": 4,
+    "composite_confidence": 0.74
+  }
 }
 ```
 

--- a/docs/runtime-ingestion-iran-war-2026.md
+++ b/docs/runtime-ingestion-iran-war-2026.md
@@ -34,7 +34,7 @@ This document specifies the runtime ingestion contract for the Iran War 2026 pac
 
 6. **Load scenario catalog** — Construct the scenario tier index. Register Tier I scenarios as primary tracking targets for all QGIA deliverables.
 
-7. **Register package node** — Emit `KNOWLEDGE_NODE_REGISTERED` event to CONSTELLATION-PRIME.
+7. **Register package node** — Emit a `qgia.knowledge.updated` event that conforms to the shared Constellation event schema, including `source_node` and a `payload` object with package registration metadata for CONSTELLATION-PRIME and AURORA-RUNTIME consumers.
 
 ---
 

--- a/docs/runtime-ingestion-iran-war-2026.md
+++ b/docs/runtime-ingestion-iran-war-2026.md
@@ -1,0 +1,127 @@
+# Iran War 2026 — Runtime Ingestion Contract
+
+## Purpose
+
+This document specifies the runtime ingestion contract for the Iran War 2026 package within Orion Station / QGIA. It defines how schema files, actor cards, probability ledgers, and scenario catalogs from the Knowledge Spine and Library should be loaded, validated, and registered for use in OSIQP simulations, ABCP updates, and QSFE scenario runs.
+
+---
+
+## Source Document Map
+
+| Document | Source Repo | Path | Ingestion Role |
+|---|---|---|---|
+| Scenario taxonomy | `qgia-knowledge-spine` | `frameworks/iran-war-scenario-taxonomy.md` | Scenario ID registry |
+| Actor card schema | `qgia-knowledge-spine` | `schemas/actor-card-schema.md` | Validation schema |
+| Ledger schema | `qgia-knowledge-spine` | `schemas/probability-ledger-schema.md` | Ledger validation |
+| Dirichlet template | `qgia-knowledge-spine` | `methods/iran-regime-dirichlet-template.md` | Prior initialization |
+| Baseline ledger | `qgia-knowledge-library` | `regions/middle-east/iran/iran-war-2026/baseline-ledger.md` | Initial state load |
+| Actor cards | `qgia-knowledge-library` | `regions/middle-east/iran/iran-war-2026/actor-cards.md` | Actor node initialization |
+| Scenario catalog | `qgia-knowledge-library` | `regions/middle-east/iran/iran-war-2026/scenario-catalog.md` | Scenario tree construction |
+
+---
+
+## Ingestion Sequence
+
+1. **Load and validate scenario taxonomy** — Register all canonical `scenario_id` values into the active scenario registry. Reject any downstream document referencing undefined IDs.
+
+2. **Load actor card schema** — Store validation rules for required fields, utility encoding constraints, and trigger rule delta bounds.
+
+3. **Load and validate actor cards** — Validate each card against the schema. Initialize actor nodes in the ABCP simulation graph with utility weights, hard constraints, and trigger rules active.
+
+4. **Load ledger schema** — Register column definitions, distribution type vocabulary, and update threshold rules.
+
+5. **Load and validate baseline ledger** — Initialize probability state for all scenarios. Load Dirichlet prior Dir(4.0, 2.0, 1.8, 1.2) for the regime trajectory family. Validate that `dirichlet_component` rows sum to 1.00 within their scenario family and window.
+
+6. **Load scenario catalog** — Construct the scenario tier index. Register Tier I scenarios as primary tracking targets for all QGIA deliverables.
+
+7. **Register package node** — Emit `KNOWLEDGE_NODE_REGISTERED` event to CONSTELLATION-PRIME.
+
+---
+
+## Validation Rules
+
+| Check | Condition | Action on Failure |
+|---|---|---|
+| Scenario ID integrity | All `scenario_id` values in ledger and actor cards exist in taxonomy | Reject document, log error |
+| Actor card required fields | All required fields present and typed correctly | Reject card, log error |
+| Utility range | All utility values are integers 1–5 | Reject card |
+| Trigger delta bounds | All `delta` values in trigger rules are 0.01–0.15 | Warn; do not reject |
+| Dirichlet sum | Regime trajectory probabilities sum to 1.00 ± 0.001 | Reject ledger section |
+| Confidence range | All confidence scores are 0.00–1.00 | Reject row |
+| Timestamp format | ISO-8601 required | Reject row |
+
+---
+
+## Configuration Contract
+
+```yaml
+package_id: qgia.iran-war-2026
+baseline_timestamp: "2026-04-19T00:00:00Z"
+theater: Iran
+status: active
+
+scenario_families:
+  - family_id: regime_trajectory
+    distribution: dirichlet
+    alpha: [4.0, 2.0, 1.8, 1.2]
+    members:
+      - IRN_REGIME_H1_HARDLINE_SURVIVAL
+      - IRN_REGIME_H2_MANAGED_TRANSITION
+      - IRN_REGIME_H3_REVOLUTIONARY_COLLAPSE
+      - IRN_REGIME_H4_FRAGMENTED_AUTHORITY
+
+  - family_id: war_outcomes
+    distribution: independent_beta
+    members:
+      - IRN_WAR_CEASEFIRE_0_60D
+      - IRN_WAR_PROTRACTED_AIR_CAMPAIGN_60_180D
+      - IRN_WAR_HORMUZ_CLOSURE_GE_60D
+      - IRN_WAR_CARRIER_COMBAT_LOSS
+      - IRN_WAR_REGION_WIDE_CONFLICT_GE_6_STATES
+      - IRN_WAR_NUCLEAR_DECISION_WITHIN_12M
+
+actor_nodes:
+  - IRGC_QF
+  - ISR_NETANYAHU_COALITION
+  - US_EXECUTIVE_TRUMP
+
+update_thresholds:
+  min_delta_to_log: 0.03
+  dirichlet_concentration_alert: 0.70
+  instability_signal_threshold: 0.45  # H3 + H4 combined
+
+confidence_floor:
+  warn_below: 0.60
+  reject_below: 0.40
+```
+
+---
+
+## Episode Step Reference
+
+A minimal episode step for OSIQP simulation:
+
+```yaml
+episode_id: iran-war-2026-ep001
+package_id: qgia.iran-war-2026
+step: 1
+timestamp: "2026-04-19T00:00:00Z"
+active_scenarios:
+  - IRN_WAR_PROTRACTED_AIR_CAMPAIGN_60_180D
+  - IRN_WAR_REGION_WIDE_CONFLICT_GE_6_STATES
+  - IRN_WAR_HORMUZ_CLOSURE_GE_60D
+observations: []
+actor_mode_overrides: {}
+ledger_snapshot: baseline
+```
+
+---
+
+## Versioning
+
+| Field | Value |
+|---|---|
+| Version | 0.1.0 |
+| Status | Draft |
+| Owner | Orion Station / QGIA Runtime |
+| Review cycle | On schema or package structural change |


### PR DESCRIPTION
## Summary

Registers the Iran War 2026 documentation package with CONSTELLATION-PRIME and provides knowledge-index integration notes, cross-repo node manifests, schema-aligned event examples, and the Orion runtime ingestion contract.

## Files Added

| File | Contents |
|---|---|
| `docs/qgia-iran-war-2026-package-registration.md` | Cross-repo node manifest, schema-compliant knowledge-index examples, `qgia.knowledge.updated` event examples, auto-index trigger notes |
| `docs/runtime-ingestion-iran-war-2026.md` | Ingestion sequence, validation rules, YAML config contract, episode step reference |

## Merge Order

This PR depends on:
1. `qgia-knowledge-spine` PR #2 (schema and taxonomy)
2. `qgia-knowledge-library` PR #3 (theater content)

Merge those two first, then trigger the auto-index pipeline after this PR merges.

## Event Pipeline

After merge, emit schema-supported `qgia.knowledge.updated` events from `QGIA-SPINE` and `QGIA-CORPUS` with required `source_node`, `timestamp`, and `payload` fields. Use the payload to notify `CONSTELLATION-PRIME` and `AURORA-RUNTIME` of package availability.
