### PR TITLE
fix: fail fast on Sonnet config load errors

### DIFF
--- a/modules/symbolic_core/sonnet4_integration_hub.py
+++ b/modules/symbolic_core/sonnet4_integration_hub.py
@@ -46,11 +46,21 @@ class Sonnet4IntegrationHub:
     def _load_config(self) -> Dict[str, Any]:
         """Load configuration from YAML file"""
         try:
-            with open(self.config_path, "r") as f:
-                return yaml.safe_load(f)
-        except Exception as e:
-            logger.error("Failed to load config: %s", str(e)[:100])
-            return {}
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Config file not found: {self.config_path}") from exc
+        except yaml.YAMLError as exc:
+            raise RuntimeError(f"Malformed config YAML in {self.config_path}: {exc}") from exc
+        except OSError as exc:
+            raise RuntimeError(f"Failed to load config {self.config_path}: {exc}") from exc
+
+        if config is None:
+            raise RuntimeError(f"Config file is empty: {self.config_path}")
+        if not isinstance(config, dict):
+            raise RuntimeError(f"Config root must be a mapping: {self.config_path}")
+
+        return config
 
     def _parse_sonnet4_config(self) -> Sonnet4Config:
         """Parse Sonnet 4 specific configuration"""
@@ -151,46 +161,48 @@ class Sonnet4IntegrationHub:
 
     async def _update_config(self):
         """Update configuration file with current Sonnet 4 settings"""
+        if not isinstance(self.config, dict):
+            raise RuntimeError("Cannot update Sonnet 4 config because loaded config is not a mapping")
+
+        self.config["claude_sonnet4"] = {
+            "enabled": self.sonnet4_config.enabled,
+            "enable_for_all_clients": self.sonnet4_config.enable_for_all_clients,
+            "api_version": self.sonnet4_config.api_version,
+            "model": self.sonnet4_config.model,
+            "features": {
+                "quantum_bridge": True,
+                "symbolic_validation": True,
+                "ethics_security": True,
+                "reflective_autonomy": True,
+                "enhanced_reasoning": True,
+            },
+            "settings": {
+                "max_tokens": self.sonnet4_config.max_tokens,
+                "temperature": self.sonnet4_config.temperature,
+                "top_p": self.sonnet4_config.top_p,
+                "safety_level": self.sonnet4_config.safety_level,
+                "context_window": self.sonnet4_config.context_window,
+            },
+            "integration": {
+                "aurora_compatibility": True,
+                "preserve_4o_logic": self.sonnet4_config.preserve_4o_logic,
+                "conflict_resolution": "merge_enhanced",
+                "fallback_model": self.sonnet4_config.fallback_model,
+            },
+            "security": {
+                "ethics_validation": True,
+                "output_filtering": True,
+                "content_safety": True,
+                "data_privacy": True,
+            },
+        }
+
+        # Use async file I/O to avoid blocking event loop
         try:
-            self.config["claude_sonnet4"] = {
-                "enabled": self.sonnet4_config.enabled,
-                "enable_for_all_clients": self.sonnet4_config.enable_for_all_clients,
-                "api_version": self.sonnet4_config.api_version,
-                "model": self.sonnet4_config.model,
-                "features": {
-                    "quantum_bridge": True,
-                    "symbolic_validation": True,
-                    "ethics_security": True,
-                    "reflective_autonomy": True,
-                    "enhanced_reasoning": True,
-                },
-                "settings": {
-                    "max_tokens": self.sonnet4_config.max_tokens,
-                    "temperature": self.sonnet4_config.temperature,
-                    "top_p": self.sonnet4_config.top_p,
-                    "safety_level": self.sonnet4_config.safety_level,
-                    "context_window": self.sonnet4_config.context_window,
-                },
-                "integration": {
-                    "aurora_compatibility": True,
-                    "preserve_4o_logic": self.sonnet4_config.preserve_4o_logic,
-                    "conflict_resolution": "merge_enhanced",
-                    "fallback_model": self.sonnet4_config.fallback_model,
-                },
-                "security": {
-                    "ethics_validation": True,
-                    "output_filtering": True,
-                    "content_safety": True,
-                    "data_privacy": True,
-                },
-            }
-
-            # Use async file I/O to avoid blocking event loop
-            async with aiofiles.open(self.config_path, "w") as f:
-                await f.write(yaml.dump(self.config, default_flow_style=False))
-
-        except Exception as e:
-            logger.error("Failed to update config: %s", str(e)[:100])
+            async with aiofiles.open(self.config_path, "w", encoding="utf-8") as f:
+                await f.write(yaml.safe_dump(self.config, default_flow_style=False))
+        except OSError as exc:
+            raise RuntimeError(f"Failed to update config {self.config_path}: {exc}") from exc
 
     def get_client_status(self, client_id: str) -> Dict[str, Any]:
         """Get Sonnet 4 status for a specific client"""

--- a/tests/test_sonnet4_enhancements.py
+++ b/tests/test_sonnet4_enhancements.py
@@ -3,7 +3,12 @@ Tests for Sonnet 4 Enhancements
 Placeholder test implementation
 """
 
+import asyncio
+from pathlib import Path
+import tempfile
 import unittest
+
+import yaml
 
 
 class TestSonnet4Enhancements(unittest.TestCase):
@@ -20,6 +25,55 @@ class TestSonnet4Enhancements(unittest.TestCase):
     def test_ethics_security(self):
         """Test ethics and security validation"""
         self.assertTrue(True)
+
+    def test_missing_config_fails_fast(self):
+        """Test missing config does not silently fall back to partial defaults."""
+        from modules.symbolic_core.sonnet4_integration_hub import Sonnet4IntegrationHub
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing_config = Path(temp_dir) / "missing_symbolic_config.yaml"
+
+            with self.assertRaisesRegex(RuntimeError, "Config file not found"):
+                Sonnet4IntegrationHub(config_path=str(missing_config))
+
+    def test_malformed_config_fails_fast(self):
+        """Test malformed config cannot be overwritten by a later update."""
+        from modules.symbolic_core.sonnet4_integration_hub import Sonnet4IntegrationHub
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "symbolic_config.yaml"
+            config_path.write_text("claude_sonnet4: [unterminated\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "Malformed config YAML"):
+                Sonnet4IntegrationHub(config_path=str(config_path))
+
+    def test_update_config_preserves_other_yaml_keys(self):
+        """Test Sonnet 4 updates preserve unrelated symbolic config sections."""
+        from modules.symbolic_core.sonnet4_integration_hub import Sonnet4IntegrationHub
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "symbolic_config.yaml"
+            original_config = {
+                "aurora_gui": {
+                    "load_on_startup": True,
+                    "routing": {"api_endpoint": "/api/symbolic"},
+                },
+                "claude_sonnet4": {
+                    "enabled": True,
+                    "enable_for_all_clients": False,
+                    "api_version": "2024-06-01",
+                    "model": "claude-3-5-sonnet-20241022",
+                },
+            }
+            config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+
+            hub = Sonnet4IntegrationHub(config_path=str(config_path))
+            hub.sonnet4_config.enable_for_all_clients = True
+            asyncio.run(hub._update_config())
+
+            updated_config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(updated_config["aurora_gui"], original_config["aurora_gui"])
+            self.assertTrue(updated_config["claude_sonnet4"]["enable_for_all_clients"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fail fast when Sonnet 4 config files are missing, malformed, empty, or not YAML mappings
- preserve unrelated YAML sections when writing the `claude_sonnet4` stanza
- add regressions for missing config, malformed config, and preservation of unrelated config keys

## Root cause
`_load_config()` caught all exceptions and returned `{}`. A later `_update_config()` call then wrote only the generated `claude_sonnet4` stanza, which could overwrite the full symbolic config with a partial file.

## Validation
- `./.venv/bin/python -m pytest tests/test_sonnet4_enhancements.py -q`
- `./.venv/bin/flake8 modules/symbolic_core/sonnet4_integration_hub.py tests/test_sonnet4_enhancements.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293`
- `git diff --check`

Fixes #591