### PR TITLE
fix: keep audit signing key out of storage

### DIFF
--- a/config/monitoring_config.yaml
+++ b/config/monitoring_config.yaml
@@ -224,7 +224,7 @@ security:
     algorithm: "HMAC-SHA256"
     # Key MUST be stored in environment variable: MONITORING_SIGNING_KEY
     # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
-    # WARNING: Using runtime-generated keys causes audit chain verification to fail across restarts
+    # Required at startup; runtime-generated keys are not used
   
   # API authentication
   api_auth:

--- a/docs/MONITORING_SYSTEM.md
+++ b/docs/MONITORING_SYSTEM.md
@@ -58,7 +58,7 @@ pip install opentelemetry-api opentelemetry-sdk
 
 ### Environment Variables
 
-Configure the following environment variables for production:
+Configure the following environment variables before starting monitoring:
 
 ```bash
 # Required for persistent audit chain verification
@@ -72,7 +72,7 @@ export ETHICS_RULES_PATH="./ethics/validation_engine/validation_rules.json"
 export MONITORING_API_TOKEN="your-api-token-here"
 ```
 
-**Important**: The `MONITORING_SIGNING_KEY` must be consistent across system restarts to maintain audit chain verification. Never use runtime-generated keys in production.
+**Important**: The `MONITORING_SIGNING_KEY` is required and must be consistent across system restarts to maintain audit chain verification.
 
 ### Setup
 

--- a/docs/implementation/IMPLEMENTATION_SUMMARY_MONITORING.md
+++ b/docs/implementation/IMPLEMENTATION_SUMMARY_MONITORING.md
@@ -147,10 +147,9 @@ tests/
 
 ### Environment Variables
 
-**Production Required:**
+**Required:**
 ```bash
-AURORA_ENV=production                      # Enable production mode
-MONITORING_SIGNING_KEY=<hex-key>          # Required in production
+MONITORING_SIGNING_KEY=<hex-key>          # Required for audit log signing
 ```
 
 **Optional Configuration:**

--- a/src/monitoring/audit_logger.py
+++ b/src/monitoring/audit_logger.py
@@ -9,6 +9,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from enum import Enum
@@ -17,6 +18,8 @@ from typing import Dict, List, Optional, Any
 from src.core.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
+
+MONITORING_SIGNING_KEY_ENV = "MONITORING_SIGNING_KEY"
 
 
 class AuditEventType(Enum):
@@ -103,25 +106,16 @@ class AuditLogger:
         
         # Try environment variable first
         if signing_key is None:
-            import os
-            signing_key = os.getenv("MONITORING_SIGNING_KEY")
-            
-            # In production, require explicit signing key
-            if signing_key is None and os.getenv("AURORA_ENV") == "production":
-                raise ValueError(
-                    "MONITORING_SIGNING_KEY environment variable must be set in production. "
-                    "Generate one with: python -c 'import secrets; print(secrets.token_hex(32))'"
-                )
-        
-        self.signing_key = signing_key or self._generate_key()
-        
-        # Warn if using generated key
-        if signing_key is None:
-            logger.warning(
-                "Using runtime-generated signing key. Audit chain verification will fail "
-                "across restarts. Set MONITORING_SIGNING_KEY environment variable for production."
+            signing_key = os.getenv(MONITORING_SIGNING_KEY_ENV)
+
+        if not signing_key:
+            raise ValueError(
+                f"{MONITORING_SIGNING_KEY_ENV} environment variable must be set. "
+                "Generate one with: python -c 'import secrets; print(secrets.token_hex(32))'"
             )
-        
+
+        self.signing_key = signing_key
+
         self.entries: List[AuditEntry] = []
         self._next_id = 1
         
@@ -133,11 +127,6 @@ class AuditLogger:
             "Audit logger initialized (storage=%s, entries=%d)",
             storage_path, len(self.entries)
         )
-    
-    def _generate_key(self) -> str:
-        """Generate a random signing key"""
-        import secrets
-        return secrets.token_hex(32)
     
     def log_drift_alert(
         self,
@@ -446,7 +435,6 @@ class AuditLogger:
         try:
             data = {
                 'entries': [e.to_dict() for e in self.entries],
-                'signing_key': self.signing_key,
                 'next_id': self._next_id
             }
             
@@ -463,7 +451,8 @@ class AuditLogger:
             with open(self.storage_path, 'r') as f:
                 data = json.load(f)
             
-            self.signing_key = data.get('signing_key', self.signing_key)
+            if 'signing_key' in data:
+                logger.warning("Ignoring persisted audit signing key")
             self._next_id = data.get('next_id', 1)
             
             for entry_data in data.get('entries', []):

--- a/tests/test_audit_logger_security.py
+++ b/tests/test_audit_logger_security.py
@@ -1,0 +1,58 @@
+"""
+Security regression tests for the audit logger signing key.
+"""
+
+import json
+import unittest
+
+import pytest
+
+from src.monitoring.audit_logger import AuditLogger
+
+
+def test_audit_logger_requires_startup_signing_key(monkeypatch):
+    """Audit logging must not silently generate a runtime-only signing key."""
+    monkeypatch.delenv("MONITORING_SIGNING_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="MONITORING_SIGNING_KEY environment variable must be set"):
+        AuditLogger()
+
+
+def test_audit_logger_does_not_persist_signing_key(tmp_path):
+    """The audit storage file must never contain the HMAC signing key."""
+    checks = unittest.TestCase()
+    storage_path = tmp_path / "audit_log.json"
+    audit_logger = AuditLogger(storage_path=storage_path, signing_key="test-audit-signing-key")
+
+    audit_logger.log_manual_override(
+        agent_id="test-agent",
+        operator="test-operator",
+        action="approve",
+        justification="security regression coverage",
+    )
+
+    persisted = json.loads(storage_path.read_text())
+    checks.assertNotIn("signing_key", persisted)
+    checks.assertEqual(persisted["next_id"], 2)
+    checks.assertEqual(len(persisted["entries"]), 1)
+
+
+def test_audit_logger_ignores_legacy_persisted_signing_key(tmp_path, monkeypatch):
+    """Legacy storage keys must not override the startup signing key."""
+    checks = unittest.TestCase()
+    storage_path = tmp_path / "audit_log.json"
+    storage_path.write_text(
+        json.dumps(
+            {
+                "entries": [],
+                "signing_key": "legacy-persisted-key",
+                "next_id": 7,
+            }
+        )
+    )
+    monkeypatch.setenv("MONITORING_SIGNING_KEY", "env-signing-key")
+
+    audit_logger = AuditLogger(storage_path=storage_path)
+
+    checks.assertEqual(audit_logger.signing_key, "env-signing-key")
+    checks.assertEqual(audit_logger._next_id, 7)

--- a/tests/test_monitoring_system.py
+++ b/tests/test_monitoring_system.py
@@ -17,6 +17,11 @@ from src.monitoring.monitoring_system import (
 
 class TestMonitoringSystem:
     """Test suite for MonitoringSystem"""
+
+    @pytest.fixture(autouse=True)
+    def monitoring_signing_key(self, monkeypatch):
+        """Provide the required audit HMAC key for monitoring tests."""
+        monkeypatch.setenv("MONITORING_SIGNING_KEY", "test-monitoring-signing-key")
     
     def test_initialization(self):
         """Test monitoring system initialization"""


### PR DESCRIPTION
## Summary
- require a startup audit signing key from MONITORING_SIGNING_KEY or an explicit constructor override
- stop serializing the HMAC signing key into persisted audit storage
- ignore legacy persisted signing keys when loading existing audit logs
- update monitoring docs/config to reflect required startup key behavior
- add regression tests for missing keys, storage output, and legacy key handling

## Validation
- ./.venv/bin/python -m pytest tests/test_audit_logger_security.py tests/test_monitoring_system.py -q
- ./.venv/bin/python -m py_compile src/monitoring/audit_logger.py tests/test_audit_logger_security.py tests/test_monitoring_system.py
- ./.venv/bin/flake8 src/monitoring/audit_logger.py tests/test_audit_logger_security.py tests/test_monitoring_system.py --max-line-length=120 --extend-ignore=E203,W503,F811,W293
- git diff --check

Fixes #599