### PR TITLE
fix: require auth for coordination mutations

### DIFF
--- a/src/coordination/event_api.py
+++ b/src/coordination/event_api.py
@@ -9,9 +9,10 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from src.middleware.exception_handler import processing_handler, integration_handler
+from src.middleware.fastapi_security import require_csrf_token
 
 from src.coordination.event_models import (
     ConflictReport,
@@ -82,7 +83,7 @@ class ConflictResolutionRequest(BaseModel):
 
 
 # Event Publishing Endpoints
-@router.post("/events/publish")
+@router.post("/events/publish", dependencies=[Depends(require_csrf_token)])
 async def publish_event(request: PublishEventRequest) -> Dict[str, Any]:
     """
     Publish event to coordination registry
@@ -132,7 +133,7 @@ async def publish_event(request: PublishEventRequest) -> Dict[str, Any]:
 
 
 # Subscription Endpoints
-@router.post("/subscriptions/subscribe")
+@router.post("/subscriptions/subscribe", dependencies=[Depends(require_csrf_token)])
 async def subscribe_to_events(request: SubscribeRequest) -> Dict[str, Any]:
     """
     Subscribe to events matching filter criteria
@@ -173,7 +174,7 @@ async def subscribe_to_events(request: SubscribeRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Subscription failed")
 
 
-@router.delete("/subscriptions/{subscription_id}")
+@router.delete("/subscriptions/{subscription_id}", dependencies=[Depends(require_csrf_token)])
 async def unsubscribe_from_events(subscription_id: str) -> Dict[str, Any]:
     """
     Unsubscribe from events
@@ -273,7 +274,7 @@ async def replay_events(
 
 
 # Conflict Detection and Resolution
-@router.post("/conflicts/detect")
+@router.post("/conflicts/detect", dependencies=[Depends(require_csrf_token)])
 async def detect_conflict(request: ConflictDetectionRequest) -> Dict[str, Any]:
     """
     Detect potential conflicts with other agents
@@ -312,7 +313,7 @@ async def detect_conflict(request: ConflictDetectionRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Conflict detection failed")
 
 
-@router.post("/conflicts/resolve")
+@router.post("/conflicts/resolve", dependencies=[Depends(require_csrf_token)])
 async def resolve_conflict(request: ConflictResolutionRequest) -> Dict[str, Any]:
     """
     Mark conflict as resolved
@@ -346,7 +347,7 @@ async def resolve_conflict(request: ConflictResolutionRequest) -> Dict[str, Any]
 
 
 # Resource Locking
-@router.post("/locks/acquire")
+@router.post("/locks/acquire", dependencies=[Depends(require_csrf_token)])
 async def acquire_lock(request: LockRequest) -> Dict[str, Any]:
     """
     Acquire exclusive lock on resource
@@ -380,7 +381,7 @@ async def acquire_lock(request: LockRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Lock acquisition failed")
 
 
-@router.delete("/locks/{resource_id}")
+@router.delete("/locks/{resource_id}", dependencies=[Depends(require_csrf_token)])
 async def release_lock(resource_id: str, agent_id: str = Query(...)) -> Dict[str, Any]:
     """
     Release lock on resource
@@ -411,7 +412,7 @@ async def release_lock(resource_id: str, agent_id: str = Query(...)) -> Dict[str
 
 
 # Workflow Orchestration
-@router.post("/workflows/create")
+@router.post("/workflows/create", dependencies=[Depends(require_csrf_token)])
 async def create_workflow(workflow: WorkflowDefinition) -> Dict[str, Any]:
     """
     Create multi-agent workflow

--- a/tests/test_coordination_event_api_auth.py
+++ b/tests/test_coordination_event_api_auth.py
@@ -1,0 +1,195 @@
+"""Regression tests for auth on event coordination mutation routes."""
+
+import os
+import unittest
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-coordination-api")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-coordination-api")
+
+from src.coordination import event_api  # noqa: E402
+from src.coordination.event_registry import EventCoordinationRegistry  # noqa: E402
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+
+
+def _auth_header() -> dict[str, str]:
+    token = generate_csrf_token("coordination-test-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _event_payload(source_agent_id: str = "agent-a") -> dict:
+    return {
+        "event_type": "task.created",
+        "priority": "normal",
+        "source_agent_id": source_agent_id,
+        "payload": {"task_id": "task-1"},
+    }
+
+
+def _subscribe_payload(agent_id: str = "agent-a") -> dict:
+    return {
+        "agent_id": agent_id,
+        "event_types": ["task.created"],
+        "priorities": ["normal"],
+    }
+
+
+def _lock_payload(agent_id: str = "agent-a", resource_id: str = "dataset-1") -> dict:
+    return {
+        "agent_id": agent_id,
+        "resource_id": resource_id,
+        "resource_type": "dataset",
+        "ttl_seconds": 300,
+    }
+
+
+def _conflict_payload(agent_id: str = "agent-b", resource_id: str = "dataset-1") -> dict:
+    return {
+        "agent_id": agent_id,
+        "resource_id": resource_id,
+        "resource_type": "dataset",
+        "operation": "write",
+    }
+
+
+def _workflow_payload() -> dict:
+    return {
+        "name": "Coordination Test Workflow",
+        "description": "Auth regression workflow",
+        "steps": [{"step_id": "step-1", "action": "fetch"}],
+        "agent_assignments": {"step-1": "agent-a"},
+        "created_by": "agent-a",
+    }
+
+
+@pytest.fixture
+def registry(monkeypatch) -> EventCoordinationRegistry:
+    registry = EventCoordinationRegistry()
+    monkeypatch.setattr(event_api, "get_event_registry", lambda: registry)
+    return registry
+
+
+@pytest.fixture
+def client(registry) -> TestClient:
+    app = FastAPI()
+    app.include_router(event_api.router)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("post", "/api/coordination/events/publish", {"json": _event_payload()}),
+        ("post", "/api/coordination/subscriptions/subscribe", {"json": _subscribe_payload()}),
+        ("delete", "/api/coordination/subscriptions/sub-1", {}),
+        ("post", "/api/coordination/conflicts/detect", {"json": _conflict_payload()}),
+        (
+            "post",
+            "/api/coordination/conflicts/resolve",
+            {"json": {"conflict_id": "conflict-1", "strategy": "manual", "resolved_by": "agent-a"}},
+        ),
+        ("post", "/api/coordination/locks/acquire", {"json": _lock_payload()}),
+        ("delete", "/api/coordination/locks/dataset-1", {"params": {"agent_id": "agent-a"}}),
+        ("post", "/api/coordination/workflows/create", {"json": _workflow_payload()}),
+    ],
+)
+def test_coordination_mutations_reject_missing_auth_before_state_change(
+    client: TestClient,
+    registry: EventCoordinationRegistry,
+    method: str,
+    path: str,
+    kwargs: dict,
+) -> None:
+    checks = unittest.TestCase()
+
+    response = getattr(client, method)(path, **kwargs)
+
+    checks.assertIn(response.status_code, (401, 403))
+    checks.assertEqual(registry._event_history, [])
+    checks.assertEqual(registry._subscriptions, {})
+    checks.assertEqual(registry._resource_locks, {})
+    checks.assertEqual(registry._workflows, {})
+
+
+def test_coordination_event_publish_accepts_valid_auth(client: TestClient) -> None:
+    response = client.post(
+        "/api/coordination/events/publish",
+        json=_event_payload(),
+        headers=_auth_header(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+def test_coordination_subscribe_and_unsubscribe_accept_valid_auth(client: TestClient) -> None:
+    subscribe_response = client.post(
+        "/api/coordination/subscriptions/subscribe",
+        json=_subscribe_payload(),
+        headers=_auth_header(),
+    )
+
+    assert subscribe_response.status_code == 200
+    subscription_id = subscribe_response.json()["subscription_id"]
+
+    unsubscribe_response = client.delete(
+        f"/api/coordination/subscriptions/{subscription_id}",
+        headers=_auth_header(),
+    )
+
+    assert unsubscribe_response.status_code == 200
+    assert unsubscribe_response.json()["success"] is True
+
+
+def test_coordination_lock_conflict_and_release_accept_valid_auth(client: TestClient) -> None:
+    acquire_response = client.post(
+        "/api/coordination/locks/acquire",
+        json=_lock_payload(),
+        headers=_auth_header(),
+    )
+
+    assert acquire_response.status_code == 200
+
+    conflict_response = client.post(
+        "/api/coordination/conflicts/detect",
+        json=_conflict_payload(),
+        headers=_auth_header(),
+    )
+
+    assert conflict_response.status_code == 200
+    conflict = conflict_response.json()["conflict"]
+
+    resolve_response = client.post(
+        "/api/coordination/conflicts/resolve",
+        json={
+            "conflict_id": conflict["conflict_id"],
+            "strategy": "manual",
+            "resolved_by": "agent-a",
+        },
+        headers=_auth_header(),
+    )
+
+    assert resolve_response.status_code == 200
+
+    release_response = client.delete(
+        "/api/coordination/locks/dataset-1",
+        params={"agent_id": "agent-a"},
+        headers=_auth_header(),
+    )
+
+    assert release_response.status_code == 200
+    assert release_response.json()["success"] is True
+
+
+def test_coordination_workflow_create_accepts_valid_auth(client: TestClient) -> None:
+    response = client.post(
+        "/api/coordination/workflows/create",
+        json=_workflow_payload(),
+        headers=_auth_header(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True


### PR DESCRIPTION
Summary: Requires CSRF bearer auth before state-changing /api/coordination routes mutate registry, lock, conflict, subscription, event, or workflow state. Adds regression coverage for missing-auth rejection and valid-auth mutation paths. Tests: python -m pytest -q tests/test_coordination_event_api_auth.py. Closes #649.