### PR TITLE
fix: prevent GC cancellation of fire-and-forget asyncio tasks

### DIFF
--- a/modules/nexus/emergence/consciousness_emergence.py
+++ b/modules/nexus/emergence/consciousness_emergence.py
@@ -12,16 +12,22 @@ Revolutionary recursive self-awareness with meta-cognitive feedback loops
 and real-time consciousness metrics for true emergent intelligence
 """
 
+import asyncio
 import hashlib
 import json
-import numpy as np
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-from typing import Dict, List, Optional, Any, Tuple, Callable
-from dataclasses import dataclass, field
-from enum import Enum
-import asyncio
 import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+import numpy as np
+
+try:
+    from src.coordination.task_utils import fire_and_forget as _fire_and_forget
+except ImportError:  # pragma: no cover
+    _fire_and_forget = None
 
 # Configure logging with symbolic anchor tracing
 logging.basicConfig(
@@ -96,6 +102,7 @@ class ConsciousnessEmergenceProtocol:
         
         # Emergence detection
         self.emergence_threshold = 0.8
+        self._pending_tasks: Set[asyncio.Task] = set()
         self.emergence_score = 0.0
         self.consciousness_metrics = {}
         
@@ -548,7 +555,14 @@ class ConsciousnessEmergenceProtocol:
         
         # Check for excessive drift
         if self.entropy_drift > self.drift_threshold:
-            asyncio.create_task(self._flag_entropy_divergence())
+            if _fire_and_forget is not None:
+                _fire_and_forget(
+                    self._flag_entropy_divergence(),
+                    name="entropy-divergence-flag",
+                    pending_tasks=self._pending_tasks,
+                )
+            else:
+                asyncio.create_task(self._flag_entropy_divergence())
             
     def _calculate_entropy_drift(self):
         """Calculate entropy drift from baseline"""

--- a/modules/opal2/config_manager.py
+++ b/modules/opal2/config_manager.py
@@ -10,7 +10,7 @@ import logging
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import toml
 import yaml
@@ -19,6 +19,11 @@ from watchdog.observers import Observer
 
 # Configure logging
 from dataclasses import dataclass
+
+try:
+    from src.coordination.task_utils import fire_and_forget as _fire_and_forget
+except ImportError:  # pragma: no cover — only missing in isolated unit test envs
+    _fire_and_forget = None
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -77,6 +82,7 @@ class ConfigurationManager:
         self.change_callbacks: Dict[str, List[Callable]] = {}
         self.file_observer: Optional[Observer] = None
         self.hot_reload_enabled = False
+        self._pending_tasks: Set[asyncio.Task] = set()
 
         # Default configuration schemas
         self._initialize_default_schemas()
@@ -427,7 +433,14 @@ class ConfigurationManager:
             for callback in self.change_callbacks[config_name]:
                 try:
                     if asyncio.iscoroutinefunction(callback):
-                        asyncio.create_task(callback(change_event))
+                        if _fire_and_forget is not None:
+                            _fire_and_forget(
+                                callback(change_event),
+                                name=f"opal2-config-callback-{config_name}",
+                                pending_tasks=self._pending_tasks,
+                            )
+                        else:
+                            asyncio.create_task(callback(change_event))
                     else:
                         callback(change_event)
                 except Exception as e:

--- a/src/coordination/event_registry.py
+++ b/src/coordination/event_registry.py
@@ -21,7 +21,9 @@ import hashlib
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
+
+from src.coordination.task_utils import fire_and_forget as _fire_and_forget
 
 from src.coordination.event_models import (
     ConflictReport,
@@ -75,6 +77,9 @@ class EventCoordinationRegistry:
 
         # Workflow orchestration
         self._workflows: Dict[str, WorkflowDefinition] = {}  # workflow_id -> WorkflowDefinition
+
+        # Holds strong references to background tasks to prevent GC cancellation.
+        self._pending_tasks: Set[asyncio.Task] = set()
 
         # Metrics and monitoring
         self._metrics = {
@@ -436,8 +441,13 @@ class EventCoordinationRegistry:
         if lock_event_to_publish:
             await self.publish_event(lock_event_to_publish)
 
-        # Schedule lock release
-        asyncio.create_task(self._auto_release_lock(resource_id, agent_id, ttl_seconds))
+        # Schedule lock release — use fire_and_forget to keep a strong reference and
+        # log failures; a silently-dropped auto-release would leave the lock held forever.
+        _fire_and_forget(
+            self._auto_release_lock(resource_id, agent_id, ttl_seconds),
+            name=f"lock-release-{resource_id}",
+            pending_tasks=self._pending_tasks,
+        )
 
         return {"success": True, "resource_id": resource_id, "expires_in": ttl_seconds}
 

--- a/src/coordination/task_utils.py
+++ b/src/coordination/task_utils.py
@@ -1,0 +1,71 @@
+"""Async task safety utilities for Aurora CloudBank Symbolic.
+
+Provides fire_and_forget() — a wrapper around asyncio.create_task() that
+prevents silent GC cancellation and ensures exceptions are logged rather
+than swallowed.
+
+Background: asyncio.create_task() returns a Task that must be kept alive by
+a strong reference. Without one, CPython may GC the task before it completes
+— a silent, non-deterministic failure. Additionally, exceptions inside a
+fire-and-forget task only surface as "Task exception was never retrieved"
+warnings unless a done-callback is attached.
+"""
+
+import asyncio
+import logging
+from typing import Coroutine, Optional, Set
+
+_logger = logging.getLogger(__name__)
+
+
+def fire_and_forget(
+    coro: Coroutine,
+    *,
+    name: str = "fire-and-forget",
+    pending_tasks: Optional[Set[asyncio.Task]] = None,
+    logger: Optional[logging.Logger] = None,
+) -> asyncio.Task:
+    """Schedule *coro* as a background Task safely.
+
+    Differences from a bare asyncio.create_task():
+    - Stores the Task in *pending_tasks* (if provided) to prevent GC.
+    - Removes itself from *pending_tasks* when done (via done-callback).
+    - Logs any unhandled exception at ERROR level instead of silently losing it.
+
+    Args:
+        coro: Coroutine to schedule.
+        name: Human-readable task name (visible in debug traces).
+        pending_tasks: Caller-owned set used to hold a strong reference. Pass
+            ``self._pending_tasks`` from the owning class. If ``None``, a
+            module-level fallback set is used — still safe, but the caller
+            cannot inspect or cancel the task.
+        logger: Logger to use for exception reporting. Defaults to this
+            module's logger.
+
+    Returns:
+        The created asyncio.Task.
+    """
+    _log = logger or _logger
+    task = asyncio.create_task(coro, name=name)
+
+    _tasks = pending_tasks if pending_tasks is not None else _fallback_tasks
+
+    _tasks.add(task)
+
+    def _done(t: asyncio.Task) -> None:
+        _tasks.discard(t)
+        if not t.cancelled() and t.exception() is not None:
+            _log.error(
+                "Unhandled exception in background task %r: %s",
+                t.get_name(),
+                t.exception(),
+                exc_info=t.exception(),
+            )
+
+    task.add_done_callback(_done)
+    return task
+
+
+# Module-level fallback set for callers that do not supply their own.
+# Prevents GC even when the caller ignores the returned Task.
+_fallback_tasks: Set[asyncio.Task] = set()

--- a/tests/test_task_utils.py
+++ b/tests/test_task_utils.py
@@ -1,0 +1,98 @@
+"""Tests for src/coordination/task_utils.fire_and_forget."""
+
+import asyncio
+import logging
+
+import pytest
+
+from src.coordination.task_utils import fire_and_forget
+
+
+@pytest.mark.unit
+class TestFireAndForget:
+    """fire_and_forget() prevents GC cancellation and logs exceptions."""
+
+    def test_task_is_returned(self):
+        """fire_and_forget returns the created Task."""
+        async def _noop():
+            pass
+
+        async def _run():
+            task = fire_and_forget(_noop(), name="test-noop")
+            assert isinstance(task, asyncio.Task)
+            await asyncio.sleep(0)  # yield so task can complete
+
+        asyncio.run(_run())
+
+    def test_task_stored_in_pending_set(self):
+        """Task is added to pending_tasks and removed on completion."""
+        pending: set = set()
+
+        async def _noop():
+            pass
+
+        async def _run():
+            fire_and_forget(_noop(), name="test-stored", pending_tasks=pending)
+            # Task is in the set immediately after scheduling
+            assert len(pending) == 1
+            await asyncio.sleep(0)  # let the task finish
+            # Task removes itself via done-callback
+            assert len(pending) == 0
+
+        asyncio.run(_run())
+
+    def test_exception_logged_not_swallowed(self, caplog):
+        """Exceptions inside the coroutine are logged at ERROR level."""
+
+        async def _raises():
+            raise RuntimeError("intentional test error")
+
+        async def _run():
+            pending: set = set()
+            with caplog.at_level(logging.ERROR, logger="src.coordination.task_utils"):
+                fire_and_forget(_raises(), name="test-raises", pending_tasks=pending)
+                await asyncio.sleep(0.05)
+
+        asyncio.run(_run())
+
+        assert any("intentional test error" in r.message for r in caplog.records), (
+            "Expected the exception message to be logged, got: "
+            + str([r.message for r in caplog.records])
+        )
+
+    def test_cancelled_task_does_not_log_error(self, caplog):
+        """A cancelled task is NOT treated as an unhandled exception."""
+
+        async def _long_running():
+            await asyncio.sleep(10)
+
+        async def _run():
+            pending: set = set()
+            with caplog.at_level(logging.ERROR, logger="src.coordination.task_utils"):
+                task = fire_and_forget(_long_running(), name="test-cancel", pending_tasks=pending)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        asyncio.run(_run())
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not error_records, f"Cancellation should not log errors, got: {error_records}"
+
+    def test_fallback_set_used_when_no_pending_tasks(self):
+        """Without pending_tasks, the module-level fallback set prevents GC."""
+        from src.coordination import task_utils
+
+        async def _noop():
+            pass
+
+        async def _run():
+            task = fire_and_forget(_noop(), name="test-fallback")
+            # The fallback set should contain the task until it finishes
+            assert task in task_utils._fallback_tasks
+            await asyncio.sleep(0)
+            assert task not in task_utils._fallback_tasks
+
+        asyncio.run(_run())


### PR DESCRIPTION
## Summary

Three `asyncio.create_task()` sites discarded the returned `Task` with no strong reference. CPython may GC such tasks before completion — a silent, non-deterministic failure. Exceptions inside the coroutine were also lost.

The most consequential site: `event_registry.py:440` auto-release of a coordination lock. A GC-cancelled task leaves the lock held past its TTL, blocking all agents on that resource.

## New helper: `src/coordination/task_utils.fire_and_forget()`

```python
fire_and_forget(
    coro,
    *,
    name: str = "fire-and-forget",
    pending_tasks: Optional[Set[asyncio.Task]] = None,
    logger: Optional[logging.Logger] = None,
) -> asyncio.Task
```

- Stores Task in `pending_tasks` (or a module-level fallback) → prevents GC
- Removes itself via `add_done_callback` when done → no manual cleanup
- Logs unhandled exceptions at ERROR level
- Cancellation is **not** treated as an error

## Applied at all 3 problem sites

| File | Line | Task | Risk of bare create_task |
|---|---|---|---|
| `modules/opal2/config_manager.py` | 430 | config-change callbacks | missed config propagation |
| `modules/nexus/emergence/consciousness_emergence.py` | 551 | entropy divergence flag | lost drift signal |
| `src/coordination/event_registry.py` | 440 | lock auto-release | lock held forever past TTL |

The other 5 `create_task` sites in the repo (`gumas_orion_integration.py`, `autonomous_orchestrator.py`, `halo_pas_controller.py`, `event_registry.py:185`) already kept references — not touched.

## Tests (`tests/test_task_utils.py`)

- Task added to `pending_tasks`, removed on completion
- Exception logged (not swallowed) — verified with `caplog`
- Cancellation does NOT trigger error log
- Module-level fallback set used when no `pending_tasks` provided

## Validation

```
OK: modules/opal2/config_manager.py
OK: modules/nexus/emergence/consciousness_emergence.py
OK: src/coordination/event_registry.py
OK: src/coordination/task_utils.py
OK: tests/test_task_utils.py
pending_tasks lifecycle: OK
exception logging: OK
All checks passed
```

## Test plan
- [ ] `test_task_utils.py` passes: all 5 test cases green
- [ ] `CI Check` and `Run Tests` green

Fixes #802

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_