### PR TITLE
fix: fail closed for collab workflow trigger

### DIFF
--- a/src/collab/api_routes.py
+++ b/src/collab/api_routes.py
@@ -29,7 +29,7 @@ from src.collab.drift_monitor import (
     DriftLevel
 )
 from src.core.native_dlp_export import NativeDLPTracker
-from src.middleware.fastapi_security import require_auth
+from src.middleware.fastapi_security import require_auth, require_csrf_token
 
 logger = logging.getLogger(__name__)
 
@@ -319,10 +319,13 @@ async def import_context(
         )
 
 
-@router.post("/workflow/trigger", response_model=WorkflowTriggerResponse)
+@router.post(
+    "/workflow/trigger",
+    response_model=WorkflowTriggerResponse,
+    dependencies=[Depends(require_csrf_token)],
+)
 async def trigger_workflow(
     request: WorkflowTriggerRequest,
-    token: HTTPAuthorizationCredentials = Depends(require_auth)
 ) -> WorkflowTriggerResponse:
     """
     Trigger build/test workflow in external repository.
@@ -342,18 +345,15 @@ async def trigger_workflow(
         "event_type": request.event_type
     })
     
-    # Generate event chain ID for tracking
-    event_chain_id = f"chain_{int(datetime.now().timestamp())}"
-    
-    # Note: Actual workflow triggering would require GitHub API integration
-    # This is a placeholder implementation
-    
-    return WorkflowTriggerResponse(
-        success=True,
-        target_repo=request.target_repo,
-        workflow_name=request.workflow_name,
-        trigger_timestamp=datetime.now().isoformat(),
-        event_chain_id=event_chain_id
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail={
+            "error": "workflow_dispatch_not_configured",
+            "message": "No external workflow dispatch provider is configured for this route.",
+            "target_repo": request.target_repo,
+            "workflow_name": request.workflow_name,
+            "event_type": request.event_type,
+        },
     )
 
 

--- a/tests/test_collab_workflow_trigger.py
+++ b/tests/test_collab_workflow_trigger.py
@@ -1,0 +1,57 @@
+"""Regression tests for collaboration workflow trigger dispatch semantics."""
+
+import os
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-collab-workflow")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-collab-workflow")
+
+from src.collab.api_routes import router  # noqa: E402
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+
+
+def _auth_headers() -> dict[str, str]:
+    token = generate_csrf_token("collab-workflow-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _workflow_payload() -> dict:
+    return {
+        "target_repo": "AUo959/aurora-cloudbank-symbolic",
+        "workflow_name": "ci.yml",
+        "event_type": "workflow_dispatch",
+        "payload": {"reason": "regression-test"},
+    }
+
+
+def test_workflow_trigger_rejects_missing_auth_before_dispatch() -> None:
+    client = _client()
+
+    response = client.post("/collab/workflow/trigger", json=_workflow_payload())
+
+    assert response.status_code in (401, 403)
+
+
+def test_workflow_trigger_fails_closed_without_dispatch_provider() -> None:
+    client = _client()
+
+    response = client.post(
+        "/collab/workflow/trigger",
+        json=_workflow_payload(),
+        headers=_auth_headers(),
+    )
+
+    assert response.status_code == 501
+    detail = response.json()["detail"]
+    assert detail["error"] == "workflow_dispatch_not_configured"
+    assert detail["target_repo"] == "AUo959/aurora-cloudbank-symbolic"
+    assert detail["workflow_name"] == "ci.yml"
+    assert "success" not in detail


### PR DESCRIPTION
Summary: Removes the placeholder success path from POST /collab/workflow/trigger. The route now requires CSRF bearer auth and returns 501 workflow_dispatch_not_configured until a real external workflow dispatch provider is wired, so success=True is no longer emitted without confirmed dispatch. Tests: python -m pytest -q tests/test_collab_workflow_trigger.py. Closes #638.