### PR TITLE
fix: make requirements.txt the single source of truth for install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,25 @@
+from pathlib import Path
+
 from setuptools import find_packages, setup
+
+
+def _load_requirements(filename):
+    """Read a requirements file, returning a list of PEP 508 specifiers.
+
+    Skips blank lines, comment lines (#), and recursive-include directives (-r).
+    Strips inline comments so entries like ``pkg>=1.0  # reason`` become ``pkg>=1.0``.
+    """
+    lines = []
+    for raw in Path(filename).read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("-r"):
+            continue
+        # Strip inline comment and trailing whitespace.
+        line = line.split("#")[0].strip()
+        if line:
+            lines.append(line)
+    return lines
+
 
 setup(
     name="aurora-cloudbank-symbolic",
@@ -7,13 +28,12 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",
-    install_requires=[
-        "black>=23.0.0",
-        "flake8>=6.0.0",
-        "pytest>=7.0.0",
-    ],
+    # Single source of truth: requirements.txt drives production install_requires.
+    # Adding a package here means adding it to requirements.txt — not both places.
+    install_requires=_load_requirements("requirements.txt"),
     extras_require={
-        "dev": ["coverage>=7.0.0"],
+        "dev": _load_requirements("requirements-dev.txt"),
+        "optional": _load_requirements("requirements-optional.txt"),
     },
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

`setup.py` declared `black`, `flake8`, and `pytest` as production `install_requires` — all dev-only tools. The 30+ real production dependencies (`fastapi`, `anthropic`, `openai`, `cryptography`, `httpx`, …) in `requirements.txt` were never referenced, so `pip install .` produced a completely wrong dependency closure.

### Root cause
Two parallel dependency trees with no link between them. `requirements.txt` was the maintained production list; `setup.py` was stale and incorrect.

### Fix (Option B from issue)
Added a `_load_requirements()` helper that reads a requirements file, stripping blank lines, comment lines, and `-r` directives, then strips inline comments from each specifier. `setup.py` now derives all three dependency groups from the three requirements files:

| Group | Source |
|---|---|
| `install_requires` | `requirements.txt` (38 production entries) |
| `extras_require["dev"]` | `requirements-dev.txt` (27 dev entries) |
| `extras_require["optional"]` | `requirements-optional.txt` (25 optional entries) |

**Single source of truth**: adding a production dependency means updating `requirements.txt` only. `setup.py` updates automatically.

### Validation

```
install_requires: 38 entries
  ✅ fastapi>=0.128.8,<1.0.0
  ✅ anthropic>=0.40.0,<1.0.0
  ✅ openai>=1.50.0,<3.0.0
  ✅ cryptography>=44.0.0,<49.0.0
  …
dev extras: 27 entries (black, flake8, pytest, …)
optional extras: 25 entries
❌ black/flake8/pytest in install_requires: False  ← dev tools correctly absent
✅ fastapi in install_requires: True
✅ anthropic in install_requires: True
setup.py --version: 1.0.0  ← parses cleanly
```

## Test plan
- [ ] `pip install .` in a fresh venv imports `fastapi`, `anthropic`, `openai`
- [ ] `pip install .[dev]` additionally imports `pytest`, `black`, `flake8`
- [ ] `validate-dependencies` CI job resolves without conflicts on 3.11 + 3.12

Fixes #836

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_