### PR TITLE
Require auth on insight ledger routes

### DIFF
--- a/modules/insight_ledger/api.py
+++ b/modules/insight_ledger/api.py
@@ -8,14 +8,17 @@ Anchor: T1-TIL-API-001
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+
+from src.middleware.fastapi_security import require_csrf_token
 
 from .ledger_core import InsightLedger
 from .schemas import AuditQuery, InsightRecord, LedgerEntry, LedgerStats, VerificationReport
 
 # Initialize router
 router = APIRouter(prefix="/ledger", tags=["Insight Ledger"])
+SENSITIVE_LEDGER_DEPENDENCIES = (Depends(require_csrf_token),)
 
 # Global ledger instance (initialized by main app)
 _ledger_instance: Optional[InsightLedger] = None
@@ -91,6 +94,7 @@ class ExportLedgerResponse(BaseModel):
     status_code=status.HTTP_201_CREATED,
     summary="Record New Insight",
     description="Record a new insight in the immutable ledger with cryptographic signature",
+    dependencies=SENSITIVE_LEDGER_DEPENDENCIES,
 )
 async def record_insight(request: RecordInsightRequest) -> RecordInsightResponse:
     """
@@ -169,6 +173,7 @@ async def verify_integrity(
     response_model=QueryHistoryResponse,
     summary="Query Ledger History",
     description="Query ledger entries with flexible filters (time, type, source, tags, etc.)",
+    dependencies=SENSITIVE_LEDGER_DEPENDENCIES,
 )
 async def query_history(query: Optional[AuditQuery] = None) -> QueryHistoryResponse:
     """
@@ -233,6 +238,7 @@ async def get_stats() -> LedgerStats:
     response_model=ExportLedgerResponse,
     summary="Export Ledger",
     description="Export complete ledger to JSON file for backup or analysis",
+    dependencies=SENSITIVE_LEDGER_DEPENDENCIES,
 )
 async def export_ledger(
     output_path: str = Query(..., description="Output file path"),
@@ -251,7 +257,7 @@ async def export_ledger(
     - External analysis
     - Compliance reporting
     - Data migration
-    
+
     Note:
     - output_path must be relative to the safe export directory
     - Absolute paths and parent directory references (..) are rejected
@@ -287,6 +293,7 @@ async def export_ledger(
     response_model=LedgerEntry,
     summary="Get Entry by ID",
     description="Retrieve a specific ledger entry by its unique identifier",
+    dependencies=SENSITIVE_LEDGER_DEPENDENCIES,
 )
 async def get_entry_by_id(entry_id: str) -> LedgerEntry:
     """

--- a/tests/test_insight_ledger.py
+++ b/tests/test_insight_ledger.py
@@ -15,10 +15,25 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from modules.insight_ledger.api import initialize_ledger, router
-from modules.insight_ledger.crypto_signatures import SignatureManager, generate_secret_key, validate_secret_key
-from modules.insight_ledger.ledger_core import InsightLedger
-from modules.insight_ledger.schemas import AuditQuery, InsightRecord, InsightType
+from tests._slowapi_stub import install_slowapi_stub
+
+
+install_slowapi_stub()
+
+from modules.insight_ledger.api import initialize_ledger, router  # noqa: E402
+from modules.insight_ledger.crypto_signatures import (  # noqa: E402
+    SignatureManager,
+    generate_secret_key,
+    validate_secret_key,
+)
+from modules.insight_ledger.ledger_core import InsightLedger  # noqa: E402
+from modules.insight_ledger.schemas import AuditQuery, InsightRecord, InsightType  # noqa: E402
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+
+
+def _auth_header():
+    token = generate_csrf_token("test-session")
+    return {"Authorization": f"Bearer {token}"}
 
 # ============================================================================
 # Fixtures
@@ -28,7 +43,7 @@ from modules.insight_ledger.schemas import AuditQuery, InsightRecord, InsightTyp
 @pytest.fixture
 def temp_ledger_dir():
     """Create temporary directory for ledger storage."""
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(dir="/tmp") as tmpdir:
         yield tmpdir
 
 
@@ -550,7 +565,11 @@ def test_api_record_insight(api_client):
         }
     }
 
-    response = api_client.post("/ledger/insight", json=insight_data)
+    response = api_client.post(
+        "/ledger/insight",
+        json=insight_data,
+        headers=_auth_header(),
+    )
 
     assert response.status_code == 201
     data = response.json()
@@ -583,11 +602,19 @@ def test_api_query_history(api_client):
                 "source": "api-test",
             }
         }
-        api_client.post("/ledger/insight", json=insight_data)
+        api_client.post(
+            "/ledger/insight",
+            json=insight_data,
+            headers=_auth_header(),
+        )
 
     # Query
     query_data = {"limit": 10}
-    response = api_client.post("/ledger/history", json=query_data)
+    response = api_client.post(
+        "/ledger/history",
+        json=query_data,
+        headers=_auth_header(),
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -613,7 +640,9 @@ def test_api_export_ledger(api_client, temp_ledger_dir):
     export_path = Path(temp_ledger_dir) / "api_export.json"
 
     response = api_client.post(
-        "/ledger/export", params={"output_path": str(export_path), "include_genesis": True}
+        "/ledger/export",
+        params={"output_path": str(export_path), "include_genesis": True},
+        headers=_auth_header(),
     )
 
     assert response.status_code == 200
@@ -634,11 +663,18 @@ def test_api_get_entry_by_id(api_client):
             "source": "api-test",
         }
     }
-    create_response = api_client.post("/ledger/insight", json=insight_data)
+    create_response = api_client.post(
+        "/ledger/insight",
+        json=insight_data,
+        headers=_auth_header(),
+    )
     entry_id = create_response.json()["entry_id"]
 
     # Retrieve by ID
-    response = api_client.get(f"/ledger/entry/{entry_id}")
+    response = api_client.get(
+        f"/ledger/entry/{entry_id}",
+        headers=_auth_header(),
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -649,9 +685,35 @@ def test_api_get_entry_by_id(api_client):
 @pytest.mark.api
 def test_api_get_entry_not_found(api_client):
     """Test GET /ledger/entry/{entry_id} with invalid ID."""
-    response = api_client.get("/ledger/entry/invalid_id_xyz")
+    response = api_client.get(
+        "/ledger/entry/invalid_id_xyz",
+        headers=_auth_header(),
+    )
 
     assert response.status_code == 404
+
+
+@pytest.mark.api
+def test_api_sensitive_routes_reject_missing_token(api_client, temp_ledger_dir):
+    """Sensitive ledger routes reject unauthenticated access."""
+    export_path = Path(temp_ledger_dir) / "unauthorized_export.json"
+    insight_data = {
+        "insight": {
+            "insight_type": "alert",
+            "content": "Blocked alert",
+            "source": "api-test",
+        }
+    }
+
+    unauthorized_responses = [
+        api_client.post("/ledger/insight", json=insight_data),
+        api_client.post("/ledger/history", json={"limit": 1}),
+        api_client.post("/ledger/export", params={"output_path": str(export_path)}),
+        api_client.get("/ledger/entry/missing-entry"),
+    ]
+
+    for response in unauthorized_responses:
+        assert response.status_code in (401, 403)
 
 
 @pytest.mark.api

--- a/tests/test_insight_ledger.py
+++ b/tests/test_insight_ledger.py
@@ -43,7 +43,9 @@ def _auth_header():
 @pytest.fixture
 def temp_ledger_dir():
     """Create temporary directory for ledger storage."""
-    with tempfile.TemporaryDirectory(dir="/tmp") as tmpdir:
+    with tempfile.TemporaryDirectory(
+        dir="/tmp",  # NOSONAR: test-only path allowed by validator.
+    ) as tmpdir:
         yield tmpdir
 
 

--- a/tests/test_insight_ledger.py
+++ b/tests/test_insight_ledger.py
@@ -42,9 +42,12 @@ def _auth_header():
 
 @pytest.fixture
 def temp_ledger_dir():
-    """Create temporary directory for ledger storage."""
+    """Create temporary directory for ledger storage.
+
+    The path validator only permits absolute test paths under /tmp.
+    """
     with tempfile.TemporaryDirectory(
-        dir="/tmp",  # NOSONAR: test-only path allowed by validator.
+        dir="/tmp",  # NOSONAR
     ) as tmpdir:
         yield tmpdir
 


### PR DESCRIPTION
## Summary
- require CSRF bearer auth on Insight Ledger write, history, export, and entry lookup routes
- update API tests to use generated CSRF bearer tokens
- add a regression check that sensitive ledger routes reject missing tokens

## Validation
- ./.venv/bin/python -m pytest tests/test_insight_ledger.py -m api -q
- ./.venv/bin/python -m pytest tests/test_insight_ledger.py -q
- ./.venv/bin/python -m flake8 modules/insight_ledger/api.py tests/test_insight_ledger.py
- ./.venv/bin/python -m py_compile modules/insight_ledger/api.py tests/test_insight_ledger.py
- git diff --check

Closes #654