### PR TITLE
fix: parse ethics condition operators safely

### DIFF
--- a/src/monitoring/ethics_engine.py
+++ b/src/monitoring/ethics_engine.py
@@ -321,14 +321,15 @@ class EthicsEngine:
         
         # Parse comparison expressions (e.g., "action_type == 'forbidden_action'")
         # Also check context attributes like action_type, agent_id
-        for op in ['==', '!=', '>', '<', '>=', '<=']:
+        for op in ['>=', '<=', '==', '!=', '>', '<']:
             if op in condition:
-                parts = condition.split(op)
+                parts = condition.split(op, 1)
                 if len(parts) == 2:
                     param, threshold = parts[0].strip(), parts[1].strip()
                     if param in context.parameters:
+                        param_value = context.parameters[param]
                         try:
-                            param_value = float(context.parameters[param])
+                            param_value = float(param_value)
                             threshold_value = float(threshold)
                             
                             if op == '>':
@@ -353,7 +354,7 @@ class EthicsEngine:
         # Check context attributes (action_type, agent_id) for comparison conditions
         for op in ['==', '!=']:
             if op in condition:
-                parts = condition.split(op)
+                parts = condition.split(op, 1)
                 if len(parts) == 2:
                     attr_name = parts[0].strip()
                     expected_value = parts[1].strip().strip("'\"")

--- a/tests/test_ethics_engine.py
+++ b/tests/test_ethics_engine.py
@@ -2,12 +2,13 @@
 Tests for Ethics Engine
 """
 
-import pytest
+import unittest
 from pathlib import Path
+
+import pytest
 from src.monitoring.ethics_engine import (
     EthicsEngine,
     EthicsRule,
-    EthicsViolation,
     ActionContext,
     ViolationSeverity,
     RuleCategory
@@ -246,6 +247,35 @@ class TestEthicsEngine:
             None
         )
         assert resource_violation is not None
+
+    @pytest.mark.parametrize(
+        ("condition", "value", "expected"),
+        [
+            ("score > 0.5", 0.51, True),
+            ("score > 0.5", 0.5, False),
+            ("score < 0.5", 0.49, True),
+            ("score < 0.5", 0.5, False),
+            ("score >= 0.5", 0.5, True),
+            ("score >= 0.5", 0.49, False),
+            ("score <= 0.5", 0.5, True),
+            ("score <= 0.5", 0.51, False),
+            ("score == 0.5", 0.5, True),
+            ("score == 0.5", 0.51, False),
+            ("score != 0.5", 0.51, True),
+            ("score != 0.5", 0.5, False),
+        ],
+    )
+    def test_condition_operator_boundaries(self, condition, value, expected):
+        """Test comparison operators parse longest-first and respect boundary values."""
+        engine = EthicsEngine()
+        context = ActionContext(
+            agent_id="test-agent",
+            action_type="resource_allocation",
+            parameters={"score": value}
+        )
+
+        checks = unittest.TestCase()
+        checks.assertIs(engine._check_condition(condition, context), expected)
     
     def test_violation_remediation(self):
         """Test remediation suggestions"""


### PR DESCRIPTION
## Summary

Fixes #592.

This updates `EthicsEngine._check_condition()` to parse comparison operators longest-first and split only once, so two-character operators such as `>=` and `<=` cannot be partially matched as `>` or `<`.

## Root Cause

The condition parser checked one-character operators before two-character operators. A condition like `score >= 0.5` could match `>` first, splitting the expression into an invalid threshold and silently avoiding the intended ethics rule evaluation.

## Validation

- `./.venv/bin/python -m pytest tests/test_ethics_engine.py::TestEthicsEngine::test_condition_operator_boundaries -q`
- `./.venv/bin/python -m pytest tests/test_ethics_engine.py::TestEthicsEngine::test_condition_comparison_operators -q`
- `./.venv/bin/python -m pytest tests/test_ethics_engine.py -q`
- `./.venv/bin/flake8 src/monitoring/ethics_engine.py tests/test_ethics_engine.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293`
- `git diff --check`

## Local Test Note

- `./.venv/bin/python -m pytest tests/test_gumas_ethics.py -q` was attempted but the local `.venv` is missing `slowapi`, so that API-level suite cannot import `src.middleware.fastapi_security` in this environment.