### PR TITLE
fix: route L2 feasibility through ARCHYEntity

### DIFF
--- a/src/aurora_orchestrator/triplex_handshake.py
+++ b/src/aurora_orchestrator/triplex_handshake.py
@@ -64,43 +64,6 @@ class ValidationResult:
             self.timestamp = datetime.now().isoformat()
 
 
-class MockARCHY:
-    """
-    Mock ARCHY (Architecture Verifier) - Future: Real Entity
-
-    ARCHY verifies technical feasibility and architectural soundness.
-    """
-
-    def __init__(self):
-        self.logger = logging.getLogger('MockARCHY')
-
-    async def verify_feasibility(self, decision) -> Dict[str, Any]:
-        """
-        Verify technical feasibility.
-
-        Returns:
-            Dict with: approved (bool), feasible (bool), constraints (list)
-        """
-        # Check context for feasibility flag
-        context = decision.context or {}
-        # Placeholder await for async compliance
-        import asyncio
-        await asyncio.sleep(0)
-        feasible = context.get('feasible', True)
-
-        constraints = []
-        if not feasible:
-            constraints.append("Technical constraints not satisfied")
-
-        return {
-            'approved': feasible,
-            'feasible': feasible,
-            'constraints': constraints,
-            'capacity_available': True,
-            'evaluator': 'ARCHY'
-        }
-
-
 class TriplexHandshakeValidator:
     """
     Triplex Handshake Validation System
@@ -130,9 +93,9 @@ class TriplexHandshakeValidator:
         self.axiomera = get_axiomera()
         self.caelion = get_caelion()
         self.halo = get_halo()
-        self.archy = MockARCHY()
-        # ARCHYEntity provides L1 architecture-level oversight for critical decisions
-        self.l1_oversight = get_archy()
+        self.archy = get_archy()
+        # ARCHYEntity provides both L2 feasibility and L1 architecture-level oversight.
+        self.l1_oversight = self.archy
 
         self.logger.info(
             "🛡️ Triplex Handshake Validator initialized (real entity mode)"
@@ -350,8 +313,8 @@ class TriplexHandshakeValidator:
             'recommendation': raw_drift['recommendation'],
         }
 
-        # ARCHY feasibility verification (mock — not yet replaced)
-        feasibility_result = await self.archy.verify_feasibility(decision)
+        # ARCHY feasibility verification via real relay entity
+        feasibility_result = await self.archy.verify_feasibility(decision, event=event)
 
         # Both must approve
         approved = drift_result['approved'] and feasibility_result['approved']

--- a/src/entities/relay_agents.py
+++ b/src/entities/relay_agents.py
@@ -386,6 +386,69 @@ class ARCHYEntity:
             "l3_considered": l3_assessment is not None,
             "timestamp": utc_iso()
         }
+
+    async def verify_feasibility(
+        self,
+        decision: Any,
+        event: Optional[Event] = None,
+    ) -> Dict[str, Any]:
+        """
+        Verify L2 technical feasibility for a Triplex decision.
+
+        This is the production ARCHY contract used by the Triplex validator.
+        It keeps the older decision-level feasibility semantics while routing
+        the architecture checks through the real ARCHYEntity.
+        """
+        constraints = self._decision_feasibility_constraints(decision)
+        architecture_result, architecture_constraints = await self._architecture_feasibility_constraints(event)
+        constraints.extend(architecture_constraints)
+
+        feasible = not constraints
+
+        return {
+            "approved": feasible,
+            "feasible": feasible,
+            "constraints": constraints,
+            "capacity_available": feasible,
+            "evaluator": self.entity_id,
+            "architecture": architecture_result,
+            "timestamp": utc_iso(),
+        }
+
+    def _decision_feasibility_constraints(self, decision: Any) -> List[str]:
+        context = getattr(decision, "context", None) or {}
+        constraints = []
+
+        if not isinstance(context, dict):
+            constraints.append("Decision context must be a mapping")
+            context = {}
+
+        required_fields = ("decision_id", "action", "rationale", "expected_outcomes")
+        missing_fields = [field for field in required_fields if not getattr(decision, field, None)]
+        if missing_fields:
+            constraints.append(f"Decision missing required fields: {', '.join(missing_fields)}")
+
+        if context.get("feasible") is False:
+            constraints.append("Decision context marks operation infeasible")
+
+        return constraints
+
+    async def _architecture_feasibility_constraints(
+        self,
+        event: Optional[Event],
+    ) -> tuple[Optional[Dict[str, Any]], List[str]]:
+        if event is None:
+            return None, []
+
+        architecture_result = await self.evaluate_for_triplex(event)
+        constraints = []
+
+        if architecture_result["recommendation"] == "BLOCK":
+            constraints.append(architecture_result["reasoning"])
+        if not event.context_tag or not event.context_tag.startswith("decision_"):
+            constraints.append("Decision event missing valid DLP context tag")
+
+        return architecture_result, constraints
     
     def enforce_pattern(self, pattern_name: str, data: Dict[str, Any]) -> bool:
         """

--- a/tests/aurora_orchestrator/test_triplex_handshake.py
+++ b/tests/aurora_orchestrator/test_triplex_handshake.py
@@ -18,6 +18,7 @@ from src.agents.aurora_consciousness_agent import AuroraDecision, DecisionPriori
 from src.aurora_orchestrator.triplex_handshake import TriplexHandshakeValidator
 from src.core.event_system import Event, EventType, StationLocation
 from src.entities.framework_agents import get_axiomera
+from src.entities.relay_agents import get_archy
 
 
 def _assertions():
@@ -112,3 +113,46 @@ async def test_validator_routes_human_consent_recommendation_to_l1_oversight():
     assertions.assertTrue(result.l3_result["requires_human_approval"])
     assertions.assertEqual(result.l3_result["ethics"]["recommendation"], "REQUIRE_HUMAN_CONSENT")
     assertions.assertEqual(result.l1_result["approval"]["approval_mode"], "architecture_oversight")
+
+
+def test_validator_uses_real_archy_singleton_for_l2_feasibility():
+    """The L2 feasibility gate must use ARCHYEntity, not a local mock."""
+    validator = TriplexHandshakeValidator()
+    assertions = _assertions()
+
+    assertions.assertIs(validator.archy, get_archy())
+    assertions.assertIs(validator.l1_oversight, validator.archy)
+
+
+@pytest.mark.asyncio
+async def test_validator_blocks_infeasible_decision_at_l2_archy():
+    """ARCHYEntity feasibility rejection should block at L2."""
+    decision = AuroraDecision(
+        decision_id="triplex-l2-infeasible",
+        timestamp=datetime.utcnow().isoformat(),
+        priority=DecisionPriority.MEDIUM,
+        context={
+            "action": "bounded_maintenance_operation",
+            "continuity_load": 0.3,
+            "feasible": False,
+        },
+        action="perform bounded maintenance operation",
+        rationale="exercise L2 ARCHY feasibility rejection",
+        expected_outcomes=["L2 rejection"],
+        risk_assessment=0.1,
+        ethical_compliance=True,
+        requires_human_approval=False,
+    )
+
+    result = await TriplexHandshakeValidator().validate_decision(decision)
+    assertions = _assertions()
+
+    assertions.assertFalse(result.approved)
+    assertions.assertEqual(result.blocked_at_level, "L2")
+    assertions.assertEqual(result.reason, "Technical feasibility check failed")
+    assertions.assertFalse(result.l2_result["feasibility"]["approved"])
+    assertions.assertEqual(result.l2_result["feasibility"]["evaluator"], "ARCHY (RELAY_001)")
+    assertions.assertIn(
+        "Decision context marks operation infeasible",
+        result.l2_result["feasibility"]["constraints"],
+    )


### PR DESCRIPTION
Closes #717. Summary: removes the local MockARCHY class from triplex_handshake.py, routes the L2 feasibility gate through the real get_archy() singleton, adds ARCHYEntity.verify_feasibility() for decision-level feasibility plus architecture/DLP checks, and covers singleton wiring plus infeasible-decision rejection at L2. Verification: CSRF_SECRET_KEY=test-csrf JWT_SECRET_KEY=test-jwt .venv/bin/python -m pytest tests/aurora_orchestrator/test_triplex_handshake.py -q; CSRF_SECRET_KEY=test-csrf JWT_SECRET_KEY=test-jwt .venv/bin/python -m pytest tests/test_slowapi_stub_isolation.py tests/test_rate_limit_headers.py tests/test_rate_limiting.py -q.