### PR TITLE
[codex] fix monitoring audit history persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ var/
 # Logs and data
 logs/
 data/
+monitoring_data/
+.monitoring/
 *.log
 
 # Backup files (timestamped dependency snapshots)

--- a/modules/gumas/api/routes.py
+++ b/modules/gumas/api/routes.py
@@ -10,6 +10,8 @@ T1: Initial implementation
 from typing import Dict, List, Any, Optional
 from datetime import datetime, timezone
 import logging
+import os
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -28,8 +30,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/gumas", tags=["GUMAS Ethics"])
 dlp_tracker = NativeDLPTracker()
 
+
+def _monitoring_storage_dir() -> Path:
+    """Resolve the shared monitoring storage directory."""
+    return Path(os.getenv("MONITORING_STORAGE_DIR", "./monitoring_data"))
+
+
 # Initialize global ethics engine
-ethics_engine = EthicsEngine()
+ethics_engine = EthicsEngine(
+    violations_path=_monitoring_storage_dir() / "ethics_violations.jsonl"
+)
 
 
 # Pydantic Models

--- a/src/monitoring/drift_detector.py
+++ b/src/monitoring/drift_detector.py
@@ -10,6 +10,7 @@ import logging
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from pathlib import Path
 from typing import Dict, List, Optional, Any
 import statistics
 
@@ -90,7 +91,8 @@ class DriftDetector:
         moving_avg_window: int = 10,
         info_threshold: float = 0.2,
         warning_threshold: float = 0.5,
-        critical_threshold: float = 0.8
+        critical_threshold: float = 0.8,
+        alerts_path: Optional[Path] = None
     ):
         """
         Initialize drift detector
@@ -101,16 +103,19 @@ class DriftDetector:
             info_threshold: Relative change threshold for info alerts (default: 0.2 = 20%)
             warning_threshold: Relative change threshold for warning alerts (default: 0.5 = 50%)
             critical_threshold: Relative change threshold for critical alerts (default: 0.8 = 80%)
+            alerts_path: Append-only JSONL path for persisted alerts
         """
         self.z_score_threshold = z_score_threshold
         self.moving_avg_window = moving_avg_window
         self.info_threshold = info_threshold
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
+        self.alerts_path = alerts_path
         
         # Storage for baselines and alerts
         self.baselines: Dict[str, BaselineMetrics] = {}
         self.alerts: List[DriftAlert] = []
+        self._load_alerts()
         
         logger.info("Drift detector initialized with z_threshold=%.1f", z_score_threshold)
     
@@ -241,6 +246,7 @@ class DriftDetector:
                 )
         
         if alert:
+            self._persist_alert(alert)
             self.alerts.append(alert)
             logger.warning(
                 "Drift detected: %s:%s [%s] - current=%.2f, baseline=%.2f",
@@ -318,6 +324,76 @@ class DriftDetector:
             ]
         
         return alerts
+
+    def export_alerts(self) -> List[Dict[str, Any]]:
+        """Export recorded alerts for persistence and diagnostics."""
+        return [alert.to_dict() for alert in self.alerts]
+
+    def import_alerts(self, data: List[Dict[str, Any]]):
+        """Import alerts from persisted data."""
+        self.alerts = [
+            self._alert_from_dict(alert_data)
+            for alert_data in data
+        ]
+        self._rewrite_alerts()
+        logger.info("Imported %d drift alerts", len(self.alerts))
+
+    def _persist_alert(self, alert: DriftAlert):
+        """Append an alert to the shared alert store."""
+        if not self.alerts_path:
+            return
+
+        try:
+            self.alerts_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.alerts_path, 'a') as f:
+                f.write(json.dumps(alert.to_dict(), sort_keys=True) + "\n")
+        except Exception as e:
+            logger.error("Failed to persist drift alert: %s", e)
+
+    def _load_alerts(self):
+        """Load persisted alerts from the shared alert store."""
+        if not self.alerts_path or not self.alerts_path.exists():
+            return
+
+        try:
+            with open(self.alerts_path, 'r') as f:
+                self.alerts = [
+                    self._alert_from_dict(json.loads(line))
+                    for line in f
+                    if line.strip()
+                ]
+            logger.info("Loaded %d drift alerts", len(self.alerts))
+        except Exception as e:
+            logger.error("Failed to load drift alerts: %s", e)
+
+    def _rewrite_alerts(self):
+        """Rewrite the shared alert store after explicit mutation."""
+        if not self.alerts_path:
+            return
+
+        try:
+            self.alerts_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.alerts_path, 'w') as f:
+                for alert in self.alerts:
+                    f.write(json.dumps(alert.to_dict(), sort_keys=True) + "\n")
+        except Exception as e:
+            logger.error("Failed to rewrite drift alerts: %s", e)
+
+    def _alert_from_dict(self, data: Dict[str, Any]) -> DriftAlert:
+        """Restore a drift alert from persisted data."""
+        return DriftAlert(
+            timestamp=data['timestamp'],
+            agent_id=data['agent_id'],
+            metric_name=data['metric_name'],
+            level=DriftLevel(data['level']),
+            method=DriftMethod(data['method']),
+            current_value=data['current_value'],
+            baseline_value=data['baseline_value'],
+            deviation=data['deviation'],
+            description=data['description'],
+            context_tag=data.get('context_tag'),
+            metadata=data.get('metadata', {})
+        )
     
     def clear_alerts(self, before: Optional[datetime] = None):
         """
@@ -333,6 +409,8 @@ class DriftDetector:
             ]
         else:
             self.alerts.clear()
+
+        self._rewrite_alerts()
         
         logger.info("Cleared drift alerts (before=%s)", before)
     

--- a/src/monitoring/ethics_engine.py
+++ b/src/monitoring/ethics_engine.py
@@ -97,22 +97,30 @@ class EthicsEngine:
     - Extensible with custom evaluators
     """
     
-    def __init__(self, rules_path: Optional[Path] = None):
+    def __init__(
+        self,
+        rules_path: Optional[Path] = None,
+        violations_path: Optional[Path] = None
+    ):
         """
         Initialize ethics engine
         
         Args:
             rules_path: Path to rules configuration file (JSON)
+            violations_path: Append-only JSONL path for persisted violations
         """
         self.rules: Dict[str, EthicsRule] = {}
         self.violations: List[EthicsViolation] = []
         self.custom_evaluators: Dict[str, Callable] = {}
+        self.violations_path = violations_path
         
         # Load default rules if available
         if rules_path and rules_path.exists():
             self.load_rules(rules_path)
         else:
             self._load_default_rules()
+
+        self._load_violations()
         
         logger.info("Ethics engine initialized with %d rules", len(self.rules))
     
@@ -242,6 +250,7 @@ class EthicsEngine:
         for rule in self.rules.values():
             violation = self._evaluate_rule(rule, context)
             if violation:
+                self._persist_violation(violation)
                 violations.append(violation)
                 self.violations.append(violation)
         
@@ -416,6 +425,76 @@ class EthicsEngine:
             ]
         
         return violations
+
+    def export_violations(self) -> List[Dict[str, Any]]:
+        """Export recorded violations for persistence and diagnostics."""
+        return [violation.to_dict() for violation in self.violations]
+
+    def import_violations(self, data: List[Dict[str, Any]]):
+        """Import violations from persisted data."""
+        self.violations = [
+            self._violation_from_dict(violation_data)
+            for violation_data in data
+        ]
+        self._rewrite_violations()
+        logger.info("Imported %d ethics violations", len(self.violations))
+
+    def _persist_violation(self, violation: EthicsViolation):
+        """Append a violation to the shared violation store."""
+        if not self.violations_path:
+            return
+
+        try:
+            self.violations_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.violations_path, 'a') as f:
+                f.write(json.dumps(violation.to_dict(), sort_keys=True) + "\n")
+        except Exception as e:
+            logger.error("Failed to persist ethics violation: %s", e)
+
+    def _load_violations(self):
+        """Load persisted violations from the shared violation store."""
+        if not self.violations_path or not self.violations_path.exists():
+            return
+
+        try:
+            with open(self.violations_path, 'r') as f:
+                self.violations = [
+                    self._violation_from_dict(json.loads(line))
+                    for line in f
+                    if line.strip()
+                ]
+            logger.info("Loaded %d ethics violations", len(self.violations))
+        except Exception as e:
+            logger.error("Failed to load ethics violations: %s", e)
+
+    def _rewrite_violations(self):
+        """Rewrite the shared violation store after explicit mutation."""
+        if not self.violations_path:
+            return
+
+        try:
+            self.violations_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.violations_path, 'w') as f:
+                for violation in self.violations:
+                    f.write(json.dumps(violation.to_dict(), sort_keys=True) + "\n")
+        except Exception as e:
+            logger.error("Failed to rewrite ethics violations: %s", e)
+
+    def _violation_from_dict(self, data: Dict[str, Any]) -> EthicsViolation:
+        """Restore a violation from persisted data."""
+        return EthicsViolation(
+            timestamp=data['timestamp'],
+            agent_id=data['agent_id'],
+            rule_id=data['rule_id'],
+            rule_name=data['rule_name'],
+            severity=ViolationSeverity(data['severity']),
+            category=RuleCategory(data['category']),
+            description=data['description'],
+            blocked=data['blocked'],
+            context=data['context'],
+            context_tag=data.get('context_tag'),
+            remediation=data.get('remediation')
+        )
     
     def check_should_block(self, violations: List[EthicsViolation]) -> bool:
         """
@@ -470,5 +549,7 @@ class EthicsEngine:
             ]
         else:
             self.violations.clear()
+
+        self._rewrite_violations()
         
         logger.info("Cleared violations (before=%s)", before)

--- a/src/monitoring/monitoring_system.py
+++ b/src/monitoring/monitoring_system.py
@@ -6,6 +6,7 @@ and alerting for comprehensive agent oversight.
 """
 
 import logging
+import json
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 from src.core.time_utils import utc_now, utc_iso
@@ -66,6 +67,19 @@ class Intervention:
         data['type'] = self.type.value
         return data
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Intervention":
+        """Restore an intervention from persisted data."""
+        return cls(
+            timestamp=data['timestamp'],
+            agent_id=data['agent_id'],
+            type=InterventionType(data['type']),
+            reason=data['reason'],
+            context=data.get('context', {}),
+            success=data['success'],
+            error=data.get('error')
+        )
+
 
 class MonitoringSystem:
     """
@@ -96,13 +110,19 @@ class MonitoringSystem:
             ethics_rules_path: Path to ethics rules configuration
             config: Alert configuration
         """
-        self.storage_dir = storage_dir or Path("./monitoring_data")
+        self.storage_dir = Path(storage_dir or "./monitoring_data")
+        self._state_path = self.storage_dir / "monitoring_state.json"
         self.config = config or AlertConfig()
         
         # Initialize subsystems
         self.behavior_monitor = BehaviorMonitor(retention_hours=168)
-        self.drift_detector = DriftDetector()
-        self.ethics_engine = EthicsEngine(rules_path=ethics_rules_path)
+        self.drift_detector = DriftDetector(
+            alerts_path=self.storage_dir / "drift_alerts.jsonl"
+        )
+        self.ethics_engine = EthicsEngine(
+            rules_path=ethics_rules_path,
+            violations_path=self.storage_dir / "ethics_violations.jsonl"
+        )
         
         audit_storage = self.storage_dir / "audit_log.json"
         self.audit_logger = AuditLogger(storage_path=audit_storage)
@@ -118,6 +138,8 @@ class MonitoringSystem:
             AlertLevel.WARNING: [],
             AlertLevel.CRITICAL: []
         }
+
+        self.import_state()
         
         logger.info("Monitoring system initialized (storage=%s)", storage_dir)
 
@@ -396,6 +418,7 @@ class MonitoringSystem:
         self.interventions.append(intervention)
         if success:
             self.last_intervention_time[agent_id] = utc_now()
+        self._persist_state()
         
         # Log to audit
         self.audit_logger.log_intervention(
@@ -568,7 +591,76 @@ class MonitoringSystem:
         """Export full monitoring system state"""
         return {
             'baselines': self.drift_detector.export_baselines(),
+            'drift_alerts': self.drift_detector.export_alerts(),
             'rules': self.ethics_engine.export_rules(),
+            'violations': self.ethics_engine.export_violations(),
             'behavior_history': self.behavior_monitor.export_history(),
-            'interventions': [i.to_dict() for i in self.interventions]
+            'interventions': [i.to_dict() for i in self.interventions],
+            'last_intervention_time': {
+                agent_id: timestamp.isoformat()
+                for agent_id, timestamp in self.last_intervention_time.items()
+            }
         }
+
+    def import_state(self, state: Optional[Dict[str, Any]] = None) -> bool:
+        """
+        Import persisted monitoring system state.
+
+        When state is omitted, the method attempts to load monitoring_state.json
+        from storage_dir. Missing state is a normal first-start condition.
+        """
+        if state is None:
+            if not self._state_path.exists():
+                return False
+
+            try:
+                with open(self._state_path, 'r') as f:
+                    state = json.load(f)
+            except Exception as e:
+                logger.error("Failed to load monitoring state: %s", e)
+                return False
+
+        if 'baselines' in state:
+            self.drift_detector.import_baselines(state['baselines'])
+        if 'drift_alerts' in state:
+            self.drift_detector.import_alerts(state['drift_alerts'])
+        if 'violations' in state:
+            self.ethics_engine.import_violations(state['violations'])
+
+        self.interventions = [
+            Intervention.from_dict(intervention_data)
+            for intervention_data in state.get('interventions', [])
+        ]
+        self.last_intervention_time = {
+            agent_id: datetime.fromisoformat(timestamp)
+            for agent_id, timestamp in state.get('last_intervention_time', {}).items()
+        }
+
+        logger.info(
+            "Imported monitoring state: interventions=%d cooldowns=%d",
+            len(self.interventions), len(self.last_intervention_time)
+        )
+        return True
+
+    def _persist_state(self):
+        """Persist intervention state needed for restart-safe cooldowns."""
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._state_path, 'w') as f:
+                json.dump(
+                    {
+                        'interventions': [
+                            intervention.to_dict()
+                            for intervention in self.interventions
+                        ],
+                        'last_intervention_time': {
+                            agent_id: timestamp.isoformat()
+                            for agent_id, timestamp in self.last_intervention_time.items()
+                        }
+                    },
+                    f,
+                    indent=2,
+                    sort_keys=True
+                )
+        except Exception as e:
+            logger.error("Failed to persist monitoring state: %s", e)

--- a/src/observability/drift_metrics_api.py
+++ b/src/observability/drift_metrics_api.py
@@ -9,7 +9,9 @@ Anchors: EOS_SEED_ORION, HALO_CONTINUITY_GRAFT_005
 """
 
 import logging
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
@@ -28,6 +30,11 @@ _drift_detector: Optional[DriftDetector] = None
 _drift_exporter = None  # Lazy import to avoid circular deps
 
 
+def _monitoring_storage_dir() -> Path:
+    """Resolve the shared monitoring storage directory."""
+    return Path(os.getenv("MONITORING_STORAGE_DIR", "./monitoring_data"))
+
+
 def _get_exporter():
     """Get or create the drift exporter instance."""
     global _drift_exporter
@@ -41,7 +48,9 @@ def _get_drift_detector():
     """Get current drift detector instance, creating one if needed."""
     global _drift_detector
     if _drift_detector is None:
-        _drift_detector = DriftDetector()
+        _drift_detector = DriftDetector(
+            alerts_path=_monitoring_storage_dir() / "drift_alerts.jsonl"
+        )
     return _drift_detector
 
 

--- a/tests/test_drift_detector.py
+++ b/tests/test_drift_detector.py
@@ -229,6 +229,24 @@ class TestDriftDetector:
         
         detector.clear_alerts()
         assert len(detector.alerts) == 0
+
+    def test_alerts_persist_across_restart(self, tmp_path):
+        """Test persisted alerts are loaded by new detector instances."""
+        alerts_path = tmp_path / "drift_alerts.jsonl"
+        detector = DriftDetector(alerts_path=alerts_path)
+
+        detector.establish_baseline("agent-1", "metric-1", [10.0, 11.0, 12.0])
+        alert = detector.detect_drift("agent-1", "metric-1", 30.0)
+
+        assert alert is not None
+        restarted = DriftDetector(alerts_path=alerts_path)
+        assert len(restarted.alerts) == 1
+        assert restarted.alerts[0].agent_id == "agent-1"
+        assert restarted.alerts[0].level == alert.level
+
+        restarted.clear_alerts()
+        empty_restart = DriftDetector(alerts_path=alerts_path)
+        assert empty_restart.alerts == []
     
     def test_export_import_baselines(self):
         """Test baseline export and import"""

--- a/tests/test_ethics_engine.py
+++ b/tests/test_ethics_engine.py
@@ -214,6 +214,27 @@ class TestEthicsEngine:
         
         engine.clear_violations()
         assert len(engine.violations) == 0
+
+    def test_violations_persist_across_restart(self, tmp_path):
+        """Test persisted violations are loaded by new engine instances."""
+        violations_path = tmp_path / "ethics_violations.jsonl"
+        engine = EthicsEngine(violations_path=violations_path)
+
+        context = ActionContext(
+            agent_id="test-agent",
+            action_type="critical",
+            parameters={'critical_decision': True, 'no_human_approval': True}
+        )
+        engine.evaluate_action(context)
+
+        restarted = EthicsEngine(violations_path=violations_path)
+        assert len(restarted.violations) == len(engine.violations)
+        assert restarted.violations[0].agent_id == "test-agent"
+        assert restarted.violations[0].rule_id == engine.violations[0].rule_id
+
+        restarted.clear_violations()
+        empty_restart = EthicsEngine(violations_path=violations_path)
+        assert empty_restart.violations == []
     
     def test_export_rules(self):
         """Test rule export"""

--- a/tests/test_monitoring_system.py
+++ b/tests/test_monitoring_system.py
@@ -227,6 +227,59 @@ class TestMonitoringSystem:
             assert 'rules' in state
             assert 'behavior_history' in state
             assert 'interventions' in state
+            assert 'last_intervention_time' in state
+            assert 'violations' in state
+            assert 'drift_alerts' in state
+
+    def test_import_state_restores_intervention_cooldowns(self):
+        """Test intervention history and cooldowns survive restart."""
+        with TemporaryDirectory() as tmpdir:
+            storage_dir = Path(tmpdir)
+            monitoring = MonitoringSystem(storage_dir=storage_dir)
+
+            monitoring.register_enforcement_handler(
+                InterventionType.SUSPEND_AGENT,
+                lambda agent_id: True
+            )
+            monitoring._execute_intervention(
+                agent_id="test-agent",
+                intervention_type=InterventionType.SUSPEND_AGENT,
+                reason="critical drift"
+            )
+
+            restarted = MonitoringSystem(storage_dir=storage_dir)
+            assert len(restarted.interventions) == 1
+            assert restarted.interventions[0].agent_id == "test-agent"
+            assert restarted.interventions[0].success is True
+            assert "test-agent" in restarted.last_intervention_time
+
+    def test_monitoring_histories_reload_from_storage_dir(self):
+        """Test violation and drift alert histories survive restart."""
+        with TemporaryDirectory() as tmpdir:
+            storage_dir = Path(tmpdir)
+            monitoring = MonitoringSystem(storage_dir=storage_dir)
+
+            monitoring.evaluate_action(
+                agent_id="test-agent",
+                action_type="critical",
+                parameters={
+                    'critical_decision': True,
+                    'no_human_approval': True
+                }
+            )
+            monitoring.establish_agent_baseline(
+                "test-agent",
+                {'decisions_made': [10, 11, 12]}
+            )
+            monitoring.record_agent_behavior(
+                agent_id="test-agent",
+                metrics={'decisions_made': 30}
+            )
+            monitoring.check_agent_behavior(agent_id="test-agent")
+
+            restarted = MonitoringSystem(storage_dir=storage_dir)
+            assert restarted.ethics_engine.get_violations(agent_id="test-agent")
+            assert restarted.drift_detector.get_alerts(agent_id="test-agent")
     
     def test_automated_intervention_disabled(self):
         """Test with automated intervention disabled"""


### PR DESCRIPTION
Fixes #593
Fixes #595

## Summary
- persist ethics violations and drift alerts through append-only JSONL stores
- reload MonitoringSystem interventions and cooldown timestamps from storage on startup
- route module-level GUMAS ethics and drift metrics singletons to MONITORING_STORAGE_DIR-backed stores
- ignore local monitoring data directories so runtime persistence files do not become repo noise

## Validation
- python -m pytest -q tests/test_ethics_engine.py tests/test_drift_detector.py tests/test_monitoring_system.py tests/test_gumas_api.py
- python -m compileall -q modules/gumas/api/routes.py src/observability/drift_metrics_api.py src/monitoring/ethics_engine.py src/monitoring/drift_detector.py src/monitoring/monitoring_system.py
- git diff --check