### PR TITLE
fix: serialize resource network metrics

### DIFF
--- a/src/subroutines/api_enhanced.py
+++ b/src/subroutines/api_enhanced.py
@@ -123,6 +123,7 @@ async def analyze_resources(request: ResourceMetricsRequest) -> Dict[str, Any]:
         optimizer = ResourceOptimizationManager()
         metrics = await optimizer.collect_resource_metrics()
         actions = await optimizer.analyze_and_optimize()
+        network_io = metrics.network_io or {}
         
         return {
             "success": True,
@@ -131,8 +132,8 @@ async def analyze_resources(request: ResourceMetricsRequest) -> Dict[str, Any]:
                 "memory_percent": metrics.memory_percent,
                 "disk_percent": metrics.disk_percent,
                 "quantum_circuit_queue": metrics.quantum_circuit_queue if request.include_quantum else None,
-                "network_io_sent": metrics.network_io_sent if request.include_network else None,
-                "network_io_recv": metrics.network_io_recv if request.include_network else None,
+                "network_io_sent": network_io.get("bytes_sent") if request.include_network else None,
+                "network_io_recv": network_io.get("bytes_recv") if request.include_network else None,
                 "active_processes": metrics.active_processes,
                 "timestamp": metrics.timestamp
             },

--- a/tests/test_subroutines_integration.py
+++ b/tests/test_subroutines_integration.py
@@ -79,6 +79,56 @@ class TestResourceOptimizationManager:
         assert isinstance(actions, list)
         # Actions may be empty if no optimization needed
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_resource_analysis_endpoint_serializes_network_io(self, monkeypatch):
+        """Test resource endpoint serializes nested network I/O fields without crashing."""
+        import src.subroutines as subroutines
+        from src.subroutines.api_enhanced import ResourceMetricsRequest, analyze_resources
+        from src.subroutines.resource_optimization import OptimizationAction, ResourceMetrics
+
+        class StubResourceOptimizationManager:
+            async def collect_resource_metrics(self):
+                return ResourceMetrics(
+                    timestamp="2026-05-08T00:00:00+00:00",
+                    cpu_percent=12.5,
+                    memory_percent=34.0,
+                    disk_percent=56.0,
+                    network_io={"bytes_sent": 1234, "bytes_recv": 5678},
+                    quantum_circuit_queue=2,
+                    api_rate_limit_remaining={},
+                    active_processes=9
+                )
+
+            async def analyze_and_optimize(self):
+                return [
+                    OptimizationAction(
+                        action_type="rebalance",
+                        resource_target="cpu",
+                        reason="test",
+                        priority="low",
+                        estimated_impact="test impact"
+                    )
+                ]
+
+        monkeypatch.setattr(subroutines, "ResourceOptimizationManager", StubResourceOptimizationManager)
+
+        result = await analyze_resources(
+            ResourceMetricsRequest(
+                include_network=True,
+                include_quantum=True
+            )
+        )
+
+        checks = unittest.TestCase()
+        checks.assertIs(result["success"], True)
+
+        metrics = result["metrics"]
+        checks.assertEqual(metrics["network_io_sent"], 1234)
+        checks.assertEqual(metrics["network_io_recv"], 5678)
+        checks.assertEqual(metrics["quantum_circuit_queue"], 2)
+        checks.assertEqual(metrics["active_processes"], 9)
+
 
 class TestAnomalyDetectionEngine:
     """Tests for Anomaly Detection Engine subroutine"""


### PR DESCRIPTION
## Summary

Fixes #601.

This updates `resources/analyze` to serialize network counters from the nested `ResourceMetrics.network_io` mapping instead of reading nonexistent flat `network_io_sent` / `network_io_recv` attributes.

## Root Cause

`ResourceMetrics` stores network counters as `network_io={"bytes_sent": ..., "bytes_recv": ...}`. The API endpoint was still using stale flat attribute names, causing `AttributeError` when `include_network=True`.

## Validation

- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py::TestResourceOptimizationManager::test_resource_analysis_endpoint_serializes_network_io -q`
- `./.venv/bin/flake8 src/subroutines/api_enhanced.py tests/test_subroutines_integration.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293`
- `git diff --check`
- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py -q` outside the sandbox: 14 passed, 6 xfailed