### PR TITLE
test: isolate SlowAPI stub coverage

### DIFF
--- a/tests/_slowapi_stub.py
+++ b/tests/_slowapi_stub.py
@@ -5,12 +5,36 @@ import sys
 import types
 from typing import Any, Callable
 
+SLOWAPI_TEST_STUB_MARKER = "__aurora_test_stub__"
+
+
+def _real_slowapi_available() -> bool:
+    try:
+        return importlib.util.find_spec("slowapi") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def assert_real_slowapi_loaded() -> None:
+    """Fail fast when a real SlowAPI integration test is accidentally using this stub."""
+    import slowapi  # type: ignore[import-not-found]
+
+    if getattr(slowapi, SLOWAPI_TEST_STUB_MARKER, False):
+        raise AssertionError("tests/_slowapi_stub.py is loaded; real SlowAPI coverage is not active")
+    if not getattr(slowapi, "__file__", None):
+        raise AssertionError("slowapi has no package file; real SlowAPI coverage is not active")
+
 
 def install_slowapi_stub() -> None:
     """Install minimal slowapi modules when the optional package is unavailable."""
-    if "slowapi" not in sys.modules and importlib.util.find_spec("slowapi") is None:
+    if _real_slowapi_available():
+        return
+
+    if "slowapi" not in sys.modules:
         slowapi_module = types.ModuleType("slowapi")
         slowapi_util_module = types.ModuleType("slowapi.util")
+        setattr(slowapi_module, SLOWAPI_TEST_STUB_MARKER, True)
+        setattr(slowapi_util_module, SLOWAPI_TEST_STUB_MARKER, True)
 
         class _Limiter:
             def __init__(self, *args: Any, **kwargs: Any):
@@ -37,6 +61,8 @@ def install_slowapi_stub() -> None:
     if "slowapi" in sys.modules and "slowapi.errors" not in sys.modules:
         slowapi_errors_module = types.ModuleType("slowapi.errors")
         slowapi_middleware_module = types.ModuleType("slowapi.middleware")
+        setattr(slowapi_errors_module, SLOWAPI_TEST_STUB_MARKER, True)
+        setattr(slowapi_middleware_module, SLOWAPI_TEST_STUB_MARKER, True)
 
         class _RateLimitExceeded(Exception):
             """Test stub for slowapi.errors.RateLimitExceeded."""

--- a/tests/test_rate_limit_headers.py
+++ b/tests/test_rate_limit_headers.py
@@ -8,9 +8,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from tests._slowapi_stub import assert_real_slowapi_loaded
 
 
 def build_isolated_app(limit_token_per_min: int = 2):
+    assert_real_slowapi_loaded()
+
     # Set env before importing router so decorator picks new value
     os.environ["RATE_LIMIT_AUTH_TOKEN_PER_MIN"] = str(limit_token_per_min)
     # Ensure limiter enabled & default strategy

--- a/tests/test_slowapi_stub_isolation.py
+++ b/tests/test_slowapi_stub_isolation.py
@@ -1,0 +1,74 @@
+"""Tests for keeping the dependency-light SlowAPI stub out of real limiter coverage."""
+
+from contextlib import contextmanager
+import sys
+from types import SimpleNamespace
+import unittest
+
+import pytest
+
+from tests import _slowapi_stub
+
+
+SLOWAPI_MODULE_NAMES = ("slowapi", "slowapi.errors", "slowapi.middleware", "slowapi.util")
+
+
+@contextmanager
+def preserved_slowapi_modules():
+    saved_modules = {name: sys.modules.get(name) for name in SLOWAPI_MODULE_NAMES}
+    for name in SLOWAPI_MODULE_NAMES:
+        sys.modules.pop(name, None)
+    try:
+        yield
+    finally:
+        for name in SLOWAPI_MODULE_NAMES:
+            sys.modules.pop(name, None)
+        for name, module in saved_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+
+
+def test_install_stub_returns_when_real_slowapi_is_discoverable(monkeypatch):
+    checks = unittest.TestCase()
+
+    def fake_find_spec(name):
+        if name == "slowapi":
+            return SimpleNamespace(origin="/venv/site-packages/slowapi/__init__.py")
+        return None
+
+    monkeypatch.setattr(_slowapi_stub.importlib.util, "find_spec", fake_find_spec)
+
+    with preserved_slowapi_modules():
+        _slowapi_stub.install_slowapi_stub()
+
+        for name in SLOWAPI_MODULE_NAMES:
+            checks.assertNotIn(name, sys.modules)
+
+
+def test_install_stub_marks_modules_when_real_slowapi_is_missing(monkeypatch):
+    checks = unittest.TestCase()
+    monkeypatch.setattr(_slowapi_stub.importlib.util, "find_spec", lambda name: None)
+
+    with preserved_slowapi_modules():
+        _slowapi_stub.install_slowapi_stub()
+
+        for name in SLOWAPI_MODULE_NAMES:
+            checks.assertIs(
+                getattr(sys.modules[name], _slowapi_stub.SLOWAPI_TEST_STUB_MARKER),
+                True,
+            )
+
+        from slowapi import Limiter
+
+        limited = Limiter().limit("1/minute")(lambda: "ok")
+        checks.assertEqual(limited(), "ok")
+
+
+def test_assert_real_slowapi_loaded_rejects_installed_stub(monkeypatch):
+    monkeypatch.setattr(_slowapi_stub.importlib.util, "find_spec", lambda name: None)
+
+    with preserved_slowapi_modules():
+        _slowapi_stub.install_slowapi_stub()
+
+        with pytest.raises(AssertionError, match="real SlowAPI coverage is not active"):
+            _slowapi_stub.assert_real_slowapi_loaded()


### PR DESCRIPTION
Closes #713. Summary: tightens tests/_slowapi_stub.py so it returns when real SlowAPI is discoverable, marks installed stub modules, makes real rate-limit header tests fail fast if the stub is loaded, and adds stub-isolation regression tests. Verification: CSRF_SECRET_KEY=test-csrf JWT_SECRET_KEY=test-jwt .venv/bin/python -m pytest tests/test_slowapi_stub_isolation.py tests/test_rate_limit_headers.py tests/test_rate_limiting.py -q; CSRF_SECRET_KEY=test-csrf JWT_SECRET_KEY=test-jwt WS_AUTH_SECRET=test-ws .venv/bin/python -m pytest tests/test_playground_auth.py tests/test_quantum_simulator.py tests/test_aumemmanager_api.py tests/test_sensitive_router_auth.py -q.