### PR TITLE
ci: include modules/nexus in lint scope

### DIFF
--- a/.github/workflows/aurora-ci-minimal.yml
+++ b/.github/workflows/aurora-ci-minimal.yml
@@ -57,29 +57,31 @@ jobs:
         run: |
           # Only check if Python files would actually break, scoped to first-class areas
           paths=""
-          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager; do
+          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager modules/nexus; do
             [ -d "$d" ] && paths="$paths $d"
           done
           if [ -z "$paths" ]; then
             echo "No target directories found for syntax check" && exit 0
           fi
+          # modules/opal2 excluded: 3 pre-existing syntax errors pending separate fix
           flake8 $paths --count --select=E9,F63,F7,F82 --show-source --statistics \
-            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,scripts/deprecated/*,examples/*,integrations/*,modules/opal2/*,modules/nexus/*,.security/*
-      
+            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,scripts/deprecated/*,examples/*,integrations/*,modules/opal2/*,.security/*
+
       # STYLE CHECKS - informational only, allowed to fail
       - name: Code style check
         continue-on-error: true
         run: |
           # Check style but don't fail the build; use same scoped areas as syntax check
           paths=""
-          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager; do
+          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager modules/nexus; do
             [ -d "$d" ] && paths="$paths $d"
           done
           if [ -z "$paths" ]; then
             echo "No target directories found for style check" && exit 0
           fi
+          # modules/opal2 excluded: 3 pre-existing syntax errors pending separate fix
           flake8 $paths --count --max-complexity=10 --max-line-length=127 --statistics \
-            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,scripts/deprecated/*,examples/*,integrations/*,modules/opal2/*,modules/nexus/*,.security/*
+            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,scripts/deprecated/*,examples/*,integrations/*,modules/opal2/*,.security/*
       
       # CRITICAL TESTS - must pass, fail closed
       # Only fails on actual test FAILURES, not on collection errors from

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -27,20 +27,22 @@ jobs:
       - name: Syntax errors (fail closed)
         run: |
           paths=""
-          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager; do
+          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager modules/nexus; do
             [ -d "$d" ] && paths="$paths $d"
           done
           [ -z "$paths" ] && echo "No target directories" && exit 0
+          # modules/opal2 excluded: 3 pre-existing syntax errors pending separate fix
           flake8 $paths --count --select=E9,F63,F7,F82 --show-source --statistics \
-            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,modules/opal2,modules/nexus
+            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,modules/opal2
 
       - name: Style and complexity (informational)
         continue-on-error: true
         run: |
           paths=""
-          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager; do
+          for d in api src tools tests modules/hr_system modules/resilience_sentinel modules/gumas modules/symbolic_core modules/aumemmanager modules/nexus; do
             [ -d "$d" ] && paths="$paths $d"
           done
           [ -z "$paths" ] && echo "No target directories" && exit 0
+          # modules/opal2 excluded: 3 pre-existing syntax errors pending separate fix
           flake8 $paths --count --max-complexity=10 --max-line-length=120 --statistics \
-            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,modules/opal2,modules/nexus
+            --exclude=.git,__pycache__,.pytest_cache,venv,env,.venv,.tox,dist,build,modules/opal2


### PR DESCRIPTION
## Summary

- Add `modules/nexus` to the directory loop in both `aurora-ci-minimal.yml` and `code-quality.yml` so it is actively linted for syntax errors
- Remove `modules/nexus/*` from the `--exclude` flag in both workflows
- Add an explanatory comment that `modules/opal2/*` remains excluded due to 3 pre-existing syntax errors (pending a separate fix)

**Validation**: `flake8 modules/nexus --select=E9,F63,F7,F82` → 0 errors (safe to include)

## Test plan

- [ ] CI syntax check passes with `modules/nexus` included in lint scope
- [ ] No new flake8 errors introduced by nexus files
- [ ] `modules/opal2` still excluded (it has 3 real syntax errors)

Fixes #795

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_