### PR TITLE
fix: require auth for sentinel metrics websocket

### DIFF
--- a/modules/resilience_sentinel/api.py
+++ b/modules/resilience_sentinel/api.py
@@ -13,10 +13,13 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 
+from src.middleware.fastapi_security import verify_ws_token
+
 from .alert_manager import AlertSeverity
 from .monitoring_engine import MonitoringEngine
 
 # Pydantic models for API requests/responses
+
 
 class MetricResponse(BaseModel):
     """Single metric response."""
@@ -470,6 +473,26 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 
+def _extract_websocket_token(websocket: WebSocket) -> Optional[str]:
+    token = websocket.query_params.get("token")
+    if token:
+        return token
+
+    authorization = websocket.headers.get("authorization")
+    if authorization and authorization.lower().startswith("bearer "):
+        return authorization.split(" ", 1)[1].strip()
+    return None
+
+
+async def _authorize_metrics_websocket(websocket: WebSocket) -> Optional[str]:
+    token = _extract_websocket_token(websocket)
+    client_id = verify_ws_token(token) if token else None
+    if not client_id:
+        await websocket.close(code=1008, reason="Unauthorized: Invalid or missing token")
+        return None
+    return client_id
+
+
 @router.websocket("/ws/metrics")
 async def websocket_metrics(websocket: WebSocket):
     """
@@ -483,6 +506,10 @@ async def websocket_metrics(websocket: WebSocket):
         - Every 60s: Sends updated dashboard data
         - On new alert: Sends alert notification
     """
+    client_id = await _authorize_metrics_websocket(websocket)
+    if not client_id:
+        return
+
     engine = get_monitoring_engine()
     await manager.connect(websocket)
 

--- a/tests/test_resilience_sentinel_websocket_auth.py
+++ b/tests/test_resilience_sentinel_websocket_auth.py
@@ -1,0 +1,83 @@
+import unittest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from modules.resilience_sentinel import api as sentinel_api
+from src.middleware.fastapi_security import generate_ws_token
+
+
+class _FakeSentinelEngine:
+    collection_interval = 60
+
+    def get_dashboard_data(self):
+        return {
+            "health": {"timestamp": 123.0},
+            "metrics": {},
+            "alerts": {},
+            "recent_alerts": [],
+            "system": {},
+        }
+
+    def collect_metrics(self):
+        return []
+
+    def evaluate_alerts(self, metrics):
+        return []
+
+
+def _build_client(monkeypatch):
+    monkeypatch.setattr(sentinel_api, "get_monitoring_engine", lambda: _FakeSentinelEngine())
+    app = FastAPI()
+    app.include_router(sentinel_api.router)
+    return TestClient(app)
+
+
+def test_metrics_websocket_rejects_missing_token(monkeypatch):
+    checks = unittest.TestCase()
+    client = _build_client(monkeypatch)
+
+    with checks.assertRaises(WebSocketDisconnect) as disconnect:
+        with client.websocket_connect("/sentinel/ws/metrics"):
+            pass
+
+    checks.assertEqual(disconnect.exception.code, 1008)
+
+
+def test_metrics_websocket_rejects_invalid_token(monkeypatch):
+    checks = unittest.TestCase()
+    client = _build_client(monkeypatch)
+
+    with checks.assertRaises(WebSocketDisconnect) as disconnect:
+        with client.websocket_connect("/sentinel/ws/metrics?token=invalid"):
+            pass
+
+    checks.assertEqual(disconnect.exception.code, 1008)
+
+
+def test_metrics_websocket_accepts_valid_query_token(monkeypatch):
+    checks = unittest.TestCase()
+    client = _build_client(monkeypatch)
+    token = generate_ws_token("sentinel-client")
+
+    with client.websocket_connect(f"/sentinel/ws/metrics?token={token}") as websocket:
+        message = websocket.receive_json()
+
+    checks.assertEqual(message["type"], "dashboard_update")
+    checks.assertEqual(message["timestamp"], 123.0)
+
+
+def test_metrics_websocket_accepts_authorization_header(monkeypatch):
+    checks = unittest.TestCase()
+    client = _build_client(monkeypatch)
+    token = generate_ws_token("sentinel-client")
+
+    with client.websocket_connect(
+        "/sentinel/ws/metrics",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as websocket:
+        message = websocket.receive_json()
+
+    checks.assertEqual(message["type"], "dashboard_update")
+    checks.assertEqual(message["timestamp"], 123.0)


### PR DESCRIPTION
Closes #645

Validation:
- .venv/bin/python -m pytest tests/test_resilience_sentinel_websocket_auth.py tests/test_resilience_sentinel.py -q
- .venv/bin/python -m flake8 modules/resilience_sentinel/api.py tests/test_resilience_sentinel_websocket_auth.py
- git diff --check