### PR TITLE
[codex] Bind Phase 6 vector state

### DIFF
--- a/modules/nexus/emergence/consciousness_emergence_enhanced.py
+++ b/modules/nexus/emergence/consciousness_emergence_enhanced.py
@@ -29,6 +29,16 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from modules.nexus.emergence.vector_binding import (
+    ECHOCHAIN_LINKS,
+    ECHOCHAIN_LOOPSET,
+    ETHICS_PROTOCOL,
+    LOCKPOINT_REFERENCE,
+    PHASE6_ANCHOR,
+    SEED_ANCHOR,
+    VECTOR_STATE,
+)
+
 __all__ = [
     "SymbolicObserver",
     "EntropyState",
@@ -38,9 +48,7 @@ __all__ = [
 ]
 
 
-PRIMARY_ANCHOR = "T6-EMERGENCE-2025"
-SEED_ANCHOR = "EOS_SEED_ORION"
-ETHICS_PROTOCOL = "Picard_Delta_3"
+PRIMARY_ANCHOR = PHASE6_ANCHOR
 DEFAULT_SNAPSHOT_INTERVAL = 5
 DEFAULT_SNAPSHOT_DIR = ".nexus/snapshots"
 
@@ -229,6 +237,10 @@ class EnhancedConsciousnessProtocol:
         self.anchor = anchor
         self.seed = SEED_ANCHOR
         self.ethics_protocol = ETHICS_PROTOCOL
+        self.vector_state = VECTOR_STATE
+        self.lockpoint_reference = LOCKPOINT_REFERENCE
+        self.echochain_loopset = ECHOCHAIN_LOOPSET
+        self.echochain_links = list(ECHOCHAIN_LINKS)
         self.observer = observer or _DefaultSymbolicObserver()
         self.snapshot_directory = Path(snapshot_directory or DEFAULT_SNAPSHOT_DIR)
         self.snapshot_directory.mkdir(parents=True, exist_ok=True)

--- a/modules/nexus/emergence/vector_binding.py
+++ b/modules/nexus/emergence/vector_binding.py
@@ -1,0 +1,207 @@
+"""Phase 6 vector and EchoChain binding verification."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import yaml
+
+PHASE6_ANCHOR = "T6-EMERGENCE-2025"
+SEED_ANCHOR = "EOS_SEED_ORION"
+ETHICS_PROTOCOL = "Picard_Delta_3"
+VECTOR_STATE = "QEM-SN1-ACTIVE::BASELINE_V1"
+LOCKPOINT_REFERENCE = "SN1_LOCKPOINT_20250406T1432Z"
+ECHOCHAIN_LOOPSET = "LOOPSET_001"
+ECHOCHAIN_LINKS = ("NESTED_001_ECHO", "DRIFTTRACE::REI")
+CONTRACT_PATH = Path(__file__).with_name("vector_binding.yaml")
+
+
+@dataclass
+class VectorBindingReceipt:
+    """Verification receipt for the Phase 6 vector binding contract."""
+
+    valid: bool
+    contract_path: str
+    checked_files: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    bindings: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "valid": self.valid,
+            "contract_path": self.contract_path,
+            "checked_files": self.checked_files,
+            "errors": self.errors,
+            "bindings": self.bindings,
+        }
+
+
+def load_vector_binding_contract(contract_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load the machine-readable Phase 6 vector binding contract."""
+    path = Path(contract_path) if contract_path else CONTRACT_PATH
+    with path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+    if not isinstance(payload, dict):
+        raise ValueError("Vector binding contract root must be a mapping.")
+    return payload
+
+
+def verify_phase6_vector_binding(
+    repo_root: Optional[Path] = None,
+    contract_path: Optional[Path] = None,
+) -> VectorBindingReceipt:
+    """Verify that Phase 6 vector identifiers are bound to runtime evidence."""
+    root = Path(repo_root) if repo_root else Path(__file__).resolve().parents[3]
+    path = Path(contract_path) if contract_path else CONTRACT_PATH
+    errors: List[str] = []
+    checked_files: List[str] = []
+
+    try:
+        contract = load_vector_binding_contract(path)
+        checked_files.append(_display_path(root, path))
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        return VectorBindingReceipt(
+            valid=False,
+            contract_path=str(path),
+            errors=[f"Cannot load vector binding contract: {exc}"],
+        )
+
+    _expect(contract, "phase_anchor", PHASE6_ANCHOR, errors)
+    _expect(contract, "seed_anchor", SEED_ANCHOR, errors)
+    _expect(contract, "ethics_protocol", ETHICS_PROTOCOL, errors)
+    _expect(contract, "vector_state", VECTOR_STATE, errors)
+    _expect(contract, "lockpoint_reference", LOCKPOINT_REFERENCE, errors)
+    _expect(contract.get("echochain", {}), "loopset", ECHOCHAIN_LOOPSET, errors)
+    _expect_sequence(contract.get("echochain", {}), "linked", ECHOCHAIN_LINKS, errors)
+
+    runtime_bindings = contract.get("runtime_bindings", {})
+    if not isinstance(runtime_bindings, Mapping):
+        errors.append("runtime_bindings must be a mapping.")
+        runtime_bindings = {}
+
+    checked_files.extend(_verify_runtime_bindings(root, runtime_bindings, errors))
+    _verify_protocol_archive(root, runtime_bindings.get("protocol_archive"), errors, checked_files)
+
+    bindings = {
+        "phase_anchor": PHASE6_ANCHOR,
+        "seed_anchor": SEED_ANCHOR,
+        "ethics_protocol": ETHICS_PROTOCOL,
+        "vector_state": VECTOR_STATE,
+        "lockpoint_reference": LOCKPOINT_REFERENCE,
+        "echochain": {
+            "loopset": ECHOCHAIN_LOOPSET,
+            "linked": list(ECHOCHAIN_LINKS),
+        },
+    }
+    return VectorBindingReceipt(
+        valid=not errors,
+        contract_path=str(path),
+        checked_files=checked_files,
+        errors=errors,
+        bindings=bindings,
+    )
+
+
+def startup_assert_phase6_vector_binding(repo_root: Optional[Path] = None) -> VectorBindingReceipt:
+    """Raise if Phase 6 vector binding evidence is incomplete."""
+    receipt = verify_phase6_vector_binding(repo_root=repo_root)
+    if not receipt.valid:
+        raise RuntimeError("; ".join(receipt.errors))
+    return receipt
+
+
+def _expect(source: Mapping[str, Any], key: str, expected: str, errors: List[str]) -> None:
+    actual = source.get(key)
+    if actual != expected:
+        errors.append(f"{key} must be {expected}; found {actual!r}.")
+
+
+def _expect_sequence(
+    source: Mapping[str, Any],
+    key: str,
+    expected: Tuple[str, ...],
+    errors: List[str],
+) -> None:
+    actual = source.get(key)
+    if list(actual or []) != list(expected):
+        errors.append(f"{key} must be {list(expected)!r}; found {actual!r}.")
+
+
+def _verify_runtime_bindings(
+    repo_root: Path,
+    runtime_bindings: Mapping[str, Any],
+    errors: List[str],
+) -> List[str]:
+    checked_files: List[str] = []
+    for binding_name, binding_ref in runtime_bindings.items():
+        if binding_name == "protocol_archive":
+            continue
+        if not isinstance(binding_ref, str):
+            errors.append(f"{binding_name} binding must be a dotted Python reference.")
+            continue
+        module_path = _dotted_reference_to_path(repo_root, binding_ref)
+        checked_files.append(_display_path(repo_root, module_path))
+        if not module_path.exists():
+            errors.append(f"{binding_name} binding path is missing: {_display_path(repo_root, module_path)}")
+    return checked_files
+
+
+def _verify_protocol_archive(
+    repo_root: Path,
+    protocol_archive: Any,
+    errors: List[str],
+    checked_files: List[str],
+) -> None:
+    if not isinstance(protocol_archive, str):
+        errors.append("protocol_archive binding must be a repo-relative path.")
+        return
+    archive_path = repo_root / protocol_archive
+    checked_files.append(_display_path(repo_root, archive_path))
+    if not archive_path.exists():
+        errors.append(f"protocol_archive is missing: {protocol_archive}")
+        return
+    with archive_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not _contains_value(payload, PHASE6_ANCHOR):
+        errors.append(f"protocol_archive does not contain anchor {PHASE6_ANCHOR}.")
+
+
+def _dotted_reference_to_path(repo_root: Path, dotted_reference: str) -> Path:
+    parts = dotted_reference.split(".")
+    module_parts = parts[:-1] if parts and parts[-1][:1].isupper() else parts
+    return repo_root.joinpath(*module_parts).with_suffix(".py")
+
+
+def _contains_value(payload: Any, expected: str) -> bool:
+    if payload == expected:
+        return True
+    if isinstance(payload, Mapping):
+        return any(_contains_value(value, expected) for value in payload.values())
+    if isinstance(payload, list):
+        return any(_contains_value(value, expected) for value in payload)
+    return False
+
+
+def _display_path(repo_root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+__all__ = [
+    "ECHOCHAIN_LINKS",
+    "ECHOCHAIN_LOOPSET",
+    "ETHICS_PROTOCOL",
+    "LOCKPOINT_REFERENCE",
+    "PHASE6_ANCHOR",
+    "SEED_ANCHOR",
+    "VECTOR_STATE",
+    "VectorBindingReceipt",
+    "load_vector_binding_contract",
+    "startup_assert_phase6_vector_binding",
+    "verify_phase6_vector_binding",
+]

--- a/modules/nexus/emergence/vector_binding.yaml
+++ b/modules/nexus/emergence/vector_binding.yaml
@@ -1,0 +1,25 @@
+contract_version: "1.0.0"
+phase_anchor: "T6-EMERGENCE-2025"
+seed_anchor: "EOS_SEED_ORION"
+ethics_protocol: "Picard_Delta_3"
+vector_state: "QEM-SN1-ACTIVE::BASELINE_V1"
+lockpoint_reference: "SN1_LOCKPOINT_20250406T1432Z"
+echochain:
+  loopset: "LOOPSET_001"
+  linked:
+    - "NESTED_001_ECHO"
+    - "DRIFTTRACE::REI"
+runtime_bindings:
+  phase6_protocol: "modules.nexus.emergence.consciousness_emergence_enhanced.EnhancedConsciousnessProtocol"
+  phase6_protocol_legacy: "modules.nexus.emergence.consciousness_emergence.ConsciousnessEmergenceProtocol"
+  scale_support: "modules.nexus.scale.distributed_consciousness.DistributedConsciousnessMesh"
+  protocol_archive: ".nexus/emergence/protocols/PROT-1758781014.405975.json"
+verification:
+  startup_assertion: "modules.nexus.emergence.vector_binding.startup_assert_phase6_vector_binding"
+  required_identifiers:
+    - "T6-EMERGENCE-2025"
+    - "QEM-SN1-ACTIVE::BASELINE_V1"
+    - "LOOPSET_001"
+    - "NESTED_001_ECHO"
+    - "DRIFTTRACE::REI"
+    - "SN1_LOCKPOINT_20250406T1432Z"

--- a/tests/test_phase6_vector_binding.py
+++ b/tests/test_phase6_vector_binding.py
@@ -1,0 +1,50 @@
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from modules.nexus.emergence.consciousness_emergence_enhanced import EnhancedConsciousnessProtocol
+from modules.nexus.emergence.vector_binding import (
+    ECHOCHAIN_LINKS,
+    ECHOCHAIN_LOOPSET,
+    LOCKPOINT_REFERENCE,
+    PHASE6_ANCHOR,
+    VECTOR_STATE,
+    load_vector_binding_contract,
+    startup_assert_phase6_vector_binding,
+    verify_phase6_vector_binding,
+)
+
+
+class Phase6VectorBindingTests(TestCase):
+    def test_contract_contains_phase6_vector_identifiers(self) -> None:
+        contract = load_vector_binding_contract()
+
+        self.assertEqual(contract["phase_anchor"], PHASE6_ANCHOR)
+        self.assertEqual(contract["vector_state"], VECTOR_STATE)
+        self.assertEqual(contract["lockpoint_reference"], LOCKPOINT_REFERENCE)
+        self.assertEqual(contract["echochain"]["loopset"], ECHOCHAIN_LOOPSET)
+        self.assertEqual(contract["echochain"]["linked"], list(ECHOCHAIN_LINKS))
+
+    def test_startup_assertion_verifies_runtime_bindings(self) -> None:
+        receipt = startup_assert_phase6_vector_binding()
+
+        self.assertTrue(receipt.valid)
+        self.assertEqual(receipt.errors, [])
+        self.assertIn("modules/nexus/emergence/consciousness_emergence_enhanced.py", receipt.checked_files)
+        self.assertIn(".nexus/emergence/protocols/PROT-1758781014.405975.json", receipt.checked_files)
+
+    def test_enhanced_protocol_exposes_vector_binding(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            protocol = EnhancedConsciousnessProtocol(snapshot_directory=tmpdir)
+
+            self.assertEqual(protocol.anchor, PHASE6_ANCHOR)
+            self.assertEqual(protocol.vector_state, VECTOR_STATE)
+            self.assertEqual(protocol.lockpoint_reference, LOCKPOINT_REFERENCE)
+            self.assertEqual(protocol.echochain_loopset, ECHOCHAIN_LOOPSET)
+            self.assertEqual(protocol.echochain_links, list(ECHOCHAIN_LINKS))
+
+    def test_verification_receipt_is_machine_readable(self) -> None:
+        receipt = verify_phase6_vector_binding().to_dict()
+
+        self.assertTrue(receipt["valid"])
+        self.assertEqual(receipt["bindings"]["vector_state"], VECTOR_STATE)
+        self.assertEqual(receipt["bindings"]["echochain"]["loopset"], ECHOCHAIN_LOOPSET)


### PR DESCRIPTION
## Summary
- Add a machine-readable Phase 6 vector/EchoChain binding contract.
- Expose the binding identifiers on the enhanced consciousness protocol runtime.
- Add startup verification and focused tests for the #711 acceptance gate.

## Validation
- .venv/bin/python -m pytest tests/test_phase6_vector_binding.py tests/test_consciousness_emergence.py -q
- .venv/bin/python -m flake8 modules/nexus/emergence/vector_binding.py modules/nexus/emergence/consciousness_emergence_enhanced.py tests/test_phase6_vector_binding.py
- git diff --check

Closes #711