### PR TITLE
fix: stream real simulation progress status

### DIFF
--- a/modules/quantum_simulator/api.py
+++ b/modules/quantum_simulator/api.py
@@ -25,6 +25,32 @@ MUTATION_DEPENDENCIES = [Depends(require_csrf_token)]
 
 # WebSocket connections for progress tracking
 active_connections: Dict[str, List[WebSocket]] = {}
+active_simulations: Dict[str, SimulationStatus] = {}
+
+
+def _completed_status_from_result(
+    simulation_id: str,
+    result: SimulationResult,
+) -> SimulationStatus:
+    return SimulationStatus(
+        simulation_id=simulation_id,
+        status=result.status,
+        progress=1.0 if result.status == "completed" else 0.0,
+        elapsed_time_seconds=result.execution_time_seconds or 0.0,
+        estimated_time_remaining=None,
+        message=f"Simulation {result.status}",
+    )
+
+
+def _not_found_status(simulation_id: str) -> SimulationStatus:
+    return SimulationStatus(
+        simulation_id=simulation_id,
+        status="not_found",
+        progress=0.0,
+        elapsed_time_seconds=0.0,
+        estimated_time_remaining=None,
+        message=f"Simulation {simulation_id} not found or not active",
+    )
 
 
 @router.post(
@@ -68,13 +94,14 @@ async def run_simulation(request: ScenarioRequest) -> SimulationResult:
         cache = get_cache()
 
         # Create scenario engine
-        engine = ScenarioEngine(orchestrator)
+        engine = ScenarioEngine(orchestrator, status_store=active_simulations)
 
         # Execute scenario
         result = await engine.execute_scenario(request)
 
         # Cache result
         cache.set(result, ttl_hours=24)
+        active_simulations.pop(result.simulation_id, None)
 
         return result
 
@@ -164,14 +191,11 @@ async def get_simulation_status(simulation_id: str) -> SimulationStatus:
 
     if result:
         # Return completed status
-        return SimulationStatus(
-            simulation_id=simulation_id,
-            status=result.status,
-            progress=1.0 if result.status == "completed" else 0.0,
-            elapsed_time_seconds=result.execution_time_seconds or 0.0,
-            estimated_time_remaining=None,
-            message=f"Simulation {result.status}"
-        )
+        return _completed_status_from_result(simulation_id, result)
+
+    status = active_simulations.get(simulation_id)
+    if status:
+        return status
 
     raise HTTPException(
         status_code=404,
@@ -383,28 +407,19 @@ async def simulation_progress_websocket(websocket: WebSocket, simulation_id: str
             # Check if simulation is completed (in cache)
             result = cache.get(simulation_id)
             if result:
-                status = SimulationStatus(
-                    simulation_id=simulation_id,
-                    status=result.status,
-                    progress=1.0,
-                    elapsed_time_seconds=result.execution_time_seconds or 0.0,
-                    estimated_time_remaining=None,
-                    message=f"Simulation {result.status}"
+                await websocket.send_json(
+                    _completed_status_from_result(simulation_id, result).model_dump(mode="json")
                 )
-                await websocket.send_json(status.model_dump(mode="json"))
                 break
 
-            # For active simulations, would query engine status
-            # For now, send periodic heartbeat
-            status = SimulationStatus(
-                simulation_id=simulation_id,
-                status="running",
-                progress=0.5,
-                elapsed_time_seconds=0.0,
-                estimated_time_remaining=None,
-                message="Simulation in progress..."
-            )
+            status = active_simulations.get(simulation_id)
+            if not status:
+                await websocket.send_json(_not_found_status(simulation_id).model_dump(mode="json"))
+                break
+
             await websocket.send_json(status.model_dump(mode="json"))
+            if status.status in {"completed", "failed", "timeout"}:
+                break
 
             await asyncio.sleep(1.0)
 
@@ -418,7 +433,8 @@ async def simulation_progress_websocket(websocket: WebSocket, simulation_id: str
     finally:
         # Cleanup connection
         if simulation_id in active_connections:
-            active_connections[simulation_id].remove(websocket)
+            if websocket in active_connections[simulation_id]:
+                active_connections[simulation_id].remove(websocket)
             if not active_connections[simulation_id]:
                 del active_connections[simulation_id]
 

--- a/modules/quantum_simulator/scenario_engine.py
+++ b/modules/quantum_simulator/scenario_engine.py
@@ -35,16 +35,23 @@ class ScenarioEngine:
     risk analysis, optimization, Monte Carlo, quantum annealing.
     """
 
-    def __init__(self, orchestrator: QuantumOrchestrator, enable_dlp: bool = True):
+    def __init__(
+        self,
+        orchestrator: QuantumOrchestrator,
+        enable_dlp: bool = True,
+        status_store: Optional[Dict[str, SimulationStatus]] = None,
+    ):
         """
         Initialize scenario engine.
 
         Args:
             orchestrator: Quantum orchestrator for backend management
             enable_dlp: Enable DLP tracking (default: True)
+            status_store: Optional shared status registry for API progress streams
         """
         self.orchestrator = orchestrator
-        self.active_simulations: Dict[str, SimulationStatus] = {}
+        self.active_simulations = status_store if status_store is not None else {}
+        self._simulation_start_times: Dict[str, float] = {}
         self.dlp_integration = get_dlp_integration() if enable_dlp else None
 
     async def execute_scenario(self, request: ScenarioRequest) -> SimulationResult:
@@ -69,6 +76,7 @@ class ScenarioEngine:
             )
 
         # Initialize status tracking
+        self._simulation_start_times[simulation_id] = start_time_epoch
         self.active_simulations[simulation_id] = SimulationStatus(
             simulation_id=simulation_id,
             status="running",
@@ -102,6 +110,8 @@ class ScenarioEngine:
             # Mark as completed
             self.active_simulations[simulation_id].status = "completed"
             self.active_simulations[simulation_id].progress = 1.0
+            self.active_simulations[simulation_id].elapsed_time_seconds = execution_time
+            self.active_simulations[simulation_id].estimated_time_remaining = None
             self.active_simulations[simulation_id].message = "Simulation completed successfully"
 
             simulation_result = SimulationResult(
@@ -137,6 +147,8 @@ class ScenarioEngine:
             # Mark as failed
             if simulation_id in self.active_simulations:
                 self.active_simulations[simulation_id].status = "failed"
+                self.active_simulations[simulation_id].elapsed_time_seconds = execution_time
+                self.active_simulations[simulation_id].estimated_time_remaining = None
                 self.active_simulations[simulation_id].message = f"Simulation failed: {str(e)}"
 
             # Track error in DLP
@@ -538,8 +550,13 @@ class ScenarioEngine:
             message: Status message
         """
         if simulation_id in self.active_simulations:
-            self.active_simulations[simulation_id].progress = progress
-            self.active_simulations[simulation_id].message = message
+            status = self.active_simulations[simulation_id]
+            status.progress = progress
+            status.elapsed_time_seconds = max(
+                0.0,
+                time.time() - self._simulation_start_times.get(simulation_id, time.time()),
+            )
+            status.message = message
 
     def get_simulation_status(self, simulation_id: str) -> Optional[SimulationStatus]:
         """

--- a/tests/test_quantum_simulator.py
+++ b/tests/test_quantum_simulator.py
@@ -35,10 +35,13 @@ from modules.quantum_simulator import (  # noqa: E402
     ScenarioRequest,
     ScenarioType,
     SimulatorQuantumProvider,
+    SimulationResult,
+    SimulationStatus,
     StateVector,
     create_ghz_state,
     create_w_state,
 )
+from modules.quantum_simulator import api as quantum_simulator_api  # noqa: E402
 from modules.quantum_simulator.api import router as quantum_simulator_router  # noqa: E402
 
 
@@ -65,6 +68,28 @@ def _simulation_payload(name="API Test Simulation"):
         "parameters": {"num_variables": 3, "max_iterations": 10},
         "seed": 42,
     }
+
+
+def _reset_progress_state():
+    quantum_simulator_api.get_cache().clear_all()
+    quantum_simulator_api.active_connections.clear()
+    quantum_simulator_api.active_simulations.clear()
+
+
+def _completed_result(simulation_id="completed-sim"):
+    start_time = datetime.now(timezone.utc)
+    return SimulationResult(
+        simulation_id=simulation_id,
+        scenario_name="Completed Simulation",
+        scenario_type=ScenarioType.OPTIMIZATION,
+        status="completed",
+        backend_used=QuantumBackend.MOCK,
+        start_time=start_time,
+        end_time=start_time,
+        execution_time_seconds=3.25,
+        parameters={},
+        metrics={},
+    )
 
 
 # ============================================================================
@@ -617,6 +642,63 @@ def test_get_simulation_result_endpoint(test_client):
     assert response.status_code == 200
     data = response.json()
     assert data["simulation_id"] == simulation_id
+
+
+@pytest.mark.api
+@pytest.mark.quantum
+def test_progress_websocket_unknown_id_returns_not_found(test_client):
+    """Progress websocket does not synthesize a running state for unknown IDs."""
+    _reset_progress_state()
+
+    with test_client.websocket_connect("/simulate/progress/missing-sim") as websocket:
+        data = websocket.receive_json()
+
+    assert data["simulation_id"] == "missing-sim"
+    assert data["status"] == "not_found"
+    assert data["progress"] == pytest.approx(0.0)
+    assert data["message"] == "Simulation missing-sim not found or not active"
+
+
+@pytest.mark.api
+@pytest.mark.quantum
+def test_progress_websocket_streams_active_status(test_client):
+    """Progress websocket reads active runtime state instead of sending a heartbeat."""
+    _reset_progress_state()
+    quantum_simulator_api.active_simulations["active-sim"] = SimulationStatus(
+        simulation_id="active-sim",
+        status="running",
+        progress=0.23,
+        elapsed_time_seconds=1.5,
+        estimated_time_remaining=4.0,
+        message="Running quantum optimization...",
+    )
+
+    with test_client.websocket_connect("/simulate/progress/active-sim") as websocket:
+        data = websocket.receive_json()
+
+    assert data["simulation_id"] == "active-sim"
+    assert data["status"] == "running"
+    assert data["progress"] == pytest.approx(0.23)
+    assert data["elapsed_time_seconds"] == pytest.approx(1.5)
+    assert data["estimated_time_remaining"] == pytest.approx(4.0)
+    assert data["message"] == "Running quantum optimization..."
+
+
+@pytest.mark.api
+@pytest.mark.quantum
+def test_progress_websocket_returns_completed_result(test_client):
+    """Progress websocket emits cached completion state for finished simulations."""
+    _reset_progress_state()
+    quantum_simulator_api.get_cache().set(_completed_result("completed-sim"))
+
+    with test_client.websocket_connect("/simulate/progress/completed-sim") as websocket:
+        data = websocket.receive_json()
+
+    assert data["simulation_id"] == "completed-sim"
+    assert data["status"] == "completed"
+    assert data["progress"] == pytest.approx(1.0)
+    assert data["elapsed_time_seconds"] == pytest.approx(3.25)
+    assert data["message"] == "Simulation completed"
 
 
 @pytest.mark.api


### PR DESCRIPTION
## Summary
- share the scenario engine's active status registry with the simulator API
- return explicit not_found progress state for unknown IDs instead of synthetic 50% running heartbeats
- cover unknown, active, and completed WebSocket progress cases

## Verification
- /Users/travisstreets/Library/Mobile Documents/com~apple~CloudDocs/Aurora_ORIONCORE_Directory_Main/GUMAS_SIM_2.5/Aurora_Sim_Architecture/aurora-cloudbank-symbolic-main/.venv/bin/python -m pytest -q tests/test_quantum_simulator.py
- /Users/travisstreets/Library/Mobile Documents/com~apple~CloudDocs/Aurora_ORIONCORE_Directory_Main/GUMAS_SIM_2.5/Aurora_Sim_Architecture/aurora-cloudbank-symbolic-main/.venv/bin/python -m compileall -q modules/quantum_simulator/api.py modules/quantum_simulator/scenario_engine.py tests/test_quantum_simulator.py

Closes #644