### PR TITLE
docs: record CloudBank backlog zero milestone

### DIFF
--- a/docs/operational/reports/BACKLOG_ZERO_MILESTONE_2026-05-26.md
+++ b/docs/operational/reports/BACKLOG_ZERO_MILESTONE_2026-05-26.md
@@ -1,0 +1,103 @@
+# CloudBank Backlog Zero Milestone
+
+## Summary
+
+Date: 2026-05-26
+Repository: AUo959/aurora-cloudbank-symbolic
+Scope: GitHub issue and pull request backlog triage for the canonical CloudBank repository.
+Status: milestone documented from live GitHub evidence.
+
+On 2026-05-26, the CloudBank GitHub backlog reached zero open issues and zero open pull requests after a sequence of issue-closing feature fixes, governance documentation, stale tracker cleanup, and dependency maintenance merges.
+
+## Live Backlog Verification
+
+Verified at: 2026-05-26T16:08:04Z
+
+Commands used:
+
+```bash
+gh issue list --state open --limit 100 --json number,title,url
+gh pr list --state open --limit 100 --json number,title,url
+```
+
+Observed results:
+
+```json
+[]
+```
+
+for both open issues and open pull requests.
+
+## Issue Closure Lane
+
+The final issue lane closed the remaining active trackers through merged PRs and direct stale-tracker closure:
+
+| Issue | Resolution path |
+| --- | --- |
+| #637 | Closed by PR #752, `fix: require real cross-repo thread transfer` |
+| #593 | Closed by PR #753, `[codex] fix monitoring audit history persistence` |
+| #595 | Closed by PR #753, `[codex] fix monitoring audit history persistence` |
+| #594 | Closed by PR #754, `[codex] fix audit logger append persistence` |
+| #596 | Closed by PR #755, `[codex] fix vision alignment review persistence` |
+| #634 | Closed by PR #756, `[codex] Define runtime API governance` |
+| #635 | Closed by PR #756, `[codex] Define runtime API governance` |
+| #636 | Closed by PR #756, `[codex] Define runtime API governance` |
+| #732 | Closed manually after confirming its referenced backlog items were already closed |
+
+## Pull Request Closure Lane
+
+Final functional and governance PRs merged:
+
+| PR | Merged at | Merge commit | Title |
+| --- | --- | --- | --- |
+| #752 | 2026-05-26T05:23:53Z | `f5017c291c5045c27f8524bb77a20613b878d834` | `fix: require real cross-repo thread transfer` |
+| #753 | 2026-05-26T05:35:34Z | `53eadccd193fff1c721e0244188fe7f9c0c82d27` | `[codex] fix monitoring audit history persistence` |
+| #754 | 2026-05-26T05:49:06Z | `6ce0772d937ea21535a1db579ec1a6ac49cb5132` | `[codex] fix audit logger append persistence` |
+| #755 | 2026-05-26T06:01:09Z | `d7c7b8abd6c98aaf1f6e56c2bb8b13e9d30de445` | `[codex] fix vision alignment review persistence` |
+| #756 | 2026-05-26T15:50:20Z | `47d02290760802babfeefd2fe3e608f37dda9d50` | `[codex] Define runtime API governance` |
+
+Final dependency PRs merged:
+
+| PR | Merged at | Merge commit | Title |
+| --- | --- | --- | --- |
+| #744 | 2026-05-26T16:02:40Z | `143f55ae698765cb9cc9eed2be4d5e540b7fb462` | `deps: bump the npm_and_yarn group across 1 directory with 2 updates` |
+| #739 | 2026-05-26T16:03:32Z | `01fb1dc3c46bce78ff095827065e995a9e27cd5d` | `deps: bump express-rate-limit from 8.5.1 to 8.5.2` |
+| #742 | 2026-05-26T16:03:47Z | `d1803d30cb97ca20923c5436961124d2b069b465` | `deps: bump tsx from 4.21.0 to 4.22.3` |
+| #741 | 2026-05-26T16:03:58Z | `bf66a5b2d772c0cc54aa450f8e911b5f90d78a15` | `deps: bump @babel/preset-env from 7.29.5 to 7.29.7` |
+| #740 | 2026-05-26T16:04:40Z | `3d9d41502626f1e4494a98f140565d8fd4b2d782` | `deps: bump jest from 30.3.0 to 30.4.2` |
+| #737 | 2026-05-26T16:04:54Z | `00500df1e468086a893c18e3a2bb54305272d64a` | `deps: update black requirement from >=25.11.0 to >=26.5.1` |
+| #736 | 2026-05-26T16:05:08Z | `55031391a1a513180ae74c16c01a6dc1d898ed25` | `deps: update ipykernel requirement from >=6.27.0 to >=7.2.0` |
+| #735 | 2026-05-26T16:05:23Z | `ddfbc226d29869f4af59a516fa92843d5ae97a43` | `deps: update python-json-logger requirement from >=2.0.7 to >=4.1.0` |
+| #734 | 2026-05-26T16:05:42Z | `44aa990324f61140f569b2a27910582037c80b24` | `deps: update pygments requirement from >=2.19.2 to >=2.20.0` |
+| #733 | 2026-05-26T16:05:53Z | `7704f471a0fa86076753383ac4776cfd744efa91` | `deps: update certifi requirement from >=2025.8.3 to >=2026.5.20` |
+
+Superseded PR closed:
+
+| PR | Closed at | Reason |
+| --- | --- | --- |
+| #738 | 2026-05-26T16:03:02Z | Closed as superseded by merged grouped dependency PR #744, which already included the `ws` 8.20.0 to 8.21.0 update plus `qs` |
+
+## Governance Outcome
+
+This milestone leaves CloudBank with:
+
+- zero open GitHub issues at verification time
+- zero open GitHub pull requests at verification time
+- runtime API governance recorded in PR #756
+- closed persistence and audit-history defects for monitoring, audit logging, and vision-alignment review state
+- dependency updates merged through Dependabot PRs with green GitHub checks
+- stale weekly tracker #732 closed after confirming its referenced work was already complete
+
+## Validation Notes
+
+Evidence source: live GitHub CLI queries against `AUo959/aurora-cloudbank-symbolic`.
+
+Dependency PR validation relied on GitHub branch protection and successful PR checks captured before merge. Local test suites were not rerun for every dependency PR in this receipt.
+
+The documentation branch was created from refreshed `origin/main` after the backlog merges. The canonical local checkout had unrelated dirty work on another branch, so this receipt was prepared in an isolated worktree to avoid altering that work.
+
+## Residual Watch Items
+
+- Confirm the post-merge `main` CI remains healthy after all dependency merges and follow-up automation commits.
+- Keep Dependabot enabled; new dependency PRs may appear after this milestone.
+- Treat this as a GitHub backlog milestone, not a claim that every deferred architectural or product idea is complete.


### PR DESCRIPTION
## Summary
- add an operational receipt for the 2026-05-26 CloudBank backlog-zero milestone
- record live GitHub verification for zero open issues and zero open PRs
- document merged dependency PRs, merged functional/governance PRs, and the superseded ws PR closure

## Validation
- git diff --cached --check
- live gh issue/pr list verification returned [] before this docs PR was opened