### PR TITLE
build: add next-major upper bounds to critical dependencies

### DIFF
--- a/docs/DEPENDENCY_VERSION_POLICY.md
+++ b/docs/DEPENDENCY_VERSION_POLICY.md
@@ -1,0 +1,71 @@
+# Dependency Version Policy
+
+**Status**: Active
+**Scope**: `requirements.txt` (core runtime dependencies)
+**Review cadence**: Quarterly
+**Review owner**: Aurora CloudBank maintainers (release/dependency steward)
+
+---
+
+## Policy
+
+Critical runtime packages in `requirements.txt` are pinned with **both** a
+floor and an upper bound set at the **next major above the current latest
+release**:
+
+```
+package>=<current_floor>,<<next_major_above_current>
+```
+
+The floor guarantees required features and security fixes; the upper bound
+prevents a fresh install (or a transitive resolution) from silently pulling a
+future **major** version whose breaking changes have not been validated against
+Aurora. The Pydantic V1 → V2 migration is the cautionary example: a
+platform-wide major bump should be an explicit, tested decision — never an
+accident of `pip install`.
+
+**Caps are calibrated to the current release reality, not a fixed number.**
+For projects still on a `0.x` line (e.g. `fastapi`, `httpx`, `anthropic`) the
+cap is `<1.0.0`; for projects already past `1.0` (e.g. `starlette` at `1.x`,
+`openai` at `2.x`, `cryptography` at `48.x`) the cap is the *next* major above
+where they are today, so the bound never downgrades the version that installs
+now. This is why the numbers below differ from any earlier draft written when
+these packages were on lower majors.
+
+Upper bounds are a **resolver hint and a human-readable contract**. They are
+complementary to, not a replacement for, a fully pinned lock file
+(see issue #787) which provides build-to-build determinism.
+
+## Critical packages and their caps
+
+| Package        | Pin                          | Current major | Rationale                                              |
+|----------------|------------------------------|---------------|--------------------------------------------------------|
+| `fastapi`      | `>=0.128.8,<1.0.0`           | `0.x`         | Pre-1.0; any 1.0 is a deliberate upgrade.              |
+| `starlette`    | `>=0.49.3,<2.0.0`            | `1.x`         | Already on 1.x; cap blocks an unvalidated 2.0.         |
+| `pydantic`     | `>=2.5.0,<3.0.0`             | `2.x`         | V2→V3 would be a breaking migration of V1→V2 shape.    |
+| `cryptography` | `>=44.0.0,<49.0.0`           | `48.x`        | Security-critical; cap blocks 49.0 until validated.    |
+| `pyjwt`        | `>=2.10.0,<3.0.0`            | `2.x`         | Auth-critical token handling.                          |
+| `httpx`        | `>=0.28.0,<1.0.0`            | `0.x`         | Pre-1.0 async HTTP client; API still evolving.         |
+| `anthropic`    | `>=0.40.0,<1.0.0`            | `0.x`         | Claude SDK; pre-1.0, surface changes between minors.   |
+| `openai`       | `>=1.50.0,<3.0.0`            | `2.x`         | Already on 2.x; cap blocks an unvalidated 3.0.         |
+
+> Caps last calibrated against PyPI latest releases as of the policy date.
+> A cap that sits below the installed major would force a downgrade — when
+> bumping a floor across a major, raise the matching cap in the same PR.
+
+## When to change a cap
+
+- **Security release above the cap** (e.g. `cryptography` 46.x with a CVE fix):
+  raise the upper bound in a dedicated PR, run the dependency-validation
+  workflow, and note the reason in the commit.
+- **Intentional major upgrade** (e.g. Pydantic V3): treat as a project, not a
+  bump — migrate code, update tests, then move the cap.
+- **Quarterly review**: confirm each cap is still one major above the floor and
+  that no upstream security advisory requires crossing it.
+
+## Out of scope
+
+- Non-critical / leaf utilities are floor-pinned only; over-capping them adds
+  resolver friction without protecting an API surface Aurora depends on.
+- Optional/heavy dependencies (`requirements-optional.txt`) follow their own
+  graceful-degradation contract and are not covered here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,21 +4,25 @@
 # Install: pip install -r requirements.txt
 # For development: pip install -r requirements.txt -r requirements-dev.txt
 # For optional features: pip install -r requirements-optional.txt
+#
+# Version policy: critical packages carry a next-major upper bound so a fresh
+# install cannot silently resolve to a breaking major. See
+# docs/DEPENDENCY_VERSION_POLICY.md (reviewed quarterly).
 
 # ===================================================================
 # CORE WEB FRAMEWORK
 # ===================================================================
-fastapi>=0.128.8                    # FastAPI web framework (updated for starlette 0.50+ compatibility)
+fastapi>=0.128.8,<1.0.0             # FastAPI web framework (updated for starlette 0.50+ compatibility)
 uvicorn[standard]>=0.24.0           # ASGI server
-starlette>=0.49.3                   # ASGI framework (SECURITY: Fixed GHSA-7f5h-v6xp-fcq8 - Range header DoS)
-pydantic>=2.5.0                     # Data validation
+starlette>=0.49.3,<2.0.0            # ASGI framework (SECURITY: Fixed GHSA-7f5h-v6xp-fcq8 - Range header DoS)
+pydantic>=2.5.0,<3.0.0             # Data validation (cap at next major; V2->V3 would be breaking)
 pydantic-settings>=2.0.0            # Settings management via environment variables
 python-multipart>=0.0.20             # File upload handling
 
 # ===================================================================
 # HTTP & NETWORKING
 # ===================================================================
-httpx>=0.28.0                       # Async HTTP client (requires httpcore 1.x)
+httpx>=0.28.0,<1.0.0                # Async HTTP client (requires httpcore 1.x)
 httpcore>=1.0.0                     # HTTP core (requires h11 0.16.0+)
 h11>=0.16.0                         # HTTP/1.1 implementation (security updates)
 websockets>=11.0.3                  # WebSocket support
@@ -27,9 +31,9 @@ aiofiles>=24.1.0                    # Async file operations
 # ===================================================================
 # SECURITY & CRYPTOGRAPHY
 # ===================================================================
-cryptography>=44.0.0                # Cryptographic library
+cryptography>=44.0.0,<49.0.0        # Cryptographic library (cap reviewed quarterly; bump for security releases)
 bcrypt>=4.1.2                       # Password hashing
-pyjwt>=2.10.0                        # JWT tokens (migrated from python-jose)
+pyjwt>=2.10.0,<3.0.0                 # JWT tokens (migrated from python-jose)
 passlib[bcrypt]>=1.7.4              # Password handling
 # python-jose removed - see security migration Nov 2025 (ecdsa vulnerability)
 
@@ -75,8 +79,8 @@ slowapi>=0.1.9                      # Rate limiting for FastAPI
 # ===================================================================
 # AI MODEL INTEGRATIONS
 # ===================================================================
-anthropic>=0.40.0                   # Claude 3.5/4.5 integration
-openai>=1.50.0                      # GPT-4/5 integration
+anthropic>=0.40.0,<1.0.0            # Claude 3.5/4.5 integration
+openai>=1.50.0,<3.0.0               # GPT-4/5 integration
 
 # ===================================================================
 # SYSTEM UTILITIES


### PR DESCRIPTION
## Summary

Every critical dependency in `requirements.txt` was floor-pinned (`>=`) with no ceiling, so a fresh install — or a transitive resolution — could silently pull a future breaking **major**. Adds upper bounds to the 8 critical packages and a documented policy.

### Caps are calibrated to current PyPI reality (this is the important part)

The issue's literal example caps were written when these packages were on lower majors and are now **stale** — applying them verbatim would have actively broken or downgraded a working install:

| Package | Issue's stale cap | Today's latest | This PR's cap | Why |
|---|---|---|---|---|
| `starlette` | `<1.0.0` | **1.2.1** | `<2.0.0` | stale cap would force a downgrade off 1.x |
| `cryptography` | `<46.0.0` | **48.0.0** | `<49.0.0` | stale cap would **downgrade a security-critical lib** |
| `openai` | `<2.0.0` | **2.40.0** | `<3.0.0` | stale cap would downgrade off 2.x |
| `fastapi` | `<1.0.0` | 0.136.3 | `<1.0.0` | ✅ unchanged |
| `pydantic` | `<3.0.0` | 2.13.4 | `<3.0.0` | ✅ unchanged |
| `pyjwt` | `<3.0.0` | 2.13.0 | `<3.0.0` | ✅ unchanged |
| `httpx` | `<1.0.0` | 0.28.1 | `<1.0.0` | ✅ unchanged |
| `anthropic` | `<1.0.0` | 0.105.2 | `<1.0.0` | ✅ unchanged |

Rule applied: **cap at the next major above the current latest** — protects against an unvalidated future major without ever downgrading what installs today.

## Validation

- ✅ All requirement specifiers parse (`packaging.Requirement`).
- ✅ Every cap sits strictly above the current latest release (no downgrades).
- ✅ `pip install --dry-run` resolve of the capped critical set succeeds.

## Docs

Adds `docs/DEPENDENCY_VERSION_POLICY.md`: the cap rule, per-package table with current major, when to move a cap (security release / intentional major upgrade / quarterly review), the quarterly cadence, and the named review owner. Complements the lock-file work in #787 (determinism) — upper bounds are the resolver hint.

## Test plan

- [ ] `dependency-validation` workflow resolves and `pip check` passes on 3.11 + 3.12
- [ ] Critical imports (`fastapi`, `httpx`, …) still import

Fixes #831

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_