### PR TITLE
Require auth on playground routes

### DIFF
--- a/src/playground/api.py
+++ b/src/playground/api.py
@@ -5,9 +5,22 @@ import secrets
 import time
 from typing import Any, Dict
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+    WebSocketException,
+    status,
+)
 from fastapi.responses import Response
+from fastapi.security import HTTPAuthorizationCredentials
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from src.middleware.fastapi_security import security, verify_csrf_token
 
 from .executor import ExecutionQueue
 from .limiter import get_rate_limiter
@@ -34,12 +47,53 @@ async def _broadcast(session_id: str, payload: Dict[str, Any]):
     await store.publish_event(session_id, payload)
 
 
+def _session_id_from_token(token: HTTPAuthorizationCredentials) -> str:
+    verify_csrf_token(token)
+    return token.credentials.split(".", 1)[0]
+
+
+def require_playground_auth(token: HTTPAuthorizationCredentials = Depends(security)) -> str:
+    """Require a valid CSRF bearer token and return its bound session id."""
+    return _session_id_from_token(token)
+
+
+def _require_session_owner(session_id: str, auth_session_id: str) -> Dict[str, Any]:
+    session = store.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.get("owner") != auth_session_id:
+        raise HTTPException(status_code=403, detail="Session access denied")
+    return session
+
+
+def _require_websocket_auth(websocket: WebSocket) -> str:
+    auth_header = websocket.headers.get("authorization")
+    if not auth_header or not auth_header.lower().startswith("bearer "):
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Missing bearer token")
+
+    scheme, credentials = auth_header.split(" ", 1)
+    try:
+        return _session_id_from_token(
+            HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials.strip())
+        )
+    except HTTPException as exc:
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason=str(exc.detail)) from exc
+
+
 @router.post("/session", response_model=SessionCreateResponse)
-async def create_session(request: SessionCreateRequest) -> SessionCreateResponse:
+async def create_session(
+    request: SessionCreateRequest,
+    auth_session_id: str = Depends(require_playground_auth),
+) -> SessionCreateResponse:
     session_id = secrets.token_urlsafe(12)
     payload = store.create_session(
         session_id,
-        {"language": request.language.value, "metadata": request.metadata, "seed_code": request.seed_code},
+        {
+            "language": request.language.value,
+            "metadata": request.metadata,
+            "owner": auth_session_id,
+            "seed_code": request.seed_code,
+        },
     )
     sessions_gauge.inc()
     await _broadcast(session_id, {"event": "session_created", "session_id": session_id, "payload": payload})
@@ -48,29 +102,49 @@ async def create_session(request: SessionCreateRequest) -> SessionCreateResponse
 
 @router.post("/execute", response_model=ExecutionStatusResponse)
 async def execute_code(
-    request: Request, body: ExecuteRequest, background_tasks: BackgroundTasks
+    request: Request,
+    body: ExecuteRequest,
+    background_tasks: BackgroundTasks,
+    auth_session_id: str = Depends(require_playground_auth),
 ) -> ExecutionStatusResponse:
     client_ip = request.client.host if request.client else "unknown"
     rate_limiter.enforce(client_ip)
     session_id = body.session_id or secrets.token_urlsafe(12)
     existing = store.get_session(session_id)
-    if not existing:
-        store.create_session(session_id, {"language": body.language.value, "metadata": {}, "seed_code": None})
+    if existing:
+        _require_session_owner(session_id, auth_session_id)
+    else:
+        store.create_session(
+            session_id,
+            {
+                "language": body.language.value,
+                "metadata": {},
+                "owner": auth_session_id,
+                "seed_code": None,
+            },
+        )
     await _broadcast(session_id, {"event": "started", "session_id": session_id})
     task_id = await queue.enqueue(session_id, body.code, body.language, body.stdin, background_tasks)
     return queue.get_status(session_id, task_id)
 
 
 @router.get("/results/{session_id}", response_model=ExecutionStatusResponse)
-async def get_results(session_id: str, task_id: str) -> ExecutionStatusResponse:
+async def get_results(
+    session_id: str,
+    task_id: str,
+    auth_session_id: str = Depends(require_playground_auth),
+) -> ExecutionStatusResponse:
+    _require_session_owner(session_id, auth_session_id)
     return queue.get_status(session_id, task_id)
 
 
 @router.post("/share", response_model=ShareResponse)
-async def share_session(body: ShareRequest, request: Request) -> ShareResponse:
-    session = store.get_session(body.session_id)
-    if not session:
-        raise HTTPException(status_code=404, detail="Session not found")
+async def share_session(
+    request: Request,
+    body: ShareRequest,
+    auth_session_id: str = Depends(require_playground_auth),
+) -> ShareResponse:
+    _require_session_owner(body.session_id, auth_session_id)
     short_code = secrets.token_urlsafe(6)
     share_payload = {
         "session_id": body.session_id,
@@ -116,11 +190,16 @@ async def healthcheck() -> PlaygroundHealth:
 
 @router.websocket("/ws/{session_id}")
 async def websocket_endpoint(websocket: WebSocket, session_id: str):
+    auth_session_id = _require_websocket_auth(websocket)
+    session = store.get_session(session_id)
+    if not session or session.get("owner") != auth_session_id:
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Session access denied")
+
     await websocket.accept()
     try:
         async for payload in store.stream_events(session_id):
             message = StreamMessage(**payload)
-            await websocket.send_json(message.dict())
+            await websocket.send_json(message.model_dump())
     except WebSocketDisconnect:
         # Client disconnected from WebSocket; no action needed.
         pass

--- a/tests/test_playground_auth.py
+++ b/tests/test_playground_auth.py
@@ -1,0 +1,193 @@
+"""Regression tests for Playground session auth and ownership gates."""
+
+import os
+import unittest
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from tests._slowapi_stub import install_slowapi_stub
+
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-playground-auth")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-playground-auth")
+install_slowapi_stub()
+
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+from src.playground import api as playground_api  # noqa: E402
+from src.playground.limiter import get_rate_limiter  # noqa: E402
+from src.playground.models import ExecutionStatusResponse  # noqa: E402
+from src.playground.storage import SessionStore  # noqa: E402
+
+
+class _QueueStub:
+    queue = None
+    runner = object()
+
+    async def enqueue(self, session_id, code, language, stdin, background_tasks):
+        return "task-test"
+
+    def get_status(self, session_id, task_id):
+        return ExecutionStatusResponse(
+            task_id=task_id,
+            session_id=session_id,
+            status="pending",
+        )
+
+
+@pytest.fixture(autouse=True)
+def isolate_playground_state(monkeypatch):
+    test_store = SessionStore()
+    monkeypatch.setattr(playground_api, "store", test_store)
+    monkeypatch.setattr(playground_api, "rate_limiter", get_rate_limiter(test_store))
+    monkeypatch.setattr(playground_api, "queue", _QueueStub())
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    app = FastAPI()
+    app.include_router(playground_api.router)
+    return TestClient(app)
+
+
+def _auth_header(session_id="owner-session"):
+    token = generate_csrf_token(session_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _session_payload():
+    return {
+        "language": "python",
+        "metadata": {"purpose": "auth-test"},
+        "seed_code": "print('ready')",
+    }
+
+
+def _execute_payload(session_id):
+    return {
+        "session_id": session_id,
+        "code": "print('hello')",
+        "language": "python",
+    }
+
+
+def _share_payload(session_id):
+    return {
+        "session_id": session_id,
+        "code": "print('shared')",
+        "language": "python",
+    }
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_playground_sensitive_http_routes_reject_missing_token(client):
+    checks = unittest.TestCase()
+
+    requests = (
+        ("post", "/playground/session", {"json": _session_payload()}),
+        ("post", "/playground/execute", {"json": _execute_payload("session-a")}),
+        ("post", "/playground/share", {"json": _share_payload("session-a")}),
+        ("get", "/playground/results/session-a", {"params": {"task_id": "task-test"}}),
+    )
+
+    for method, url, kwargs in requests:
+        response = getattr(client, method)(url, **kwargs)
+        checks.assertIn(response.status_code, (401, 403))
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_playground_sensitive_http_routes_accept_owner_token(client):
+    checks = unittest.TestCase()
+    headers = _auth_header("owner-a")
+
+    session_response = client.post("/playground/session", json=_session_payload(), headers=headers)
+    checks.assertEqual(session_response.status_code, 200)
+    session_id = session_response.json()["session_id"]
+
+    execute_response = client.post(
+        "/playground/execute",
+        json=_execute_payload(session_id),
+        headers=headers,
+    )
+    checks.assertEqual(execute_response.status_code, 200)
+    checks.assertEqual(execute_response.json()["session_id"], session_id)
+
+    results_response = client.get(
+        f"/playground/results/{session_id}",
+        params={"task_id": "task-test"},
+        headers=headers,
+    )
+    checks.assertEqual(results_response.status_code, 200)
+
+    share_response = client.post(
+        "/playground/share",
+        json=_share_payload(session_id),
+        headers=headers,
+    )
+    checks.assertEqual(share_response.status_code, 200)
+    checks.assertEqual(share_response.json()["session_id"], session_id)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_playground_session_owner_is_enforced(client):
+    checks = unittest.TestCase()
+    owner_headers = _auth_header("owner-a")
+    other_headers = _auth_header("owner-b")
+
+    session_response = client.post("/playground/session", json=_session_payload(), headers=owner_headers)
+    checks.assertEqual(session_response.status_code, 200)
+    session_id = session_response.json()["session_id"]
+
+    blocked_requests = (
+        ("post", "/playground/execute", {"json": _execute_payload(session_id), "headers": other_headers}),
+        ("post", "/playground/share", {"json": _share_payload(session_id), "headers": other_headers}),
+        (
+            "get",
+            f"/playground/results/{session_id}",
+            {"params": {"task_id": "task-test"}, "headers": other_headers},
+        ),
+    )
+
+    for method, url, kwargs in blocked_requests:
+        response = getattr(client, method)(url, **kwargs)
+        checks.assertEqual(response.status_code, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_playground_websocket_requires_owner_token(client, monkeypatch):
+    checks = unittest.TestCase()
+    owner_headers = _auth_header("owner-a")
+    other_headers = _auth_header("owner-b")
+
+    session_response = client.post("/playground/session", json=_session_payload(), headers=owner_headers)
+    checks.assertEqual(session_response.status_code, 200)
+    session_id = session_response.json()["session_id"]
+
+    with checks.assertRaises(WebSocketDisconnect):
+        with client.websocket_connect(f"/playground/ws/{session_id}"):
+            pass
+
+    with checks.assertRaises(WebSocketDisconnect):
+        with client.websocket_connect(f"/playground/ws/{session_id}", headers=other_headers):
+            pass
+
+    async def _stream_events(requested_session_id):
+        yield {
+            "event": "authorized",
+            "session_id": requested_session_id,
+            "payload": {},
+        }
+
+    monkeypatch.setattr(playground_api.store, "stream_events", _stream_events)
+
+    with client.websocket_connect(f"/playground/ws/{session_id}", headers=owner_headers) as websocket:
+        message = websocket.receive_json()
+
+    checks.assertEqual(message["event"], "authorized")
+    checks.assertEqual(message["session_id"], session_id)


### PR DESCRIPTION
Closes #652.

## Summary
- Require CSRF bearer auth on /playground session creation, code execution, sharing, result lookup, and WebSocket streams.
- Bind playground sessions to the CSRF token session id and reject cross-owner execution, sharing, results, and streams.
- Add focused HTTP and WebSocket auth regression tests.

## Validation
- ./.venv/bin/python -m pytest tests/test_playground_auth.py -q
- ./.venv/bin/python -m flake8 src/playground/api.py tests/test_playground_auth.py
- ./.venv/bin/python -m py_compile src/playground/api.py tests/test_playground_auth.py
- git diff --check