### PR TITLE
fix: align Python version floor to 3.11 across all declarations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1323,7 +1323,7 @@ bottlenecks = analyzer.identify_bottlenecks()
 - Pydantic V2 migration complete
 
 **Dependencies**:
-- Python 3.8+ required (3.12 recommended)
+- Python 3.11+ required (3.12 recommended)
 - Node.js 20+ for web components
 - Graceful degradation for optional deps (qiskit, scipy, pandas)
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description="Quantum-Symbolic Computing Platform with AI Integration",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     install_requires=[
         "black>=23.0.0",
         "flake8>=6.0.0",
@@ -19,9 +19,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )


### PR DESCRIPTION
## Summary

Fixes #834

`setup.py` declared `python_requires=">=3.8"` with classifiers for Python 3.8–3.11, while every other source in the repo agreed on **3.11+**:

| Source | Before | After |
|---|---|---|
| `setup.py` | `>=3.8`, classifiers 3.8–3.11 | `>=3.11`, classifiers 3.11–3.12 |
| `CLAUDE.md` summary | "Python 3.8+ required" | "Python 3.11+ required" |
| `runtime.txt` | `python-3.12.0` | unchanged ✅ |
| `sdk/python/pyproject.toml` | `>=3.11` | unchanged ✅ |
| `cli/pyproject.toml` | `>=3.11` | unchanged ✅ |
| `CLAUDE.md` header | "Backend (Python 3.11+)" | unchanged ✅ |
| CI matrix | 3.11 + 3.12 | unchanged ✅ |

## Changed paths
- `setup.py` — `python_requires`, classifiers
- `CLAUDE.md` — summary section dependency line

## Validation
```bash
grep "python_requires" setup.py           # >=3.11
grep "Python :: 3\." setup.py            # 3.11, 3.12 only
grep "3\.8" CLAUDE.md                    # no results
grep "requires-python" sdk/python/pyproject.toml cli/pyproject.toml  # both >=3.11
```

## Claim
- **Claimed by:** Claude Code (cloud session)
- **Issue:** #834
- **Branch:** `claude/issue-834-python-version-floor`
- **Paths:** `setup.py`, `CLAUDE.md`
- **Claim released** — work complete, no blockers

Do not merge without explicit authorization.

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_