### PR TITLE
fix: require real cross-repo thread transfer

### DIFF
--- a/modules/reflective_autonomy/thread_transfer/v2/cross_repo_bridge.py
+++ b/modules/reflective_autonomy/thread_transfer/v2/cross_repo_bridge.py
@@ -18,9 +18,13 @@ Ethics: Picard_Delta_3_Extended
 """
 
 import asyncio
+import hashlib
+import json
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional, Any
 from enum import Enum
 
@@ -422,20 +426,108 @@ class CrossRepositoryBridge:
         bridge.current_stage = CrossRepoHandshakeStage.THREAD_TRANSFER
         
         try:
-            # Transfer thread context (metadata, glyph chain, etc.)
-            # This is placeholder logic - would integrate with actual thread transfer
+            context_payload = self._resolve_thread_context_payload(bridge)
+            if not context_payload:
+                bridge.metadata["thread_context_transferred"] = False
+                return {
+                    "success": False,
+                    "stage": "thread_transfer",
+                    "error": "No thread context payload available for transfer"
+                }
+
+            target_repo_path = bridge.metadata.get("target_repo_path")
+            if not target_repo_path:
+                bridge.metadata["thread_context_transferred"] = False
+                return {
+                    "success": False,
+                    "stage": "thread_transfer",
+                    "error": "Target repository path is unavailable"
+                }
+
+            transfer_timestamp = datetime.now().isoformat()
+            transfer_record = {
+                "bridge_id": bridge.bridge_id,
+                "thread_id": bridge.thread_id,
+                "source_repo_id": bridge.source_repo_id,
+                "target_repo_id": bridge.target_repo_id,
+                "anchor_hash": bridge.anchor_hash,
+                "transferred_at": transfer_timestamp,
+                "context": context_payload,
+                "source_anchor": bridge.metadata.get("source_anchor"),
+            }
+            transfer_bytes = json.dumps(
+                transfer_record,
+                sort_keys=True,
+                indent=2,
+                default=str,
+            ).encode("utf-8")
+            transfer_hash = hashlib.sha256(transfer_bytes).hexdigest()
+
+            transfer_path = self._thread_context_path(target_repo_path, bridge.thread_id)
+            transfer_path.parent.mkdir(parents=True, exist_ok=True)
+            transfer_path.write_bytes(transfer_bytes)
+
+            written_bytes = transfer_path.read_bytes()
+            written_hash = hashlib.sha256(written_bytes).hexdigest()
+            if written_hash != transfer_hash:
+                bridge.metadata["thread_context_transferred"] = False
+                return {
+                    "success": False,
+                    "stage": "thread_transfer",
+                    "error": "Transferred thread context failed hash verification"
+                }
+
             bridge.metadata["thread_context_transferred"] = True
-            bridge.metadata["transfer_timestamp"] = datetime.now().isoformat()
+            bridge.metadata["thread_context_transfer"] = {
+                "target_path": str(transfer_path),
+                "sha256": transfer_hash,
+                "bytes_transferred": len(written_bytes),
+                "transfer_timestamp": transfer_timestamp,
+            }
             
             logger.info(f"Stage 5 complete for bridge {bridge.bridge_id}")
-            return {"success": True, "stage": "thread_transfer"}
+            return {
+                "success": True,
+                "stage": "thread_transfer",
+                "sha256": transfer_hash,
+                "bytes_transferred": len(written_bytes),
+                "target_path": str(transfer_path),
+            }
             
         except Exception as e:
+            bridge.metadata["thread_context_transferred"] = False
             return {
                 "success": False,
                 "stage": "thread_transfer",
                 "error": str(e)
             }
+
+    def _resolve_thread_context_payload(self, bridge: CrossRepoBridge) -> Optional[Dict[str, Any]]:
+        """Resolve a concrete thread context payload for stage-5 transfer."""
+        direct_context = (
+            bridge.metadata.get("thread_context")
+            or bridge.metadata.get("context_data")
+            or bridge.metadata.get("thread_payload")
+        )
+        if isinstance(direct_context, dict) and direct_context:
+            return direct_context
+
+        source_anchor = bridge.metadata.get("source_anchor") or {}
+        source_metadata = source_anchor.get("metadata", {}) if isinstance(source_anchor, dict) else {}
+        anchor_context = (
+            source_metadata.get("thread_context")
+            or source_metadata.get("context_data")
+            or source_metadata.get("thread_payload")
+        )
+        if isinstance(anchor_context, dict) and anchor_context:
+            return anchor_context
+
+        return None
+
+    def _thread_context_path(self, target_repo_path: str, thread_id: str) -> Path:
+        """Return the target-repo path for a transferred thread context record."""
+        safe_thread_id = re.sub(r"[^A-Za-z0-9_.-]+", "_", thread_id).strip("_") or "thread"
+        return Path(target_repo_path) / ".aurora" / "thread_context" / f"{safe_thread_id}.json"
 
     async def _stage6_sync_execution(self, bridge: CrossRepoBridge) -> Dict[str, Any]:
         """Stage 6: Sync Execution."""
@@ -487,6 +579,14 @@ class CrossRepositoryBridge:
         try:
             target_repo_path = bridge.metadata["target_repo_path"]
             target_branch = bridge.metadata["target_branch"]
+
+            transfer_verification = self._verify_thread_context_transfer(bridge)
+            if not transfer_verification["success"]:
+                return {
+                    "success": False,
+                    "stage": "verification",
+                    "error": transfer_verification["error"]
+                }
             
             # Verify target anchor matches source
             target_anchor = await self.propagator.read_anchor(
@@ -522,6 +622,39 @@ class CrossRepositoryBridge:
                 "stage": "verification",
                 "error": str(e)
             }
+
+    def _verify_thread_context_transfer(self, bridge: CrossRepoBridge) -> Dict[str, Any]:
+        """Verify the stage-5 thread context artifact still matches its receipt."""
+        receipt = bridge.metadata.get("thread_context_transfer")
+        if not bridge.metadata.get("thread_context_transferred") or not isinstance(receipt, dict):
+            return {
+                "success": False,
+                "error": "Thread context transfer receipt is missing"
+            }
+
+        target_path = receipt.get("target_path")
+        expected_hash = receipt.get("sha256")
+        if not target_path or not expected_hash:
+            return {
+                "success": False,
+                "error": "Thread context transfer receipt is incomplete"
+            }
+
+        transfer_path = Path(target_path)
+        if not transfer_path.exists():
+            return {
+                "success": False,
+                "error": "Thread context transfer artifact is missing"
+            }
+
+        actual_hash = hashlib.sha256(transfer_path.read_bytes()).hexdigest()
+        if actual_hash != expected_hash:
+            return {
+                "success": False,
+                "error": "Thread context transfer artifact hash mismatch"
+            }
+
+        return {"success": True}
 
     def get_bridge(self, bridge_id: str) -> Optional[CrossRepoBridge]:
         """Get bridge information."""

--- a/tests/test_cross_repo_bridge_thread_transfer.py
+++ b/tests/test_cross_repo_bridge_thread_transfer.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+
+from modules.reflective_autonomy.thread_transfer.v2.cross_repo_bridge import (
+    CrossRepoBridge,
+    CrossRepositoryBridge,
+)
+
+
+@pytest.mark.asyncio
+async def test_stage5_transfers_thread_context_payload(tmp_path):
+    target_repo = tmp_path / "target"
+    target_repo.mkdir()
+    bridge = CrossRepoBridge(
+        bridge_id="bridge-001",
+        source_repo_id="source-repo",
+        target_repo_id="target-repo",
+        thread_id="thread/context:001",
+        anchor_hash="anchor-001",
+        metadata={
+            "target_repo_path": str(target_repo),
+            "thread_context": {
+                "messages": [{"role": "system", "content": "preserve continuity"}],
+                "glyph_chain": ["EOS_SEED_ORION_v2"],
+            },
+            "source_anchor": {"anchor_hash": "anchor-001", "metadata": {"source": "test"}},
+        },
+    )
+    manager = CrossRepositoryBridge()
+
+    result = await manager._stage5_thread_transfer(bridge)
+
+    assert result["success"] is True
+    assert result["bytes_transferred"] > 0
+    assert bridge.metadata["thread_context_transferred"] is True
+    receipt = bridge.metadata["thread_context_transfer"]
+    assert receipt["sha256"] == result["sha256"]
+
+    transfer_path = target_repo / ".aurora" / "thread_context" / "thread_context_001.json"
+    assert transfer_path.exists()
+    transferred = json.loads(transfer_path.read_text(encoding="utf-8"))
+    assert transferred["thread_id"] == "thread/context:001"
+    assert transferred["context"]["glyph_chain"] == ["EOS_SEED_ORION_v2"]
+    assert manager._verify_thread_context_transfer(bridge)["success"] is True
+
+    transfer_path.write_text("tampered", encoding="utf-8")
+    verification = manager._verify_thread_context_transfer(bridge)
+    assert verification["success"] is False
+    assert "hash mismatch" in verification["error"]
+
+
+@pytest.mark.asyncio
+async def test_stage5_fails_without_thread_context_payload(tmp_path):
+    bridge = CrossRepoBridge(
+        bridge_id="bridge-002",
+        source_repo_id="source-repo",
+        target_repo_id="target-repo",
+        thread_id="thread-002",
+        anchor_hash="anchor-002",
+        metadata={"target_repo_path": str(tmp_path / "target")},
+    )
+    manager = CrossRepositoryBridge()
+
+    result = await manager._stage5_thread_transfer(bridge)
+
+    assert result["success"] is False
+    assert result["stage"] == "thread_transfer"
+    assert "No thread context payload" in result["error"]
+    assert bridge.metadata["thread_context_transferred"] is False


### PR DESCRIPTION
## Summary
- make stage 5 fail when no concrete thread context payload is available
- persist transferred context under the target repo with a SHA-256 receipt
- verify the transfer artifact during final handshake verification

## Verification
- /Users/travisstreets/Library/Mobile Documents/com~apple~CloudDocs/Aurora_ORIONCORE_Directory_Main/GUMAS_SIM_2.5/Aurora_Sim_Architecture/aurora-cloudbank-symbolic-main/.venv/bin/python -m pytest -q tests/test_cross_repo_bridge_thread_transfer.py tests/test_thread_transfer_bridge_v2.py -k "anchor_propagation_lifecycle or repository_synchronizer_registration or cross_repo or stage5 or thread_transfer"
- /Users/travisstreets/Library/Mobile Documents/com~apple~CloudDocs/Aurora_ORIONCORE_Directory_Main/GUMAS_SIM_2.5/Aurora_Sim_Architecture/aurora-cloudbank-symbolic-main/.venv/bin/python -m compileall -q modules/reflective_autonomy/thread_transfer/v2/cross_repo_bridge.py tests/test_cross_repo_bridge_thread_transfer.py

Closes #637