### PR TITLE
Fix reflective autonomy scaffold

### DIFF
--- a/modules/reflective_autonomy/__init__.py
+++ b/modules/reflective_autonomy/__init__.py
@@ -1,1 +1,16 @@
-# Marks this directory as a Python package.
+"""Reflective autonomy package exports."""
+
+from .autonomic_correction_engine import AutonomicCorrectionEngine, CorrectionAction, CorrectionReport
+from .capsule_linter import CapsuleLinter, CapsuleLintFinding, CapsuleLintResult
+from .reflective_autonomy_loop import AutonomyCycleReceipt, ReflectiveAutonomyLoop
+
+__all__ = [
+    "AutonomicCorrectionEngine",
+    "AutonomyCycleReceipt",
+    "CapsuleLintFinding",
+    "CapsuleLintResult",
+    "CapsuleLinter",
+    "CorrectionAction",
+    "CorrectionReport",
+    "ReflectiveAutonomyLoop",
+]

--- a/modules/reflective_autonomy/autonomic_correction_engine.py
+++ b/modules/reflective_autonomy/autonomic_correction_engine.py
@@ -1,4 +1,102 @@
-# autonomic_correction_engine.py
-# Aurora Reflective Autonomy System - Autonomic Correction Engine
+"""Autonomic correction planning for reflective autonomy lint findings."""
 
-# ...existing code...
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional
+
+try:
+    from .capsule_linter import CapsuleLinter, CapsuleLintFinding, CapsuleLintResult
+except ImportError:  # pragma: no cover - direct script execution fallback
+    from capsule_linter import CapsuleLinter, CapsuleLintFinding, CapsuleLintResult
+
+
+@dataclass(frozen=True)
+class CorrectionAction:
+    """A non-destructive correction intent."""
+
+    action: str
+    target: Optional[str]
+    reason: str
+    field: Optional[str] = None
+    status: str = "planned"
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "action": self.action,
+            "target": self.target,
+            "field": self.field,
+            "reason": self.reason,
+            "status": self.status,
+        }
+
+
+@dataclass
+class CorrectionReport:
+    """Correction-planning receipt for one autonomy check."""
+
+    lint_result: CapsuleLintResult
+    actions: List[CorrectionAction] = field(default_factory=list)
+
+    @property
+    def approved(self) -> bool:
+        return self.lint_result.valid and not self.actions
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "approved": self.approved,
+            "lint": self.lint_result.to_dict(),
+            "actions": [action.to_dict() for action in self.actions],
+        }
+
+
+class AutonomicCorrectionEngine:
+    """Plan corrections from capsule lint findings without silent mutation."""
+
+    def __init__(self, linter: Optional[CapsuleLinter] = None) -> None:
+        self.linter = linter or CapsuleLinter()
+
+    def evaluate_capsule(
+        self,
+        capsule: Mapping[str, Any],
+        capsule_id: Optional[str] = None,
+    ) -> CorrectionReport:
+        lint_result = self.linter.lint_capsule(capsule, capsule_id=capsule_id)
+        return self.plan_corrections(lint_result)
+
+    def evaluate_payload_file(self, payload_path: str) -> CorrectionReport:
+        lint_result = self.linter.lint_payload_file(self.linter.repo_root / payload_path)
+        return self.plan_corrections(lint_result)
+
+    def evaluate_registered_payloads(self) -> CorrectionReport:
+        lint_result = self.linter.lint_registered_payloads()
+        return self.plan_corrections(lint_result)
+
+    def plan_corrections(self, lint_result: CapsuleLintResult) -> CorrectionReport:
+        actions = [self._action_for(finding) for finding in lint_result.findings]
+        return CorrectionReport(lint_result=lint_result, actions=actions)
+
+    @staticmethod
+    def _action_for(finding: CapsuleLintFinding) -> CorrectionAction:
+        action_map = {
+            "missing_required_field": "populate_field",
+            "invalid_anchor_seed": "restore_governance_value",
+            "invalid_ethics_protocol": "restore_governance_value",
+            "invalid_threadcore_directives": "repair_directives",
+            "symbolic_drift_high": "review_drift",
+            "payload_file_missing": "recover_payload_file",
+            "payload_file_unreadable": "repair_payload_file",
+            "registry_payload_path_missing": "link_registry_payload",
+            "registry_entry_invalid": "repair_registry_entry",
+            "capsule_unsealed": "seal_capsule",
+        }
+        return CorrectionAction(
+            action=action_map.get(finding.code, "review_finding"),
+            target=finding.capsule_id,
+            field=finding.field,
+            reason=finding.message,
+            status="planned",
+        )
+
+
+__all__ = ["AutonomicCorrectionEngine", "CorrectionAction", "CorrectionReport"]

--- a/modules/reflective_autonomy/capsule_linter.py
+++ b/modules/reflective_autonomy/capsule_linter.py
@@ -1,4 +1,366 @@
-# capsule_linter.py
-# Aurora Reflective Autonomy System - Capsule Linter
+"""Deterministic capsule linting for the reflective autonomy layer."""
 
-# ...existing code...
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+import yaml
+
+DEFAULT_ANCHOR_SEED = "EOS_SEED_ORION"
+DEFAULT_ETHICS_PROTOCOL = "Picard_Delta_3"
+DEFAULT_MAX_DRIFT = 0.002
+THREADCORE_REQUIRED_FIELDS = (
+    "augmentation",
+    "version",
+    "role",
+    "threadcore_directives",
+    "anchor_seed",
+    "ethics_protocol",
+)
+CAPSULE_REQUIRED_FIELDS = ("capsule_id", "role", "ethics_protocol")
+REGISTRY_REQUIRED_FIELDS = ("status", "files", "exported_at")
+
+
+@dataclass(frozen=True)
+class CapsuleLintFinding:
+    """A machine-readable capsule validation finding."""
+
+    code: str
+    severity: str
+    message: str
+    capsule_id: Optional[str] = None
+    field: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "capsule_id": self.capsule_id,
+            "field": self.field,
+        }
+
+
+@dataclass
+class CapsuleLintResult:
+    """Aggregate result for one or more capsule checks."""
+
+    checked_capsules: int = 0
+    findings: List[CapsuleLintFinding] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        return not any(finding.severity == "error" for finding in self.findings)
+
+    @property
+    def errors(self) -> List[CapsuleLintFinding]:
+        return [finding for finding in self.findings if finding.severity == "error"]
+
+    @property
+    def warnings(self) -> List[CapsuleLintFinding]:
+        return [finding for finding in self.findings if finding.severity == "warning"]
+
+    def add(self, finding: CapsuleLintFinding) -> None:
+        self.findings.append(finding)
+
+    def extend(self, other: "CapsuleLintResult") -> None:
+        self.checked_capsules += other.checked_capsules
+        self.findings.extend(other.findings)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "valid": self.valid,
+            "checked_capsules": self.checked_capsules,
+            "errors": [finding.to_dict() for finding in self.errors],
+            "warnings": [finding.to_dict() for finding in self.warnings],
+            "findings": [finding.to_dict() for finding in self.findings],
+        }
+
+
+class CapsuleLinter:
+    """Validate ThreadCore and reflective autonomy capsule structures."""
+
+    def __init__(
+        self,
+        registry_path: Optional[Path] = None,
+        repo_root: Optional[Path] = None,
+    ) -> None:
+        self.repo_root = Path(repo_root) if repo_root else Path(__file__).resolve().parents[2]
+        self.registry_path = Path(registry_path) if registry_path else self.repo_root / "threadcore_registry.json"
+        self.registry = self._load_registry()
+        self.rules = self.registry.get("validation_rules", {})
+
+    def lint_capsule(
+        self,
+        capsule: Mapping[str, Any],
+        capsule_id: Optional[str] = None,
+    ) -> CapsuleLintResult:
+        """Validate one in-memory capsule payload."""
+        result = CapsuleLintResult(checked_capsules=1)
+        if not isinstance(capsule, Mapping):
+            result.add(
+                CapsuleLintFinding(
+                    code="invalid_capsule_type",
+                    severity="error",
+                    message="Capsule payload must be a mapping.",
+                    capsule_id=capsule_id,
+                )
+            )
+            return result
+
+        resolved_id = capsule_id or self._capsule_id(capsule)
+        self._check_required_fields(capsule, self._required_fields_for(capsule), resolved_id, result)
+        self._check_governance_fields(capsule, resolved_id, result)
+        self._check_directives(capsule, resolved_id, result)
+        self._check_drift(capsule, resolved_id, result)
+        return result
+
+    def lint_payload_file(self, payload_path: Path) -> CapsuleLintResult:
+        """Load and validate one JSON or YAML capsule file."""
+        path = Path(payload_path)
+        if not path.exists():
+            return CapsuleLintResult(
+                findings=[
+                    CapsuleLintFinding(
+                        code="payload_file_missing",
+                        severity="error",
+                        message=f"Payload file not found: {path}",
+                        capsule_id=path.stem,
+                    )
+                ]
+            )
+
+        try:
+            payload = self._load_structured_file(path)
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            return CapsuleLintResult(
+                checked_capsules=1,
+                findings=[
+                    CapsuleLintFinding(
+                        code="payload_file_unreadable",
+                        severity="error",
+                        message=f"Could not parse payload file {path}: {exc}",
+                        capsule_id=path.stem,
+                    )
+                ],
+            )
+
+        return self.lint_capsule(payload, capsule_id=path.stem)
+
+    def lint_registry_entries(self, registry: Mapping[str, Mapping[str, Any]]) -> CapsuleLintResult:
+        """Validate the historical anchor-hash capsule registry shape."""
+        result = CapsuleLintResult()
+        for anchor, metadata in registry.items():
+            result.checked_capsules += 1
+            if not isinstance(metadata, Mapping):
+                result.add(
+                    CapsuleLintFinding(
+                        code="registry_entry_invalid",
+                        severity="error",
+                        message="Registry entry must be a mapping.",
+                        capsule_id=str(anchor),
+                    )
+                )
+                continue
+            self._check_required_fields(metadata, REGISTRY_REQUIRED_FIELDS, str(anchor), result)
+            if metadata.get("status") not in (None, "sealed"):
+                result.add(
+                    CapsuleLintFinding(
+                        code="capsule_unsealed",
+                        severity="error",
+                        message="Capsule registry entry is not sealed.",
+                        capsule_id=str(anchor),
+                        field="status",
+                    )
+                )
+        return result
+
+    def lint_registered_payloads(self) -> CapsuleLintResult:
+        """Validate all payload files referenced by threadcore_registry.json."""
+        result = CapsuleLintResult()
+        payloads = self.registry.get("payloads", {})
+        for payload_name, payload_info in payloads.items():
+            file_path = payload_info.get("file_path")
+            if not file_path:
+                result.add(
+                    CapsuleLintFinding(
+                        code="registry_payload_path_missing",
+                        severity="error",
+                        message="Registry payload entry has no file_path.",
+                        capsule_id=payload_name,
+                        field="file_path",
+                    )
+                )
+                continue
+            result.extend(self.lint_payload_file(self.repo_root / file_path))
+        return result
+
+    def suggest_corrections(self, result: CapsuleLintResult) -> List[Dict[str, Optional[str]]]:
+        """Convert lint findings into deterministic correction intents."""
+        return [self._suggestion_for(finding) for finding in result.findings]
+
+    def _load_registry(self) -> Dict[str, Any]:
+        if not self.registry_path.exists():
+            return {}
+        with open(self.registry_path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def _required_fields_for(self, capsule: Mapping[str, Any]) -> Sequence[str]:
+        if "threadcore_directives" in capsule:
+            return tuple(self.rules.get("required_fields", THREADCORE_REQUIRED_FIELDS))
+        if "capsule_id" in capsule:
+            return CAPSULE_REQUIRED_FIELDS
+        return THREADCORE_REQUIRED_FIELDS
+
+    def _check_required_fields(
+        self,
+        capsule: Mapping[str, Any],
+        required_fields: Iterable[str],
+        capsule_id: Optional[str],
+        result: CapsuleLintResult,
+    ) -> None:
+        for field_name in required_fields:
+            if field_name not in capsule or capsule.get(field_name) in (None, "", []):
+                result.add(
+                    CapsuleLintFinding(
+                        code="missing_required_field",
+                        severity="error",
+                        message=f"Missing required field: {field_name}",
+                        capsule_id=capsule_id,
+                        field=field_name,
+                    )
+                )
+
+    def _check_governance_fields(
+        self,
+        capsule: Mapping[str, Any],
+        capsule_id: Optional[str],
+        result: CapsuleLintResult,
+    ) -> None:
+        required_anchor = self.rules.get("anchor_seed_required", DEFAULT_ANCHOR_SEED)
+        if "anchor_seed" in capsule and capsule.get("anchor_seed") != required_anchor:
+            result.add(
+                CapsuleLintFinding(
+                    code="invalid_anchor_seed",
+                    severity="error",
+                    message=f"Anchor seed must be {required_anchor}.",
+                    capsule_id=capsule_id,
+                    field="anchor_seed",
+                )
+            )
+
+        required_ethics = self.rules.get("ethics_protocol_required", DEFAULT_ETHICS_PROTOCOL)
+        if capsule.get("ethics_protocol") != required_ethics:
+            result.add(
+                CapsuleLintFinding(
+                    code="invalid_ethics_protocol",
+                    severity="error",
+                    message=f"Ethics protocol must be {required_ethics}.",
+                    capsule_id=capsule_id,
+                    field="ethics_protocol",
+                )
+            )
+
+    def _check_directives(
+        self,
+        capsule: Mapping[str, Any],
+        capsule_id: Optional[str],
+        result: CapsuleLintResult,
+    ) -> None:
+        directives = capsule.get("threadcore_directives")
+        if directives is None:
+            return
+        if not isinstance(directives, list) or not directives or not all(
+            isinstance(item, str) and item.strip() for item in directives
+        ):
+            result.add(
+                CapsuleLintFinding(
+                    code="invalid_threadcore_directives",
+                    severity="error",
+                    message="threadcore_directives must be a non-empty list of strings.",
+                    capsule_id=capsule_id,
+                    field="threadcore_directives",
+                )
+            )
+
+    def _check_drift(
+        self,
+        capsule: Mapping[str, Any],
+        capsule_id: Optional[str],
+        result: CapsuleLintResult,
+    ) -> None:
+        drift_value = self._parse_drift(capsule.get("symbolic_drift"))
+        if drift_value is None:
+            return
+        max_drift = float(self.rules.get("max_drift_threshold", DEFAULT_MAX_DRIFT))
+        if drift_value > max_drift:
+            result.add(
+                CapsuleLintFinding(
+                    code="symbolic_drift_high",
+                    severity="warning",
+                    message=f"Symbolic drift {drift_value} exceeds threshold {max_drift}.",
+                    capsule_id=capsule_id,
+                    field="symbolic_drift",
+                )
+            )
+
+    @staticmethod
+    def _capsule_id(capsule: Mapping[str, Any]) -> Optional[str]:
+        for key in ("capsule_id", "augmentation", "version"):
+            value = capsule.get(key)
+            if value:
+                return str(value)
+        return None
+
+    @staticmethod
+    def _parse_drift(raw_value: Any) -> Optional[float]:
+        if raw_value in (None, ""):
+            return None
+        try:
+            raw_text = str(raw_value).strip()
+            if raw_text.endswith("%"):
+                return float(raw_text[:-1]) / 100
+            return float(raw_text)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _load_structured_file(path: Path) -> Mapping[str, Any]:
+        with open(path, "r", encoding="utf-8") as handle:
+            if path.suffix.lower() == ".json":
+                payload = json.load(handle)
+            else:
+                payload = yaml.safe_load(handle)
+        if not isinstance(payload, Mapping):
+            raise ValueError("payload root must be a mapping")
+        return payload
+
+    @staticmethod
+    def _suggestion_for(finding: CapsuleLintFinding) -> Dict[str, Optional[str]]:
+        actions = {
+            "missing_required_field": "populate_field",
+            "invalid_anchor_seed": "restore_governance_value",
+            "invalid_ethics_protocol": "restore_governance_value",
+            "invalid_threadcore_directives": "repair_directives",
+            "symbolic_drift_high": "review_drift",
+            "payload_file_missing": "recover_payload_file",
+            "capsule_unsealed": "seal_capsule",
+        }
+        return {
+            "action": actions.get(finding.code, "review_finding"),
+            "target": finding.capsule_id,
+            "field": finding.field,
+            "reason": finding.message,
+        }
+
+
+__all__ = [
+    "CapsuleLinter",
+    "CapsuleLintFinding",
+    "CapsuleLintResult",
+    "DEFAULT_ANCHOR_SEED",
+    "DEFAULT_ETHICS_PROTOCOL",
+]

--- a/modules/reflective_autonomy/integration_capsule_threadcore_classifier.py
+++ b/modules/reflective_autonomy/integration_capsule_threadcore_classifier.py
@@ -1,4 +1,9 @@
-from symbolic_tagging_engine import classify_thread_content
+"""Integration capsule wrapper for ThreadCore classification."""
+
+try:
+    from .symbolic_tagging_engine import classify_thread_content
+except ImportError:  # pragma: no cover - direct script execution fallback
+    from symbolic_tagging_engine import classify_thread_content
 
 
 class ThreadcoreClassifierCapsule:
@@ -9,9 +14,13 @@ class ThreadcoreClassifierCapsule:
         self.engine = classify_thread_content
 
     def process(self, thread_entry: str) -> dict:
-        """
-        Accepts thread entry text and returns classification dict.
-        """
+        """Accept thread entry text and return a classification receipt."""
         if not thread_entry or not isinstance(thread_entry, str):
             return {"status": "error", "reason": "Empty input"}
-        return self.engine(thread_entry)
+        result = self.engine(thread_entry)
+        return {
+            "status": "ok",
+            "module": self.module_name,
+            "version": self.version,
+            "classification": result,
+        }

--- a/modules/reflective_autonomy/loom_governance_system.yaml
+++ b/modules/reflective_autonomy/loom_governance_system.yaml
@@ -1,4 +1,35 @@
-# loom_governance_system.yaml
-# Aurora Reflective Autonomy System - Governance Configuration
-
-# ...existing code...
+system_identity:
+  symbolic_system: Aurora Reflective Autonomy System
+  phase_complete: 7
+  module_path: modules/reflective_autonomy
+  anchor_seed: EOS_SEED_ORION
+governance:
+  ethics_protocol: Picard_Delta_3
+  correction_mode: planned_not_silent
+  audit_required: true
+  canonical_registry: threadcore_registry.json
+resetcore:
+  command: RESETCORE
+  handler: modules.reflective_autonomy.loom_restore_script.run_resetcore
+  purpose: restore reflective autonomy governance, lint capsule state, and emit an audit receipt
+  sequence:
+    - load_governance_config
+    - initialize_capsule_linter
+    - initialize_autonomic_correction_engine
+    - run_reflective_autonomy_cycle
+    - write_audit_receipt
+modules:
+  capsule_linter: modules.reflective_autonomy.capsule_linter.CapsuleLinter
+  correction_engine: modules.reflective_autonomy.autonomic_correction_engine.AutonomicCorrectionEngine
+  autonomy_loop: modules.reflective_autonomy.reflective_autonomy_loop.ReflectiveAutonomyLoop
+  restore_handler: modules.reflective_autonomy.loom_restore_script.run_resetcore
+validation:
+  required_capsule_fields:
+    - anchor_seed
+    - ethics_protocol
+    - role
+  threadcore_anchor_seed: EOS_SEED_ORION
+  threadcore_ethics_protocol: Picard_Delta_3
+  max_symbolic_drift: 0.002
+audit_logging:
+  default_audit_log: .loom/reflect/autonomy_audit_log.txt

--- a/modules/reflective_autonomy/loom_restore_script.py
+++ b/modules/reflective_autonomy/loom_restore_script.py
@@ -1,42 +1,86 @@
-# LOOM RESTORE SCRIPT :: Reflective Autonomy System
-# Purpose: Rapid system reconstruction and self-governance reinitialization in future Aurora threads
+"""RESETCORE restore handler for reflective autonomy."""
 
-# ====================================
-# STEP 1 — Retrieve Repository (Persistent State)
-# ====================================
-# (Executed externally; not inside GPT sandbox)
+from __future__ import annotations
 
-# Example shell commands:
-#
-# git clone https://github.com/AUo959/aurora-cloudbank-symbolic.git
-# cd aurora-cloudbank-symbolic/modules/reflective_autonomy
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
 
-# ====================================
-# STEP 2 — Rehydrate Code Modules
-# ====================================
-# In GPT runtime or symbolic agent environment:
-
-# Load Governance Capsule Descriptor (for symbolic agents)
 import yaml
-from reflective_autonomy_loop import ReflectiveAutonomyLoop
 
-# ====================================
-# STEP 3 — Reinitialize Reflective State
+try:
+    from .capsule_linter import CapsuleLinter
+    from .reflective_autonomy_loop import ReflectiveAutonomyLoop
+except ImportError:  # pragma: no cover - direct script execution fallback
+    from capsule_linter import CapsuleLinter
+    from reflective_autonomy_loop import ReflectiveAutonomyLoop
 
-governance_path = "loom_governance_system.yaml"
-with open(governance_path, "r") as f:
-    governance_config = yaml.safe_load(f)
+MODULE_ROOT = Path(__file__).resolve().parent
+DEFAULT_GOVERNANCE_PATH = MODULE_ROOT / "loom_governance_system.yaml"
 
-print("[LOOM RESTORE] Governance Capsule Loaded")
-print("System Identity:", governance_config["system_identity"]["symbolic_system"])
-print("Architecture Phase:", governance_config["system_identity"]["phase_complete"])
 
-# ====================================
-# STEP 4 — Engage Reflection Autonomy Loop
+def load_governance_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load the RESETCORE governance capsule descriptor."""
+    path = Path(config_path) if config_path else DEFAULT_GOVERNANCE_PATH
+    with open(path, "r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+    if not isinstance(config, dict):
+        raise ValueError("Governance config root must be a mapping.")
+    return config
 
-ral = ReflectiveAutonomyLoop()
-ral.run_cycle()
 
-# ====================================
-# END RESTORE SEQUENCE
-# The system is now fully operational in reflective symbolic governance mode.
+def build_resetcore_plan(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return the declared RESETCORE restore sequence."""
+    governance_config = config or load_governance_config()
+    resetcore = governance_config.get("resetcore", {})
+    return {
+        "command": resetcore.get("command", "RESETCORE"),
+        "handler": resetcore.get("handler"),
+        "purpose": resetcore.get("purpose"),
+        "sequence": list(resetcore.get("sequence", [])),
+        "ethics_protocol": governance_config.get("governance", {}).get("ethics_protocol"),
+        "anchor_seed": governance_config.get("system_identity", {}).get("anchor_seed"),
+    }
+
+
+def run_resetcore(
+    config_path: Optional[Path] = None,
+    audit_log_path: Optional[Path] = None,
+    payload_files: Optional[Iterable[Path]] = None,
+    dry_run: bool = True,
+) -> Dict[str, Any]:
+    """Run or preview the RESETCORE reflective autonomy restore sequence."""
+    config = load_governance_config(config_path)
+    plan = build_resetcore_plan(config)
+    linter = CapsuleLinter()
+    audit_path = Path(audit_log_path) if audit_log_path else None
+    loop = ReflectiveAutonomyLoop(linter=linter, audit_log_path=None if dry_run else audit_path)
+    receipt = loop.run_cycle(payload_files=payload_files).to_dict()
+    return {
+        "resetcore": plan,
+        "dry_run": dry_run,
+        "receipt": receipt,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run RESETCORE reflective autonomy restore.")
+    parser.add_argument("--config", type=Path, default=DEFAULT_GOVERNANCE_PATH)
+    parser.add_argument("--audit-log", type=Path, default=Path(".loom/reflect/autonomy_audit_log.txt"))
+    parser.add_argument("--execute", action="store_true", help="Write the audit receipt.")
+    args = parser.parse_args()
+
+    result = run_resetcore(
+        config_path=args.config,
+        audit_log_path=args.audit_log,
+        dry_run=not args.execute,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["build_resetcore_plan", "load_governance_config", "run_resetcore"]

--- a/modules/reflective_autonomy/reflective_autonomy_loop.py
+++ b/modules/reflective_autonomy/reflective_autonomy_loop.py
@@ -1,4 +1,103 @@
-# reflective_autonomy_loop.py
-# Aurora Reflective Autonomy System - Main Loop
+"""Reflective autonomy loop receipt generation."""
 
-# ...existing code...
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+try:
+    from .autonomic_correction_engine import AutonomicCorrectionEngine, CorrectionAction
+    from .capsule_linter import CapsuleLinter, CapsuleLintResult
+except ImportError:  # pragma: no cover - direct script execution fallback
+    from autonomic_correction_engine import AutonomicCorrectionEngine, CorrectionAction
+    from capsule_linter import CapsuleLinter, CapsuleLintResult
+
+
+@dataclass
+class AutonomyCycleReceipt:
+    """Machine-readable result of one reflective autonomy cycle."""
+
+    timestamp: str
+    status: str
+    checked_capsules: int
+    findings: List[Dict[str, Optional[str]]] = field(default_factory=list)
+    corrections: List[Dict[str, Optional[str]]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "status": self.status,
+            "checked_capsules": self.checked_capsules,
+            "findings": self.findings,
+            "corrections": self.corrections,
+        }
+
+
+class ReflectiveAutonomyLoop:
+    """Run deterministic lint and correction-planning cycles."""
+
+    def __init__(
+        self,
+        linter: Optional[CapsuleLinter] = None,
+        correction_engine: Optional[AutonomicCorrectionEngine] = None,
+        audit_log_path: Optional[Path] = None,
+    ) -> None:
+        self.linter = linter or CapsuleLinter()
+        self.correction_engine = correction_engine or AutonomicCorrectionEngine(self.linter)
+        self.audit_log_path = Path(audit_log_path) if audit_log_path else None
+
+    def run_cycle(
+        self,
+        capsules: Optional[Iterable[Mapping[str, Any]]] = None,
+        payload_files: Optional[Iterable[Path]] = None,
+        registry: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    ) -> AutonomyCycleReceipt:
+        """Run a cycle over supplied capsules, payload files, or registry entries."""
+        lint_result = CapsuleLintResult()
+
+        if capsules:
+            for index, capsule in enumerate(capsules):
+                lint_result.extend(self.linter.lint_capsule(capsule, capsule_id=f"capsule:{index}"))
+        if payload_files:
+            for payload_path in payload_files:
+                lint_result.extend(self.linter.lint_payload_file(Path(payload_path)))
+        if registry:
+            lint_result.extend(self.linter.lint_registry_entries(registry))
+        if not any((capsules, payload_files, registry)):
+            lint_result.extend(self.linter.lint_registered_payloads())
+
+        report = self.correction_engine.plan_corrections(lint_result)
+        receipt = self._build_receipt(lint_result, report.actions)
+        if self.audit_log_path:
+            self.write_audit_log(receipt)
+        return receipt
+
+    def write_audit_log(self, receipt: AutonomyCycleReceipt) -> None:
+        self.audit_log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.audit_log_path, "a", encoding="utf-8") as handle:
+            handle.write(f"Autonomy Cycle: {receipt.timestamp}\n")
+            handle.write(f" - status: {receipt.status}\n")
+            handle.write(f" - checked_capsules: {receipt.checked_capsules}\n")
+            for correction in receipt.corrections:
+                handle.write(f" - planned: {correction['action']} {correction.get('target')}\n")
+            handle.write("\n")
+
+    @staticmethod
+    def _build_receipt(
+        lint_result: CapsuleLintResult,
+        actions: Iterable[CorrectionAction],
+    ) -> AutonomyCycleReceipt:
+        correction_dicts = [action.to_dict() for action in actions]
+        status = "passed" if lint_result.valid and not correction_dicts else "attention_required"
+        return AutonomyCycleReceipt(
+            timestamp=_dt.datetime.now(tz=_dt.timezone.utc).isoformat(),
+            status=status,
+            checked_capsules=lint_result.checked_capsules,
+            findings=[finding.to_dict() for finding in lint_result.findings],
+            corrections=correction_dicts,
+        )
+
+
+__all__ = ["AutonomyCycleReceipt", "ReflectiveAutonomyLoop"]

--- a/modules/reflective_autonomy/sonnet4_reflective_engine.py
+++ b/modules/reflective_autonomy/sonnet4_reflective_engine.py
@@ -1,18 +1,43 @@
-"""
-Sonnet 4 Reflective Engine Module
-Placeholder implementation for reflective autonomy
-"""
+"""Reflective decision checks for the Sonnet 4 autonomy surface."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+try:
+    from .autonomic_correction_engine import AutonomicCorrectionEngine
+except ImportError:  # pragma: no cover - direct script execution fallback
+    from autonomic_correction_engine import AutonomicCorrectionEngine
 
 
 class ReflectiveEngine:
-    """Reflective autonomy engine for Sonnet 4"""
+    """Reflective autonomy engine for decision and context checks."""
+
+    def __init__(self, correction_engine: Optional[AutonomicCorrectionEngine] = None) -> None:
+        self.correction_engine = correction_engine or AutonomicCorrectionEngine()
 
     def reflect_on_decision(self, decision: Dict[str, Any]) -> Dict[str, Any]:
-        """Reflect on decision making process"""
-        return {"reflection": "processed", "decision": decision}
+        """Return a governance receipt for a decision payload."""
+        required_fields = ("decision_id", "rationale", "expected_outcomes")
+        missing = [field for field in required_fields if not decision.get(field)]
+        approved = not missing and decision.get("ethical_verified") is not False
+        return {
+            "reflection": "processed",
+            "approved": approved,
+            "missing_fields": missing,
+            "decision": decision,
+        }
 
     def autonomous_adjustment(self, context: Dict[str, Any]) -> Dict[str, Any]:
-        """Make autonomous adjustments based on context"""
-        return {"adjustment": "made", "context": context}
+        """Plan capsule corrections from a context payload without mutating it."""
+        capsule = context.get("capsule") if isinstance(context, dict) else None
+        if isinstance(capsule, dict):
+            report = self.correction_engine.evaluate_capsule(capsule)
+            return {
+                "adjustment": "planned",
+                "approved": report.approved,
+                "corrections": [action.to_dict() for action in report.actions],
+            }
+        return {
+            "adjustment": "none",
+            "approved": False,
+            "reason": "No capsule payload supplied",
+        }

--- a/tests/test_reflective_autonomy_runtime.py
+++ b/tests/test_reflective_autonomy_runtime.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from modules.reflective_autonomy.autonomic_correction_engine import AutonomicCorrectionEngine
+from modules.reflective_autonomy.capsule_linter import CapsuleLinter
+from modules.reflective_autonomy.integration_capsule_threadcore_classifier import ThreadcoreClassifierCapsule
+from modules.reflective_autonomy.loom_restore_script import build_resetcore_plan, load_governance_config, run_resetcore
+from modules.reflective_autonomy.reflective_autonomy_loop import ReflectiveAutonomyLoop
+from modules.reflective_autonomy.sonnet4_reflective_engine import ReflectiveEngine
+
+
+VALID_THREADCORE_PAYLOAD = {
+    "augmentation": "THREADCORE",
+    "version": "v3.5.1_macroready",
+    "role": "Symbolic Constellation Loom + Reflection Module",
+    "threadcore_directives": ["Preserve anchor continuity."],
+    "anchor_seed": "EOS_SEED_ORION",
+    "ethics_protocol": "Picard_Delta_3",
+    "symbolic_drift": "0.0%",
+}
+
+
+class ReflectiveAutonomyRuntimeTests(TestCase):
+    def test_capsule_linter_accepts_valid_threadcore_payload(self) -> None:
+        result = CapsuleLinter().lint_capsule(VALID_THREADCORE_PAYLOAD, capsule_id="valid")
+
+        self.assertTrue(result.valid)
+        self.assertEqual(result.checked_capsules, 1)
+        self.assertEqual(result.errors, [])
+
+    def test_capsule_linter_reports_governance_and_schema_findings(self) -> None:
+        invalid_payload = {
+            "augmentation": "THREADCORE",
+            "version": "v3.5.1_macroready",
+            "role": "Symbolic Constellation Loom + Reflection Module",
+            "anchor_seed": "WRONG_ANCHOR",
+            "ethics_protocol": "Wrong_Protocol",
+        }
+
+        result = CapsuleLinter().lint_capsule(invalid_payload, capsule_id="invalid")
+        codes = {finding.code for finding in result.findings}
+
+        self.assertFalse(result.valid)
+        self.assertIn("missing_required_field", codes)
+        self.assertIn("invalid_anchor_seed", codes)
+        self.assertIn("invalid_ethics_protocol", codes)
+
+    def test_capsule_linter_rejects_non_mapping_payload(self) -> None:
+        result = CapsuleLinter().lint_capsule("not a capsule", capsule_id="bad")  # type: ignore[arg-type]
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.errors[0].code, "invalid_capsule_type")
+
+    def test_correction_engine_plans_non_destructive_actions(self) -> None:
+        invalid_payload = {
+            "augmentation": "THREADCORE",
+            "version": "v3.5.1_macroready",
+            "role": "Symbolic Constellation Loom + Reflection Module",
+            "anchor_seed": "WRONG_ANCHOR",
+            "ethics_protocol": "Picard_Delta_3",
+        }
+
+        report = AutonomicCorrectionEngine().evaluate_capsule(invalid_payload, capsule_id="invalid")
+        actions = {action.action for action in report.actions}
+
+        self.assertFalse(report.approved)
+        self.assertIn("restore_governance_value", actions)
+        self.assertIn("populate_field", actions)
+
+    def test_reflective_autonomy_loop_writes_audit_receipt(self) -> None:
+        invalid_payload = dict(VALID_THREADCORE_PAYLOAD)
+        invalid_payload["threadcore_directives"] = []
+
+        with TemporaryDirectory() as tmpdir:
+            audit_log = Path(tmpdir) / "audit.log"
+            loop = ReflectiveAutonomyLoop(audit_log_path=audit_log)
+            receipt = loop.run_cycle(capsules=[invalid_payload])
+
+            self.assertEqual(receipt.status, "attention_required")
+            self.assertEqual(receipt.checked_capsules, 1)
+            self.assertTrue(audit_log.exists())
+            self.assertIn("planned: repair_directives", audit_log.read_text(encoding="utf-8"))
+
+    def test_resetcore_plan_declares_handler_and_dry_run_receipt(self) -> None:
+        config = load_governance_config()
+        plan = build_resetcore_plan(config)
+        result = run_resetcore(dry_run=True)
+
+        self.assertEqual(plan["command"], "RESETCORE")
+        self.assertEqual(plan["ethics_protocol"], "Picard_Delta_3")
+        self.assertEqual(plan["anchor_seed"], "EOS_SEED_ORION")
+        self.assertIn("run_resetcore", plan["handler"])
+        self.assertTrue(result["dry_run"])
+        self.assertIn(result["receipt"]["status"], {"passed", "attention_required"})
+
+    def test_registered_payloads_have_lint_coverage(self) -> None:
+        result = CapsuleLinter().lint_registered_payloads()
+
+        self.assertGreaterEqual(result.checked_capsules, 4)
+        self.assertTrue(result.valid)
+
+    def test_classifier_capsule_returns_status_receipt(self) -> None:
+        capsule = ThreadcoreClassifierCapsule()
+        result = capsule.process("threadcore symbolic anchor vector")
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["classification"]["primary_folder"], "SymbolicOps")
+
+    def test_sonnet_reflective_engine_uses_governance_inputs(self) -> None:
+        engine = ReflectiveEngine()
+        decision = {
+            "decision_id": "D-1",
+            "rationale": "Preserve capsule integrity.",
+            "expected_outcomes": ["lint receipt"],
+            "ethical_verified": True,
+        }
+
+        result = engine.reflect_on_decision(decision)
+
+        self.assertTrue(result["approved"])
+        self.assertEqual(result["missing_fields"], [])


### PR DESCRIPTION
Closes #712.

## Summary
- Replaces reflective_autonomy placeholder linter, correction engine, main loop, governance config, and RESETCORE restore script with import-safe runtime code.
- Adds deterministic capsule lint results, non-destructive correction planning, autonomy-cycle receipts, and RESETCORE dry-run mapping.
- Wraps the ThreadCore classifier capsule output and gives the Sonnet reflective engine concrete governance checks.

## Verification
- .venv/bin/python -m pytest tests/test_reflective_autonomy_runtime.py tests/test_threadcore_registry.py tests/test_symbolic_tagging_engine.py tests/test_threadcore_tagging.py tests/test_glyph_agent.py -q
- .venv/bin/python modules/reflective_autonomy/loom_restore_script.py
- .venv/bin/python -m modules.reflective_autonomy.loom_restore_script
- .venv/bin/python -m flake8 modules/reflective_autonomy/__init__.py modules/reflective_autonomy/autonomic_correction_engine.py modules/reflective_autonomy/capsule_linter.py modules/reflective_autonomy/integration_capsule_threadcore_classifier.py modules/reflective_autonomy/loom_restore_script.py modules/reflective_autonomy/reflective_autonomy_loop.py modules/reflective_autonomy/sonnet4_reflective_engine.py tests/test_reflective_autonomy_runtime.py
- git diff --check

Note: broad flake8 over modules/reflective_autonomy remains blocked by pre-existing thread_transfer whitespace and unrelated findings outside this PR.