### PR TITLE
fix: label synergy components as static topology

### DIFF
--- a/src/synergy/dashboard_api.py
+++ b/src/synergy/dashboard_api.py
@@ -27,14 +27,19 @@ router = APIRouter(prefix="/api/synergy", tags=["synergy"])
 
 # Data models
 class ComponentStatus(BaseModel):
-    """Real-time component status"""
+    """Static component registry entry."""
     component_id: str
     name: str
-    status: str = Field(description="active|degraded|offline")
-    health_score: float = Field(ge=0.0, le=100.0)
-    last_heartbeat: str
-    uptime_seconds: int
-    resource_usage: Dict[str, float]
+    category: str
+    description: str
+    endpoints: List[str]
+    status: str = Field(description="documented")
+    telemetry_available: bool = False
+    telemetry_source: str = "static_registry"
+    health_score: Optional[float] = Field(default=None, ge=0.0, le=100.0)
+    last_heartbeat: Optional[str] = None
+    uptime_seconds: Optional[int] = None
+    resource_usage: Optional[Dict[str, float]] = None
 
 
 class ComponentInteraction(BaseModel):
@@ -219,29 +224,23 @@ def calculate_synergy_score(component1: str, component2: str) -> float:
 
 # API Endpoints
 
-@router.get("/components", response_model=List[ComponentStatus])
+@router.get("/components", response_model=List[ComponentStatus], response_model_exclude_none=True)
 async def get_components(
-    status_filter: Optional[str] = Query(None, description="Filter by status: active|degraded|offline")
+    status_filter: Optional[str] = Query(None, description="Filter by status: documented")
 ) -> List[ComponentStatus]:
     """
-    Get all registered R-2 components with real-time status
+    Get registered R-2 component topology entries.
+
+    This route intentionally returns static registry data only. It does not
+    synthesize health, uptime, heartbeat, or resource usage values.
     
     DLP: synergy_dashboard_components
     """
     components = get_component_registry()
-    now = datetime.now(timezone.utc).isoformat()
     
     statuses = []
     for comp in components:
-        health = calculate_component_health(comp["id"])
-        
-        # Determine status from health score
-        if health >= 80:
-            status = "active"
-        elif health >= 50:
-            status = "degraded"
-        else:
-            status = "offline"
+        status = "documented"
         
         # Apply filter if specified
         if status_filter and status != status_filter:
@@ -250,14 +249,12 @@ async def get_components(
         statuses.append(ComponentStatus(
             component_id=comp["id"],
             name=comp["name"],
+            category=comp["category"],
+            description=comp["description"],
+            endpoints=comp["endpoints"],
             status=status,
-            health_score=health,
-            last_heartbeat=now,
-            uptime_seconds=86400,  # Placeholder
-            resource_usage={
-                "cpu_percent": 25.0 + (hash(comp["id"]) % 20),
-                "memory_mb": 128.0 + (hash(comp["id"]) % 256),
-            }
+            telemetry_available=False,
+            telemetry_source="static_registry",
         ))
     
     # Track with DLP

--- a/tests/test_synergy_dashboard.py
+++ b/tests/test_synergy_dashboard.py
@@ -22,7 +22,7 @@ class TestSynergyDashboardAPI:
         """Test dashboard health check endpoint"""
         response = test_client.get("/api/synergy/health")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["status"] == "healthy"
         assert data["service"] == "synergy_dashboard_api"
@@ -30,10 +30,10 @@ class TestSynergyDashboardAPI:
         assert "version" in data
     
     def test_get_components(self, test_client):
-        """Test retrieving all components"""
+        """Test retrieving static component topology entries."""
         response = test_client.get("/api/synergy/components")
         assert response.status_code == 200
-        
+
         components = response.json()
         assert isinstance(components, list)
         assert len(components) > 0
@@ -42,29 +42,46 @@ class TestSynergyDashboardAPI:
         component = components[0]
         assert "component_id" in component
         assert "name" in component
+        assert "category" in component
+        assert "description" in component
+        assert "endpoints" in component
         assert "status" in component
-        assert "health_score" in component
-        assert "last_heartbeat" in component
-        assert "uptime_seconds" in component
-        assert "resource_usage" in component
-        
-        # Verify health score range
-        assert 0 <= component["health_score"] <= 100
-        
-        # Verify status values
-        assert component["status"] in ["active", "degraded", "offline"]
+        assert "telemetry_available" in component
+        assert "telemetry_source" in component
+
+        # The route is static topology, not live health telemetry.
+        assert component["status"] == "documented"
+        assert component["telemetry_available"] is False
+        assert component["telemetry_source"] == "static_registry"
+        assert "health_score" not in component
+        assert "last_heartbeat" not in component
+        assert "uptime_seconds" not in component
+        assert "resource_usage" not in component
     
     def test_get_components_with_filter(self, test_client):
         """Test retrieving components with status filter"""
-        response = test_client.get("/api/synergy/components?status_filter=active")
+        response = test_client.get("/api/synergy/components?status_filter=documented")
         assert response.status_code == 200
         
         components = response.json()
         assert isinstance(components, list)
         
-        # All returned components should be active
+        # All returned components should be documented static entries.
         for component in components:
-            assert component["status"] == "active"
+            assert component["status"] == "documented"
+
+    def test_components_do_not_report_placeholder_live_health(self, test_client):
+        """Static component entries do not expose synthetic live-health fields."""
+        response = test_client.get("/api/synergy/components")
+        assert response.status_code == 200
+
+        for component in response.json():
+            assert component["telemetry_available"] is False
+            assert component["telemetry_source"] == "static_registry"
+            assert "health_score" not in component
+            assert "last_heartbeat" not in component
+            assert "uptime_seconds" not in component
+            assert "resource_usage" not in component
     
     def test_get_topology(self, test_client):
         """Test retrieving component topology"""


### PR DESCRIPTION
Summary: Changes /api/synergy/components from a live-looking status payload to explicit static registry/topology data. Removes synthetic health_score, last_heartbeat, uptime_seconds, and resource_usage from the response, and adds telemetry_available/telemetry_source labels. Tests: python -m pytest -q tests/test_synergy_dashboard.py. Closes #647.