### PR TITLE
[codex] Fix requirements inventory drift

### DIFF
--- a/.github/CODACY_INTEGRATION.md
+++ b/.github/CODACY_INTEGRATION.md
@@ -155,7 +155,7 @@ Add to workflow for faster Python setup:
   with:
     python-version: '3.12'
     cache: 'pip'
-    cache-dependency-path: requirements-lock.txt
+    cache-dependency-path: requirements*.txt
 ```
 
 ## 📝 Next Steps

--- a/.github/QUICK_REFERENCE.md
+++ b/.github/QUICK_REFERENCE.md
@@ -22,8 +22,8 @@ python api/aurora_api.py       # Start server
 | Component | ❌ WRONG | ✅ CORRECT |
 |-----------|----------|-----------|
 | **API Server** | `python aurora_api.py` | `python api/aurora_api.py` |
-| **Dependencies** | `pip install -r requirements.txt` | `make setup` |
-| **Lock File** | `requirements.txt` | `requirements-lock.txt` |
+| **Dependencies** | Undocumented ad hoc installs | `make setup` |
+| **Requirements Inventory** | Missing requirements files | `requirements.txt`, `requirements-dev.txt`, `requirements-optional.txt` |
 | **Test Run** | `pytest` (slow!) | `pytest -m unit` (fast) |
 
 ---

--- a/.github/chatmodes/code-quality-auditor.md
+++ b/.github/chatmodes/code-quality-auditor.md
@@ -288,7 +288,7 @@ pytest -m "not slow"                    # Fast tests only (CI pattern)
 ## Standards Reference
 
 ### Critical Infrastructure Rules
-1. **NEVER** run `pip install -r requirements.txt` directly → Use `make setup`
+1. **Prefer `make setup` over direct pip installs**; it validates the tracked requirements inventory first.
 2. **API Path:** Server is at `api/aurora_api.py` (NOT root)
 3. **Test Markers:** Use `pytest -m unit` for fast tests
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -188,9 +188,9 @@ This repository models a quantum-symbolic governance stack where every feature m
    make setup  # Runs scripts/setup_environment.sh
    python scripts/dev-status.py  # Confirm environment status
    ```
-   - **NEVER** run `pip install -r requirements.txt` directly
+   - Prefer `make setup` over ad hoc `pip install` commands
    - Always use `make setup` which handles version conflicts and venv creation
-   - Uses `requirements-lock.txt` for pinned dependencies, not `requirements.txt`
+   - Uses the tracked requirements inventory: `requirements.txt`, `requirements-dev.txt`, and `requirements-optional.txt`
    
 2. **Check Status:** `make status` - View Python version, venv, and setup state
 
@@ -384,8 +384,8 @@ For deliverables touching security or memory:
 ## Common Pitfalls to Avoid
 
 ### Critical Infrastructure Mistakes
-1. **Wrong pip Command:** NEVER run `pip install -r requirements.txt` - always use `make setup`
-   - Project uses `requirements-lock.txt` for pinned dependencies
+1. **Wrong pip Command:** Prefer `make setup` over direct pip installs
+   - Project tracks runtime, development, and optional dependency files separately
    - Direct pip bypasses httpx/httpcore conflict resolution
    - `scripts/setup_environment.sh` handles version conflicts automatically
 2. **Wrong API Path:** Server is at `api/aurora_api.py` (NOT root `aurora_api.py`)
@@ -624,7 +624,7 @@ from modules.gumas.api import router as gumas_router
 ### Dependency Validation
 - **Matrix Testing:** Python 3.11 and 3.12
 - **Dry-Run Phase:** Catches conflicts before installation
-- **Lock File:** Uses `requirements-lock.txt` for reproducibility
+- **Requirements Inventory:** Validates tracked requirements files against current docs
 - **Local Validation:** `python scripts/validate_dependencies.py`
 
 ### Running CI Locally

--- a/.github/copilot/modes/code-quality-auditor.md
+++ b/.github/copilot/modes/code-quality-auditor.md
@@ -288,7 +288,7 @@ pytest -m "not slow"                    # Fast tests only (CI pattern)
 ## Standards Reference
 
 ### Critical Infrastructure Rules
-1. **NEVER** run `pip install -r requirements.txt` directly → Use `make setup`
+1. **Prefer `make setup` over direct pip installs**; it validates the tracked requirements inventory first.
 2. **API Path:** Server is at `api/aurora_api.py` (NOT root)
 3. **Test Markers:** Use `pytest -m unit` for fast tests
 

--- a/.github/instructions/aurora-ai-instructions.md
+++ b/.github/instructions/aurora-ai-instructions.md
@@ -122,7 +122,8 @@ See `docs/BRANCH_PROTECTION_BYPASS.md` for complete documentation.
 - `package.json` - Node.js dependencies and scripts
 - `pyproject.toml` - Python project configuration
 - `requirements.txt` - Python dependencies
-- `requirements-lock.txt` - Locked versions
+- `requirements-dev.txt` - Development and test dependencies
+- `requirements-optional.txt` - Optional integration dependencies
 
 **Documentation:**
 - `CONTRIBUTING.md` - 348-line comprehensive contributor guide

--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -5,11 +5,44 @@ on:
     paths:
       - 'requirements*.txt'
       - 'pyproject.toml'
+      - 'CLAUDE.md'
+      - 'README.md'
+      - 'docs/DEPENDENCIES.md'
+      - 'docs/guides/VERCEL_DEPLOYMENT.md'
+      - 'Makefile'
+      - '.github/CODACY_INTEGRATION.md'
+      - '.github/QUICK_REFERENCE.md'
+      - '.github/chatmodes/**'
+      - '.github/copilot/modes/**'
+      - '.github/instructions/**'
+      - '.github/copilot-instructions.md'
       - '.github/workflows/dependency-validation.yml'
+      - 'scripts/audit_requirements_inventory.py'
+      - 'scripts/infallible_codespace_init.py'
+      - 'scripts/setup_environment.sh'
+      - 'scripts/validate_dependencies.py'
+      - 'tests/test_audit_requirements_inventory.py'
   pull_request:
     paths:
       - 'requirements*.txt'
       - 'pyproject.toml'
+      - 'CLAUDE.md'
+      - 'README.md'
+      - 'docs/DEPENDENCIES.md'
+      - 'docs/guides/VERCEL_DEPLOYMENT.md'
+      - 'Makefile'
+      - '.github/CODACY_INTEGRATION.md'
+      - '.github/QUICK_REFERENCE.md'
+      - '.github/chatmodes/**'
+      - '.github/copilot/modes/**'
+      - '.github/instructions/**'
+      - '.github/copilot-instructions.md'
+      - '.github/workflows/dependency-validation.yml'
+      - 'scripts/audit_requirements_inventory.py'
+      - 'scripts/infallible_codespace_init.py'
+      - 'scripts/setup_environment.sh'
+      - 'scripts/validate_dependencies.py'
+      - 'tests/test_audit_requirements_inventory.py'
 
 jobs:
   validate-dependencies:
@@ -20,6 +53,9 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+
+    - name: Audit requirements inventory references
+      run: python3 scripts/audit_requirements_inventory.py
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -45,18 +81,14 @@ jobs:
       run: |
         source .venv/bin/activate
         echo "🧪 Testing dependency resolution..."
-        if [[ -f "requirements-lock.txt" ]]; then
-          pip install -r requirements-lock.txt --dry-run --report dependency_report.json || echo "⚠️ Dependency resolution check failed (non-blocking)"
-        elif [[ -f "requirements.txt" ]]; then
+        if [[ -f "requirements.txt" ]]; then
           pip install -r requirements.txt --dry-run || echo "⚠️ Dependency resolution check failed (non-blocking)"
         fi
     
     - name: Install dependencies
       run: |
         source .venv/bin/activate
-        if [[ -f "requirements-lock.txt" ]]; then
-          pip install -r requirements-lock.txt
-        elif [[ -f "requirements.txt" ]]; then
+        if [[ -f "requirements.txt" ]]; then
           pip install -r requirements.txt
         fi
     

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1241,12 +1241,9 @@ bottlenecks = analyzer.identify_bottlenecks()
 
 ### Requirements Files
 
-- **`requirements.txt`**: Vercel production (lightweight)
-- **`requirements-full.txt`**: Complete with optional dependencies
-- **`requirements-lock.txt`**: Locked versions
-- **`requirements-dev.txt`**: Development tools
-- **`requirements-secure.txt`**: Security-focused subset
-- **`requirements-optional.txt`**: Optional heavy dependencies (qiskit, scipy, pandas)
+- **`requirements.txt`**: Core runtime dependencies
+- **`requirements-dev.txt`**: Development and test tooling
+- **`requirements-optional.txt`**: Optional integrations and heavyweight feature dependencies
 
 ### Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ ensure-venv: ## Ensure the local virtual environment exists
 	fi
 
 install:
-	@echo "📦 Installing FULL dependencies for local development..."
-	pip install -r requirements-full.txt
+	@echo "📦 Installing runtime and optional dependencies for local development..."
+	pip install -r requirements.txt -r requirements-optional.txt
 
 install-vercel:
-	@echo "📦 Installing lightweight dependencies (Vercel-compatible)..."
+	@echo "📦 Installing runtime dependencies..."
 	pip install -r requirements.txt
 
 # New dependency management targets
@@ -50,7 +50,9 @@ deps-check: validate ## Check for dependency conflicts
 deps-update: ## Update dependencies (with backup)
 	@echo "📦 Updating dependencies..."
 	@if [ ! -d ".backup/requirements" ]; then mkdir -p .backup/requirements; fi
-	@cp requirements-lock.txt .backup/requirements/requirements-lock.txt.$(shell date +%Y%m%d_%H%M%S) 2>/dev/null || true
+	@cp requirements.txt .backup/requirements/requirements.txt.$(shell date +%Y%m%d_%H%M%S) 2>/dev/null || true
+	@cp requirements-dev.txt .backup/requirements/requirements-dev.txt.$(shell date +%Y%m%d_%H%M%S) 2>/dev/null || true
+	@cp requirements-optional.txt .backup/requirements/requirements-optional.txt.$(shell date +%Y%m%d_%H%M%S) 2>/dev/null || true
 
 backup: ## Backup current environment and requirements
 	@echo "💾 Creating backup..."

--- a/README.md
+++ b/README.md
@@ -1856,7 +1856,7 @@ Complete API documentation now available:
 # Standard Python environment
 python -m venv .venv
 source .venv/bin/activate  # or `.venv\Scripts\activate` on Windows
-pip install -r requirements-lock.txt
+pip install -r requirements.txt
 python api/aurora_api.py
 ```
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,173 +1,54 @@
-# Aurora CloudBank Dependencies Documentation
+# Aurora CloudBank Dependencies
 
-## 📦 Dependency Files Overview
+Aurora CloudBank currently tracks three root-level Python requirements files.
+Keep this page and `CLAUDE.md` aligned with the actual files in the repository.
 
-Aurora CloudBank uses a **two-tier dependency strategy** to support both full-featured local development and lightweight Vercel deployments.
+## Dependency Files
 
-### Dependency Files
+| File | Purpose | Typical use |
+|------|---------|-------------|
+| `requirements.txt` | Core runtime dependencies | Application runtime, containers, dependency CI |
+| `requirements-dev.txt` | Development and test tooling | Local testing, linting, maintenance scripts |
+| `requirements-optional.txt` | Optional integrations and heavier feature dependencies | Quantum cloud backends, notebooks, telemetry extensions |
 
-| File | Purpose | Size | Used By |
-|------|---------|------|---------|
-| `requirements.txt` | **Vercel Production** - Lightweight dependencies | ~40MB | Vercel deployments |
-| `requirements-full.txt` | **Local Development** - Complete dependencies | ~150MB | Local development, CI/CD |
-| `requirements-lock.txt` | **Pinned versions** - Reproducible builds | ~150MB | `make setup` script |
-| `requirements-dev.txt` | **Development tools** - Testing, linting, etc. | Variable | Local testing |
-| `requirements-optional.txt` | **Optional features** - Advanced integrations | Variable | As needed |
+## Recommended Setup
 
-## 🎯 Which File to Use?
-
-### For Local Development (Full Features)
 ```bash
-# Option 1: Use make (recommended)
-make install
-
-# Option 2: Direct pip install
-pip install -r requirements-full.txt
+make setup
 ```
 
-### For Vercel-Compatible Testing
+`make setup` runs `scripts/setup_environment.sh`, installs `requirements.txt`,
+and then installs `requirements-dev.txt` when present.
+
+For a direct runtime-only install:
+
 ```bash
-make install-vercel
-# OR
 pip install -r requirements.txt
 ```
 
-### For Reproducible Setup
+For local work that needs optional integrations:
+
 ```bash
-make setup  # Uses requirements-lock.txt with pinned versions
+pip install -r requirements.txt -r requirements-optional.txt
 ```
 
-## 🔍 What's Different?
+## Inventory Guard
 
-### requirements.txt (Lightweight - Vercel)
-**Included:**
-- ✅ FastAPI, uvicorn, starlette (web framework)
-- ✅ httpx, websockets, aiofiles (networking)
-- ✅ cryptography, JWT, security middleware
-- ✅ anthropic, openai (AI integrations)
-- ✅ numpy (basic math)
-- ✅ All authentication and rate limiting
+Run the requirements inventory audit after changing dependency docs,
+workflows, or setup scripts:
 
-**Excluded (gracefully degrades):**
-- ❌ qiskit, qiskit-aer (~100MB) - Quantum computing
-- ❌ scipy (~50MB) - Advanced scientific computing
-- ❌ pandas (~50MB) - Data analysis
-- ❌ plotly (~30MB) - Visualizations
-- ❌ redis (~20MB) - Caching
-
-### requirements-full.txt (Complete - Local Dev)
-**Includes everything** from `requirements.txt` PLUS:
-- ✅ qiskit, qiskit-aer - Full quantum computing support
-- ✅ scipy - Scientific computing
-- ✅ pandas - Data analysis
-- ✅ plotly - Interactive visualizations
-- ✅ redis - Caching support
-
-## 🔧 How It Works
-
-### Graceful Degradation
-All excluded dependencies have **graceful fallback implementations** in the codebase:
-
-```python
-# Example from the codebase
-try:
-    from qiskit import QuantumCircuit
-    QUANTUM_AVAILABLE = True
-except ImportError:
-    QUANTUM_AVAILABLE = False
-    # Uses mock implementation
-```
-
-This means:
-- **Vercel deployment** works with core API features
-- **Local development** has full quantum/scientific capabilities
-- **No runtime errors** - features degrade gracefully
-
-## 🚀 Common Tasks
-
-### Fresh Install (Local Development)
 ```bash
-# Clean install with full dependencies
-python -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-make install
+python scripts/audit_requirements_inventory.py
 ```
 
-### Update Dependencies
-```bash
-# Update lock file (keeps versions consistent)
-pip freeze > requirements-lock.txt
+The audit fails if current operational docs or dependency CI reference a
+root-level `requirements*.txt` file that is not tracked in the repository.
 
-# Update full requirements
-# (Edit requirements-full.txt manually, then reinstall)
-make install
-```
+## Maintenance Rules
 
-### Test Vercel Compatibility Locally
-```bash
-# Install lightweight deps
-make install-vercel
-
-# Test the app
-cd api && python index.py
-# Should show warnings about missing optional deps, but run successfully
-```
-
-## ⚠️ Important Notes
-
-1. **DO NOT** delete `requirements-full.txt` - it's your backup for local development
-2. **Vercel automatically** uses `requirements.txt` - no manual configuration needed
-3. **CI/CD** should use `requirements-lock.txt` for reproducible builds
-4. **Local dev** can use either `requirements-full.txt` or `requirements-lock.txt`
-
-## 🔄 Migration from Old Setup
-
-If you previously had the full `requirements.txt`:
-```bash
-# Your old requirements.txt is now saved as requirements-full.txt
-# Your local environment is UNAFFECTED - packages stay installed
-# To reinstall if needed:
-make install  # Installs from requirements-full.txt
-```
-
-## 📊 Deployment Size Comparison
-
-| Environment | Dependencies | Install Size | Build Time |
-|------------|--------------|--------------|------------|
-| Vercel (before) | requirements.txt (full) | ~150MB | ❌ FAILED |
-| Vercel (after) | requirements.txt (light) | ~40MB | ✅ ~2-3 min |
-| Local Dev | requirements-full.txt | ~150MB | ✅ ~5 min |
-
-## 🎓 Best Practices
-
-1. **Use `make install`** for local development (installs full deps)
-2. **Use `make setup`** for fresh environments (uses pinned versions)
-3. **Test locally** before pushing to Vercel
-4. **Keep both files** - don't delete `requirements-full.txt`
-5. **Update both** when adding new core dependencies
-
-## 🆘 Troubleshooting
-
-### "Module not found" error locally
-```bash
-# You need the full dependencies
-make install
-```
-
-### Vercel deployment failing
-```bash
-# Check deployment size
-# Should use requirements.txt (lightweight)
-# Verify api/index.py exists
-```
-
-### Want full quantum features on Vercel?
-Not possible due to Vercel's 50MB limit. Consider:
-- Using AWS Lambda with larger limits
-- Self-hosting with Docker
-- Using Vercel for API only, compute elsewhere
-
----
-
-**Last Updated:** November 14, 2025  
-**Vercel Deployment Commit:** 26818bd4
+1. Add runtime packages to `requirements.txt`.
+2. Add test, lint, and maintenance tooling to `requirements-dev.txt`.
+3. Add optional integrations or heavyweight feature dependencies to
+   `requirements-optional.txt`.
+4. Update this document and run the inventory audit whenever the tracked
+   requirements inventory changes.

--- a/docs/guides/VERCEL_DEPLOYMENT.md
+++ b/docs/guides/VERCEL_DEPLOYMENT.md
@@ -13,23 +13,22 @@ Your repository is now configured for Vercel deployment with the following files
    - Routes all traffic to `api/index.py`
    - Set memory to 3008 MB and max duration to 60s
 
-### 3. **`requirements.txt`** - Lightweight Dependencies for Vercel
-   - **PRODUCTION DEPLOYMENT ONLY** - excludes heavy packages (qiskit, scipy, pandas, plotly, redis)
-   - Optimized for Vercel's 50MB deployment size limit
-   - All excluded packages gracefully degrade with mock implementations
+### 3. **`requirements.txt`** - Runtime Dependencies
+   - Root runtime dependency inventory used by dependency validation
+   - For local development, use `make setup` so the dev tooling inventory is installed too
 
-### 4. **`requirements-full.txt`** - Complete Dependencies for Local Development
-   - **LOCAL DEVELOPMENT** - includes ALL packages
-   - Use this for local setup: `pip install -r requirements-full.txt`
-   - Includes quantum computing (qiskit), scientific computing (scipy), data analysis (pandas)
+### 4. **`requirements-optional.txt`** - Optional Integrations
+   - Optional heavyweight features and provider integrations
+   - Install only when a local task needs these integrations
 
 ## 🏗️ Dependency Strategy
 
-**Two-Tier Approach:**
-- **Vercel (Production):** Uses `requirements.txt` (lightweight, ~40MB)
-- **Local Dev:** Uses `requirements-full.txt` (complete, ~150MB)
+**Current tracked inventory:**
+- **Runtime:** `requirements.txt`
+- **Development:** `requirements-dev.txt`
+- **Optional integrations:** `requirements-optional.txt`
 
-This allows full-featured local development while keeping deployments within Vercel limits.
+Run `python scripts/audit_requirements_inventory.py` after changing dependency docs or setup scripts.
 
 ## 🔧 Environment Variables Required
 

--- a/scripts/audit_requirements_inventory.py
+++ b/scripts/audit_requirements_inventory.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Audit current docs and CI for stale root requirements-file references."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REQUIREMENTS_REF_RE = re.compile(r"\brequirements(?:-[A-Za-z0-9_]+)?\.txt\b")
+
+DEFAULT_SCAN_PATHS = (
+    "CLAUDE.md",
+    "README.md",
+    "Makefile",
+    "docs/DEPENDENCIES.md",
+    "docs/guides/VERCEL_DEPLOYMENT.md",
+    ".github/QUICK_REFERENCE.md",
+    ".github/CODACY_INTEGRATION.md",
+    ".github/copilot-instructions.md",
+    ".github/chatmodes/code-quality-auditor.md",
+    ".github/copilot/modes/code-quality-auditor.md",
+    ".github/instructions/aurora-ai-instructions.md",
+    ".github/workflows/dependency-validation.yml",
+    "scripts/infallible_codespace_init.py",
+    "scripts/setup_environment.sh",
+    "scripts/validate_dependencies.py",
+)
+
+
+@dataclass(frozen=True)
+class MissingReference:
+    path: Path
+    line_number: int
+    reference: str
+
+
+def root_requirements_files(repo_root: Path) -> set[str]:
+    """Return tracked root requirements-file names that exist on disk."""
+    return {path.name for path in repo_root.glob("requirements*.txt") if path.is_file()}
+
+
+def iter_scan_files(repo_root: Path, scan_paths: tuple[str, ...]) -> list[Path]:
+    """Return existing files from the configured scan list."""
+    files: list[Path] = []
+    for raw_path in scan_paths:
+        path = repo_root / raw_path
+        if path.is_file():
+            files.append(path)
+    return files
+
+
+def collect_missing_references(
+    repo_root: Path,
+    scan_paths: tuple[str, ...] = DEFAULT_SCAN_PATHS,
+) -> list[MissingReference]:
+    """Find requirements-file references that do not exist at the repo root."""
+    existing = root_requirements_files(repo_root)
+    missing: list[MissingReference] = []
+
+    for path in iter_scan_files(repo_root, scan_paths):
+        relative_path = path.relative_to(repo_root)
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for reference in sorted(set(REQUIREMENTS_REF_RE.findall(line))):
+                if reference not in existing:
+                    missing.append(MissingReference(relative_path, line_number, reference))
+
+    return missing
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root to audit. Defaults to the parent of scripts/.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    missing = collect_missing_references(repo_root)
+
+    if missing:
+        print("Stale requirements-file references found:")
+        for item in missing:
+            print(f"- {item.path}:{item.line_number}: {item.reference} does not exist at repo root")
+        print("\nUpdate the reference or add the missing requirements file intentionally.")
+        return 1
+
+    existing = ", ".join(sorted(root_requirements_files(repo_root)))
+    print(f"Requirements inventory references are current: {existing}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/infallible_codespace_init.py
+++ b/scripts/infallible_codespace_init.py
@@ -32,7 +32,7 @@ def ensure_workspace_venv():
 def install_python_dependencies():
     env = get_venv_env()
     setup_script = WORKSPACE_DIR / "scripts" / "setup_environment.sh"
-    requirements_file = "requirements-lock.txt"
+    requirements_file = "requirements.txt"
     if not (WORKSPACE_DIR / requirements_file).exists():
         requirements_file = "requirements.txt"
 

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -11,7 +11,7 @@ echo "===================================="
 # Configuration
 PYTHON_VERSION="3.12"
 VENV_DIR=".venv"
-REQUIREMENTS_FILE="requirements-lock.txt"
+REQUIREMENTS_FILE="requirements.txt"
 BACKUP_DIR=".backup"
 
 # Colors for output
@@ -88,7 +88,7 @@ backup_state() {
     mkdir -p "$BACKUP_DIR/venv"
     
     # Backup requirements files
-    for file in requirements.txt requirements-lock.txt pyproject.toml; do
+    for file in requirements.txt requirements-dev.txt requirements-optional.txt pyproject.toml; do
         if [[ -f "$file" ]]; then
             cp "$file" "$BACKUP_DIR/requirements/$file.$(date +%Y%m%d_%H%M%S)"
             log_success "Backed up $file"
@@ -127,10 +127,9 @@ install_dependencies() {
     
     source "$VENV_DIR/bin/activate"
     
-    # Fallback to requirements.txt when lock file is missing
     if [[ ! -f "$REQUIREMENTS_FILE" ]]; then
-        log_warning "Lock file $REQUIREMENTS_FILE not found; falling back to requirements.txt"
-        REQUIREMENTS_FILE="requirements.txt"
+        log_error "Required dependency file $REQUIREMENTS_FILE not found"
+        return 1
     fi
     
     # Test dependency resolution first

--- a/scripts/validate_dependencies.py
+++ b/scripts/validate_dependencies.py
@@ -67,7 +67,8 @@ def backup_requirements():
     """Backup current requirements before changes."""
     requirements_files = [
         "requirements.txt",
-        "requirements-lock.txt",
+        "requirements-dev.txt",
+        "requirements-optional.txt",
         "pyproject.toml"
     ]
 

--- a/tests/test_audit_requirements_inventory.py
+++ b/tests/test_audit_requirements_inventory.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from scripts.audit_requirements_inventory import collect_missing_references
+
+
+def test_current_requirements_inventory_references_are_valid() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    assert collect_missing_references(repo_root) == []
+
+
+def test_missing_requirements_reference_is_reported(tmp_path: Path) -> None:
+    (tmp_path / "requirements.txt").write_text("fastapi>=0.128.8\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("Install from requirements-missing.txt\n", encoding="utf-8")
+
+    missing = collect_missing_references(tmp_path, ("README.md",))
+
+    assert len(missing) == 1
+    assert missing[0].path == Path("README.md")
+    assert missing[0].line_number == 1
+    assert missing[0].reference == "requirements-missing.txt"


### PR DESCRIPTION
## Summary

Fixes the requirements inventory drift from #830 by aligning current operational docs and setup guidance with the three root requirements files that actually exist:

- `requirements.txt`
- `requirements-dev.txt`
- `requirements-optional.txt`

This also removes the dead `requirements-lock.txt` branch from dependency validation and adds a focused audit to prevent current docs/CI from referencing missing root `requirements*.txt` files.

## Changes

- Rewrote current requirements guidance in `CLAUDE.md`, `docs/DEPENDENCIES.md`, README setup instructions, Vercel dependency guidance, and agent-facing GitHub docs.
- Updated setup/validation helpers to back up and install the tracked requirements inventory instead of looking for a missing lock file.
- Added `scripts/audit_requirements_inventory.py` plus focused tests.
- Wired the audit into `.github/workflows/dependency-validation.yml` and expanded path filters for the governed docs/scripts.

## Validation

- `python3 scripts/audit_requirements_inventory.py`
- `python3 -m pytest -q tests/test_audit_requirements_inventory.py`
- `python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/dependency-validation.yml").read_text()); print("workflow yaml ok")'`
- `git diff --check`

Closes #830.