### PR TITLE
Require auth on memory manager routes

### DIFF
--- a/modules/aumemmanager/api_integration.py
+++ b/modules/aumemmanager/api_integration.py
@@ -3,21 +3,20 @@ AuMemManager API Integration for Aurora CloudBank
 FastAPI endpoints for hierarchical memory management with quantum-symbolic capabilities
 """
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 import time
 
-from modules.aumemmanager import (
-    HierarchicalMemoryManager,
-    MemoryType
-)
+from modules.aumemmanager import HierarchicalMemoryManager, MemoryType
+from src.middleware.fastapi_security import require_csrf_token
 
 # Global memory manager instance (in production, this would be properly managed)
 memory_manager = HierarchicalMemoryManager(max_active_memories=1000)
 
 # Create router for AuMemManager endpoints
 router = APIRouter(prefix="/memory", tags=["AuMemManager"])
+SENSITIVE_MEMORY_DEPENDENCIES = (Depends(require_csrf_token),)
 
 # Pydantic models for API requests/responses
 
@@ -32,33 +31,24 @@ class MemoryCreateRequest(BaseModel):
     aurora_anchors: Optional[List[str]] = Field(default=None, description="Aurora CloudBank symbolic anchors")
     cultural_score: float = Field(0.0, ge=0.0, le=1.0, description="CASK cultural relevance score")
 
+
 class MemoryRetrievalRequest(BaseModel):
     query: str = Field(
-        ...,
-        min_length=1,
-        max_length=500,
-        description="Search query (1-500 characters, HIGH-5 validated)"
+        ..., min_length=1, max_length=500, description="Search query (1-500 characters, HIGH-5 validated)"
     )
     owner: Optional[str] = Field(
         default=None,
-        pattern=r'^[a-zA-Z0-9_-]+$',
+        pattern=r"^[a-zA-Z0-9_-]+$",
         max_length=64,
-        description="Filter by owner (alphanumeric, HIGH-5 validated)"
+        description="Filter by owner (alphanumeric, HIGH-5 validated)",
     )
     memory_type: Optional[str] = Field(default=None, description="Filter by memory type")
-    top_k: int = Field(
-        5,
-        ge=1,
-        le=100,
-        description="Number of results to return (1-100, HIGH-5 range expanded)"
-    )
+    top_k: int = Field(5, ge=1, le=100, description="Number of results to return (1-100, HIGH-5 range expanded)")
     include_quantum: bool = Field(True, description="Include quantum vector data")
     cultural_filter: Optional[float] = Field(
-        default=None,
-        ge=0.0,
-        le=1.0,
-        description="Minimum cultural score filter (0.0-1.0, HIGH-5 validated)"
+        default=None, ge=0.0, le=1.0, description="Minimum cultural score filter (0.0-1.0, HIGH-5 validated)"
     )
+
 
 class QuantumVectorRequest(BaseModel):
     vector_id: str = Field(..., description="Quantum vector identifier")
@@ -67,11 +57,13 @@ class QuantumVectorRequest(BaseModel):
     aurora_anchors: Optional[List[str]] = Field(default=None, description="Aurora symbolic anchors")
     dlp_classification: str = Field("DLP_L1_OK", description="DLP security classification")
 
+
 class TrajectoryRequest(BaseModel):
     vector_id: str = Field(..., description="Quantum vector identifier")
     target_magnitude: float = Field(..., description="Target magnitude")
     target_phase: float = Field(..., description="Target phase")
     trajectory_type: str = Field("quantum_optimal", description="Trajectory computation type")
+
 
 class MemoryResponse(BaseModel):
     id: str
@@ -86,6 +78,7 @@ class MemoryResponse(BaseModel):
     cask_cultural_score: float
     quantum_vector: Optional[Dict[str, Any]]
 
+
 class SystemMetricsResponse(BaseModel):
     total_memories: int
     active_memories: int
@@ -97,9 +90,8 @@ class SystemMetricsResponse(BaseModel):
     average_cultural_score: float
     quantum_network_density: float
 
-@router.post("/create", response_model=Dict[str, str])
 
-
+@router.post("/create", response_model=Dict[str, str], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 async def create_memory(request: MemoryCreateRequest):
     """Create a new memory item with quantum-symbolic capabilities"""
     try:
@@ -117,21 +109,20 @@ async def create_memory(request: MemoryCreateRequest):
             tags=request.tags,
             quantum_properties=request.quantum_properties,
             aurora_anchors=request.aurora_anchors,
-            cultural_score=request.cultural_score
+            cultural_score=request.cultural_score,
         )
 
         return {
             "memory_id": memory_id,
             "status": "created",
-            "message": f"Memory created successfully with ID: {memory_id}"
+            "message": f"Memory created successfully with ID: {memory_id}",
         }
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to create memory: {str(e)}")
 
+
 @router.post("/retrieve", response_model=List[MemoryResponse])
-
-
 async def retrieve_memories(request: MemoryRetrievalRequest):
     """Retrieve memories using attention-based scoring"""
     try:
@@ -149,7 +140,7 @@ async def retrieve_memories(request: MemoryRetrievalRequest):
             memory_type=memory_type,
             top_k=request.top_k,
             include_quantum=request.include_quantum,
-            cultural_filter=request.cultural_filter
+            cultural_filter=request.cultural_filter,
         )
 
         # Convert to response format
@@ -163,31 +154,32 @@ async def retrieve_memories(request: MemoryRetrievalRequest):
                     "phase": memory.quantum_vector.phase,
                     "coherence_time": memory.quantum_vector.coherence_time,
                     "entanglement_links": memory.quantum_vector.entanglement_links,
-                    "symbolic_anchors": memory.quantum_vector.symbolic_anchors
+                    "symbolic_anchors": memory.quantum_vector.symbolic_anchors,
                 }
 
-            response_memories.append(MemoryResponse(
-                id=memory.id,
-                content=memory.content,
-                memory_type=memory.memory_type.value,
-                owner=memory.owner,
-                importance=memory.importance,
-                strength=memory.strength,
-                access_count=memory.access_count,
-                status=memory.status.value,
-                symbolic_anchors=memory.symbolic_anchors,
-                cask_cultural_score=memory.cask_cultural_score,
-                quantum_vector=quantum_data
-            ))
+            response_memories.append(
+                MemoryResponse(
+                    id=memory.id,
+                    content=memory.content,
+                    memory_type=memory.memory_type.value,
+                    owner=memory.owner,
+                    importance=memory.importance,
+                    strength=memory.strength,
+                    access_count=memory.access_count,
+                    status=memory.status.value,
+                    symbolic_anchors=memory.symbolic_anchors,
+                    cask_cultural_score=memory.cask_cultural_score,
+                    quantum_vector=quantum_data,
+                )
+            )
 
         return response_memories
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to retrieve memories: {str(e)}")
 
-@router.post("/quantum/create_vector", response_model=Dict[str, Any])
 
-
+@router.post("/quantum/create_vector", response_model=Dict[str, Any], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 async def create_quantum_vector(request: QuantumVectorRequest):
     """Create a quantum-symbolic vector for memory management"""
     try:
@@ -196,7 +188,7 @@ async def create_quantum_vector(request: QuantumVectorRequest):
             magnitude=request.magnitude,
             phase=request.phase,
             aurora_anchors=request.aurora_anchors,
-            dlp_classification=request.dlp_classification
+            dlp_classification=request.dlp_classification,
         )
 
         return {
@@ -205,15 +197,14 @@ async def create_quantum_vector(request: QuantumVectorRequest):
             "phase": qv.phase,
             "coherence_time": qv.coherence_time,
             "symbolic_anchors": qv.symbolic_anchors,
-            "status": "created"
+            "status": "created",
         }
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to create quantum vector: {str(e)}")
 
-@router.post("/quantum/entangle", response_model=Dict[str, str])
 
-
+@router.post("/quantum/entangle", response_model=Dict[str, str], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 async def entangle_vectors(vector1_id: str, vector2_id: str):
     """Create quantum entanglement between two vectors"""
     try:
@@ -224,7 +215,7 @@ async def entangle_vectors(vector1_id: str, vector2_id: str):
                 "status": "entangled",
                 "vector1_id": vector1_id,
                 "vector2_id": vector2_id,
-                "message": f"Successfully entangled vectors {vector1_id} and {vector2_id}"
+                "message": f"Successfully entangled vectors {vector1_id} and {vector2_id}",
             }
         else:
             raise HTTPException(status_code=404, detail="One or both vectors not found")
@@ -232,21 +223,15 @@ async def entangle_vectors(vector1_id: str, vector2_id: str):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to entangle vectors: {str(e)}")
 
-@router.post("/quantum/trajectory", response_model=Dict[str, Any])
 
-
+@router.post("/quantum/trajectory", response_model=Dict[str, Any], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 async def compute_trajectory(request: TrajectoryRequest):
     """Compute quantum vector trajectory using flight control"""
     try:
-        target_state = {
-            "magnitude": request.target_magnitude,
-            "phase": request.target_phase
-        }
+        target_state = {"magnitude": request.target_magnitude, "phase": request.target_phase}
 
         trajectory = memory_manager.flight_controller.compute_trajectory(
-            vector_id=request.vector_id,
-            target_state=target_state,
-            trajectory_type=request.trajectory_type
+            vector_id=request.vector_id, target_state=target_state, trajectory_type=request.trajectory_type
         )
 
         return {
@@ -254,38 +239,36 @@ async def compute_trajectory(request: TrajectoryRequest):
             "trajectory_type": request.trajectory_type,
             "waypoints": len(trajectory),
             "trajectory": trajectory,
-            "status": "computed"
+            "status": "computed",
         }
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to compute trajectory: {str(e)}")
 
+
 @router.get("/metrics", response_model=SystemMetricsResponse)
-
-
 async def get_system_metrics():
     """Get comprehensive system metrics"""
     try:
         metrics = memory_manager.get_metrics()
 
         return SystemMetricsResponse(
-            total_memories=metrics.get('total_memories', 0),
-            active_memories=metrics.get('active_memories', 0),
-            compressed_memories=metrics.get('compressed_memories', 0),
-            archived_memories=metrics.get('archived_memories', 0),
-            quantum_vectors=metrics.get('quantum_vectors', 0),
-            entangled_pairs=metrics.get('entangled_pairs', 0),
-            aurora_anchor_coverage=metrics.get('aurora_anchor_coverage', 0),
-            average_cultural_score=metrics.get('average_cultural_score', 0.0),
-            quantum_network_density=metrics.get('quantum_network_density', 0.0)
+            total_memories=metrics.get("total_memories", 0),
+            active_memories=metrics.get("active_memories", 0),
+            compressed_memories=metrics.get("compressed_memories", 0),
+            archived_memories=metrics.get("archived_memories", 0),
+            quantum_vectors=metrics.get("quantum_vectors", 0),
+            entangled_pairs=metrics.get("entangled_pairs", 0),
+            aurora_anchor_coverage=metrics.get("aurora_anchor_coverage", 0),
+            average_cultural_score=metrics.get("average_cultural_score", 0.0),
+            quantum_network_density=metrics.get("quantum_network_density", 0.0),
         )
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to get metrics: {str(e)}")
 
-@router.post("/lifecycle/batch_process", response_model=Dict[str, Any])
 
-
+@router.post("/lifecycle/batch_process", response_model=Dict[str, Any], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 async def batch_process_lifecycle():
     """Process memory lifecycle operations (decay, compression, cleanup)"""
     try:
@@ -295,72 +278,59 @@ async def batch_process_lifecycle():
             "status": "completed",
             "timestamp": time.time(),
             "results": results,
-            "message": "Batch lifecycle processing completed successfully"
+            "message": "Batch lifecycle processing completed successfully",
         }
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to process lifecycle: {str(e)}")
 
-@router.post("/compress", response_model=Dict[str, Any])
 
-
+@router.post("/compress", response_model=Dict[str, Any], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 async def compress_memories(
     compression_ratio: float = Query(0.5, ge=0.1, le=0.9, description="Compression ratio"),
-    importance_threshold: float = Query(5.0, ge=0.0, le=10.0, description="Importance threshold")
+    importance_threshold: float = Query(5.0, ge=0.0, le=10.0, description="Importance threshold"),
 ):
     """Manually trigger memory compression"""
     try:
         results = memory_manager.compress_memories(
-            compression_ratio=compression_ratio,
-            importance_threshold=importance_threshold
+            compression_ratio=compression_ratio, importance_threshold=importance_threshold
         )
 
         return {
             "status": "completed",
             "compression_ratio": compression_ratio,
             "importance_threshold": importance_threshold,
-            "results": results
+            "results": results,
         }
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to compress memories: {str(e)}")
 
-@router.get("/export", response_model=Dict[str, Any])
 
-
+@router.get("/export", response_model=Dict[str, Any], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 async def export_system_state():
     """Export complete system state"""
     try:
         state = memory_manager.export_state()
-        return {
-            "status": "exported",
-            "export_timestamp": state["export_timestamp"],
-            "system_state": state
-        }
+        return {"status": "exported", "export_timestamp": state["export_timestamp"], "system_state": state}
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to export state: {str(e)}")
 
+
 @router.get("/quantum/network_analysis", response_model=Dict[str, Any])
-
-
 async def get_quantum_network_analysis():
     """Get detailed quantum entanglement network analysis"""
     try:
         analysis = memory_manager.flight_controller.get_entanglement_network_analysis()
-        return {
-            "status": "analyzed",
-            "timestamp": time.time(),
-            "network_analysis": analysis
-        }
+        return {"status": "analyzed", "timestamp": time.time(), "network_analysis": analysis}
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to analyze quantum network: {str(e)}")
 
+
 # Health check endpoint
 @router.get("/health")
-
-
 async def health_check():
     """Health check for AuMemManager system"""
     try:
@@ -368,13 +338,9 @@ async def health_check():
         return {
             "status": "healthy",
             "timestamp": time.time(),
-            "active_memories": metrics.get('active_memories', 0),
-            "quantum_vectors": metrics.get('quantum_vectors', 0),
-            "system_uptime": time.time() - metrics.get('last_cleanup', time.time())
+            "active_memories": metrics.get("active_memories", 0),
+            "quantum_vectors": metrics.get("quantum_vectors", 0),
+            "system_uptime": time.time() - metrics.get("last_cleanup", time.time()),
         }
     except Exception as e:
-        return {
-            "status": "unhealthy",
-            "error": str(e),
-            "timestamp": time.time()
-        }
+        return {"status": "unhealthy", "error": str(e), "timestamp": time.time()}

--- a/tests/test_aumemmanager_api.py
+++ b/tests/test_aumemmanager_api.py
@@ -3,6 +3,7 @@ API tests for AuMemManager FastAPI router
 """
 
 import os
+import unittest
 
 import pytest
 from fastapi import FastAPI
@@ -103,6 +104,7 @@ def test_create_and_retrieve_memory_flow(client):
 @pytest.mark.aurora
 @pytest.mark.security
 def test_sensitive_memory_routes_reject_missing_token(client):
+    checks = unittest.TestCase()
     requests = (
         ("post", "/memory/create", {"json": _memory_payload()}),
         ("post", "/memory/lifecycle/batch_process", {}),
@@ -112,27 +114,28 @@ def test_sensitive_memory_routes_reject_missing_token(client):
 
     for method, url, kwargs in requests:
         response = getattr(client, method)(url, **kwargs)
-        assert response.status_code in (401, 403)
+        checks.assertIn(response.status_code, (401, 403))
 
 
 @pytest.mark.api
 @pytest.mark.aurora
 @pytest.mark.security
 def test_sensitive_memory_routes_accept_valid_token(client):
+    checks = unittest.TestCase()
     headers = _auth_header()
 
     create_response = client.post("/memory/create", json=_memory_payload(), headers=headers)
-    assert create_response.status_code == 200
-    assert create_response.json()["status"] == "created"
+    checks.assertEqual(create_response.status_code, 200)
+    checks.assertEqual(create_response.json()["status"], "created")
 
     lifecycle_response = client.post("/memory/lifecycle/batch_process", headers=headers)
-    assert lifecycle_response.status_code == 200
-    assert lifecycle_response.json()["status"] == "completed"
+    checks.assertEqual(lifecycle_response.status_code, 200)
+    checks.assertEqual(lifecycle_response.json()["status"], "completed")
 
     compress_response = client.post("/memory/compress", headers=headers)
-    assert compress_response.status_code == 200
-    assert compress_response.json()["status"] == "completed"
+    checks.assertEqual(compress_response.status_code, 200)
+    checks.assertEqual(compress_response.json()["status"], "completed")
 
     export_response = client.get("/memory/export", headers=headers)
-    assert export_response.status_code == 200
-    assert export_response.json()["status"] == "exported"
+    checks.assertEqual(export_response.status_code, 200)
+    checks.assertEqual(export_response.json()["status"], "exported")

--- a/tests/test_aumemmanager_api.py
+++ b/tests/test_aumemmanager_api.py
@@ -2,11 +2,38 @@
 API tests for AuMemManager FastAPI router
 """
 
+import os
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from modules.aumemmanager.api_integration import router as aumem_router
+from tests._slowapi_stub import install_slowapi_stub
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-aumemmanager-api")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-aumemmanager-api")
+install_slowapi_stub()
+
+from modules.aumemmanager.api_integration import router as aumem_router  # noqa: E402
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+
+
+def _auth_header():
+    token = generate_csrf_token("test-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _memory_payload():
+    return {
+        "content": {"note": "integration-test memory"},
+        "memory_type": "agent",
+        "owner": "test_agent",
+        "importance": 3.5,
+        "tags": ["test", "integration"],
+        "quantum_properties": {"vector_id": "vec_it_001", "magnitude": 0.9, "phase": 0.1},
+        "aurora_anchors": ["T1:1", "SRB:1"],
+        "cultural_score": 0.42,
+    }
 
 
 @pytest.fixture
@@ -56,17 +83,7 @@ def test_memory_metrics_endpoint(client):
 @pytest.mark.aurora
 def test_create_and_retrieve_memory_flow(client):
     # Create
-    create_payload = {
-        "content": {"note": "integration-test memory"},
-        "memory_type": "agent",
-        "owner": "test_agent",
-        "importance": 3.5,
-        "tags": ["test", "integration"],
-        "quantum_properties": {"vector_id": "vec_it_001", "magnitude": 0.9, "phase": 0.1},
-        "aurora_anchors": ["T1:1", "SRB:1"],
-        "cultural_score": 0.42,
-    }
-    c_resp = client.post("/memory/create", json=create_payload)
+    c_resp = client.post("/memory/create", json=_memory_payload(), headers=_auth_header())
     assert c_resp.status_code == 200
     c_data = c_resp.json()
     assert c_data.get("status") == "created"
@@ -80,3 +97,42 @@ def test_create_and_retrieve_memory_flow(client):
     assert isinstance(items, list)
     # At least one memory should match the flow
     assert any(m.get("owner") == "test_agent" for m in items)
+
+
+@pytest.mark.api
+@pytest.mark.aurora
+@pytest.mark.security
+def test_sensitive_memory_routes_reject_missing_token(client):
+    requests = (
+        ("post", "/memory/create", {"json": _memory_payload()}),
+        ("post", "/memory/lifecycle/batch_process", {}),
+        ("post", "/memory/compress", {}),
+        ("get", "/memory/export", {}),
+    )
+
+    for method, url, kwargs in requests:
+        response = getattr(client, method)(url, **kwargs)
+        assert response.status_code in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.aurora
+@pytest.mark.security
+def test_sensitive_memory_routes_accept_valid_token(client):
+    headers = _auth_header()
+
+    create_response = client.post("/memory/create", json=_memory_payload(), headers=headers)
+    assert create_response.status_code == 200
+    assert create_response.json()["status"] == "created"
+
+    lifecycle_response = client.post("/memory/lifecycle/batch_process", headers=headers)
+    assert lifecycle_response.status_code == 200
+    assert lifecycle_response.json()["status"] == "completed"
+
+    compress_response = client.post("/memory/compress", headers=headers)
+    assert compress_response.status_code == 200
+    assert compress_response.json()["status"] == "completed"
+
+    export_response = client.get("/memory/export", headers=headers)
+    assert export_response.status_code == 200
+    assert export_response.json()["status"] == "exported"

--- a/tests/test_aumemmanager_quantum_api.py
+++ b/tests/test_aumemmanager_quantum_api.py
@@ -2,11 +2,35 @@
 Quantum API tests for AuMemManager FastAPI router
 """
 
+import os
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from modules.aumemmanager.api_integration import router as aumem_router
+from tests._slowapi_stub import install_slowapi_stub
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-aumemmanager-quantum-api")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-aumemmanager-quantum-api")
+install_slowapi_stub()
+
+from modules.aumemmanager.api_integration import router as aumem_router  # noqa: E402
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+
+
+def _auth_header():
+    token = generate_csrf_token("test-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _quantum_payload(vector_id):
+    return {
+        "vector_id": vector_id,
+        "magnitude": 0.75,
+        "phase": 0.2,
+        "aurora_anchors": ["T1:2", "SRB:3"],
+        "dlp_classification": "DLP_L1_OK",
+    }
 
 
 @pytest.fixture
@@ -24,14 +48,7 @@ def client(app):
 @pytest.mark.api
 @pytest.mark.quantum
 def test_create_quantum_vector(client):
-    payload = {
-        "vector_id": "vec_qt_001",
-        "magnitude": 0.75,
-        "phase": 0.2,
-        "aurora_anchors": ["T1:2", "SRB:3"],
-        "dlp_classification": "DLP_L1_OK",
-    }
-    resp = client.post("/memory/quantum/create_vector", json=payload)
+    resp = client.post("/memory/quantum/create_vector", json=_quantum_payload("vec_qt_001"), headers=_auth_header())
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "created"
@@ -45,18 +62,15 @@ def test_entangle_vectors(client):
     for vid in ("vec_qt_002", "vec_qt_003"):
         client.post(
             "/memory/quantum/create_vector",
-            json={
-                "vector_id": vid,
-                "magnitude": 0.6,
-                "phase": 0.1,
-                "aurora_anchors": ["T1:3"],
-                "dlp_classification": "DLP_L1_OK",
-            },
+            json=_quantum_payload(vid),
+            headers=_auth_header(),
         )
 
     # Entangle using query params (function signature takes plain args)
     resp = client.post(
-        "/memory/quantum/entangle", params={"vector1_id": "vec_qt_002", "vector2_id": "vec_qt_003"}
+        "/memory/quantum/entangle",
+        params={"vector1_id": "vec_qt_002", "vector2_id": "vec_qt_003"},
+        headers=_auth_header(),
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -70,13 +84,8 @@ def test_compute_trajectory(client):
     # Create a vector first
     client.post(
         "/memory/quantum/create_vector",
-        json={
-            "vector_id": "vec_qt_traj",
-            "magnitude": 0.5,
-            "phase": 0.0,
-            "aurora_anchors": ["T1:4"],
-            "dlp_classification": "DLP_L1_OK",
-        },
+        json=_quantum_payload("vec_qt_traj"),
+        headers=_auth_header(),
     )
 
     # Compute a trajectory
@@ -88,6 +97,7 @@ def test_compute_trajectory(client):
             "target_phase": 0.8,
             "trajectory_type": "quantum_optimal",
         },
+        headers=_auth_header(),
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -106,3 +116,34 @@ def test_quantum_network_analysis(client):
     data = resp.json()
     assert data["status"] == "analyzed"
     assert "network_analysis" in data
+
+
+@pytest.mark.api
+@pytest.mark.quantum
+@pytest.mark.security
+def test_quantum_mutation_routes_reject_missing_token(client):
+    requests = (
+        (
+            "/memory/quantum/create_vector",
+            {"json": _quantum_payload("vec_blocked")},
+        ),
+        (
+            "/memory/quantum/entangle",
+            {"params": {"vector1_id": "vec_blocked_1", "vector2_id": "vec_blocked_2"}},
+        ),
+        (
+            "/memory/quantum/trajectory",
+            {
+                "json": {
+                    "vector_id": "vec_blocked_traj",
+                    "target_magnitude": 0.9,
+                    "target_phase": 0.8,
+                    "trajectory_type": "quantum_optimal",
+                }
+            },
+        ),
+    )
+
+    for url, kwargs in requests:
+        response = client.post(url, **kwargs)
+        assert response.status_code in (401, 403)

--- a/tests/test_aumemmanager_quantum_api.py
+++ b/tests/test_aumemmanager_quantum_api.py
@@ -3,6 +3,7 @@ Quantum API tests for AuMemManager FastAPI router
 """
 
 import os
+import unittest
 
 import pytest
 from fastapi import FastAPI
@@ -122,6 +123,7 @@ def test_quantum_network_analysis(client):
 @pytest.mark.quantum
 @pytest.mark.security
 def test_quantum_mutation_routes_reject_missing_token(client):
+    checks = unittest.TestCase()
     requests = (
         (
             "/memory/quantum/create_vector",
@@ -146,4 +148,4 @@ def test_quantum_mutation_routes_reject_missing_token(client):
 
     for url, kwargs in requests:
         response = client.post(url, **kwargs)
-        assert response.status_code in (401, 403)
+        checks.assertIn(response.status_code, (401, 403))


### PR DESCRIPTION
Closes #653.

## Summary
- Require CSRF bearer auth on sensitive /memory mutation, lifecycle, compression, export, and quantum-control routes.
- Keep read-only health, metrics, retrieve, and network-analysis routes readable.
- Extend AuMemManager API tests for authorized access and missing-token rejection.

## Validation
- ./.venv/bin/python -m pytest tests/test_aumemmanager_api.py tests/test_aumemmanager_quantum_api.py -q
- ./.venv/bin/python -m flake8 modules/aumemmanager/api_integration.py tests/test_aumemmanager_api.py tests/test_aumemmanager_quantum_api.py
- ./.venv/bin/python -m py_compile modules/aumemmanager/api_integration.py tests/test_aumemmanager_api.py tests/test_aumemmanager_quantum_api.py
- git diff --check