### PR TITLE
fix: pin kube-linter install to a versioned release

### DIFF
--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -247,9 +247,14 @@ jobs:
       - name: Lint Kubernetes manifests
         continue-on-error: true
         run: |
-          # Install kube-linter
-          curl -sSfL https://raw.githubusercontent.com/stackrox/kube-linter/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-          
+          # Install kube-linter from a pinned release (avoids curl|sh from mutable main)
+          KUBE_LINTER_VERSION="v0.6.7"
+          curl -sSfL \
+            "https://github.com/stackrox/kube-linter/releases/download/${KUBE_LINTER_VERSION}/kube-linter_linux_amd64.tar.gz" \
+            -o /tmp/kube-linter.tar.gz
+          tar -xzf /tmp/kube-linter.tar.gz -C /tmp kube-linter
+          sudo mv /tmp/kube-linter /usr/local/bin/kube-linter
+
           # Run kube-linter
           kube-linter lint k8s/ --config .kube-linter.yaml 2>/dev/null || \
           kube-linter lint k8s/ || echo "⚠️ Some linting issues found (non-blocking)"


### PR DESCRIPTION
## Summary

- The kube-linter install step in `k8s-deploy.yml` piped a remote script directly to `sh` via `curl -sSfL ... | sh`. This is a supply-chain risk: the content at `stackrox/kube-linter/main/scripts/install.sh` is mutable and could be modified at any time.
- Replaced with a direct tarball download from the GitHub Releases API at a pinned version (`v0.6.7`), which is immutable and auditable.
- The step already has `continue-on-error: true`, so the risk surface during rollout is minimal.

## Test plan

- [ ] Confirm the kube-linter install step in CI uses the pinned URL
- [ ] Verify the `kube-linter lint` command still runs (or fails gracefully with `continue-on-error`)
- [ ] To upgrade: bump `KUBE_LINTER_VERSION` to the desired release tag

Fixes #767

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_