### PR TITLE
fix: add user_id to cache key to prevent cross-tenant memory leakage

### DIFF
--- a/modules/memory_retrieval/cache.py
+++ b/modules/memory_retrieval/cache.py
@@ -169,17 +169,23 @@ class MemoryCache:
             "utilization": size / self._max_size if self._max_size else 0.0,
         }
 
-    def make_query_key(self, context_id: str, query: str, top_k: int) -> str:
+    def make_query_key(self, *, user_id: str, context_id: str, query: str, top_k: int) -> str:
         """
-        Generate cache key for query.
+        Generate a scoped cache key for a query result.
 
         Args:
-            context_id: Context identifier
-            query: Query string
-            top_k: Number of results
+            user_id: Caller-supplied user or tenant identifier. Pass ``"public"``
+                     only when multi-tenant isolation is genuinely irrelevant.
+                     Required; callers must not omit it.
+            context_id: Context (session / agent) identifier.
+            query: Raw query string.
+            top_k: Number of results requested.
 
         Returns:
-            Cache key string
+            Cache key string unique per (user, context, query, top_k) tuple.
         """
-        query_hash = hashlib.sha256(query.encode()).hexdigest()[:8]
-        return f"query:{context_id}:{query_hash}:{top_k}"
+        # 16 hex chars = 64 bits of entropy; reduces collision probability from
+        # ~50% at 77k entries (8-char/32-bit) to negligible at realistic scales.
+        query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
+        # context_id comes first so invalidate(f"query:{context_id}:") still works.
+        return f"query:{context_id}:{user_id}:{query_hash}:{top_k}"

--- a/modules/memory_retrieval/core.py
+++ b/modules/memory_retrieval/core.py
@@ -68,13 +68,26 @@ class MemoryRetrievalCore:
         logger.info("Added memory %s to context %s", memory_id, context_id, extra={"context_tag": context_tag})
         return memory_id
 
-    def retrieve_memories(self, context_id: str, query: str, top_k: int = 10) -> List[Dict]:
-        """Retrieve scored memories for a context/query pair."""
+    def retrieve_memories(
+        self, context_id: str, query: str, top_k: int = 10, *, user_id: str = "default"
+    ) -> List[Dict]:
+        """Retrieve scored memories for a context/query pair.
+
+        Args:
+            context_id: Context (session / agent) identifier.
+            query: Query string.
+            top_k: Maximum number of results to return.
+            user_id: Tenant / user identifier used for cache isolation.
+                Pass the authenticated user's ID; use ``"default"`` only in
+                single-tenant deployments where cross-user leakage is impossible.
+        """
         context_tag = f"mrm:query:{context_id}"
         if self._dlp_tracker:
             self._register_dlp_event("query_memory", context_id, context_tag, query[:100])
 
-        cache_key = self._cache.make_query_key(context_id, query, top_k)
+        cache_key = self._cache.make_query_key(
+            user_id=user_id, context_id=context_id, query=query, top_k=top_k
+        )
         cached_results = self._cache.get(cache_key)
         if cached_results is not None:
             return cached_results

--- a/tests/mrm_bootstrap.py
+++ b/tests/mrm_bootstrap.py
@@ -463,20 +463,21 @@ class MemoryCache:
             "size": len(self._cache),
         }
     
-    def make_query_key(self, context_id: str, query: str, top_k: int) -> str:
+    def make_query_key(self, *, user_id: str, context_id: str, query: str, top_k: int) -> str:
         """
-        Generate cache key for query.
-        
+        Generate a scoped cache key for a query result.
+
         Args:
-            context_id: Context identifier
-            query: Query string
-            top_k: Number of results
-        
+            user_id: User/tenant identifier for cache isolation.
+            context_id: Context identifier.
+            query: Query string.
+            top_k: Number of results.
+
         Returns:
             Cache key string
         """
-        query_hash = hashlib.sha256(query.encode()).hexdigest()[:8]
-        return f"query:{context_id}:{query_hash}:{top_k}"
+        query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
+        return f"query:{context_id}:{user_id}:{query_hash}:{top_k}"
 '''
 
 
@@ -597,21 +598,24 @@ class MemoryRetrievalCore:
         logger.info(f"Added memory {memory_id} to context {context_id}", extra={"context_tag": context_tag})
         return memory_id
     
-    def retrieve_memories(self, context_id: str, query: str, top_k: int = 10) -> List[Dict]:
+    def retrieve_memories(
+        self, context_id: str, query: str, top_k: int = 10, *, user_id: str = "default"
+    ) -> List[Dict]:
         """
         Main retrieval method combining cache, store, and scoring.
-        
+
         Args:
             context_id: Context to search within
             query: Search query
             top_k: Number of results to return
-        
+            user_id: Tenant/user identifier for cache isolation.
+
         Returns:
             List of scored and ranked memory results
         """
         # Add DLP tracking for query operation
         context_tag = f"MRM:query:{context_id}"
-        
+
         if self._dlp_tracker:
             tag_id = self._dlp_tracker.create_tag("query_memory", {
                 "context_id": context_id,
@@ -621,9 +625,11 @@ class MemoryRetrievalCore:
             tag = self._dlp_tracker.tags[tag_id]
             tag.add_anchor_protocol("Picard_Delta_3")
             tag.metadata["context_tag"] = context_tag
-        
+
         # Check cache first
-        cache_key = self._cache.make_query_key(context_id, query, top_k)
+        cache_key = self._cache.make_query_key(
+            user_id=user_id, context_id=context_id, query=query, top_k=top_k
+        )
         cached_results = self._cache.get(cache_key)
         
         if cached_results is not None:

--- a/tests/test_memory_retrieval_full.py
+++ b/tests/test_memory_retrieval_full.py
@@ -447,18 +447,58 @@ class TestMemoryCache:
         config = MemoryRetrievalConfig()
         cache = MemoryCache(config)
 
-        key = cache.make_query_key("context1", "test query", 10)
+        key = cache.make_query_key(user_id="user1", context_id="context1", query="test query", top_k=10)
 
         assert key.startswith("query:context1:")
+        assert "user1" in key
         assert ":10" in key
 
         # Same inputs should produce same key
-        key2 = cache.make_query_key("context1", "test query", 10)
+        key2 = cache.make_query_key(user_id="user1", context_id="context1", query="test query", top_k=10)
         assert key == key2
 
-        # Different inputs should produce different keys
-        key3 = cache.make_query_key("context2", "test query", 10)
+        # Different context_id should produce different key
+        key3 = cache.make_query_key(user_id="user1", context_id="context2", query="test query", top_k=10)
         assert key != key3
+
+    def test_cache_key_user_isolation(self):
+        """Different user_ids with identical other params produce distinct keys (cross-tenant safety)."""
+        config = MemoryRetrievalConfig()
+        cache = MemoryCache(config)
+
+        key_a = cache.make_query_key(user_id="alice", context_id="ctx", query="same query", top_k=5)
+        key_b = cache.make_query_key(user_id="bob", context_id="ctx", query="same query", top_k=5)
+
+        assert key_a != key_b, "Different users must not share cache keys"
+
+    def test_cache_key_includes_user_id(self):
+        """user_id is embedded in the key so entries from different users never collide."""
+        config = MemoryRetrievalConfig()
+        cache = MemoryCache(config)
+
+        key = cache.make_query_key(user_id="tenant-99", context_id="ctx", query="q", top_k=1)
+        assert "tenant-99" in key
+
+    def test_cache_key_hash_length(self):
+        """Query hash uses 16 hex characters (64-bit entropy) to reduce collision probability."""
+        config = MemoryRetrievalConfig()
+        cache = MemoryCache(config)
+
+        key = cache.make_query_key(user_id="u", context_id="c", query="test query here", top_k=10)
+        # Format: query:{context_id}:{user_id}:{16-hex-hash}:{top_k}
+        parts = key.split(":")
+        # parts[0]=query, parts[1]=context_id, parts[2]=user_id, parts[3]=hash, parts[4]=top_k
+        query_hash = parts[3]
+        assert len(query_hash) == 16, f"Expected 16-char hash, got {len(query_hash)}: {query_hash}"
+
+    def test_cache_single_user_sentinel_produces_stable_keys(self):
+        """Passing user_id='public' is the documented sentinel for single-tenant usage."""
+        config = MemoryRetrievalConfig()
+        cache = MemoryCache(config)
+
+        k1 = cache.make_query_key(user_id="public", context_id="ctx", query="q", top_k=3)
+        k2 = cache.make_query_key(user_id="public", context_id="ctx", query="q", top_k=3)
+        assert k1 == k2
 
     def test_cache_enforces_max_size(self):
         """Cache never exceeds the configured max_size."""


### PR DESCRIPTION
## Summary

`make_query_key` keyed only on `context_id + query_hash + top_k`. Two users with identical queries against the same `context_id` shared cached results — cross-tenant memory leakage.

## Root cause

No user/tenant identifier in the key. The 8-char (32-bit) hash also raised collision odds: ~50% probability at ~77k entries.

## Changes

### `modules/memory_retrieval/cache.py`
- `make_query_key` now requires `user_id` as a keyword-only argument
- Key format: `query:{context_id}:{user_id}:{hash}:{top_k}`
  - `context_id` placed first so `invalidate(f"query:{context_id}:")` still sweeps all entries for a context across all users in one prefix match
- Hash widened from 8 → 16 hex chars (32 → 64-bit entropy)

### `modules/memory_retrieval/core.py`
- `retrieve_memories` gains `user_id: str = "default"` kwarg (backward-compatible; single-tenant callers pass nothing, multi-tenant callers pass the authenticated user ID)

### `tests/mrm_bootstrap.py`
- Mirror changes to the bootstrap mock (`make_query_key` + `retrieve_memories`)

### `tests/test_memory_retrieval_full.py`
- Updated existing `test_cache_make_query_key` to pass `user_id=`
- **4 new tests**:
  - `test_cache_key_user_isolation` — alice/bob with identical params → different keys
  - `test_cache_key_includes_user_id` — user_id appears in the key string
  - `test_cache_key_hash_length` — hash is exactly 16 hex chars
  - `test_cache_single_user_sentinel_produces_stable_keys` — `"public"` sentinel is stable

## Validation

```
key: query:ctx1:alice:b94d27b9934d3e08:10
invalidation removed 3 entries (should be 3)  ← prefix still works
All checks passed
```

## Test plan
- [ ] All new tests pass: isolation, hash length, sentinel stability
- [ ] Existing cache tests unaffected
- [ ] `validate-dependencies` and `Run Tests` CI green

Fixes #800

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_