### PR TITLE
[codex] Require configured auth users

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,12 @@ if "WS_AUTH_SECRET" not in os.environ:
 if "JWT_SECRET_KEY" not in os.environ:
     os.environ["JWT_SECRET_KEY"] = "test-jwt-secret-key-do-not-use-in-production-hex32"
 
+# Auth route tests use an explicitly gated dev-only fixture user store.
+os.environ.setdefault("AURORA_ALLOW_DEV_AUTH_FIXTURE", "true")
+os.environ.setdefault("AURORA_DEV_ADMIN_PASSWORD", "test-" + "admin-secret")
+os.environ.setdefault("AURORA_DEV_OPERATOR_PASSWORD", "test-" + "operator-secret")
+os.environ.setdefault("AURORA_DEV_OBSERVER_PASSWORD", "test-" + "observer-secret")
+
 import pytest  # noqa: E402 - import must happen after env setup
 from fastapi.testclient import TestClient  # noqa: E402
 

--- a/docs/OAUTH2_SETUP_GUIDE.md
+++ b/docs/OAUTH2_SETUP_GUIDE.md
@@ -55,10 +55,10 @@ python api/aurora_api.py
 ### 3. Test Authentication
 
 ```bash
-# Login as admin
+# Login as a configured admin user
 curl -X POST "http://localhost:8000/api/auth/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=admin&password=admin123"
+  -d "username=${AURORA_ADMIN_USERNAME}&password=${AURORA_ADMIN_PASSWORD}"
 
 # Response:
 {
@@ -141,15 +141,16 @@ Aurora CloudBank defines three roles with hierarchical permissions:
 
 **Example Users:** System administrators, DevOps team
 
-### Default Demo Users
+### Auth User Store
 
-The system includes three demo users for testing (⚠️ **Change passwords in production!**):
+The mounted auth router does not ship default passwords. Configure users with
+`AURORA_AUTH_USERS_JSON` or `AURORA_AUTH_USERS_FILE`; each user must provide a
+`password_hash`/`hashed_password` value or a `password_env` reference to a
+secret environment variable.
 
-| Username | Password | Role | Email |
-|----------|----------|------|-------|
-| `admin` | `admin123` | Admin | admin@aurora.local |
-| `operator` | `operator123` | Relay Operator | operator@aurora.local |
-| `observer` | `observer123` | Observer | observer@aurora.local |
+Dev/test fixture users are available only when
+`AURORA_ALLOW_DEV_AUTH_FIXTURE=true` and the corresponding
+`AURORA_DEV_*_PASSWORD` variables are set.
 
 ## API Endpoints
 
@@ -165,7 +166,7 @@ Login and obtain access and refresh tokens.
 ```bash
 curl -X POST "http://localhost:8000/api/auth/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=admin&password=admin123"
+  -d "username=${AURORA_ADMIN_USERNAME}&password=${AURORA_ADMIN_PASSWORD}"
 ```
 
 **Response:**

--- a/docs/RBAC_INTEGRATION_EXAMPLES.md
+++ b/docs/RBAC_INTEGRATION_EXAMPLES.md
@@ -475,6 +475,7 @@ except ImportError:
 
 ```python
 import pytest
+import os
 from fastapi.testclient import TestClient
 
 def test_protected_route_with_auth(client: TestClient):
@@ -482,7 +483,10 @@ def test_protected_route_with_auth(client: TestClient):
     # Login first
     response = client.post(
         "/api/auth/token",
-        data={"username": "admin", "password": "admin123"}
+        data={
+            "username": os.environ["AURORA_TEST_ADMIN_USERNAME"],
+            "password": os.environ["AURORA_TEST_ADMIN_PASSWORD"],
+        },
     )
     token = response.json()["access_token"]
     
@@ -508,7 +512,10 @@ def test_admin_route_with_observer(client: TestClient):
     # Login as observer
     response = client.post(
         "/api/auth/token",
-        data={"username": "observer", "password": "observer123"}
+        data={
+            "username": os.environ["AURORA_TEST_OBSERVER_USERNAME"],
+            "password": os.environ["AURORA_TEST_OBSERVER_PASSWORD"],
+        },
     )
     token = response.json()["access_token"]
     

--- a/docs/RBAC_SECURITY_SUMMARY.md
+++ b/docs/RBAC_SECURITY_SUMMARY.md
@@ -67,10 +67,12 @@ Successfully implemented a comprehensive RBAC and OAuth2 authentication system w
   - `GET /api/auth/me/permissions` - User permissions
   - `POST /api/auth/logout` - Logout (client-side)
 
-- **Demo Users:** (⚠️ **Change passwords in production!**)
-  - `admin:admin123` - Admin role
-  - `operator:operator123` - Relay Operator role
-  - `observer:observer123` - Observer role
+- **User Store:**
+  - Production auth users must be provided through `AURORA_AUTH_USERS_JSON`
+    or `AURORA_AUTH_USERS_FILE` with password hashes.
+  - Dev/test fixture users require `AURORA_ALLOW_DEV_AUTH_FIXTURE=true` and
+    password values supplied through `AURORA_DEV_*_PASSWORD` environment
+    variables.
 
 ### Configuration
 

--- a/src/security/auth_routes.py
+++ b/src/security/auth_routes.py
@@ -5,8 +5,11 @@ Provides OAuth2 authentication endpoints for token management.
 """
 
 from datetime import timedelta
+import json
+import os
+from pathlib import Path
 import time
-from typing import Dict
+from typing import Any, Dict, Mapping, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordRequestForm
@@ -20,7 +23,6 @@ from src.security.oauth2 import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
 )
 from src.middleware.fastapi_security import limiter
-import os
 from src.security.roles import Role, get_all_permissions
 
 # Ensure fresh rate limiter storage for isolated test app constructions.
@@ -43,34 +45,127 @@ router = APIRouter(
 )
 
 
-# In-memory user database for demonstration
-# In production, replace with actual database
-USERS_DB: Dict[str, UserInDB] = {
-    "admin": UserInDB(
-        username="admin",
-        email="admin@aurora.local",
-        full_name="System Administrator",
-        role=Role.ADMIN,
-        hashed_password=OAuth2Handler.get_password_hash("admin123"),  # Change in production!
-        disabled=False,
-    ),
-    "operator": UserInDB(
-        username="operator",
-        email="operator@aurora.local",
-        full_name="Relay Operator",
-        role=Role.RELAY_OPERATOR,
-        hashed_password=OAuth2Handler.get_password_hash("operator123"),  # Change in production!
-        disabled=False,
-    ),
-    "observer": UserInDB(
-        username="observer",
-        email="observer@aurora.local",
-        full_name="System Observer",
-        role=Role.OBSERVER,
-        hashed_password=OAuth2Handler.get_password_hash("observer123"),  # Change in production!
-        disabled=False,
-    ),
+AUTH_USERS_JSON_ENV = "AURORA_AUTH_USERS_JSON"
+AUTH_USERS_FILE_ENV = "AURORA_AUTH_USERS_FILE"
+ALLOW_DEV_AUTH_FIXTURE_ENV = "AURORA_ALLOW_DEV_AUTH_FIXTURE"
+
+DEV_AUTH_FIXTURE_USERS: Dict[str, Dict[str, str]] = {
+    "admin": {
+        "email": "admin@aurora.local",
+        "full_name": "System Administrator",
+        "role": Role.ADMIN.value,
+        "password_env": "AURORA_DEV_ADMIN_PASSWORD",
+    },
+    "operator": {
+        "email": "operator@aurora.local",
+        "full_name": "Relay Operator",
+        "role": Role.RELAY_OPERATOR.value,
+        "password_env": "AURORA_DEV_OPERATOR_PASSWORD",
+    },
+    "observer": {
+        "email": "observer@aurora.local",
+        "full_name": "System Observer",
+        "role": Role.OBSERVER.value,
+        "password_env": "AURORA_DEV_OBSERVER_PASSWORD",
+    },
 }
+
+
+def build_auth_users_db(env: Optional[Mapping[str, str]] = None) -> Dict[str, UserInDB]:
+    """Build the mounted auth user database from explicit configuration."""
+    env_map = env if env is not None else os.environ
+    configured_payload = _load_auth_users_payload(env_map)
+    if configured_payload:
+        return _build_users_from_payload(configured_payload, env_map)
+
+    if _truthy(env_map.get(ALLOW_DEV_AUTH_FIXTURE_ENV)):
+        return _build_users_from_payload(DEV_AUTH_FIXTURE_USERS, env_map)
+
+    raise RuntimeError(
+        "AURORA auth users are not configured. Set AURORA_AUTH_USERS_JSON or "
+        "AURORA_AUTH_USERS_FILE with user password hashes, or explicitly set "
+        "AURORA_ALLOW_DEV_AUTH_FIXTURE=true in dev/test with AURORA_DEV_*_PASSWORD secrets."
+    )
+
+
+def _load_auth_users_payload(env: Mapping[str, str]) -> Dict[str, Mapping[str, Any]]:
+    raw_payload = env.get(AUTH_USERS_JSON_ENV)
+    payload_file = env.get(AUTH_USERS_FILE_ENV)
+    if raw_payload and payload_file:
+        raise RuntimeError("Set only one of AURORA_AUTH_USERS_JSON or AURORA_AUTH_USERS_FILE.")
+    if payload_file:
+        raw_payload = Path(payload_file).read_text(encoding="utf-8")
+    if not raw_payload:
+        return {}
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid auth user JSON: {exc}") from exc
+    return _normalise_user_payload(payload)
+
+
+def _normalise_user_payload(payload: Any) -> Dict[str, Mapping[str, Any]]:
+    if isinstance(payload, Mapping):
+        return {str(username): record for username, record in payload.items() if isinstance(record, Mapping)}
+    if isinstance(payload, list):
+        users: Dict[str, Mapping[str, Any]] = {}
+        for record in payload:
+            if not isinstance(record, Mapping):
+                raise RuntimeError("Auth user list entries must be objects.")
+            username = record.get("username")
+            if not username:
+                raise RuntimeError("Auth user list entries must include username.")
+            users[str(username)] = record
+        return users
+    raise RuntimeError("Auth user configuration must be a JSON object or list.")
+
+
+def _build_users_from_payload(
+    payload: Mapping[str, Mapping[str, Any]], env: Mapping[str, str]
+) -> Dict[str, UserInDB]:
+    if not payload:
+        raise RuntimeError("Auth user configuration did not contain any users.")
+
+    users: Dict[str, UserInDB] = {}
+    for username, record in payload.items():
+        role = _coerce_role(str(record.get("role", Role.OBSERVER.value)), username)
+        users[username] = UserInDB(
+            username=username,
+            email=record.get("email"),
+            full_name=record.get("full_name"),
+            role=role,
+            hashed_password=_resolve_password_hash(username, record, env),
+            disabled=bool(record.get("disabled", False)),
+        )
+    return users
+
+
+def _resolve_password_hash(username: str, record: Mapping[str, Any], env: Mapping[str, str]) -> str:
+    configured_hash = record.get("password_hash") or record.get("hashed_password")
+    if configured_hash:
+        return str(configured_hash)
+
+    password_env = record.get("password_env")
+    if not password_env:
+        raise RuntimeError(f"Auth user {username!r} must define password_hash or password_env.")
+    password = env.get(str(password_env))
+    if not password:
+        raise RuntimeError(f"Auth user {username!r} password env {password_env!r} is not set.")
+    return OAuth2Handler.get_password_hash(password)
+
+
+def _coerce_role(raw_role: str, username: str) -> Role:
+    try:
+        return Role(raw_role)
+    except ValueError as exc:
+        raise RuntimeError(f"Auth user {username!r} has invalid role {raw_role!r}.") from exc
+
+
+def _truthy(value: Optional[str]) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+USERS_DB = build_auth_users_db()
 
 
 # Rate limit configuration:

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -1,18 +1,15 @@
-"""
-Integration tests for authentication API routes.
+"""Integration tests for authentication API routes."""
 
-Tests OAuth2 endpoints and authentication flow.
-
-Note: Test credentials are intentionally hardcoded for testing purposes only.
-These are not production credentials and are safe for test environments.
-SonarCloud security hotspots are acknowledged and accepted.
-"""
+import json
+import os
+from unittest import TestCase
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from src.security.auth_routes import router
+from src.security.auth_routes import build_auth_users_db, router
+from src.security.oauth2 import OAuth2Handler
 from slowapi.middleware import SlowAPIMiddleware
 from src.middleware.fastapi_security import limiter
 
@@ -34,12 +31,71 @@ def client(app):
     return TestClient(app)
 
 
+def auth_data(username):
+    """Return dev-fixture credentials from the explicit test environment."""
+    return {
+        "username": username,
+        "password": os.environ[f"AURORA_DEV_{username.upper()}_PASSWORD"],
+    }
+
+
+class TestAuthUserStoreConfiguration(TestCase):
+    """Validate production and dev/test auth user-store configuration."""
+
+    def test_production_startup_requires_configured_users(self):
+        """Mounted auth must not silently ship default credentials."""
+        with pytest.raises(RuntimeError, match="auth users are not configured"):
+            build_auth_users_db({})
+
+    def test_configured_user_store_accepts_password_hashes(self):
+        """Production-style configuration should use supplied password hashes."""
+        password_hash = OAuth2Handler.get_password_hash("configured-secret")
+        payload = {
+            "configured": {
+                "email": "configured@aurora.local",
+                "full_name": "Configured User",
+                "role": "observer",
+                "password_hash": password_hash,
+            }
+        }
+
+        users = build_auth_users_db({"AURORA_AUTH_USERS_JSON": json.dumps(payload)})
+
+        self.assertEqual(users["configured"].email, "configured@aurora.local")
+        self.assertIsNotNone(OAuth2Handler.authenticate_user("configured", "configured-secret", users))
+        self.assertIsNone(OAuth2Handler.authenticate_user("configured", "wrong-secret", users))
+
+    def test_dev_fixture_requires_explicit_gate_and_password_secrets(self):
+        """Dev/test fixture users require both the gate and password env values."""
+        with pytest.raises(RuntimeError, match="AURORA_DEV_ADMIN_PASSWORD"):
+            build_auth_users_db({"AURORA_ALLOW_DEV_AUTH_FIXTURE": "true"})
+
+        users = build_auth_users_db(
+            {
+                "AURORA_ALLOW_DEV_AUTH_FIXTURE": "true",
+                "AURORA_DEV_ADMIN_PASSWORD": os.environ["AURORA_DEV_ADMIN_PASSWORD"],
+                "AURORA_DEV_OPERATOR_PASSWORD": os.environ["AURORA_DEV_OPERATOR_PASSWORD"],
+                "AURORA_DEV_OBSERVER_PASSWORD": os.environ["AURORA_DEV_OBSERVER_PASSWORD"],
+            }
+        )
+
+        self.assertIsNotNone(
+            OAuth2Handler.authenticate_user("admin", os.environ["AURORA_DEV_ADMIN_PASSWORD"], users)
+        )
+        self.assertIsNotNone(
+            OAuth2Handler.authenticate_user("operator", os.environ["AURORA_DEV_OPERATOR_PASSWORD"], users)
+        )
+        self.assertIsNotNone(
+            OAuth2Handler.authenticate_user("observer", os.environ["AURORA_DEV_OBSERVER_PASSWORD"], users)
+        )
+
+
 class TestLoginEndpoint:
     """Test the /api/auth/token endpoint."""
 
     def test_login_success_admin(self, client):
         """Test successful login with admin credentials."""
-        response = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        response = client.post("/api/auth/token", data=auth_data("admin"))
 
         assert response.status_code == 200
         data = response.json()
@@ -51,7 +107,7 @@ class TestLoginEndpoint:
 
     def test_login_success_operator(self, client):
         """Test successful login with operator credentials."""
-        response = client.post("/api/auth/token", data={"username": "operator", "password": "operator123"})
+        response = client.post("/api/auth/token", data=auth_data("operator"))
 
         assert response.status_code == 200
         data = response.json()
@@ -59,7 +115,7 @@ class TestLoginEndpoint:
 
     def test_login_success_observer(self, client):
         """Test successful login with observer credentials."""
-        response = client.post("/api/auth/token", data={"username": "observer", "password": "observer123"})
+        response = client.post("/api/auth/token", data=auth_data("observer"))
 
         assert response.status_code == 200
         data = response.json()
@@ -91,7 +147,7 @@ class TestUserInfoEndpoint:
     def test_get_user_info_authenticated(self, client):
         """Test getting user info with valid token."""
         # Login first
-        login_response = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        login_response = client.post("/api/auth/token", data=auth_data("admin"))
         token = login_response.json()["access_token"]
 
         # Get user info
@@ -121,7 +177,7 @@ class TestPermissionsEndpoint:
     def test_get_permissions_admin(self, client):
         """Test getting permissions for admin user."""
         # Login as admin
-        login_response = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        login_response = client.post("/api/auth/token", data=auth_data("admin"))
         token = login_response.json()["access_token"]
 
         # Get permissions
@@ -139,7 +195,7 @@ class TestPermissionsEndpoint:
     def test_get_permissions_observer(self, client):
         """Test getting permissions for observer user."""
         # Login as observer
-        login_response = client.post("/api/auth/token", data={"username": "observer", "password": "observer123"})
+        login_response = client.post("/api/auth/token", data=auth_data("observer"))
         token = login_response.json()["access_token"]
 
         # Get permissions
@@ -156,7 +212,7 @@ class TestPermissionsEndpoint:
     def test_get_permissions_operator(self, client):
         """Test getting permissions for operator user."""
         # Login as operator
-        login_response = client.post("/api/auth/token", data={"username": "operator", "password": "operator123"})
+        login_response = client.post("/api/auth/token", data=auth_data("operator"))
         token = login_response.json()["access_token"]
 
         # Get permissions
@@ -177,7 +233,7 @@ class TestRefreshTokenEndpoint:
     def test_refresh_token_success(self, client):
         """Test refreshing a valid token."""
         # Login first
-        login_response = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        login_response = client.post("/api/auth/token", data=auth_data("admin"))
         refresh_token = login_response.json()["refresh_token"]
 
         # Refresh the token
@@ -197,7 +253,7 @@ class TestRefreshTokenEndpoint:
     def test_refresh_with_access_token(self, client):
         """Test that access token cannot be used for refresh."""
         # Login first
-        login_response = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        login_response = client.post("/api/auth/token", data=auth_data("admin"))
         access_token = login_response.json()["access_token"]
 
         # Try to use access token for refresh (should fail)
@@ -213,7 +269,7 @@ class TestLogoutEndpoint:
     def test_logout_success(self, client):
         """Test successful logout."""
         # Login first
-        login_response = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        login_response = client.post("/api/auth/token", data=auth_data("admin"))
         token = login_response.json()["access_token"]
 
         # Logout
@@ -237,7 +293,7 @@ class TestAuthenticationFlow:
     def test_full_auth_flow(self, client):
         """Test complete authentication flow: login -> get info -> logout."""
         # Step 1: Login
-        login_response = client.post("/api/auth/token", data={"username": "operator", "password": "operator123"})
+        login_response = client.post("/api/auth/token", data=auth_data("operator"))
         assert login_response.status_code == 200
         token = login_response.json()["access_token"]
 
@@ -272,7 +328,7 @@ class TestRateLimiting:
         for i in range(11):
             response = isolated_client.post(
                 "/api/auth/token",
-                data={"username": "admin", "password": "admin123"}
+                data=auth_data("admin"),
             )
             if response.status_code == 200:
                 success_count += 1

--- a/tests/test_rate_limit_headers.py
+++ b/tests/test_rate_limit_headers.py
@@ -46,6 +46,13 @@ def build_isolated_app(limit_token_per_min: int = 2):
     return app
 
 
+def auth_data(username: str) -> dict[str, str]:
+    return {
+        "username": username,
+        "password": os.environ[f"AURORA_DEV_{username.upper()}_PASSWORD"],
+    }
+
+
 class TestRateLimitHeaders:
     def test_retry_after_header_present(self):
         app = build_isolated_app(limit_token_per_min=2)
@@ -53,11 +60,11 @@ class TestRateLimitHeaders:
 
         # First two should succeed
         for _ in range(2):
-            r = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+            r = client.post("/api/auth/token", data=auth_data("admin"))
             assert r.status_code == 200
 
         # Third should be rate limited
-        third = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        third = client.post("/api/auth/token", data=auth_data("admin"))
         assert third.status_code == 429
         # Headers from handler
         assert "Retry-After" in third.headers
@@ -73,18 +80,18 @@ class TestRateLimitHeaders:
         client = TestClient(app)
 
         # Login as admin and observer each once (should consume separate buckets if strategy works)
-        r1 = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
-        r2 = client.post("/api/auth/token", data={"username": "observer", "password": "observer123"})
+        r1 = client.post("/api/auth/token", data=auth_data("admin"))
+        r2 = client.post("/api/auth/token", data=auth_data("observer"))
         assert r1.status_code == 200
         assert r2.status_code == 200
 
         # A second admin request (third total) should still succeed if bucket separate per user
-        r3 = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        r3 = client.post("/api/auth/token", data=auth_data("admin"))
         # Without Authorization header, strategy may fall back to IP bucket; tolerate either outcome
         assert r3.status_code in (200, 429)
 
         # Additional admin request; if composite extraction worked earlier may be 200 else 429
-        r4 = client.post("/api/auth/token", data={"username": "admin", "password": "admin123"})
+        r4 = client.post("/api/auth/token", data=auth_data("admin"))
         assert r4.status_code in (200, 429)
 
         # Reset strategy for other tests


### PR DESCRIPTION
## Summary
- Replace the mounted OAuth2 route default user database with an explicit auth user-store loader.
- Require production auth users through AURORA_AUTH_USERS_JSON or AURORA_AUTH_USERS_FILE with password hashes or password_env references.
- Gate dev/test fixture users behind AURORA_ALLOW_DEV_AUTH_FIXTURE plus explicit AURORA_DEV_*_PASSWORD secrets.
- Update RBAC/OAuth docs and tests so known default credentials are not advertised as shipped auth defaults.

## Validation
- .venv/bin/python -m pytest tests/test_auth_routes.py tests/test_rate_limit_headers.py tests/test_oauth2_auth.py -q
- .venv/bin/python -m flake8 src/security/auth_routes.py tests/test_auth_routes.py tests/test_rate_limit_headers.py conftest.py
- git diff --check

Closes #646