### PR TITLE
fix: use performance report endpoint

### DIFF
--- a/src/subroutines/api_enhanced.py
+++ b/src/subroutines/api_enhanced.py
@@ -368,7 +368,7 @@ async def get_performance_profile() -> Dict[str, Any]:
         from src.subroutines import PerformanceProfiler
         
         profiler = PerformanceProfiler()
-        stats = profiler.get_profiler_stats()
+        stats = profiler.get_performance_report()
         
         return {
             "success": True,

--- a/tests/test_subroutines_integration.py
+++ b/tests/test_subroutines_integration.py
@@ -367,6 +367,23 @@ class TestDependencyHealthMonitor:
 
 class TestPerformanceProfiler:
     """Tests for Performance Profiler subroutine"""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_performance_profile_endpoint_uses_report_method(self):
+        """Test performance profile endpoint returns the implemented report schema."""
+        from src.subroutines.api_enhanced import get_performance_profile
+
+        result = await get_performance_profile()
+
+        checks = unittest.TestCase()
+        checks.assertIs(result["success"], True)
+
+        profile = result["performance_profile"]
+        checks.assertIn("timestamp", profile)
+        checks.assertEqual(profile["operations_profiled"], 0)
+        checks.assertEqual(profile["slow_operations_detected"], 0)
+        checks.assertEqual(profile["profiles"], {})
     
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #602.

This updates `/performance/profile` to call the implemented `PerformanceProfiler.get_performance_report()` method instead of the nonexistent `get_profiler_stats()` method.

## Root Cause

`PerformanceProfiler` exposes `get_performance_report()` as its report API. The endpoint had a stale method name, which raised `AttributeError` on every request.

## Validation

- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py::TestPerformanceProfiler::test_performance_profile_endpoint_uses_report_method -q`
- `./.venv/bin/flake8 src/subroutines/api_enhanced.py tests/test_subroutines_integration.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293`
- `git diff --check`
- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py -q` outside the sandbox: 15 passed, 6 xfailed