### PR TITLE
[codex] Define runtime API governance

### DIFF
--- a/docs/api/API_CATALOG_GOVERNANCE.md
+++ b/docs/api/API_CATALOG_GOVERNANCE.md
@@ -1,0 +1,96 @@
+# API Catalog Governance
+
+**Status:** Active governance decision
+**Last reviewed:** 2026-05-26
+**Inventory:** `docs/api/api_surface_inventory.json`
+
+## Decision
+
+CloudBank uses a primary FastAPI application plus declared standalone services.
+The main API catalog is not monolith-only, and it is not free-form
+multi-service sprawl. Every active HTTP or WebSocket service must have an owner,
+entrypoint, mount path, runtime class, and status in
+`docs/api/api_surface_inventory.json`.
+
+Decision label:
+
+```text
+primary-fastapi-with-declared-standalone-services
+```
+
+## Source of Truth Order
+
+For API catalog claims, use this order:
+
+1. Committed runtime entrypoints and routers
+2. `docs/api/api_surface_inventory.json`
+3. Generated OpenAPI/catalog snapshots under `docs/api/`
+4. Human-facing docs and historical reports
+
+If generated snapshots disagree with current router code, mark the snapshot as
+stale and regenerate it. Do not repeat the stale route as current.
+
+## Required Inventory Fields
+
+Each inventory entry must include:
+
+- `id`
+- `owner`
+- `runtime`
+- `entrypoint`
+- `mount_path`
+- `service_class`
+- `status`
+- `status_evidence`
+- `notes`
+
+## Status Semantics
+
+| Status | Meaning |
+| --- | --- |
+| active | Included or launched by committed runtime evidence without optional dependency gating. |
+| active-optional | Included by the main app through guarded import or optional dependency handling. |
+| active-standalone | Runs as a separate service or helper and is not mounted into the main app. |
+| superseded | Kept for compatibility or tests, but no longer the route authority. |
+| test-only | Mounted or exercised by tests only. |
+| inactive-unverified | Present in repo, but no current production or operator mount was verified. |
+| generated-snapshot | Derived catalog output; useful for details, not ownership authority. |
+
+## Current Governance Notes
+
+- `api/aurora_api.py` is the main FastAPI app and owner of the primary HTTP
+  aggregation surface.
+- Monitoring is now active in the main app through `/monitoring`, `/sentinel`,
+  `/api/drift`, and `/r2-telemetry` entries.
+- HR is split by function: `/rd` is R&D productization, while `/hr_system` is
+  staffing and character generation.
+- `src/servers/l2_integration_server.py` is the canonical Mesh Runtime V1
+  service surface for `/api/mesh/*`, `/api/bridge/*`, and `/ws/mesh`.
+- `src/api/mesh_api.js` is not the current production mesh authority based on
+  repo evidence. It is a legacy Express router and test target.
+- `src/bridge/enhanced_api_bridge.js` is a compatibility bridge, superseded as
+  route authority by the Python mesh runtime unless a deployment surface later
+  mounts it explicitly.
+- `docs/api/API_CATALOG.json` and `docs/api/api_schema.json` are generated
+  snapshots. Use them for route detail only after confirming their generated
+  timestamp is current.
+
+## Update Workflow
+
+1. Add or modify the runtime router or service entrypoint.
+2. Update `docs/api/api_surface_inventory.json` with owner, mount, status, and
+   evidence.
+3. Update `docs/architecture/RUNTIME_PATH_DRIFT_LEDGER.md` if older docs,
+   commands, or routes now conflict.
+4. Regenerate OpenAPI/catalog snapshots only when route-level detail changed and
+   the generator output path is understood.
+5. Run `python3 -m pytest -q tests/test_api_surface_inventory.py`.
+
+## Review Cadence
+
+Review this inventory when:
+
+- A router is added to or removed from `api/aurora_api.py`.
+- A standalone service gains operator or deployment support.
+- A generated API snapshot is refreshed.
+- A stale docs issue cites conflicting route or command paths.

--- a/docs/api/api_surface_inventory.json
+++ b/docs/api/api_surface_inventory.json
@@ -1,0 +1,409 @@
+{
+  "schema_version": "1.0",
+  "last_reviewed": "2026-05-26",
+  "governance_decision": "primary-fastapi-with-declared-standalone-services",
+  "status_values": [
+    "active",
+    "active-optional",
+    "active-standalone",
+    "superseded",
+    "test-only",
+    "inactive-unverified",
+    "generated-snapshot"
+  ],
+  "entries": [
+    {
+      "id": "primary_fastapi_app",
+      "owner": "platform-api",
+      "runtime": "fastapi",
+      "entrypoint": "api/aurora_api.py",
+      "mount_path": "/",
+      "service_class": "primary-application",
+      "status": "active",
+      "status_evidence": [
+        "Defines app = FastAPI(...).",
+        "Includes active and optional module routers."
+      ],
+      "notes": "Canonical primary HTTP aggregation surface."
+    },
+    {
+      "id": "aumemmanager",
+      "owner": "memory",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/aumemmanager/api_integration.py",
+      "mount_path": "/memory",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /memory.",
+        "api/aurora_api.py includes it when AUMEMMANAGER_AVAILABLE is true."
+      ],
+      "notes": "Optional dependency surface with guarded import."
+    },
+    {
+      "id": "data_guardian",
+      "owner": "data-governance",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/data_guardian/api.py",
+      "mount_path": "/data",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /data.",
+        "api/aurora_api.py includes it when DATA_GUARDIAN_AVAILABLE is true."
+      ],
+      "notes": "PII scan/redaction surface."
+    },
+    {
+      "id": "insight_ledger",
+      "owner": "audit-ledger",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/insight_ledger/api.py",
+      "mount_path": "/ledger",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /ledger.",
+        "api/aurora_api.py includes it when INSIGHT_LEDGER_AVAILABLE is true."
+      ],
+      "notes": "Audit and insight history surface."
+    },
+    {
+      "id": "quantum_simulator",
+      "owner": "simulation",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/quantum_simulator/api.py",
+      "mount_path": "/simulate",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /simulate.",
+        "api/aurora_api.py includes it when QUANTUM_SIMULATOR_AVAILABLE is true."
+      ],
+      "notes": "Current prefix is /simulate; older /quantum claims are legacy unless reintroduced."
+    },
+    {
+      "id": "rd_pipeline",
+      "owner": "hr-rd-productization",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/hr/rd_api.py",
+      "mount_path": "/rd",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /rd.",
+        "api/aurora_api.py includes rd_router when RD_PIPELINE_AVAILABLE is true."
+      ],
+      "notes": "Distinct from HR staffing and character generation."
+    },
+    {
+      "id": "hr_system",
+      "owner": "hr-staffing",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/hr_system/api/hr_routes.py",
+      "mount_path": "/hr_system",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /hr_system.",
+        "api/aurora_api.py imports modules.hr_system.api.hr_routes and includes the router."
+      ],
+      "notes": "Staffing and character generation surface."
+    },
+    {
+      "id": "cross_repo_collaboration",
+      "owner": "collaboration",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/collab/api_routes.py",
+      "mount_path": "/collab",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /collab.",
+        "api/aurora_api.py imports src.collab.api_routes and includes the router."
+      ],
+      "notes": "Context export/import, invites, sync, and drift routes."
+    },
+    {
+      "id": "subroutines",
+      "owner": "subroutines",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/subroutines/api.py",
+      "mount_path": "/subroutines",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Base and enhanced routers use prefix /subroutines.",
+        "api/aurora_api.py includes src.subroutines.api and src.subroutines.api_enhanced."
+      ],
+      "notes": "Enhanced router entrypoint is src/subroutines/api_enhanced.py."
+    },
+    {
+      "id": "event_coordination",
+      "owner": "coordination",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/coordination/event_api.py",
+      "mount_path": "/api/coordination",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /api/coordination.",
+        "api/aurora_api.py includes it when EVENT_COORDINATION_AVAILABLE is true."
+      ],
+      "notes": "Event, subscription, conflict, lock, workflow, and metrics surface."
+    },
+    {
+      "id": "fleet_bridge",
+      "owner": "fleet",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/integrations/fleet_bridge.py",
+      "mount_path": "/api/fleet",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /api/fleet.",
+        "api/aurora_api.py includes it when FLEET_BRIDGE_AVAILABLE is true."
+      ],
+      "notes": "Fleet status and craft profile API."
+    },
+    {
+      "id": "relay_manager",
+      "owner": "relay",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/aurora/relays/api_routes.py",
+      "mount_path": "/relay",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /relay.",
+        "api/aurora_api.py includes it when RELAY_MANAGER_AVAILABLE is true."
+      ],
+      "notes": "Relay send, status, stats, and health surface."
+    },
+    {
+      "id": "synergy_api",
+      "owner": "synergy",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/synergy/api.py",
+      "mount_path": "/synergy",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /synergy.",
+        "api/aurora_api.py imports src.synergy routers and includes them."
+      ],
+      "notes": "Component registry and dependency surface."
+    },
+    {
+      "id": "synergy_dashboard",
+      "owner": "synergy",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/synergy/dashboard_api.py",
+      "mount_path": "/api/synergy",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /api/synergy.",
+        "api/aurora_api.py imports src.synergy routers and includes them."
+      ],
+      "notes": "Dashboard component topology and scores."
+    },
+    {
+      "id": "resilience_sentinel",
+      "owner": "monitoring-resilience",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/resilience_sentinel/api.py",
+      "mount_path": "/sentinel",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /sentinel.",
+        "api/aurora_api.py imports modules.resilience_sentinel.api and includes the router."
+      ],
+      "notes": "Monitoring, alerts, notifications, dashboard, and WebSocket metrics."
+    },
+    {
+      "id": "monitoring_dashboard",
+      "owner": "monitoring",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/monitoring/dashboard_api.py",
+      "mount_path": "/monitoring",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "create_monitoring_router() uses prefix /monitoring.",
+        "api/aurora_api.py creates and includes the monitoring router when available."
+      ],
+      "notes": "Behavior, ethics, drift, audit, compliance, and export surface."
+    },
+    {
+      "id": "gumas_ethics",
+      "owner": "gumas-ethics",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/gumas/api/routes.py",
+      "mount_path": "/gumas",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /gumas.",
+        "api/aurora_api.py imports modules.gumas.api and includes the router."
+      ],
+      "notes": "Ethics evaluation and rule management surface."
+    },
+    {
+      "id": "oauth2_rbac",
+      "owner": "security",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/security/auth_routes.py",
+      "mount_path": "/api/auth",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /api/auth.",
+        "api/aurora_api.py imports src.security.auth_routes and includes the router."
+      ],
+      "notes": "Token, refresh, current user, permissions, and logout surface."
+    },
+    {
+      "id": "r2_telemetry",
+      "owner": "telemetry",
+      "runtime": "fastapi-router",
+      "entrypoint": "api/r2_telemetry_routes.py",
+      "mount_path": "/r2-telemetry",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /r2-telemetry.",
+        "api/aurora_api.py imports api.r2_telemetry_routes and includes the router."
+      ],
+      "notes": "R2 metrics, summaries, recent operations, anomalies, and test operation."
+    },
+    {
+      "id": "crew_agents",
+      "owner": "crew",
+      "runtime": "fastapi-router",
+      "entrypoint": "api/aurora_api.py",
+      "mount_path": "/api/crew",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "api/aurora_api.py defines crew_router with prefix /api/crew.",
+        "api/aurora_api.py includes crew_router in the R2 Telemetry integration block."
+      ],
+      "notes": "Crew collaboration endpoint currently lives in the main API file."
+    },
+    {
+      "id": "l2_meta_agents",
+      "owner": "l2-agents",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/api/l2_meta_agent_api.py",
+      "mount_path": "/api/l2-agents",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /api/l2-agents.",
+        "api/aurora_api.py imports src.api.l2_meta_agent_api and includes the router."
+      ],
+      "notes": "L2 constellation and activation phrase surface."
+    },
+    {
+      "id": "drift_metrics",
+      "owner": "observability",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/observability/drift_metrics_api.py",
+      "mount_path": "/api/drift",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /api/drift.",
+        "api/aurora_api.py imports src.observability.drift_metrics_api and includes the router."
+      ],
+      "notes": "Drift metrics and Prometheus exporter surface."
+    },
+    {
+      "id": "playground",
+      "owner": "developer-experience",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/playground/api.py",
+      "mount_path": "/playground",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /playground.",
+        "api/aurora_api.py imports src.playground and includes playground_router."
+      ],
+      "notes": "Interactive execution, share, health, metrics, and WebSocket surface."
+    },
+    {
+      "id": "mesh_runtime_v1",
+      "owner": "mesh-runtime",
+      "runtime": "fastapi-standalone",
+      "entrypoint": "src/servers/l2_integration_server.py",
+      "mount_path": "/api/mesh, /api/bridge, /ws/mesh",
+      "service_class": "standalone-service",
+      "status": "active-standalone",
+      "status_evidence": [
+        "create_app() defines /api/mesh/status, /api/mesh/messages, /api/mesh/channels/{channel_id}/history, /api/mesh/events, bridge compatibility routes, and /ws/mesh.",
+        "tests/test_mesh_router_v1.py validates the API and UI contract."
+      ],
+      "notes": "Canonical Mesh Runtime V1 surface."
+    },
+    {
+      "id": "api_bridge_server",
+      "owner": "bridge",
+      "runtime": "node-standalone",
+      "entrypoint": "src/bridge/api_bridge_server.js",
+      "mount_path": ":3838",
+      "service_class": "standalone-helper",
+      "status": "active-standalone",
+      "status_evidence": [
+        "Exports ApiBridgeServer and starts when executed directly.",
+        "scripts/initialize_l1_station.sh starts the bridge when present."
+      ],
+      "notes": "Not mounted into the FastAPI app."
+    },
+    {
+      "id": "mesh_api_js",
+      "owner": "mesh-runtime",
+      "runtime": "express-router",
+      "entrypoint": "src/api/mesh_api.js",
+      "mount_path": "/api/mesh",
+      "service_class": "legacy-router",
+      "status": "test-only",
+      "status_evidence": [
+        "Exports an Express router.",
+        "tests/node/mesh_api_activation.test.js mounts it for node tests.",
+        "No current production server mount was found during the 2026-05-26 review."
+      ],
+      "notes": "Use mesh_runtime_v1 for current runtime authority unless a deployment surface mounts this router."
+    },
+    {
+      "id": "enhanced_api_bridge",
+      "owner": "bridge",
+      "runtime": "express-router-helper",
+      "entrypoint": "src/bridge/enhanced_api_bridge.js",
+      "mount_path": "/api/bridge",
+      "service_class": "compatibility-bridge",
+      "status": "superseded",
+      "status_evidence": [
+        "Exports EnhancedApiBridge and is covered by node tests.",
+        "Current canonical mesh and bridge endpoints are served by src/servers/l2_integration_server.py."
+      ],
+      "notes": "Compatibility bridge, not current route authority."
+    },
+    {
+      "id": "generated_api_catalog_snapshot",
+      "owner": "api-docs",
+      "runtime": "generated-json",
+      "entrypoint": "docs/api/API_CATALOG.json",
+      "mount_path": "n/a",
+      "service_class": "generated-snapshot",
+      "status": "generated-snapshot",
+      "status_evidence": [
+        "Snapshot has a generated timestamp and route list.",
+        "It is not an ownership or deployment authority."
+      ],
+      "notes": "Regenerate before using for current route-level detail."
+    }
+  ]
+}

--- a/docs/architecture/RUNTIME_PATH_DRIFT_LEDGER.md
+++ b/docs/architecture/RUNTIME_PATH_DRIFT_LEDGER.md
@@ -1,0 +1,51 @@
+# Runtime Path Drift Ledger
+
+**Status:** Current repo evidence review
+**Last reviewed:** 2026-05-26
+**Purpose:** Track stale, conflicting, legacy, test-only, and unverified runtime
+or operator entrypoint claims.
+
+This ledger is a documentation control surface. It does not move files, rename
+entrypoints, or change runtime behavior.
+
+## Classification
+
+| Classification | Meaning |
+| --- | --- |
+| canonical | Current owner path or operating reference confirmed by committed repo evidence. |
+| active | Current runtime path included or launched by committed repo surfaces. |
+| active-optional | Current runtime path included through guarded optional import. |
+| standalone | Current service or helper that runs separately from the main FastAPI app. |
+| legacy | Older path or command that may remain in archived docs, scripts, or compatibility notes. |
+| stale | Claim contradicted by current committed runtime evidence. |
+| test-only | Path is mounted or exercised only by tests in current evidence. |
+| unverified | Mention exists, but current production or operator mount was not verified in this review. |
+
+## Ledger
+
+| Claim or path | Classification | Current evidence | Canonical replacement or action |
+| --- | --- | --- | --- |
+| `aurora_api.py` at repo root | stale | `find . -maxdepth 2 -name aurora_api.py` finds only `api/aurora_api.py`. Multiple archived docs still mention the root path. | Use `api/aurora_api.py`, `python api/aurora_api.py`, or `uvicorn api.aurora_api:app`. |
+| `api/aurora_api.py` | canonical, active | Defines the primary FastAPI app and includes module routers. | Keep as the main HTTP aggregation point. |
+| `docs/reports/SYSTEM_RETROSPECTIVE_REPORT.md` statements that `hr_system`, monitoring dashboard, resilience sentinel, and GUMAS API are not integrated | stale | Current `api/aurora_api.py` includes `modules.hr_system.api.hr_routes`, `src.monitoring.dashboard_api`, `modules.resilience_sentinel.api`, and `modules.gumas.api`. | Treat the retrospective as historical. Current topology is in `docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md`. |
+| `/quantum/*` as the quantum simulator mount | legacy/stale for current router | `modules/quantum_simulator/api.py` declares `APIRouter(prefix="/simulate")`. Some older docs describe `/quantum/*`. | Use `/simulate/*` for current Quantum Simulator API unless a migration explicitly reintroduces `/quantum`. |
+| `src/api/mesh_api.js` as production mesh authority | test-only, unverified production mount | The Express router is mounted in `tests/node/mesh_api_activation.test.js`. No current production server mount was found in this review. | Use `src/servers/l2_integration_server.py` and `src/mesh/runtime.py` for canonical mesh runtime endpoints. |
+| `src/servers/l2_integration_server.py` | canonical, standalone | Defines `create_app()` with `/api/mesh/*`, `/api/bridge/*`, `/ws/mesh`, `/chamber`, and dashboard routes; covered by `tests/test_mesh_router_v1.py`. | Keep as Mesh Runtime V1 entrypoint. |
+| `skills/mesh-router/references/runtime-contract.md` `/api/mesh/agents` routes | unverified contract drift | The contract lists `/api/mesh/agents`, `/api/mesh/agents/{id}`, and `/api/mesh/agents/{id}/activate`; current `src/servers/l2_integration_server.py#create_app()` evidence does not show those mesh-agent routes. | Keep the implemented surface documented in `RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md`; add or verify the missing routes in a runtime issue before treating them as active. |
+| `src/bridge/enhanced_api_bridge.js` as route authority | superseded, test-covered | Defines bridge handlers and is tested by node tests. Current canonical route surface is the Python mesh runtime. | Treat as compatibility bridge until a deployment surface mounts it explicitly. |
+| `src/bridge/api_bridge_server.js` | standalone | Instantiated by station initialization scripts and tested by `tests/node/api_bridge_server.test.js`. | Document as standalone helper, not a FastAPI route. |
+| `modules/hr/rd_api.py` and `modules/hr_system/api/hr_routes.py` relationship | canonical split | R&D productization is mounted at `/rd`; HR staffing and character generation is mounted at `/hr_system`. | Keep both inventory records; do not collapse them into one owner. |
+| `docs/api/API_CATALOG.json` and `docs/api/api_schema.json` | generated snapshot | Snapshot was generated in 2025 and may not reflect current router additions. | Use `docs/api/api_surface_inventory.json` for governance ownership, and regenerate catalog snapshots when route details must be current. |
+| `scripts/generate_api_catalog.py` output location | unverified workflow drift | Script writes `api_schema.json`, `API_CATALOG.json`, and `API_CATALOG.md` to the current working directory. Existing tracked snapshots live under `docs/api/`. | Run from `docs/api` or update the generator in a separate issue before treating output paths as canonical. |
+| `docs/LAYER_BOUNDARY_REFERENCE.md` references to `aurora_api.py` without `api/` | legacy wording inside canonical boundary doc | The layer definitions remain canonical, but the entrypoint spelling reflects older path language. | Interpret the API component as `api/aurora_api.py` until the boundary doc is updated. |
+
+## Maintenance Rule
+
+When adding or modifying a runtime entrypoint, update:
+
+1. `docs/api/api_surface_inventory.json`
+2. `docs/api/API_CATALOG_GOVERNANCE.md`
+3. This ledger if an older path or status changes
+
+Do not delete stale references from archived reports just to make search output
+clean. Mark the authoritative replacement instead.

--- a/docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md
+++ b/docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md
@@ -1,0 +1,114 @@
+# Runtime Topology and L3 Communications Authority
+
+**Status:** Current repo evidence review
+**Last reviewed:** 2026-05-26
+**Scope:** CloudBank runtime and operator entrypoints in this repository
+
+This document resolves the active runtime topology and the L3 communications
+authority map from committed repo evidence. It does not claim that any service
+is deployed in production unless a deployment surface in this repo proves that
+mount.
+
+## Topology Decision
+
+The canonical HTTP application is the FastAPI app in `api/aurora_api.py`. The
+repo also contains standalone and compatibility surfaces, but those must be
+declared in the API surface inventory before they are treated as active service
+entrypoints.
+
+Runtime entrypoint classes:
+
+| Class | Runtime surface | Status | Evidence |
+| --- | --- | --- | --- |
+| Primary application | `api/aurora_api.py` | active in repo | Defines `app = FastAPI(...)` and includes module routers. |
+| Main module routers | `/memory`, `/data`, `/ledger`, `/simulate`, `/rd`, `/hr_system`, `/collab`, `/subroutines`, `/api/coordination`, `/api/fleet`, `/relay`, `/synergy`, `/api/synergy`, `/sentinel`, `/monitoring`, `/gumas`, `/api/auth`, `/r2-telemetry`, `/api/l2-agents`, `/api/drift`, `/playground` | active or active-optional in repo | Included by `api/aurora_api.py`; optional modules use guarded imports. |
+| Mesh runtime V1 | `src/servers/l2_integration_server.py` with `src/mesh/runtime.py` | active standalone | Provides implemented mesh routes, bridge compatibility routes, `/ws/mesh`, `/chamber`, and root dashboard routes; covered by `tests/test_mesh_router_v1.py`. |
+| JavaScript mesh router | `src/api/mesh_api.js` | inactive for production mount, test-mounted only | Defines an Express router and is mounted in `tests/node/mesh_api_activation.test.js`; no repo production server mount was found in the current review. |
+| Enhanced API bridge | `src/bridge/enhanced_api_bridge.js` | superseded compatibility bridge | Defines Custom GPT bridge handlers and is covered by node tests, but current canonical mesh endpoints are provided by the Python mesh runtime surface. |
+| API bridge server | `src/bridge/api_bridge_server.js` | active standalone helper | Started by station initialization scripts and covered by `tests/node/api_bridge_server.test.js`; it is not mounted into the FastAPI app. |
+
+## Active FastAPI Router Map
+
+`api/aurora_api.py` is the aggregation point for the primary HTTP surface. It
+loads optional module routers with guarded imports so a missing optional
+dependency degrades that module rather than disabling the full app.
+
+| Owner lane | Mount path | Entrypoint | Status |
+| --- | --- | --- | --- |
+| AuMemManager | `/memory` | `modules/aumemmanager/api_integration.py` | active-optional |
+| Data Guardian | `/data` | `modules/data_guardian/api.py` | active-optional |
+| Insight Ledger | `/ledger` | `modules/insight_ledger/api.py` | active-optional |
+| Quantum Simulator | `/simulate` | `modules/quantum_simulator/api.py` | active-optional |
+| R&D pipeline | `/rd` | `modules/hr/rd_api.py` | active |
+| HR staffing system | `/hr_system` | `modules/hr_system/api/hr_routes.py` | active |
+| Cross-repo collaboration | `/collab` | `src/collab/api_routes.py` | active |
+| Subroutines | `/subroutines` | `src/subroutines/api.py`, `src/subroutines/api_enhanced.py` | active |
+| Event coordination | `/api/coordination` | `src/coordination/event_api.py` | active-optional |
+| Fleet bridge | `/api/fleet` | `src/integrations/fleet_bridge.py` | active-optional |
+| Relay manager | `/relay` | `src/aurora/relays/api_routes.py` | active-optional |
+| Synergy | `/synergy`, `/api/synergy` | `src/synergy/api.py`, `src/synergy/dashboard_api.py` | active |
+| Resilience sentinel | `/sentinel` | `modules/resilience_sentinel/api.py` | active |
+| Monitoring dashboard | `/monitoring` | `src/monitoring/dashboard_api.py` | active |
+| GUMAS ethics | `/gumas` | `modules/gumas/api/routes.py` | active |
+| OAuth2/RBAC | `/api/auth` | `src/security/auth_routes.py` | active |
+| R2 telemetry | `/r2-telemetry` | `api/r2_telemetry_routes.py` | active |
+| L2 meta-agent bridge | `/api/l2-agents` | `src/api/l2_meta_agent_api.py` | active |
+| Drift metrics | `/api/drift` | `src/observability/drift_metrics_api.py` | active |
+| Playground | `/playground` | `src/playground/api.py` | active |
+
+The API governance registry for these surfaces lives at
+`docs/api/api_surface_inventory.json`.
+
+## Mesh and Bridge Authority
+
+The implemented Python mesh runtime V1 surface currently confirmed by
+`src/servers/l2_integration_server.py` and `tests/test_mesh_router_v1.py` is:
+
+- `GET /api/mesh/status`
+- `POST /api/mesh/messages`
+- `GET /api/mesh/channels/{id}/history`
+- `GET /api/mesh/events?after=<cursor>`
+- `POST /api/bridge/gpt/connect/{agent_id}`
+- `GET /api/bridge/constellation/status`
+- `GET /ws/mesh` by native WebSocket
+- `GET /chamber`
+- `GET /`
+
+`skills/mesh-router/references/runtime-contract.md` lists additional
+`/api/mesh/agents` routes. Those routes are an expected contract surface, but
+they are not verified as implemented in `create_app()` during this review and
+are therefore tracked as path drift rather than current runtime authority.
+
+`src/api/mesh_api.js` still has value as a legacy Express router and node test
+target, but it is not the production-mounted authority in the current repo
+evidence. `src/bridge/enhanced_api_bridge.js` remains a compatibility bridge
+for Custom GPT style handlers, but the route authority has moved to the mesh
+runtime and L2 integration server.
+
+## L3 Authority Map
+
+`docs/LAYER_BOUNDARY_REFERENCE.md` remains the canonical layer definition:
+
+- L1 is Orion Station physical or station-operation context.
+- L2 is sandboxed simulation and meta-agent context.
+- L3 is the ethics, continuity, anchor, DLP, and drift overlay spanning L1 and
+  L2.
+
+L3 does not independently authorize runtime mutation. It evaluates, blocks,
+requires human consent, or records lineage. Runtime mutation still requires the
+appropriate L1/L2 owner path, authentication, CSRF or route-specific mutation
+guard, and any human approval required by the operation.
+
+| L3 function | Current owner surface | Authority boundary |
+| --- | --- | --- |
+| Ethics evaluation | `modules/gumas/api/routes.py`, `src/monitoring/ethics_engine.py`, `src/entities/framework_agents.py` | Can evaluate and report violations; cannot bypass route auth or human-consent gates. |
+| Anchor and continuity validation | `src/entities/framework_agents.py`, `src/core/native_dlp_export.py`, thread continuity modules | Can validate continuity and emit DLP lineage; cannot silently promote or execute state changes. |
+| Drift detection and metrics | `src/monitoring/drift_detector.py`, `src/observability/drift_metrics_api.py`, `src/entities/relay_agents.py` | Can expose drift and trigger recommended intervention; direct corrective action remains an owning runtime concern. |
+| Mesh communication | `src/servers/l2_integration_server.py`, `src/mesh/runtime.py` | Routes mesh messages through declared mesh endpoints; L3 assessment does not equal approval to send or mutate. |
+| Audit trail | `src/monitoring/audit_logger.py`, `modules/insight_ledger/api.py` | Records evidence and lineage; not a deploy or execution authority. |
+
+## Operator Rule
+
+When docs disagree with the committed runtime, prefer the committed entrypoint,
+router, test, and inventory evidence. Label older claims as stale or unverified
+instead of repeating them as active topology.

--- a/tests/test_api_surface_inventory.py
+++ b/tests/test_api_surface_inventory.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INVENTORY_PATH = REPO_ROOT / "docs" / "api" / "api_surface_inventory.json"
+
+
+def test_api_surface_inventory_is_valid() -> None:
+    inventory = json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+
+    allowed_statuses = set(inventory["status_values"])
+    assert inventory["governance_decision"] == "primary-fastapi-with-declared-standalone-services"
+    assert inventory["entries"]
+
+    required_fields = {
+        "id",
+        "owner",
+        "runtime",
+        "entrypoint",
+        "mount_path",
+        "service_class",
+        "status",
+        "status_evidence",
+        "notes",
+    }
+
+    seen_ids = set()
+    for entry in inventory["entries"]:
+        assert required_fields <= set(entry), entry
+        assert entry["id"] not in seen_ids
+        seen_ids.add(entry["id"])
+        assert entry["status"] in allowed_statuses
+        assert entry["status_evidence"]
+
+        if entry["mount_path"] != "n/a":
+            assert entry["mount_path"].startswith(("/", ":")), entry
+
+        path = REPO_ROOT / entry["entrypoint"]
+        assert path.exists(), entry
+
+
+def test_required_api_surface_entries_are_present() -> None:
+    inventory = json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+    ids = {entry["id"] for entry in inventory["entries"]}
+
+    assert {
+        "primary_fastapi_app",
+        "hr_system",
+        "monitoring_dashboard",
+        "drift_metrics",
+        "gumas_ethics",
+        "mesh_runtime_v1",
+        "mesh_api_js",
+        "enhanced_api_bridge",
+    } <= ids


### PR DESCRIPTION
## Summary

- add a runtime topology and L3 communications authority map grounded in current repo evidence
- add a runtime path-drift ledger for stale API paths, mesh bridge status, and outdated historical docs
- add API catalog governance plus a machine-readable API surface inventory
- validate the inventory with a focused pytest check

Closes #634.
Closes #635.
Closes #636.

## Validation

- `python3 -m pytest -q tests/test_api_surface_inventory.py`
- `python3 -m json.tool docs/api/api_surface_inventory.json`
- `git diff --check`
