### PR TITLE
[codex] require auth on sensitive CloudBank routers

### DIFF
--- a/api/r2_telemetry_routes.py
+++ b/api/r2_telemetry_routes.py
@@ -12,8 +12,10 @@ from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import PlainTextResponse
+
+from src.middleware.fastapi_security import require_csrf_token
 
 try:
     from src.observability import get_r2_telemetry
@@ -22,14 +24,18 @@ except ImportError:
     from observability import get_r2_telemetry
 
 
-router = APIRouter(prefix="/r2-telemetry", tags=["R-2 Agent Telemetry"])
+router = APIRouter(
+    prefix="/r2-telemetry",
+    tags=["R-2 Agent Telemetry"],
+    dependencies=[Depends(require_csrf_token)],
+)
 
 
 @router.get("/metrics", response_class=PlainTextResponse)
 async def get_prometheus_metrics():
     """
     Export R-2 agent metrics in Prometheus format
-    
+
     This endpoint is designed to be scraped by Prometheus for monitoring.
     Returns metrics in the Prometheus text exposition format.
     """
@@ -50,11 +56,11 @@ async def get_metrics_summary(
 ) -> Dict[str, Any]:
     """
     Get comprehensive metrics summary for R-2 agent operations
-    
+
     Args:
         time_window: Time window in seconds (default: 3600 = 1 hour)
         context_tag: Optional DLP context tag
-        
+
     Returns:
         Summary with counts, success rates, and performance metrics
     """
@@ -74,12 +80,12 @@ async def get_recent_operations(
 ) -> List[Dict[str, Any]]:
     """
     Get recent R-2 agent operations
-    
+
     Args:
         limit: Maximum number of operations to return
         operation_type: Filter by specific operation type
         failures_only: Only return failed operations
-        
+
     Returns:
         List of operation metrics
     """
@@ -89,7 +95,7 @@ async def get_recent_operations(
         operation_type=operation_type,
         include_failures_only=failures_only
     )
-    
+
     return [asdict(op) for op in operations]
 
 
@@ -97,26 +103,26 @@ async def get_recent_operations(
 async def get_telemetry_health() -> Dict[str, Any]:
     """
     Get R-2 agent telemetry system health status
-    
+
     Returns:
         Health status with system information
     """
     telemetry = get_r2_telemetry()
-    
+
     # Get recent metrics summary
     summary = telemetry.get_metrics_summary(time_window_seconds=300)  # Last 5 minutes
-    
+
     # Determine health status
     success_rate = summary.get("success_rate", 0)
     anomaly_count = summary.get("anomaly_count", 0)
-    
+
     if success_rate >= 0.95 and anomaly_count == 0:
         status = "healthy"
     elif success_rate >= 0.80:
         status = "degraded"
     else:
         status = "unhealthy"
-    
+
     return {
         "status": status,
         "timestamp": datetime.utcnow().isoformat(),
@@ -137,18 +143,18 @@ async def get_detected_anomalies(
 ) -> List[Dict[str, Any]]:
     """
     Get recently detected anomalies in R-2 agent operations
-    
+
     Args:
         limit: Maximum number of anomalies to return
-        
+
     Returns:
         List of detected anomalies with details
     """
     telemetry = get_r2_telemetry()
-    
+
     # Use public method to get anomalies
     anomalies = telemetry.get_recent_anomalies(limit=limit)
-    
+
     return [asdict(anomaly) for anomaly in anomalies]
 
 
@@ -156,15 +162,15 @@ async def get_detected_anomalies(
 async def get_operation_types() -> Dict[str, Any]:
     """
     Get list of all tracked operation types with statistics
-    
+
     Returns:
         Dictionary of operation types with their statistics
     """
     telemetry = get_r2_telemetry()
     summary = telemetry.get_metrics_summary()
-    
+
     operations_by_type = summary.get("operations_by_type", {})
-    
+
     return {
         "total_types": len(operations_by_type),
         "operations": operations_by_type
@@ -178,18 +184,18 @@ async def test_telemetry_operation(
 ) -> Dict[str, Any]:
     """
     Test endpoint to generate sample telemetry data
-    
+
     Args:
         operation_type: Type of operation to simulate
         should_fail: Whether to simulate a failure
-        
+
     Returns:
         Test operation result
     """
     import time
-    
+
     telemetry = get_r2_telemetry()
-    
+
     with telemetry.trace_agent_operation(
         operation_type=operation_type,
         context_tag=f"test_operation_{int(time.time())}",
@@ -198,14 +204,14 @@ async def test_telemetry_operation(
     ) as metrics:
         # Simulate work
         time.sleep(0.1)
-        
+
         # Add some metadata
         metrics.decisions_made = 3
         metrics.tools_invoked = ["test_tool_1", "test_tool_2"]
-        
+
         if should_fail:
             raise ValueError("Simulated test failure")
-    
+
     return {
         "success": True,
         "message": "Test operation completed successfully",

--- a/src/aurora/relays/api_routes.py
+++ b/src/aurora/relays/api_routes.py
@@ -13,14 +13,19 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from src.aurora.relays.relay_manager import RelayManager, RelayMessage
 from src.aurora.ethics.ethics_gate import EthicsViolation
+from src.middleware.fastapi_security import require_csrf_token
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/relay", tags=["relay-manager"])
+router = APIRouter(
+    prefix="/relay",
+    tags=["relay-manager"],
+    dependencies=[Depends(require_csrf_token)],
+)
 
 # Singleton relay manager instance
 _relay_manager_instance: Optional[RelayManager] = None

--- a/src/middleware/fastapi_security.py
+++ b/src/middleware/fastapi_security.py
@@ -22,7 +22,7 @@ import os
 import time
 import re
 
-from fastapi import HTTPException
+from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette.middleware.cors import CORSMiddleware
 from slowapi import Limiter
@@ -252,6 +252,13 @@ def verify_csrf_token(token: HTTPAuthorizationCredentials, session_id: Optional[
     except Exception:
         # Log error securely without exposing details to client
         raise HTTPException(status_code=403, detail='CSRF token validation failed')
+
+
+def require_csrf_token(
+    token: HTTPAuthorizationCredentials = Depends(security),
+) -> None:
+    """FastAPI dependency that requires a valid CSRF bearer token."""
+    verify_csrf_token(token)
 
 
 # ================================

--- a/src/monitoring/dashboard_api.py
+++ b/src/monitoring/dashboard_api.py
@@ -10,20 +10,23 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any
 
 try:
-    from fastapi import APIRouter, HTTPException, Query
+    from fastapi import APIRouter, Depends, HTTPException, Query
     from pydantic import BaseModel, Field
     FASTAPI_AVAILABLE = True
 except ImportError:
     FASTAPI_AVAILABLE = False
     APIRouter = None
+    Depends = None
     HTTPException = None
     Query = None
     BaseModel = object
-    Field = lambda **kwargs: None
 
-from .monitoring_system import MonitoringSystem, AlertConfig, AlertLevel
-from .ethics_engine import ActionContext
+    def Field(*args, **kwargs):
+        return None
+
+from .monitoring_system import MonitoringSystem
 from src.core.time_utils import utc_now, utc_iso
+from src.middleware.fastapi_security import require_csrf_token
 
 logger = logging.getLogger(__name__)
 
@@ -71,13 +74,13 @@ def get_monitoring_system(
 ) -> MonitoringSystem:
     """Get or create global monitoring system instance"""
     global _monitoring_system
-    
+
     if _monitoring_system is None:
         # Use default paths if not provided
         if storage_dir is None:
             import os
             storage_dir = Path(os.getenv("MONITORING_STORAGE_DIR", "./monitoring_data"))
-        
+
         if ethics_rules_path is None:
             import os
             # Try environment variable first, then default path
@@ -85,12 +88,12 @@ def get_monitoring_system(
             ethics_path = Path(ethics_path_str)
             if ethics_path.exists():
                 ethics_rules_path = ethics_path
-        
+
         _monitoring_system = MonitoringSystem(
             storage_dir=storage_dir,
             ethics_rules_path=ethics_rules_path
         )
-    
+
     return _monitoring_system
 
 
@@ -100,23 +103,27 @@ def create_monitoring_router(
 ) -> Optional[APIRouter]:
     """
     Create FastAPI router for monitoring dashboard
-    
+
     Args:
         storage_dir: Directory for persistent storage
         ethics_rules_path: Path to ethics rules configuration
-    
+
     Returns:
         APIRouter with monitoring endpoints (None if FastAPI not available)
     """
     if not FASTAPI_AVAILABLE:
         logger.warning("FastAPI not available - monitoring routes disabled")
         return None
-    
-    router = APIRouter(prefix="/monitoring", tags=["monitoring"])
-    
+
+    router = APIRouter(
+        prefix="/monitoring",
+        tags=["monitoring"],
+        dependencies=[Depends(require_csrf_token)],
+    )
+
     # Initialize monitoring system
     monitoring = get_monitoring_system(storage_dir, ethics_rules_path)
-    
+
     @router.get("/health")
     async def health_check():
         """Health check for monitoring system"""
@@ -125,7 +132,7 @@ def create_monitoring_router(
             "timestamp": utc_iso(),
             "audit_chain_valid": monitoring.audit_logger.verify_chain()
         }
-    
+
     @router.post("/baseline")
     async def establish_baseline(input: BaselineInput):
         """Establish behavioral baseline for an agent"""
@@ -134,7 +141,7 @@ def create_monitoring_router(
                 agent_id=input.agent_id,
                 historical_data=input.historical_data
             )
-            
+
             return {
                 "success": True,
                 "agent_id": input.agent_id,
@@ -144,7 +151,7 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to establish baseline: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.post("/behavior/record")
     async def record_behavior(input: BehaviorMetricsInput):
         """Record behavioral metrics for an agent"""
@@ -154,7 +161,7 @@ def create_monitoring_router(
                 metrics=input.metrics,
                 context_tag=input.context_tag
             )
-            
+
             return {
                 "success": True,
                 "agent_id": input.agent_id,
@@ -164,7 +171,7 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to record behavior: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.post("/behavior/check")
     async def check_behavior(
         agent_id: str = Query(..., description="Agent identifier"),
@@ -176,12 +183,12 @@ def create_monitoring_router(
                 agent_id=agent_id,
                 context_tag=context_tag
             )
-            
+
             return result
         except Exception as e:
             logger.error("Failed to check behavior: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.post("/action/evaluate")
     async def evaluate_action(input: ActionEvaluationInput):
         """Evaluate action against ethics rules"""
@@ -192,12 +199,12 @@ def create_monitoring_router(
                 parameters=input.parameters,
                 context_tag=input.context_tag
             )
-            
+
             return result
         except Exception as e:
             logger.error("Failed to evaluate action: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.get("/agent/{agent_id}/status")
     async def get_agent_status(agent_id: str):
         """Get comprehensive status for an agent"""
@@ -207,7 +214,7 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to get agent status: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.get("/alerts")
     async def get_alerts(
         agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
@@ -217,16 +224,16 @@ def create_monitoring_router(
         """Get drift alerts"""
         try:
             since = utc_now() - timedelta(hours=since_hours)
-            
+
             from .drift_detector import DriftLevel
             drift_level = DriftLevel(level) if level else None
-            
+
             alerts = monitoring.drift_detector.get_alerts(
                 agent_id=agent_id,
                 level=drift_level,
                 since=since
             )
-            
+
             return {
                 "alerts": [a.to_dict() for a in alerts],
                 "count": len(alerts),
@@ -235,7 +242,7 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to get alerts: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.get("/violations")
     async def get_violations(
         agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
@@ -245,16 +252,16 @@ def create_monitoring_router(
         """Get ethics violations"""
         try:
             since = utc_now() - timedelta(hours=since_hours)
-            
+
             from .ethics_engine import ViolationSeverity
             violation_severity = ViolationSeverity(severity) if severity else None
-            
+
             violations = monitoring.ethics_engine.get_violations(
                 agent_id=agent_id,
                 severity=violation_severity,
                 since=since
             )
-            
+
             return {
                 "violations": [v.to_dict() for v in violations],
                 "count": len(violations),
@@ -263,7 +270,7 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to get violations: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.get("/audit")
     async def get_audit_log(
         agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
@@ -273,16 +280,16 @@ def create_monitoring_router(
         """Get audit log entries"""
         try:
             since = utc_now() - timedelta(hours=since_hours)
-            
+
             from .audit_logger import AuditEventType
             audit_type = AuditEventType(event_type) if event_type else None
-            
+
             entries = monitoring.audit_logger.get_entries(
                 agent_id=agent_id,
                 event_type=audit_type,
                 since=since
             )
-            
+
             return {
                 "entries": [e.to_dict() for e in entries],
                 "count": len(entries),
@@ -292,7 +299,7 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to get audit log: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.get("/compliance/report")
     async def get_compliance_report(
         since_hours: Optional[int] = Query(168, description="Hours to look back"),
@@ -301,17 +308,17 @@ def create_monitoring_router(
         """Generate compliance report"""
         try:
             since = utc_now() - timedelta(hours=since_hours)
-            
+
             report = monitoring.generate_compliance_report(
                 since=since,
                 agent_id=agent_id
             )
-            
+
             return report
         except Exception as e:
             logger.error("Failed to generate compliance report: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.get("/export")
     async def export_state():
         """Export full monitoring system state"""
@@ -321,21 +328,21 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to export state: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     @router.get("/dashboard/stats")
     async def get_dashboard_stats():
         """Get overall dashboard statistics"""
         try:
             agent_ids = monitoring.behavior_monitor.get_agent_ids()
             since_24h = utc_now() - timedelta(hours=24)
-            
+
             total_alerts = len(monitoring.drift_detector.get_alerts(since=since_24h))
             total_violations = len(monitoring.ethics_engine.get_violations(since=since_24h))
             total_interventions = len([
                 i for i in monitoring.interventions
                 if datetime.fromisoformat(i.timestamp) >= since_24h
             ])
-            
+
             return {
                 "agents_monitored": len(agent_ids),
                 "alerts_24h": total_alerts,
@@ -348,7 +355,7 @@ def create_monitoring_router(
         except Exception as e:
             logger.error("Failed to get dashboard stats: %s", e)
             raise HTTPException(status_code=500, detail=str(e))
-    
+
     logger.info("Monitoring API router created with %d routes", len(router.routes))
-    
+
     return router

--- a/tests/test_sensitive_router_auth.py
+++ b/tests/test_sensitive_router_auth.py
@@ -1,0 +1,188 @@
+"""Regression tests for authentication on sensitive mounted routers."""
+
+import unittest
+import importlib.util
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+if "slowapi" not in sys.modules and importlib.util.find_spec("slowapi") is None:
+    slowapi_module = types.ModuleType("slowapi")
+    slowapi_util_module = types.ModuleType("slowapi.util")
+
+    class _Limiter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def limit(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    slowapi_module.Limiter = _Limiter
+    slowapi_util_module.get_remote_address = lambda request: "test-client"
+    sys.modules["slowapi"] = slowapi_module
+    sys.modules["slowapi.util"] = slowapi_util_module
+
+if "slowapi" in sys.modules and "slowapi.errors" not in sys.modules:
+    slowapi_errors_module = types.ModuleType("slowapi.errors")
+    slowapi_middleware_module = types.ModuleType("slowapi.middleware")
+
+    class _RateLimitExceeded(Exception):
+        pass
+
+    class _SlowAPIMiddleware:
+        def __init__(self, app, *args, **kwargs):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            await self.app(scope, receive, send)
+
+    slowapi_errors_module.RateLimitExceeded = _RateLimitExceeded
+    slowapi_middleware_module.SlowAPIMiddleware = _SlowAPIMiddleware
+    sys.modules["slowapi.errors"] = slowapi_errors_module
+    sys.modules["slowapi.middleware"] = slowapi_middleware_module
+
+from api import r2_telemetry_routes
+from src.aurora.relays import api_routes as relay_api_routes
+from src.middleware.fastapi_security import generate_csrf_token
+from src.monitoring import dashboard_api
+
+
+def _auth_header() -> dict[str, str]:
+    token = generate_csrf_token("test-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+class SensitiveRouterAuthTests(unittest.TestCase):
+    """Sensitive telemetry, monitoring, and relay routes require CSRF bearer auth."""
+
+    def test_r2_telemetry_routes_reject_missing_token(self) -> None:
+        app = FastAPI()
+        app.include_router(r2_telemetry_routes.router)
+        client = TestClient(app)
+
+        response = client.get("/r2-telemetry/metrics")
+
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_r2_telemetry_routes_accept_valid_token(self) -> None:
+        class _Telemetry:
+            enabled = True
+            service_name = "test-r2"
+
+            def export_prometheus_metrics(self) -> str:
+                return "aurora_r2_test 1\n"
+
+        app = FastAPI()
+        app.include_router(r2_telemetry_routes.router)
+        client = TestClient(app)
+
+        with patch.object(
+            r2_telemetry_routes,
+            "get_r2_telemetry",
+            return_value=_Telemetry(),
+        ):
+            response = client.get(
+                "/r2-telemetry/metrics",
+                headers=_auth_header(),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("aurora_r2_test 1", response.text)
+
+    def test_monitoring_routes_reject_missing_token(self) -> None:
+        monitoring = SimpleNamespace(
+            audit_logger=SimpleNamespace(verify_chain=lambda: True),
+        )
+
+        with patch.object(
+            dashboard_api,
+            "get_monitoring_system",
+            return_value=monitoring,
+        ):
+            router = dashboard_api.create_monitoring_router()
+
+        app = FastAPI()
+        self.assertIsNotNone(router)
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.get("/monitoring/audit")
+
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_monitoring_routes_accept_valid_token(self) -> None:
+        monitoring = SimpleNamespace(
+            audit_logger=SimpleNamespace(verify_chain=lambda: True),
+        )
+
+        with patch.object(
+            dashboard_api,
+            "get_monitoring_system",
+            return_value=monitoring,
+        ):
+            router = dashboard_api.create_monitoring_router()
+
+        app = FastAPI()
+        self.assertIsNotNone(router)
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.get(
+            "/monitoring/health",
+            headers=_auth_header(),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["audit_chain_valid"])
+
+    def test_relay_routes_reject_missing_token(self) -> None:
+        app = FastAPI()
+        app.include_router(relay_api_routes.router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/relay/send",
+            json={
+                "source_layer": "L1",
+                "target_layer": "L2",
+                "payload": {"message": "blocked"},
+            },
+        )
+
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_relay_routes_accept_valid_token(self) -> None:
+        relay = SimpleNamespace(
+            messages_processed=2,
+            messages_blocked=0,
+            ethics_gate=object(),
+        )
+
+        app = FastAPI()
+        app.include_router(relay_api_routes.router)
+        client = TestClient(app)
+
+        with patch.object(
+            relay_api_routes,
+            "get_relay_manager",
+            return_value=relay,
+        ):
+            response = client.get(
+                "/relay/status",
+                headers=_auth_header(),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["messages_processed"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -2,8 +2,26 @@
 Integration tests for telemetry activation in FastAPI application
 """
 
+import hashlib
+import hmac
+import os
+import time
+
 import pytest
 from fastapi.testclient import TestClient
+
+
+def _auth_header():
+    session_id = "test-session"
+    timestamp = str(int(time.time()))
+    message = f"{session_id}.{timestamp}"
+    signature = hmac.new(
+        os.environ["CSRF_SECRET_KEY"].encode(),
+        message.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    token = f"{session_id}.{timestamp}.{signature}"
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.mark.integration
@@ -65,12 +83,12 @@ def test_r2_telemetry_routes_available():
     client = TestClient(app)
 
     # Test metrics endpoint
-    response = client.get("/r2-telemetry/metrics")
+    response = client.get("/r2-telemetry/metrics", headers=_auth_header())
     assert response.status_code == 200
     assert "r2_agent" in response.text or "# HELP" in response.text
 
     # Test health endpoint
-    response = client.get("/r2-telemetry/health")
+    response = client.get("/r2-telemetry/health", headers=_auth_header())
     assert response.status_code == 200
     data = response.json()
     assert "status" in data
@@ -84,7 +102,7 @@ def test_r2_telemetry_summary():
     from api.aurora_api import app
 
     client = TestClient(app)
-    response = client.get("/r2-telemetry/summary")
+    response = client.get("/r2-telemetry/summary", headers=_auth_header())
 
     assert response.status_code == 200
     data = response.json()


### PR DESCRIPTION
## Summary
- add a reusable FastAPI dependency for the existing CSRF bearer-token verifier
- attach that dependency to the R-2 telemetry, monitoring dashboard, and relay manager routers
- add regression coverage for rejected unauthenticated calls and accepted valid-token calls

Fixes #656
Fixes #657
Fixes #658

## Validation
- ./.venv/bin/python -m pytest tests/test_sensitive_router_auth.py -q
- ./.venv/bin/python -m py_compile src/middleware/fastapi_security.py api/r2_telemetry_routes.py src/monitoring/dashboard_api.py src/aurora/relays/api_routes.py tests/test_sensitive_router_auth.py tests/test_telemetry_integration.py
- ./.venv/bin/python -m flake8 src/middleware/fastapi_security.py api/r2_telemetry_routes.py src/monitoring/dashboard_api.py src/aurora/relays/api_routes.py tests/test_sensitive_router_auth.py tests/test_telemetry_integration.py
- git diff --check