### PR TITLE
fix: execute CloudHub VSA and quantum routes

### DIFF
--- a/api/aurora_gui_cloudhub_fastapi.py
+++ b/api/aurora_gui_cloudhub_fastapi.py
@@ -4,7 +4,7 @@ import uuid
 import hashlib
 import uvicorn
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Annotated, Dict, List, Optional, Any
 
 import aiofiles
 import numpy as np
@@ -111,6 +111,34 @@ async def _require_websocket_auth(websocket: WebSocket) -> Optional[str]:
         await websocket.close(code=1008, reason="Unauthorized: Invalid or missing token")
         return None
     return client_id
+
+
+def _aligned_vsa_vectors(symbol_a: str, symbol_b: str) -> tuple[np.ndarray, np.ndarray, int]:
+    vec_a = vsa_store.get(symbol_a)
+    vec_b = vsa_store.get(symbol_b)
+    if vec_a is None or vec_b is None:
+        raise HTTPException(status_code=404, detail="One or both symbols not found")
+
+    arr_a = np.asarray(vec_a.vector)
+    arr_b = np.asarray(vec_b.vector)
+    min_dim = min(len(arr_a), len(arr_b))
+    return arr_a[:min_dim], arr_b[:min_dim], min_dim
+
+
+def _store_vsa_vector(symbol: str, vector: np.ndarray) -> QuantumSymbolicVector:
+    result_qsv = QuantumSymbolicVector(symbol, len(vector))
+    result_qsv.vector = np.asarray(vector)
+    result_qsv.dim = len(vector)
+    result_qsv.vector_type = "bipolar"
+    vsa_store[symbol] = result_qsv
+    return result_qsv
+
+
+def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    denominator = float(np.linalg.norm(vec_a) * np.linalg.norm(vec_b))
+    if np.isclose(denominator, 0.0):
+        return 0.0
+    return float(np.dot(vec_a, vec_b) / denominator)
 
 # Serve static files if needed in the future
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -235,6 +263,19 @@ def _apply_symbolic_gates(qc, depth: int, qubits: int) -> None:
             else:
                 if q < qubits - 1:
                     qc.cx(q, q + 1)
+
+
+def _serialize_quantum_circuit(qc) -> Optional[str]:
+    qasm_method = getattr(qc, "qasm", None)
+    if callable(qasm_method):
+        return qasm_method()
+
+    try:
+        from qiskit import qasm2
+
+        return qasm2.dumps(qc)
+    except Exception:
+        return None
 
 
 @app.post("/upload/", dependencies=[Depends(security)])  # verify_csrf inside
@@ -636,6 +677,7 @@ def mcp_route_command(
     summary="VSA Operation",
     response_description="Result of VSA operation",
     dependencies=[Depends(security)],
+    responses={400: {"description": "Unsupported paired VSA operation type"}},
 )
 def vsa_operation(req: VSAOperationRequest, token: HTTPAuthorizationCredentials = Depends(security)):
     """Perform an operation on the VSA symbolic vector.
@@ -647,17 +689,11 @@ def vsa_operation(req: VSAOperationRequest, token: HTTPAuthorizationCredentials 
     if req.operation_type == "generate":
         vec = quantum_symbolic_vector(req.symbol, req.dimension)
         result = vec.tolist()
-    elif req.operation_type == "bind":
-        # Binding logic here
-        _ = "Binding not implemented in demo"
-    elif req.operation_type == "unbind":
-        # Unbinding logic here
-        _ = "Unbinding not implemented in demo"
-    elif req.operation_type == "similarity":
-        # Similarity logic here
-        result = "Similarity not implemented in demo"
     else:
-        raise HTTPException(status_code=400, detail="Invalid operation type")
+        raise HTTPException(
+            status_code=400,
+            detail="Only generate is supported by /vsa/operation; use /vsa/bind or /vsa/similarity for paired vectors",
+        )
 
     return {"symbol": req.symbol, "dimension": req.dimension, "result": result}
 
@@ -675,19 +711,13 @@ def vsa_bind(req: VSABindRequest, token: HTTPAuthorizationCredentials = Depends(
     Response: {"result_name": str, "dimension": int, "result": Any}
     """
     verify_csrf_token(token)
-    # Retrieve vectors from store
-    vec_a = vsa_store.get(req.symbol_a)
-    vec_b = vsa_store.get(req.symbol_b)
-    if vec_a is None or vec_b is None:
-        raise HTTPException(status_code=404, detail="One or both symbols not found")
-
-    # Perform binding (placeholder logic)
-    bound_vector = vec_a  # Replace with actual binding logic
-    vsa_store[req.result_name] = bound_vector
+    vec_a, vec_b, dimension = _aligned_vsa_vectors(req.symbol_a, req.symbol_b)
+    bound_vector = vec_a * vec_b
+    _store_vsa_vector(req.result_name, bound_vector)
 
     return {
         "result_name": req.result_name,
-        "dimension": req.dimension,
+        "dimension": dimension,
         "result": bound_vector.tolist(),
     }
 
@@ -705,42 +735,32 @@ def vsa_similarity(req: VSASimilarityRequest, token: HTTPAuthorizationCredential
     Response: {"symbol_a": str, "symbol_b": str, "similarity": float}
     """
     verify_csrf_token(token)
-    # Retrieve vectors from store
-    vec_a = vsa_store.get(req.symbol_a)
-    vec_b = vsa_store.get(req.symbol_b)
-    if vec_a is None or vec_b is None:
-        raise HTTPException(status_code=404, detail="One or both symbols not found")
-
-    # Compute similarity (placeholder logic)
-    similarity_score = float(_rng.random())  # Placeholder similarity using modern RNG
+    vec_a, vec_b, dimension = _aligned_vsa_vectors(req.symbol_a, req.symbol_b)
+    similarity_score = _cosine_similarity(vec_a, vec_b)
 
     return {
         "symbol_a": req.symbol_a,
         "symbol_b": req.symbol_b,
         "similarity": similarity_score,
+        "dimension": dimension,
     }
 
 
-@app.post(  # verify_csrf inside
+@app.post(
     "/quantum/circuit",
     summary="Quantum Circuit",
     response_description="Result of quantum circuit operation",
-)
-def quantum_circuit(req: QuantumCircuitRequest):
+)  # verify_csrf inside
+def quantum_circuit(
+    req: QuantumCircuitRequest,
+    token: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+):
     """
-    Execute a quantum circuit and return the result.
+    Execute a quantum circuit using the canonical API backend.
     Request body: {"symbol": str, "depth": int, "qubits": int}
     Response: {"symbol": str, "depth": int, "qubits": int, "result": Any}
     """
-    # Placeholder for quantum circuit execution
-    result = {
-        "message": "Quantum circuit executed",
-        "symbol": req.symbol,
-        "depth": req.depth,
-        "qubits": req.qubits,
-    }
-
-    return result
+    return generate_quantum_circuit(req, token)
 
 
 @app.post(  # verify_csrf inside
@@ -990,7 +1010,7 @@ def generate_quantum_circuit(req: QuantumCircuitRequest, token: HTTPAuthorizatio
             "most_frequent_state": most_frequent[0],
             "most_frequent_probability": most_frequent[1] / 1000,
             "total_shots": 1000,
-            "circuit_qasm": qc.qasm(),
+            "circuit_qasm": _serialize_quantum_circuit(qc),
         }
     except Exception as e:  # pragma: no cover
         raise HTTPException(status_code=500, detail=f"Quantum circuit generation failed: {str(e)}")

--- a/tests/test_cloudhub_real_vsa_quantum_routes.py
+++ b/tests/test_cloudhub_real_vsa_quantum_routes.py
@@ -1,0 +1,112 @@
+"""Regression tests for CloudHub VSA and quantum route placeholders."""
+
+import os
+import unittest
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-cloudhub-real-routes")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-cloudhub-real-routes")
+
+from api.aurora_gui_cloudhub_fastapi import app, vsa_store  # noqa: E402
+from modules.symbolic_core.quantum_vsa import QuantumSymbolicVector  # noqa: E402
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+
+
+def _auth_headers() -> dict[str, str]:
+    token = generate_csrf_token("cloudhub-real-routes-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _client() -> TestClient:
+    vsa_store.clear()
+    return TestClient(app)
+
+
+def _store_vector(symbol: str, values: list[int]) -> None:
+    vector = QuantumSymbolicVector(symbol, len(values))
+    vector.vector = np.asarray(values)
+    vector.dim = len(values)
+    vector.vector_type = "bipolar"
+    vsa_store[symbol] = vector
+
+
+def test_public_quantum_circuit_route_requires_auth() -> None:
+    client = _client()
+
+    response = client.post(
+        "/quantum/circuit",
+        json={"symbol": "alpha", "depth": 2, "qubits": 3},
+    )
+
+    assert response.status_code in (401, 403)
+
+
+def test_public_quantum_circuit_route_uses_real_backend() -> None:
+    client = _client()
+
+    response = client.post(
+        "/quantum/circuit",
+        json={"symbol": "alpha", "depth": 2, "qubits": 3},
+        headers=_auth_headers(),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("message") != "Quantum circuit executed"
+    assert "circuit_qasm" in payload or payload.get("error") == "Qiskit not available"
+
+
+def test_vsa_bind_route_uses_elementwise_vector_binding() -> None:
+    client = _client()
+    _store_vector("a", [1, -1, 1, -1])
+    _store_vector("b", [1, 1, -1, -1])
+
+    response = client.post(
+        "/vsa/bind",
+        json={"symbol_a": "a", "symbol_b": "b", "result_name": "a_bound_b", "dimension": 4},
+        headers=_auth_headers(),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["result"] == [1, -1, -1, 1]
+    assert vsa_store["a_bound_b"].vector.tolist() == [1, -1, -1, 1]
+
+
+def test_vsa_similarity_route_is_deterministic_and_vector_based() -> None:
+    client = _client()
+    _store_vector("a", [1, -1, 1, -1])
+    _store_vector("b", [1, 1, -1, -1])
+
+    first = client.post(
+        "/vsa/similarity",
+        json={"symbol_a": "a", "symbol_b": "b"},
+        headers=_auth_headers(),
+    )
+    second = client.post(
+        "/vsa/similarity",
+        json={"symbol_a": "a", "symbol_b": "b"},
+        headers=_auth_headers(),
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["similarity"] == second.json()["similarity"]
+    assert first.json()["similarity"] == pytest.approx(0.0)
+
+
+def test_vsa_operation_rejects_non_executable_placeholder_operations() -> None:
+    checks = unittest.TestCase()
+    client = _client()
+
+    response = client.post(
+        "/vsa/operation",
+        json={"symbol": "alpha", "dimension": 4, "operation_type": "similarity"},
+        headers=_auth_headers(),
+    )
+
+    checks.assertEqual(response.status_code, 400)
+    checks.assertNotIn("Similarity not implemented in demo", response.text)


### PR DESCRIPTION
Summary: Removes CloudHub placeholder successes by making /vsa/bind perform element-wise vector binding, /vsa/similarity compute deterministic cosine similarity, /vsa/operation reject unsupported paired operations instead of returning demo strings, and /quantum/circuit reuse the canonical authenticated circuit backend. Also adds a Qiskit qasm serialization fallback for current Qiskit versions. Tests: python -m pytest -q tests/test_cloudhub_websocket_auth.py tests/test_cloudhub_real_vsa_quantum_routes.py. Closes #642. Closes #639.