### PR TITLE
fix: record intervention enforcement outcomes

### DIFF
--- a/src/monitoring/audit_logger.py
+++ b/src/monitoring/audit_logger.py
@@ -9,7 +9,7 @@ import hashlib
 import hmac
 import json
 import logging
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -222,7 +222,9 @@ class AuditLogger:
         intervention_type: str,
         action_taken: str,
         reason: str,
-        context_tag: Optional[str] = None
+        context_tag: Optional[str] = None,
+        success: Optional[bool] = None,
+        error: Optional[str] = None
     ) -> AuditEntry:
         """
         Log automated intervention
@@ -234,20 +236,28 @@ class AuditLogger:
             action_taken: Action that was taken
             reason: Reason for intervention
             context_tag: DLP context tag
+            success: Whether the enforcement action was confirmed
+            error: Failure reason when enforcement was not confirmed
         
         Returns:
             Created audit entry
         """
+        data = {
+            'intervention_type': intervention_type,
+            'action_taken': action_taken,
+            'reason': reason
+        }
+        if success is not None:
+            data['success'] = success
+        if error:
+            data['error'] = error
+
         return self._create_entry(
             event_type=AuditEventType.INTERVENTION,
             agent_id=agent_id,
             severity=severity,
             description=f"Intervention: {intervention_type}",
-            data={
-                'intervention_type': intervention_type,
-                'action_taken': action_taken,
-                'reason': reason
-            },
+            data=data,
             context_tag=context_tag
         )
     

--- a/src/monitoring/monitoring_system.py
+++ b/src/monitoring/monitoring_system.py
@@ -58,6 +58,7 @@ class Intervention:
     reason: str
     context: Dict[str, Any]
     success: bool
+    error: Optional[str] = None
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary"""
@@ -109,6 +110,7 @@ class MonitoringSystem:
         # Intervention tracking
         self.interventions: List[Intervention] = []
         self.last_intervention_time: Dict[str, datetime] = {}
+        self._enforcement_handlers: Dict[InterventionType, Callable] = {}
         
         # Alert handlers
         self.alert_handlers: Dict[AlertLevel, List[Callable]] = {
@@ -118,6 +120,20 @@ class MonitoringSystem:
         }
         
         logger.info("Monitoring system initialized (storage=%s)", storage_dir)
+
+    def register_enforcement_handler(
+        self,
+        intervention_type: InterventionType,
+        handler: Callable
+    ):
+        """
+        Register a concrete handler for an automated intervention type.
+
+        Handlers receive agent_id and should return True only after the
+        enforcement action is complete.
+        """
+        self._enforcement_handlers[intervention_type] = handler
+        logger.info("Registered enforcement handler for %s", intervention_type.value)
     
     def register_alert_handler(self, level: AlertLevel, handler: Callable):
         """
@@ -348,34 +364,72 @@ class MonitoringSystem:
         reason: str
     ):
         """Execute an automated intervention"""
+        success = False
+        error = None
+        handler = self._enforcement_handlers.get(intervention_type)
+
+        if handler:
+            try:
+                success = self._run_enforcement_handler(
+                    handler,
+                    agent_id=agent_id
+                )
+            except Exception as exc:
+                error = str(exc)
+                logger.error(
+                    "Intervention handler failed for %s on %s: %s",
+                    intervention_type.value, agent_id, error
+                )
+        else:
+            error = f"No enforcement handler registered for {intervention_type.value}"
+
         intervention = Intervention(
             timestamp=utc_iso(),
             agent_id=agent_id,
             type=intervention_type,
             reason=reason,
             context={},
-            success=True  # Would be set based on actual execution
+            success=success,
+            error=error
         )
         
         self.interventions.append(intervention)
-        self.last_intervention_time[agent_id] = utc_now()
+        if success:
+            self.last_intervention_time[agent_id] = utc_now()
         
         # Log to audit
         self.audit_logger.log_intervention(
             agent_id=agent_id,
             severity="critical",
             intervention_type=intervention_type.value,
-            action_taken=intervention_type.value,
-            reason=reason
+            action_taken=intervention_type.value if success else "not_executed",
+            reason=reason,
+            success=success,
+            error=error
         )
         
         logger.warning(
-            "Intervention executed for %s: %s - %s",
-            agent_id, intervention_type.value, reason
+            "Intervention recorded for %s: %s success=%s - %s",
+            agent_id, intervention_type.value, success, reason
         )
         
         # Notify critical handlers
         self._notify_handlers(AlertLevel.CRITICAL, intervention.to_dict())
+
+    def _run_enforcement_handler(
+        self,
+        handler: Callable,
+        agent_id: str
+    ) -> bool:
+        """Run a registered enforcement handler and normalize its result."""
+        result = handler(agent_id)
+
+        if isinstance(result, dict):
+            if not result.get("success", False) and result.get("error"):
+                raise RuntimeError(str(result["error"]))
+            return bool(result.get("success", False))
+
+        return bool(result)
     
     def _map_drift_to_alert_level(self, drift_level: DriftLevel) -> AlertLevel:
         """Map drift level to alert level"""

--- a/tests/test_monitoring_system.py
+++ b/tests/test_monitoring_system.py
@@ -3,6 +3,7 @@ Tests for Integrated Monitoring System
 """
 
 import pytest
+import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from datetime import datetime, timedelta, timezone
@@ -243,6 +244,91 @@ class TestMonitoringSystem:
             
             # No intervention should be recorded
             assert len(monitoring.interventions) == 0
+
+    def test_intervention_without_handler_records_failed_audit_receipt(self):
+        """Test interventions are not marked successful without enforcement."""
+        with TemporaryDirectory() as tmpdir:
+            monitoring = MonitoringSystem(storage_dir=Path(tmpdir))
+
+            monitoring._execute_intervention(
+                agent_id="test-agent",
+                intervention_type=InterventionType.SUSPEND_AGENT,
+                reason="critical drift"
+            )
+
+            checks = unittest.TestCase()
+            checks.assertEqual(len(monitoring.interventions), 1)
+            intervention = monitoring.interventions[0]
+            checks.assertIs(intervention.success, False)
+            checks.assertIn("No enforcement handler registered", intervention.error)
+            checks.assertNotIn("test-agent", monitoring.last_intervention_time)
+
+            audit_entry = monitoring.audit_logger.entries[-1]
+            checks.assertEqual(audit_entry.data["intervention_type"], "suspend_agent")
+            checks.assertEqual(audit_entry.data["action_taken"], "not_executed")
+            checks.assertIs(audit_entry.data["success"], False)
+            checks.assertIn("No enforcement handler registered", audit_entry.data["error"])
+
+    def test_registered_intervention_handler_records_success(self):
+        """Test successful intervention receipts require handler confirmation."""
+        with TemporaryDirectory() as tmpdir:
+            monitoring = MonitoringSystem(storage_dir=Path(tmpdir))
+            handled = []
+
+            def suspend_handler(agent_id):
+                handled.append(agent_id)
+                return True
+
+            monitoring.register_enforcement_handler(
+                InterventionType.SUSPEND_AGENT,
+                suspend_handler
+            )
+            monitoring._execute_intervention(
+                agent_id="test-agent",
+                intervention_type=InterventionType.SUSPEND_AGENT,
+                reason="critical drift"
+            )
+
+            checks = unittest.TestCase()
+            checks.assertEqual(handled, ["test-agent"])
+            intervention = monitoring.interventions[0]
+            checks.assertIs(intervention.success, True)
+            checks.assertIsNone(intervention.error)
+            checks.assertIn("test-agent", monitoring.last_intervention_time)
+
+            audit_entry = monitoring.audit_logger.entries[-1]
+            checks.assertEqual(audit_entry.data["action_taken"], "suspend_agent")
+            checks.assertIs(audit_entry.data["success"], True)
+            checks.assertNotIn("error", audit_entry.data)
+
+    def test_intervention_handler_exception_records_failed_receipt(self):
+        """Test handler errors are preserved as failed audit receipts."""
+        with TemporaryDirectory() as tmpdir:
+            monitoring = MonitoringSystem(storage_dir=Path(tmpdir))
+
+            def failing_handler(agent_id):
+                raise RuntimeError("suspension backend unavailable")
+
+            monitoring.register_enforcement_handler(
+                InterventionType.SUSPEND_AGENT,
+                failing_handler
+            )
+            monitoring._execute_intervention(
+                agent_id="test-agent",
+                intervention_type=InterventionType.SUSPEND_AGENT,
+                reason="critical drift"
+            )
+
+            checks = unittest.TestCase()
+            intervention = monitoring.interventions[0]
+            checks.assertIs(intervention.success, False)
+            checks.assertEqual(intervention.error, "suspension backend unavailable")
+            checks.assertNotIn("test-agent", monitoring.last_intervention_time)
+
+            audit_entry = monitoring.audit_logger.entries[-1]
+            checks.assertEqual(audit_entry.data["action_taken"], "not_executed")
+            checks.assertIs(audit_entry.data["success"], False)
+            checks.assertEqual(audit_entry.data["error"], "suspension backend unavailable")
     
     def test_audit_log_integrity(self):
         """Test audit log maintains integrity"""


### PR DESCRIPTION
## Summary
- stop marking automated monitoring interventions as successful by default
- add explicit enforcement handlers so `success=True` is recorded only after a handler confirms the action completed
- record failed/no-handler intervention attempts as `success=False` with `action_taken=not_executed` and an audit error
- add regressions for no-handler, successful handler, and handler-exception intervention receipts

## Root cause
`MonitoringSystem._execute_intervention()` always created `Intervention(..., success=True)` and wrote the intervention type as the audit `action_taken`, even though no enforcement backend was invoked. The compliance report and hash-chained audit log could therefore claim a suspend/block action occurred when it did not.

## Validation
- `./.venv/bin/python -m pytest tests/test_monitoring_system.py -q`
- `./.venv/bin/flake8 src/monitoring/monitoring_system.py src/monitoring/audit_logger.py tests/test_monitoring_system.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293`
- `git diff --check`

Fixes #605