### PR TITLE
fix: serialize anomaly detection schema

### DIFF
--- a/src/subroutines/api_enhanced.py
+++ b/src/subroutines/api_enhanced.py
@@ -10,7 +10,7 @@ Additional API endpoints for new subroutine functionality.
 """
 
 from fastapi import APIRouter, HTTPException, status
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any
 from pydantic import BaseModel, Field
 import logging
 
@@ -175,16 +175,20 @@ async def detect_anomaly(request: AnomalyCheckRequest) -> Dict[str, Any]:
         )
         
         if anomaly:
+            metadata = anomaly.metadata or {}
             return {
                 "success": True,
                 "anomaly_detected": True,
                 "anomaly": {
-                    "metric_name": anomaly.metric_name,
-                    "current_value": anomaly.current_value,
-                    "expected_value": anomaly.expected_value,
-                    "deviation": anomaly.deviation,
+                    "anomaly_id": anomaly.anomaly_id,
+                    "anomaly_type": anomaly.anomaly_type,
                     "severity": anomaly.severity,
                     "confidence_score": anomaly.confidence_score,
+                    "metric_name": metadata.get("metric", request.metric_name),
+                    "current_value": metadata.get("current_value"),
+                    "baseline_mean": metadata.get("baseline_mean"),
+                    "baseline_std": metadata.get("baseline_std"),
+                    "deviation_score": metadata.get("deviation_score"),
                     "affected_components": anomaly.affected_components,
                     "recommended_actions": anomaly.recommended_actions,
                     "timestamp": anomaly.timestamp

--- a/tests/test_subroutines_integration.py
+++ b/tests/test_subroutines_integration.py
@@ -117,6 +117,36 @@ class TestAnomalyDetectionEngine:
         assert hasattr(result, 'severity')
         assert hasattr(result, 'confidence_score')
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_anomaly_endpoint_serializes_dataclass_schema(self):
+        """Test anomaly endpoint returns the current dataclass schema without crashing."""
+        from src.subroutines.api_enhanced import AnomalyCheckRequest, detect_anomaly
+
+        result = await detect_anomaly(
+            AnomalyCheckRequest(
+                metric_name="test_metric",
+                current_value=1000.0,
+                context={}
+            )
+        )
+
+        checks = unittest.TestCase()
+        checks.assertIs(result["success"], True)
+        checks.assertIs(result["anomaly_detected"], True)
+
+        anomaly = result["anomaly"]
+        checks.assertIn("anomaly_id", anomaly)
+        checks.assertEqual(anomaly["anomaly_type"], "statistical_deviation")
+        checks.assertEqual(anomaly["severity"], "high")
+        checks.assertEqual(anomaly["metric_name"], "test_metric")
+        checks.assertEqual(anomaly["current_value"], 1000.0)
+        checks.assertEqual(anomaly["baseline_mean"], 50.0)
+        checks.assertEqual(anomaly["baseline_std"], 10.0)
+        checks.assertAlmostEqual(anomaly["deviation_score"], 95.0)
+        checks.assertIn("test_metric", anomaly["affected_components"])
+        checks.assertTrue(anomaly["recommended_actions"])
+
 
 class TestIntegrationValidator:
     """Tests for Integration Validator subroutine"""


### PR DESCRIPTION
## Summary
Fixes #600 by updating the anomaly detection endpoint response to serialize the current `AnomalyDetection` dataclass schema instead of reading stale fields that do not exist.

## Changes
- serialize `anomaly_id`, `anomaly_type`, `severity`, and `confidence_score` from the dataclass
- read metric details from `anomaly.metadata`: `metric`, `current_value`, `baseline_mean`, `baseline_std`, and `deviation_score`
- add endpoint-level regression coverage for the real anomaly response path

## Validation
- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py -k anomaly -q`
- `./.venv/bin/flake8 src/subroutines/api_enhanced.py tests/test_subroutines_integration.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293`
- `git diff --check`
- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py -q` outside the sandbox: 13 passed, 6 xfailed