### PR TITLE
fix: report ethics block decisions separately

### DIFF
--- a/src/subroutines/api_enhanced.py
+++ b/src/subroutines/api_enhanced.py
@@ -74,6 +74,7 @@ async def check_ethics_compliance(request: EthicsCheckRequest) -> Dict[str, Any]
             "operation_id": result.operation_id,
             "ethics_score": result.ethics_score,
             "threshold": result.threshold,
+            "blocked": result.blocked,
             "violations": result.violations,
             "warnings": result.warnings,
             "timestamp": result.timestamp

--- a/src/subroutines/ethics_compliance_monitor.py
+++ b/src/subroutines/ethics_compliance_monitor.py
@@ -30,6 +30,7 @@ class EthicsCheckResult:
     warnings: List[str]
     timestamp: str
     metadata: Dict[str, Any]
+    blocked: bool = False
 
 
 class EthicsComplianceMonitor:
@@ -74,6 +75,7 @@ class EthicsComplianceMonitor:
         self._checks_performed = 0
         self._violations_detected = 0
         self._operations_blocked = 0
+        self._blocked_operation_ids = set()
 
     def _get_default_ethics_gate(self):
         """Get default ethics gate"""
@@ -162,16 +164,18 @@ class EthicsComplianceMonitor:
             # Check thresholds
             threshold = self.config.get("ethics_threshold", 0.7)
             critical_threshold = self.config.get("critical_threshold", 0.5)
+            auto_block_enabled = self.config.get("auto_block_enabled", False)
             
             warnings = []
             if ethics_score < threshold:
                 warnings.append(f"Ethics score {ethics_score:.2f} below threshold {threshold}")
             
+            blocked = auto_block_enabled and ethics_score < critical_threshold
+
             if ethics_score < critical_threshold:
                 self._violations_detected += 1
-                if self.config.get("auto_block_enabled"):
-                    self._operations_blocked += 1
-                    warnings.append("CRITICAL: Operation auto-blocked")
+                if blocked:
+                    warnings.append("CRITICAL: Operation block required")
                 
                 # Alert on critical violations
                 if self.alert_system and self.config.get("alert_on_violation"):
@@ -180,11 +184,11 @@ class EthicsComplianceMonitor:
             # Audit trail
             if self.audit_log and self.config.get("audit_all_checks"):
                 self._log_compliance_check(
-                    operation_id, operation_type, ethics_score, violations
+                    operation_id, operation_type, ethics_score, violations, blocked
                 )
             
             result = EthicsCheckResult(
-                success=approved and ethics_score >= threshold,
+                success=approved and ethics_score >= threshold and not blocked,
                 operation_id=operation_id,
                 ethics_score=ethics_score,
                 threshold=threshold,
@@ -194,8 +198,11 @@ class EthicsComplianceMonitor:
                 metadata={
                     "operation_type": operation_type,
                     "verdict": verdict,
-                    "context_keys": list(operation_context.keys())
-                }
+                    "context_keys": list(operation_context.keys()),
+                    "auto_block_enabled": auto_block_enabled,
+                    "critical_threshold": critical_threshold
+                },
+                blocked=blocked
             )
             
             logger.info(
@@ -215,7 +222,8 @@ class EthicsComplianceMonitor:
                 violations=[{"type": "check_failure", "message": str(e)}],
                 warnings=["Ethics check system error"],
                 timestamp=timestamp,
-                metadata={"error": str(e)}
+                metadata={"error": str(e)},
+                blocked=False
             )
 
     async def _send_alert(self, operation_id: str, score: float, violations: List):
@@ -241,7 +249,8 @@ class EthicsComplianceMonitor:
         operation_id: str,
         operation_type: str,
         score: float,
-        violations: List
+        violations: List,
+        blocked: bool = False
     ):
         """Log compliance check to audit trail"""
         if not self.audit_log:
@@ -254,13 +263,33 @@ class EthicsComplianceMonitor:
                     "operation_id": operation_id,
                     "operation_type": operation_type,
                     "ethics_score": score,
-                    "violations": violations
+                    "violations": violations,
+                    "blocked": blocked
                 },
                 context_tag=f"ethics_check_{operation_id}",
                 symbolic_validation=True
             )
         except Exception as e:
             logger.error("Failed to log compliance check: %s", str(e))
+
+    def record_operation_blocked(self, result: EthicsCheckResult) -> bool:
+        """
+        Record that a caller actually halted a blocked operation.
+
+        check_operation_ethics() only reports whether the ethics gate requires
+        blocking. This method should be called after the caller enforces that
+        decision, keeping operations_blocked tied to an actual halted action.
+        """
+        if not result.blocked:
+            return False
+
+        if result.operation_id in self._blocked_operation_ids:
+            return False
+
+        self._blocked_operation_ids.add(result.operation_id)
+        self._operations_blocked += 1
+        logger.info("Ethics block enforced: operation=%s", result.operation_id)
+        return True
 
     def get_compliance_stats(self) -> Dict[str, Any]:
         """Get compliance monitoring statistics"""
@@ -280,6 +309,7 @@ class EthicsComplianceMonitor:
         self._checks_performed = 0
         self._violations_detected = 0
         self._operations_blocked = 0
+        self._blocked_operation_ids.clear()
         logger.info("Compliance statistics reset")
 
 

--- a/tests/test_subroutines_integration.py
+++ b/tests/test_subroutines_integration.py
@@ -13,6 +13,16 @@ import asyncio
 import unittest
 
 
+class StubEthicsGate:
+    """Controllable async ethics gate for focused monitor tests."""
+
+    def __init__(self, verdict):
+        self.verdict = verdict
+
+    async def evaluate(self, action, context):
+        return self.verdict
+
+
 class TestEthicsComplianceMonitor:
     """Tests for Ethics Compliance Monitor subroutine"""
     
@@ -33,6 +43,123 @@ class TestEthicsComplianceMonitor:
         assert hasattr(result, 'success')
         assert hasattr(result, 'ethics_score')
         assert hasattr(result, 'violations')
+        checks = unittest.TestCase()
+        checks.assertTrue(hasattr(result, 'blocked'))
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_critical_score_requires_block_without_counting_unhalted_operation(self):
+        """Test passive checks do not count a block until a caller enforces it."""
+        from src.subroutines import EthicsComplianceMonitor
+
+        monitor = EthicsComplianceMonitor(
+            ethics_gate=StubEthicsGate({
+                "approved": False,
+                "score": 0.2,
+                "violations": [{"rule": "critical_test"}],
+            }),
+            audit_log=None,
+            alert_system=None,
+            config={
+                "ethics_threshold": 0.7,
+                "critical_threshold": 0.5,
+                "auto_block_enabled": True,
+                "alert_on_violation": False,
+                "audit_all_checks": False,
+            },
+        )
+
+        result = await monitor.check_operation_ethics(
+            operation_id="critical_op_001",
+            operation_type="state_modification",
+            operation_context={"resource": "critical_state"},
+        )
+
+        checks = unittest.TestCase()
+        checks.assertIs(result.success, False)
+        checks.assertIs(result.blocked, True)
+        checks.assertIn("CRITICAL: Operation block required", result.warnings)
+
+        stats = monitor.get_compliance_stats()
+        checks.assertEqual(stats["violations_detected"], 1)
+        checks.assertEqual(stats["operations_blocked"], 0)
+
+        checks.assertIs(monitor.record_operation_blocked(result), True)
+        checks.assertEqual(monitor.get_compliance_stats()["operations_blocked"], 1)
+
+        checks.assertIs(monitor.record_operation_blocked(result), False)
+        checks.assertEqual(monitor.get_compliance_stats()["operations_blocked"], 1)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_critical_score_without_auto_block_does_not_set_blocked(self):
+        """Test critical verdicts remain non-blocking when auto-block is disabled."""
+        from src.subroutines import EthicsComplianceMonitor
+
+        monitor = EthicsComplianceMonitor(
+            ethics_gate=StubEthicsGate({
+                "approved": False,
+                "score": 0.2,
+                "violations": [{"rule": "critical_test"}],
+            }),
+            audit_log=None,
+            alert_system=None,
+            config={
+                "ethics_threshold": 0.7,
+                "critical_threshold": 0.5,
+                "auto_block_enabled": False,
+                "alert_on_violation": False,
+                "audit_all_checks": False,
+            },
+        )
+
+        result = await monitor.check_operation_ethics(
+            operation_id="critical_op_002",
+            operation_type="state_modification",
+            operation_context={"resource": "critical_state"},
+        )
+
+        checks = unittest.TestCase()
+        checks.assertIs(result.success, False)
+        checks.assertIs(result.blocked, False)
+        checks.assertIs(monitor.record_operation_blocked(result), False)
+        checks.assertEqual(monitor.get_compliance_stats()["operations_blocked"], 0)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_ethics_endpoint_exposes_blocked_verdict(self, monkeypatch):
+        """Test endpoint response includes the enforcement gate verdict."""
+        import src.subroutines as subroutines
+        from src.subroutines.api_enhanced import EthicsCheckRequest, check_ethics_compliance
+        from src.subroutines.ethics_compliance_monitor import EthicsCheckResult
+
+        class StubMonitor:
+            async def check_operation_ethics(self, operation_id, operation_type, operation_context):
+                return EthicsCheckResult(
+                    success=False,
+                    operation_id=operation_id,
+                    ethics_score=0.2,
+                    threshold=0.7,
+                    violations=[],
+                    warnings=["CRITICAL: Operation block required"],
+                    timestamp="2026-05-08T00:00:00+00:00",
+                    metadata={"operation_type": operation_type},
+                    blocked=True,
+                )
+
+        monkeypatch.setattr(subroutines, "EthicsComplianceMonitor", StubMonitor)
+
+        result = await check_ethics_compliance(
+            EthicsCheckRequest(
+                operation_id="critical_op_003",
+                operation_type="state_modification",
+                operation_context={"resource": "critical_state"},
+            )
+        )
+
+        checks = unittest.TestCase()
+        checks.assertIs(result["success"], False)
+        checks.assertIs(result["blocked"], True)
     
     @pytest.mark.unit
     def test_ethics_stats(self):


### PR DESCRIPTION
## Summary
- add `blocked` to `EthicsCheckResult` so callers can distinguish a failed ethics verdict from an enforcement gate decision
- stop incrementing `operations_blocked` during passive checks; record it only through `record_operation_blocked()` after a caller actually halts the operation
- expose `blocked` from the ethics check API response and add regressions for critical block decisions, disabled auto-blocking, endpoint serialization, and duplicate enforcement receipts

## Root cause
`EthicsComplianceMonitor.check_operation_ethics()` incremented `operations_blocked` as soon as a critical score was detected with auto-block enabled. The method only produced a verdict and did not halt the caller's operation, so the compliance stats could claim a block that never happened.

## Validation
- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py::TestEthicsComplianceMonitor -q`
- `./.venv/bin/python -m pytest tests/test_subroutines_integration.py -q` outside sandbox for psutil process-list access
- `./.venv/bin/python -m pytest tests/test_subroutines_quick.py -q` outside sandbox for psutil process-list access
- `./.venv/bin/flake8 src/subroutines/ethics_compliance_monitor.py src/subroutines/api_enhanced.py tests/test_subroutines_integration.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293`
- `git diff --check`

Fixes #590