### PR TITLE
fix: secure subroutine API execution surface

### DIFF
--- a/src/subroutines/api.py
+++ b/src/subroutines/api.py
@@ -10,10 +10,13 @@ FastAPI router for subroutine management and execution.
 Provides endpoints for registering, querying, and monitoring subroutines.
 """
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import APIKeyHeader
 from typing import Dict, Any, List, Optional
 from pydantic import BaseModel, Field
+import hmac
 import logging
+import os
 import time
 
 from src.subroutines.registry import (
@@ -28,6 +31,39 @@ from src.subroutines.registry import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/subroutines", tags=["subroutines"])
+
+SUBROUTINE_API_KEY_ENV = "AURORA_SUBROUTINE_API_KEY"
+SUBROUTINE_API_KEY_FALLBACK_ENV = "AURORA_API_KEY"
+SUBROUTINE_API_KEY_HEADER = "X-API-Key"
+ALLOWED_SUBROUTINE_MODULE_PREFIXES = ("src.subroutines.", "modules.")
+
+api_key_header = APIKeyHeader(name=SUBROUTINE_API_KEY_HEADER, auto_error=False)
+
+
+def verify_subroutine_api_key(api_key: Optional[str] = Depends(api_key_header)) -> None:
+    """Require an API key for mutation and execution endpoints."""
+    expected_key = os.getenv(SUBROUTINE_API_KEY_ENV) or os.getenv(SUBROUTINE_API_KEY_FALLBACK_ENV)
+    if not expected_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Subroutine API key is not configured",
+        )
+    if not api_key or not hmac.compare_digest(api_key, expected_key):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid subroutine API key",
+        )
+
+
+def validate_subroutine_module_path(module_path: str) -> None:
+    """Reject dynamic imports outside the approved subroutine module namespaces."""
+    if module_path.startswith(ALLOWED_SUBROUTINE_MODULE_PREFIXES):
+        return
+    logger.warning("Rejected non-allowlisted subroutine module path")
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Subroutine module path is not allowed",
+    )
 
 
 # Pydantic Models for API
@@ -86,7 +122,11 @@ class SubroutineSearchRequest(BaseModel):
     tags: Optional[List[str]] = Field(None, description="Filter by tags")
 
 
-@router.post("/register", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/register",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(verify_subroutine_api_key)],
+)
 async def register_subroutine(request: SubroutineCreate) -> Dict[str, Any]:
     """
     Register a new subroutine in the system.
@@ -96,6 +136,7 @@ async def register_subroutine(request: SubroutineCreate) -> Dict[str, Any]:
     """
     try:
         registry = get_subroutine_registry()
+        validate_subroutine_module_path(request.module_path)
         
         # Convert category string to enum
         try:
@@ -313,7 +354,7 @@ async def search_subroutines(request: SubroutineSearchRequest) -> Dict[str, Any]
         )
 
 
-@router.put("/status/{subroutine_id}")
+@router.put("/status/{subroutine_id}", dependencies=[Depends(verify_subroutine_api_key)])
 async def update_subroutine_status(
     subroutine_id: str,
     request: SubroutineStatusUpdate
@@ -364,7 +405,7 @@ async def update_subroutine_status(
         )
 
 
-@router.post("/execute")
+@router.post("/execute", dependencies=[Depends(verify_subroutine_api_key)])
 async def execute_subroutine(request: SubroutineExecutionRequest) -> Dict[str, Any]:
     """
     Execute a subroutine with provided inputs.
@@ -390,6 +431,7 @@ async def execute_subroutine(request: SubroutineExecutionRequest) -> Dict[str, A
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Subroutine '{request.subroutine_id}' is not active (status: {subroutine.status.value})"
             )
+        validate_subroutine_module_path(subroutine.module_path)
         
         # Dynamic import and execution
         start_time = time.time()

--- a/tests/test_subroutines.py
+++ b/tests/test_subroutines.py
@@ -14,6 +14,7 @@ Comprehensive tests for Aurora's subroutine system including:
 
 import pytest
 from datetime import datetime, timedelta, UTC
+from uuid import uuid4
 from src.subroutines.reality_sim_monitor import RealitySimMonitor, RealityCheckResult
 from src.subroutines.aurora_vision_alignment import (
     VisionAlignmentManager,
@@ -436,6 +437,28 @@ class TestSubroutineAPI:
         app.include_router(router)
         return TestClient(app)
 
+    def auth_headers(self, monkeypatch):
+        """Configure test API key auth headers for protected subroutine routes."""
+        monkeypatch.setenv("AURORA_SUBROUTINE_API_KEY", "test-subroutine-key")
+        return {"X-API-Key": "test-subroutine-key"}
+
+    def register_payload(self, module_path="src.subroutines.resource_optimization"):
+        """Build a unique valid registration payload."""
+        return {
+            "id": f"test_secure_subroutine_{uuid4().hex}",
+            "name": "Test Secure Subroutine",
+            "version": "1.0.0",
+            "description": "Focused API security test subroutine",
+            "author": {
+                "name": "Test Author",
+                "team": "Aurora Test",
+            },
+            "category": "utility",
+            "module_path": module_path,
+            "class_name": "ResourceOptimizationManager",
+            "entry_point": "optimize_resources",
+        }
+
     def test_health_check(self, client):
         """Test health endpoint"""
         response = client.get("/subroutines/health")
@@ -501,6 +524,88 @@ class TestSubroutineAPI:
         assert data["success"] is True
         assert "export" in data
         assert "subroutines" in data["export"]
+
+    def test_register_requires_api_key(self, client, monkeypatch):
+        """Registration must not accept unauthenticated registry writes."""
+        monkeypatch.setenv("AURORA_SUBROUTINE_API_KEY", "test-subroutine-key")
+
+        response = client.post("/subroutines/register", json=self.register_payload())
+
+        assert response.status_code == 403
+
+    def test_register_rejects_non_allowlisted_module_path(self, client, monkeypatch):
+        """Registration must reject unsafe dynamic import module paths."""
+        response = client.post(
+            "/subroutines/register",
+            json=self.register_payload(module_path="os"),
+            headers=self.auth_headers(monkeypatch),
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Subroutine module path is not allowed"
+
+    def test_register_allows_authenticated_allowlisted_module_path(self, client, monkeypatch):
+        """Registration still works for authenticated allowlisted subroutine modules."""
+        response = client.post(
+            "/subroutines/register",
+            json=self.register_payload(),
+            headers=self.auth_headers(monkeypatch),
+        )
+
+        assert response.status_code == 201
+        assert response.json()["success"] is True
+
+    def test_execute_requires_api_key(self, client, monkeypatch):
+        """Execution must not accept unauthenticated callers."""
+        monkeypatch.setenv("AURORA_SUBROUTINE_API_KEY", "test-subroutine-key")
+
+        response = client.post(
+            "/subroutines/execute",
+            json={"subroutine_id": "reality_sim_monitor", "inputs": {}},
+        )
+
+        assert response.status_code == 403
+
+    def test_execute_rejects_non_allowlisted_registered_module(self, client, monkeypatch):
+        """Execution validates stored module paths before dynamic import."""
+        registry = get_subroutine_registry()
+        subroutine_id = f"unsafe_test_subroutine_{uuid4().hex}"
+        registry.register(
+            Subroutine(
+                id=subroutine_id,
+                name="Unsafe Test Subroutine",
+                version="1.0.0",
+                description="Unsafe module path regression fixture",
+                author=SubroutineAuthor(name="Test Author", team="Aurora Test"),
+                created_at=datetime.now(UTC).isoformat(),
+                updated_at=datetime.now(UTC).isoformat(),
+                status=SubroutineStatus.ACTIVE,
+                category=SubroutineCategory.UTILITY,
+                module_path="os",
+                class_name="system",
+                entry_point="system",
+            )
+        )
+
+        response = client.post(
+            "/subroutines/execute",
+            json={"subroutine_id": subroutine_id, "inputs": {"command": "echo unsafe"}},
+            headers=self.auth_headers(monkeypatch),
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Subroutine module path is not allowed"
+
+    def test_status_update_requires_api_key(self, client, monkeypatch):
+        """Status mutation must not accept unauthenticated callers."""
+        monkeypatch.setenv("AURORA_SUBROUTINE_API_KEY", "test-subroutine-key")
+
+        response = client.put(
+            "/subroutines/status/reality_sim_monitor",
+            json={"status": "active"},
+        )
+
+        assert response.status_code == 403
 
 
 # Add markers for pytest


### PR DESCRIPTION
## Summary
- require X-API-Key authentication on subroutine registration, execution, and status mutation endpoints
- enforce an allowlist for dynamically imported subroutine module paths during registration and execution
- add regression coverage for unauthenticated access and unsafe module paths

## Validation
- ./.venv/bin/python -m pytest tests/test_subroutines.py -q
- ./.venv/bin/python -m py_compile src/subroutines/api.py tests/test_subroutines.py
- ./.venv/bin/flake8 src/subroutines/api.py tests/test_subroutines.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293
- git diff --cached --check

Fixes #597
Fixes #598