### PR TITLE
test: mark tests with >1s sleep as @pytest.mark.slow

### DIFF
--- a/tests/aurora_orchestrator/test_autonomous_orchestrator.py
+++ b/tests/aurora_orchestrator/test_autonomous_orchestrator.py
@@ -48,6 +48,7 @@ async def test_orchestrator_initialization(orchestrator):
     assert orchestrator.config.enabled
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_orchestrator_start_stop(orchestrator):
     """Test orchestrator can start and stop"""
@@ -76,6 +77,7 @@ async def test_system_observation(orchestrator):
     assert 0.0 <= state['overall_health'] <= 1.0
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_decision_making(orchestrator):
     """Test Aurora can make decisions"""

--- a/tests/test_event_coordination.py
+++ b/tests/test_event_coordination.py
@@ -362,6 +362,7 @@ class TestEventCoordinationRegistry:
         result4 = await registry.acquire_lock("agent-002", "resource-123")
         assert result4["success"] is True
 
+    @pytest.mark.slow
     @pytest.mark.asyncio
     async def test_lock_auto_release(self, registry):
         """Test automatic lock release after TTL"""

--- a/tests/test_memory_retrieval_full.py
+++ b/tests/test_memory_retrieval_full.py
@@ -379,6 +379,7 @@ class TestMemoryCache:
         assert value is None
         assert cache._stats["misses"] == 1
 
+    @pytest.mark.slow
     def test_cache_ttl_expiration(self):
         """Test that cache entries expire after TTL."""
         config = MemoryRetrievalConfig(cache_ttl_seconds=1)
@@ -555,6 +556,7 @@ class TestMemoryCache:
         assert len(cache._cache) == 1
         assert cache.get("key") == "v3"
 
+    @pytest.mark.slow
     def test_cache_clear_expired_reclaims_cold_entries(self):
         """clear_expired removes expired entries that were never read back."""
         config = MemoryRetrievalConfig(cache_ttl_seconds=1, cache_max_size=100)


### PR DESCRIPTION
## Summary

- Five test functions contain `time.sleep()` / `asyncio.sleep()` calls that block for >1 second, making them unexpectedly slow in any test run that doesn't filter them.
- Added `@pytest.mark.slow` so callers can exclude them with `-m 'not slow'` for fast feedback.

| File | Test | Sleep |
|---|---|---|
| `test_memory_retrieval_full.py` | `test_cache_ttl_expiration` | 1.1 s |
| `test_memory_retrieval_full.py` | `test_cache_clear_expired_reclaims_cold_entries` | 1.1 s |
| `test_event_coordination.py` | `test_lock_auto_release` | 1.5 s |
| `test_autonomous_orchestrator.py` | `test_orchestrator_start_stop` | 2 s |
| `test_autonomous_orchestrator.py` | `test_decision_making` | 3 s |

The `slow` marker is already registered in `pyproject.toml` (line 67).

## Test plan

- [ ] `pytest -m slow` still collects and runs all 5 tests
- [ ] `pytest -m 'not slow'` completes without the 5 flagged tests
- [ ] All 5 tests still pass when run individually

Fixes #792

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_