### PR TITLE
fix: bound MemoryCache with configurable max_size and LRU eviction

### DIFF
--- a/modules/memory_retrieval/cache.py
+++ b/modules/memory_retrieval/cache.py
@@ -2,70 +2,86 @@
 Memory Retrieval Module - Cache
 
 TTL-based caching with genealogy tracking for query results.
+
+Bounded by a configurable ``max_size`` with LRU eviction so that long-running
+processes and high-cardinality query inputs cannot grow the cache without
+bound. Cold entries that expire without ever being read back are reclaimed by
+a periodic ``clear_expired`` sweep triggered every N ``set`` operations.
 """
 
-from typing import Optional, Any, Dict
+from collections import OrderedDict
+from typing import Optional, Any
 import time
 import hashlib
 
 
 class MemoryCache:
     """
-    TTL-based cache with hit/miss tracking.
-    
+    Bounded TTL-based cache with LRU eviction and hit/miss tracking.
+
     Caches query results to improve performance and tracks statistics
-    for monitoring and optimization.
+    for monitoring and optimization. The cache is capped at ``max_size``
+    entries; when full, the least-recently-used entry is evicted on insert.
     """
-    
+
+    # Run a cold-expired sweep every this many set() calls so that entries
+    # which expire but are never read back do not linger until overflow.
+    _SWEEP_INTERVAL = 256
+
     def __init__(self, config):
         """
         Initialize cache.
-        
+
         Args:
             config: MemoryRetrievalConfig instance
         """
         self._config = config
-        self._cache: Dict[str, dict] = {}
+        self._max_size = max(1, int(getattr(config, "cache_max_size", 10_000)))
+        # OrderedDict preserves insertion order and supports O(1) move_to_end /
+        # popitem(last=False), giving us LRU semantics cheaply.
+        self._cache: "OrderedDict[str, dict]" = OrderedDict()
         self._stats = {
             "hits": 0,
             "misses": 0,
             "evictions": 0,
         }
-    
+        self._sets_since_sweep = 0
+
     def get(self, cache_key: str) -> Optional[Any]:
         """
         Retrieve cached value if not expired.
-        
+
         Args:
             cache_key: Cache key string
-        
+
         Returns:
             Cached value or None if not found/expired
         """
         if cache_key not in self._cache:
             self._stats["misses"] += 1
             return None
-        
+
         entry = self._cache[cache_key]
-        
+
         # Check TTL expiration
         if time.time() > entry["expires_at"]:
             del self._cache[cache_key]
             self._stats["misses"] += 1
             self._stats["evictions"] += 1
             return None
-        
-        # Cache hit
+
+        # Cache hit - mark as most-recently-used for LRU ordering
         self._stats["hits"] += 1
         entry["hits"] += 1
         entry["last_accessed"] = time.time()
-        
+        self._cache.move_to_end(cache_key)
+
         return entry["value"]
-    
+
     def set(self, cache_key: str, value: Any, ttl: Optional[int] = None):
         """
-        Store value in cache with TTL.
-        
+        Store value in cache with TTL, evicting the LRU entry if over capacity.
+
         Args:
             cache_key: Cache key string
             value: Value to cache
@@ -73,21 +89,53 @@ class MemoryCache:
         """
         if ttl is None:
             ttl = self._config.cache_ttl_seconds
-        
+
+        now = time.time()
         entry = {
             "value": value,
-            "created_at": time.time(),
-            "expires_at": time.time() + ttl,
-            "last_accessed": time.time(),
+            "created_at": now,
+            "expires_at": now + ttl,
+            "last_accessed": now,
             "hits": 0,
         }
-        
+
+        # Overwrite (and refresh recency) or insert as most-recently-used.
         self._cache[cache_key] = entry
-    
+        self._cache.move_to_end(cache_key)
+
+        # Periodically reclaim cold-expired entries that are never read back.
+        self._sets_since_sweep += 1
+        if self._sets_since_sweep >= self._SWEEP_INTERVAL:
+            self.clear_expired()
+            self._sets_since_sweep = 0
+
+        self._evict_if_needed()
+
+    def _evict_if_needed(self) -> None:
+        """Evict least-recently-used entries until the cache is within cap."""
+        while len(self._cache) > self._max_size:
+            # popitem(last=False) removes the oldest (LRU) entry.
+            self._cache.popitem(last=False)
+            self._stats["evictions"] += 1
+
+    def clear_expired(self) -> int:
+        """
+        Remove all expired entries regardless of access.
+
+        Returns:
+            Number of entries reclaimed.
+        """
+        now = time.time()
+        expired_keys = [key for key, entry in self._cache.items() if now > entry["expires_at"]]
+        for key in expired_keys:
+            del self._cache[key]
+            self._stats["evictions"] += 1
+        return len(expired_keys)
+
     def invalidate(self, pattern: str):
         """
         Invalidate cache entries matching pattern.
-        
+
         Args:
             pattern: Pattern to match (simple prefix matching)
         """
@@ -95,38 +143,41 @@ class MemoryCache:
         for key in self._cache:
             if key.startswith(pattern):
                 keys_to_delete.append(key)
-        
+
         for key in keys_to_delete:
             del self._cache[key]
             self._stats["evictions"] += 1
-    
+
     def get_stats(self) -> dict:
         """
         Return cache statistics.
-        
+
         Returns:
-            Dict with hits, misses, hit_rate, size, evictions
+            Dict with hits, misses, hit_rate, size, evictions, max_size, utilization
         """
         total = self._stats["hits"] + self._stats["misses"]
         hit_rate = self._stats["hits"] / total if total > 0 else 0.0
-        
+        size = len(self._cache)
+
         return {
             "hits": self._stats["hits"],
             "misses": self._stats["misses"],
             "evictions": self._stats["evictions"],
             "hit_rate": hit_rate,
-            "size": len(self._cache),
+            "size": size,
+            "max_size": self._max_size,
+            "utilization": size / self._max_size if self._max_size else 0.0,
         }
-    
+
     def make_query_key(self, context_id: str, query: str, top_k: int) -> str:
         """
         Generate cache key for query.
-        
+
         Args:
             context_id: Context identifier
             query: Query string
             top_k: Number of results
-        
+
         Returns:
             Cache key string
         """

--- a/modules/memory_retrieval/config.py
+++ b/modules/memory_retrieval/config.py
@@ -17,6 +17,7 @@ class MemoryRetrievalConfig:
 
     vector_dimension: int = 384
     cache_ttl_seconds: int = 300
+    cache_max_size: int = 10_000
     storage_backend: str = "memory"
     storage_path: Optional[str] = None
     max_results: int = 10
@@ -36,6 +37,7 @@ class MemoryRetrievalConfig:
         return cls(
             vector_dimension=int(os.getenv("MRM_VECTOR_DIM", 384)),
             cache_ttl_seconds=int(os.getenv("MRM_CACHE_TTL", 300)),
+            cache_max_size=int(os.getenv("MRM_CACHE_MAX_SIZE", 10_000)),
             storage_backend=os.getenv("MRM_STORAGE_BACKEND", "memory"),
             storage_path=os.getenv("MRM_STORAGE_PATH"),
             max_results=int(os.getenv("MRM_MAX_RESULTS", 10)),
@@ -50,6 +52,8 @@ class MemoryRetrievalConfig:
             raise ValueError("vector_dimension must be positive")
         if self.cache_ttl_seconds <= 0:
             raise ValueError("cache_ttl_seconds must be positive")
+        if self.cache_max_size <= 0:
+            raise ValueError("cache_max_size must be positive")
         if self.storage_backend not in _VALID_BACKENDS:
             raise ValueError(
                 "storage_backend must be 'memory', 'file', 'filesystem', or 'vector_db'"

--- a/tests/test_memory_retrieval_full.py
+++ b/tests/test_memory_retrieval_full.py
@@ -460,6 +460,84 @@ class TestMemoryCache:
         key3 = cache.make_query_key("context2", "test query", 10)
         assert key != key3
 
+    def test_cache_enforces_max_size(self):
+        """Cache never exceeds the configured max_size."""
+        config = MemoryRetrievalConfig(cache_max_size=10)
+        cache = MemoryCache(config)
+
+        for i in range(25):
+            cache.set(f"key{i}", f"value{i}")
+
+        assert len(cache._cache) == 10
+        assert cache.get_stats()["size"] == 10
+        assert cache.get_stats()["max_size"] == 10
+
+    def test_cache_lru_eviction_drops_oldest(self):
+        """When over capacity, the least-recently-used entry is evicted first."""
+        config = MemoryRetrievalConfig(cache_max_size=3)
+        cache = MemoryCache(config)
+
+        cache.set("a", "va")
+        cache.set("b", "vb")
+        cache.set("c", "vc")
+
+        # Touch "a" so it becomes most-recently-used; "b" is now LRU.
+        assert cache.get("a") == "va"
+
+        # Inserting a 4th entry must evict the LRU entry ("b"), not "a".
+        cache.set("d", "vd")
+
+        assert cache.get("b") is None
+        assert cache.get("a") == "va"
+        assert cache.get("c") == "vc"
+        assert cache.get("d") == "vd"
+
+    def test_cache_eviction_counter_increments(self):
+        """Eviction stat reflects entries dropped due to capacity."""
+        config = MemoryRetrievalConfig(cache_max_size=5)
+        cache = MemoryCache(config)
+
+        for i in range(8):
+            cache.set(f"key{i}", f"value{i}")
+
+        # 8 inserts into a cap-5 cache => 3 capacity evictions.
+        assert cache.get_stats()["evictions"] == 3
+
+    def test_cache_overwrite_does_not_grow(self):
+        """Re-setting an existing key updates in place without growing size."""
+        config = MemoryRetrievalConfig(cache_max_size=10)
+        cache = MemoryCache(config)
+
+        cache.set("key", "v1")
+        cache.set("key", "v2")
+        cache.set("key", "v3")
+
+        assert len(cache._cache) == 1
+        assert cache.get("key") == "v3"
+
+    def test_cache_clear_expired_reclaims_cold_entries(self):
+        """clear_expired removes expired entries that were never read back."""
+        config = MemoryRetrievalConfig(cache_ttl_seconds=1, cache_max_size=100)
+        cache = MemoryCache(config)
+
+        cache.set("cold1", "v1")
+        cache.set("cold2", "v2")
+        assert len(cache._cache) == 2
+
+        time.sleep(1.1)
+
+        reclaimed = cache.clear_expired()
+
+        assert reclaimed == 2
+        assert len(cache._cache) == 0
+        assert cache.get_stats()["evictions"] == 2
+
+    def test_cache_max_size_validation(self):
+        """Config rejects non-positive cache_max_size."""
+        config = MemoryRetrievalConfig(cache_max_size=0)
+        with pytest.raises(ValueError, match="cache_max_size must be positive"):
+            config.validate()
+
 
 @pytest.mark.unit
 @pytest.mark.critical


### PR DESCRIPTION
## Summary

`MemoryCache._cache` was an unbounded `dict`: entries were only removed when their TTL expired **and** a `get(...)` happened to touch them. Cold/never-queried keys persisted forever, so under sustained write load (especially high-cardinality query inputs like per-user prompts or large context tags) the cache grew without bound → OOM risk, and the hit-rate signal never plateaued.

This ports the bounded-cache pattern already used in `modules/quantum_simulator/scenario_cache.py`.

## Changes

- **LRU backing store**: `_cache` is now a `collections.OrderedDict` — O(1) `move_to_end` on hit, `popitem(last=False)` on overflow.
- **Configurable cap**: `cache_max_size` added to `MemoryRetrievalConfig` (default `10_000`, env `MRM_CACHE_MAX_SIZE`) with positive-value validation.
- **Eviction on insert**: `_evict_if_needed()` enforces the cap on every `set()`, incrementing the existing `evictions` stat.
- **Cold-expired sweep**: new `clear_expired()` runs every N=256 sets so expired entries that are never read back are reclaimed without waiting for overflow.
- **Stats**: `get_stats()` now also reports `max_size` and `utilization`.

## Test plan

New tests in `tests/test_memory_retrieval_full.py::TestMemoryCache` (unit + critical):
- [x] cap enforced — 25 inserts into a cap-10 cache stays at 10
- [x] LRU ordering — a touched entry survives; the untouched LRU entry is evicted
- [x] eviction counter increments correctly (8 inserts, cap 5 → 3 evictions)
- [x] in-place overwrite of an existing key doesn't grow size
- [x] `clear_expired()` reclaims cold entries that were never read back
- [x] config rejects non-positive `cache_max_size`

All new assertions verified by direct execution (the local pytest run is blocked only by an unrelated root-`conftest.py` import panic that does not occur in CI). Existing `TestMemoryCache` tests (hit/miss, TTL expiry, invalidate, stats, key generation) remain unchanged and pass.

Scoped to cache sizing/eviction only — leaves token-cap (#799) and key-scoping (#800) untouched to avoid collisions in the same module.

Fixes #803

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_