### PR TITLE
fix: add close() and context-manager to ThreadPoolExecutor owners

### DIFF
--- a/modules/nexus/scale/distributed_consciousness.py
+++ b/modules/nexus/scale/distributed_consciousness.py
@@ -94,9 +94,19 @@ class DistributedConsciousnessMesh:
         
         # Thread executor for parallel operations
         self.executor = ThreadPoolExecutor(max_workers=10)
-        
+
         # Logging
         self.logger = self._setup_logger()
+
+    def close(self) -> None:
+        """Shut down the thread-pool executor cleanly."""
+        self.executor.shutdown(wait=True, cancel_futures=False)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
         
     def _setup_logger(self) -> logging.Logger:
         """Setup distributed logging"""

--- a/modules/opal2/aurora_diff_optimizer.py
+++ b/modules/opal2/aurora_diff_optimizer.py
@@ -85,8 +85,18 @@ class AuroraDiffOptimizer:
             max_workers=self.config.parallel_workers
         )
         self._lock = threading.Lock()
-        
-    async def optimize_diff(self, source_data: Any, target_data: Any = None, 
+
+    def close(self) -> None:
+        """Shut down the thread-pool executor cleanly."""
+        self.executor.shutdown(wait=True, cancel_futures=False)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+    async def optimize_diff(self, source_data: Any, target_data: Any = None,
                            optimization_params: Dict[str, Any] = None) -> Dict[str, Any]:
         """
         Main entry point for Aurora diff optimization
@@ -303,9 +313,9 @@ class AuroraDiffOptimizer:
             }
         }
         
-        logger.info("Integrity validation: {"PASS' if integrity_valid else 'FAIL'}")
-        logger.info("Performance validation: {"PASS' if performance_valid else 'FAIL'}")
-        logger.info("Signature validation: {"PASS' if signature_valid else 'FAIL'}")
+        logger.info("Integrity validation: %s", "PASS" if integrity_valid else "FAIL")
+        logger.info("Performance validation: %s", "PASS" if performance_valid else "FAIL")
+        logger.info("Signature validation: %s", "PASS" if signature_valid else "FAIL")
         logger.info("Accuracy score: {self.metrics.accuracy_score:.2%}")
         
         # Store optimization history for adaptive learning

--- a/tests/test_threadpool_shutdown.py
+++ b/tests/test_threadpool_shutdown.py
@@ -1,0 +1,63 @@
+"""Tests for ThreadPoolExecutor lifecycle management (Issue #804).
+
+Both AuroraDiffOptimizer and DistributedConsciousnessMesh must expose
+close() and a context-manager interface so callers can guarantee the
+executor is shut down on process exit.
+"""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestAuroraDiffOptimizerExecutorLifecycle:
+    """AuroraDiffOptimizer.close() and context-manager support."""
+
+    def _make_optimizer(self):
+        from modules.opal2.aurora_diff_optimizer import AuroraDiffOptimizer
+        return AuroraDiffOptimizer()
+
+    def test_close_shuts_down_executor(self):
+        opt = self._make_optimizer()
+        opt.close()
+        # After shutdown, submitting work raises RuntimeError.
+        with pytest.raises(RuntimeError):
+            opt.executor.submit(lambda: None)
+
+    def test_context_manager_calls_close(self):
+        with self._make_optimizer() as opt:
+            assert not opt.executor._shutdown
+        with pytest.raises(RuntimeError):
+            opt.executor.submit(lambda: None)
+
+    def test_context_manager_returns_self(self):
+        opt_outer = self._make_optimizer()
+        with opt_outer as opt_inner:
+            assert opt_inner is opt_outer
+        opt_outer.close()  # idempotent — second call is harmless
+
+
+@pytest.mark.unit
+class TestDistributedConsciousnessMeshExecutorLifecycle:
+    """DistributedConsciousnessMesh.close() and context-manager support."""
+
+    def _make_mesh(self):
+        from modules.nexus.scale.distributed_consciousness import DistributedConsciousnessMesh
+        return DistributedConsciousnessMesh()
+
+    def test_close_shuts_down_executor(self):
+        mesh = self._make_mesh()
+        mesh.close()
+        with pytest.raises(RuntimeError):
+            mesh.executor.submit(lambda: None)
+
+    def test_context_manager_calls_close(self):
+        with self._make_mesh() as mesh:
+            assert not mesh.executor._shutdown
+        with pytest.raises(RuntimeError):
+            mesh.executor.submit(lambda: None)
+
+    def test_context_manager_returns_self(self):
+        mesh_outer = self._make_mesh()
+        with mesh_outer as mesh_inner:
+            assert mesh_inner is mesh_outer
+        mesh_outer.close()


### PR DESCRIPTION
## Summary

- `AuroraDiffOptimizer` and `DistributedConsciousnessMesh` each create a `ThreadPoolExecutor` in `__init__` but never call `shutdown()`, leaving worker threads alive until CPython GC runs — which is non-deterministic and masks resource leaks in tests.
- Added `close()` (calls `executor.shutdown(wait=True, cancel_futures=False)`) and `__enter__`/`__exit__` to both classes, enabling `with` usage and explicit teardown.
- `GUMASOrionIntegration` extends `DistributedConsciousnessMesh` and inherits the fix with no changes needed.
- Fixed a pre-existing syntax error in `aurora_diff_optimizer.py` line 316 (mixed quote styles in f-string producing a `SyntaxError`).

## Test plan

- [ ] `pytest tests/test_threadpool_shutdown.py -v` — 6 new unit tests all pass
- [ ] Verify `with AuroraDiffOptimizer() as opt: ...` and `with DistributedConsciousnessMesh() as mesh: ...` patterns work as expected
- [ ] Existing opal2 / nexus tests remain green

Fixes #804

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_