### PR TITLE
fix: require auth for GUMAS mutations

### DIFF
--- a/modules/gumas/api/routes.py
+++ b/modules/gumas/api/routes.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Any, Optional
 from datetime import datetime, timezone
 import logging
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from src.monitoring.ethics_engine import (
@@ -22,6 +22,7 @@ from src.monitoring.ethics_engine import (
     RuleCategory
 )
 from src.core.native_dlp_export import NativeDLPTracker
+from src.middleware.fastapi_security import require_csrf_token
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/gumas", tags=["GUMAS Ethics"])
@@ -268,7 +269,12 @@ async def get_rule(rule_id: str) -> RuleResponse:
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/rules", response_model=RuleResponse, status_code=201)
+@router.post(
+    "/rules",
+    response_model=RuleResponse,
+    status_code=201,
+    dependencies=[Depends(require_csrf_token)],
+)
 async def add_rule(request: AddRuleRequest) -> RuleResponse:
     """
     Add a new ethics rule
@@ -329,7 +335,11 @@ async def add_rule(request: AddRuleRequest) -> RuleResponse:
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.delete("/rules/{rule_id}", status_code=204)
+@router.delete(
+    "/rules/{rule_id}",
+    status_code=204,
+    dependencies=[Depends(require_csrf_token)],
+)
 async def delete_rule(rule_id: str):
     """
     Delete an ethics rule
@@ -377,7 +387,11 @@ async def register_custom_evaluator(
     )
 
 
-@router.delete("/violations", status_code=204)
+@router.delete(
+    "/violations",
+    status_code=204,
+    dependencies=[Depends(require_csrf_token)],
+)
 async def clear_violations(
     before: Optional[str] = Query(None, description="Clear violations before this ISO timestamp")
 ):

--- a/tests/test_gumas_api.py
+++ b/tests/test_gumas_api.py
@@ -30,9 +30,14 @@ from src.monitoring.ethics_engine import (
     ViolationSeverity,
     RuleCategory
 )
+from src.middleware.fastapi_security import generate_csrf_token
 
 # Create test client
 client = TestClient(app)
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {generate_csrf_token('gumas-test-session')}"}
 
 
 @pytest.fixture
@@ -326,7 +331,7 @@ class TestGumasRulesManagement:
             "metadata": {"created_by": "test"}
         }
 
-        response = client.post("/gumas/rules", json=new_rule)
+        response = client.post("/gumas/rules", json=new_rule, headers=_auth_headers())
 
         assert response.status_code == 201
         data = response.json()
@@ -347,11 +352,11 @@ class TestGumasRulesManagement:
         }
 
         # Add rule first time
-        response1 = client.post("/gumas/rules", json=rule_data)
+        response1 = client.post("/gumas/rules", json=rule_data, headers=_auth_headers())
         assert response1.status_code == 201
 
         # Try to add again
-        response2 = client.post("/gumas/rules", json=rule_data)
+        response2 = client.post("/gumas/rules", json=rule_data, headers=_auth_headers())
         assert response2.status_code == 409  # Conflict
         assert "already exists" in response2.json()["detail"]
 
@@ -368,7 +373,7 @@ class TestGumasRulesManagement:
             "metadata": {}
         }
 
-        response = client.post("/gumas/rules", json=rule_data)
+        response = client.post("/gumas/rules", json=rule_data, headers=_auth_headers())
 
         assert response.status_code == 400
         assert "Invalid parameter" in response.json()["detail"]
@@ -386,7 +391,7 @@ class TestGumasRulesManagement:
             "metadata": {}
         }
 
-        response = client.post("/gumas/rules", json=rule_data)
+        response = client.post("/gumas/rules", json=rule_data, headers=_auth_headers())
 
         assert response.status_code == 400
 
@@ -406,7 +411,7 @@ class TestGumasRulesManagement:
         clean_ethics_engine.add_rule(test_rule)
 
         # Delete the rule
-        response = client.delete("/gumas/rules/rule_to_delete")
+        response = client.delete("/gumas/rules/rule_to_delete", headers=_auth_headers())
 
         assert response.status_code == 204
 
@@ -416,7 +421,7 @@ class TestGumasRulesManagement:
 
     def test_delete_nonexistent_rule(self, clean_ethics_engine):
         """Test deleting a rule that doesn't exist."""
-        response = client.delete("/gumas/rules/nonexistent_rule")
+        response = client.delete("/gumas/rules/nonexistent_rule", headers=_auth_headers())
 
         assert response.status_code == 404
 
@@ -456,7 +461,7 @@ class TestGumasUtilityEndpoints:
 
     def test_clear_violations(self, clean_ethics_engine):
         """Test clearing old violations."""
-        response = client.delete("/gumas/violations")
+        response = client.delete("/gumas/violations", headers=_auth_headers())
 
         assert response.status_code == 204
 
@@ -467,13 +472,13 @@ class TestGumasUtilityEndpoints:
         # URL-encode the timestamp to handle the + in timezone offset
         encoded_timestamp = quote(timestamp, safe='')
 
-        response = client.delete(f"/gumas/violations?before={encoded_timestamp}")
+        response = client.delete(f"/gumas/violations?before={encoded_timestamp}", headers=_auth_headers())
 
         assert response.status_code == 204
 
     def test_clear_violations_invalid_timestamp(self, clean_ethics_engine):
         """Test clearing violations with invalid timestamp."""
-        response = client.delete("/gumas/violations?before=invalid_timestamp")
+        response = client.delete("/gumas/violations?before=invalid_timestamp", headers=_auth_headers())
 
         assert response.status_code == 400
         assert "Invalid timestamp" in response.json()["detail"]
@@ -507,7 +512,7 @@ class TestGumasApiIntegration:
             "metadata": {"test": "lifecycle"}
         }
 
-        add_response = client.post("/gumas/rules", json=new_rule)
+        add_response = client.post("/gumas/rules", json=new_rule, headers=_auth_headers())
         assert add_response.status_code == 201
 
         # 2. Verify rule exists
@@ -525,7 +530,7 @@ class TestGumasApiIntegration:
         assert eval_response.status_code == 200
 
         # 4. Delete the rule
-        delete_response = client.delete("/gumas/rules/lifecycle_test_rule")
+        delete_response = client.delete("/gumas/rules/lifecycle_test_rule", headers=_auth_headers())
         assert delete_response.status_code == 204
 
         # 5. Verify rule is deleted
@@ -550,7 +555,7 @@ class TestGumasApiIntegration:
         ]
 
         for rule in rules:
-            response = client.post("/gumas/rules", json=rule)
+            response = client.post("/gumas/rules", json=rule, headers=_auth_headers())
             assert response.status_code == 201
 
         # Verify all rules are present
@@ -562,13 +567,59 @@ class TestGumasApiIntegration:
 
         # Clean up
         for i in range(3):
-            client.delete(f"/gumas/rules/multi_rule_{i}")
+            client.delete(f"/gumas/rules/multi_rule_{i}", headers=_auth_headers())
 
 
 @pytest.mark.api
 @pytest.mark.security
 class TestGumasApiSecurity:
     """Test API security considerations."""
+
+    def test_add_rule_requires_auth_before_mutation(self, clean_ethics_engine):
+        """Unauthenticated callers cannot add ethics rules."""
+        rule_data = {
+            "id": "unauthenticated_rule",
+            "name": "Unauthenticated Rule",
+            "description": "Should not be added",
+            "category": "safety",
+            "severity": "low",
+            "auto_block": False,
+            "conditions": [],
+            "metadata": {}
+        }
+
+        response = client.post("/gumas/rules", json=rule_data)
+
+        assert response.status_code in (401, 403)
+        assert "unauthenticated_rule" not in clean_ethics_engine.rules
+
+    def test_delete_rule_requires_auth_before_mutation(self, clean_ethics_engine):
+        """Unauthenticated callers cannot delete ethics rules."""
+        clean_ethics_engine.add_rule(EthicsRule(
+            id="protected_rule",
+            name="Protected Rule",
+            description="Should remain present",
+            category=RuleCategory.SAFETY,
+            severity=ViolationSeverity.LOW,
+            auto_block=False,
+            conditions=[],
+            metadata={}
+        ))
+
+        response = client.delete("/gumas/rules/protected_rule")
+
+        assert response.status_code in (401, 403)
+        assert "protected_rule" in clean_ethics_engine.rules
+
+    def test_clear_violations_requires_auth_before_mutation(self, clean_ethics_engine):
+        """Unauthenticated callers cannot clear recorded violations."""
+        violation_marker = object()
+        clean_ethics_engine.violations.append(violation_marker)
+
+        response = client.delete("/gumas/violations")
+
+        assert response.status_code in (401, 403)
+        assert clean_ethics_engine.violations == [violation_marker]
 
     def test_input_validation_prevents_injection(self, clean_ethics_engine):
         """Test that input validation prevents injection attacks."""
@@ -583,7 +634,7 @@ class TestGumasApiSecurity:
             "metadata": {}
         }
 
-        response = client.post("/gumas/rules", json=malicious_rule)
+        response = client.post("/gumas/rules", json=malicious_rule, headers=_auth_headers())
 
         # Should either succeed with sanitized input or fail validation
         # But should not cause server errors
@@ -604,7 +655,7 @@ class TestGumasApiSecurity:
             "metadata": large_metadata
         }
 
-        response = client.post("/gumas/rules", json=rule_data)
+        response = client.post("/gumas/rules", json=rule_data, headers=_auth_headers())
 
         # Should handle large payloads gracefully
         assert response.status_code in [201, 413, 422]


### PR DESCRIPTION
## Summary
- require the existing CSRF bearer dependency before GUMAS rule add/delete and violation clear mutations
- keep read-only GUMAS routes public
- add regression tests proving unauthenticated writes do not mutate ethics state while authorized writes still work

Closes #651.

## Validation
- .venv/bin/python -m pytest -q tests/test_gumas_api.py
- .venv/bin/python -m pytest -q tests/test_security_middleware.py tests/test_gumas_api.py