### PR TITLE
feat: add [tool.coverage] config and enforce 60% coverage floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,38 @@ markers = [
 
 # Fix pytest-asyncio deprecation warning
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.coverage.run]
+source = ["modules", "src"]
+omit = [
+    "*/tests/*",
+    "*/test_*",
+    "*/__pycache__/*",
+    "*/migrations/*",
+    "*/conftest.py",
+    "*/setup.py",
+    "*/scripts/*",
+    "*/cli/*",
+    "*/sdk/*",
+]
+branch = true
+
+[tool.coverage.report]
+# Enforce a minimum coverage floor; raise incrementally as coverage improves.
+fail_under = 60
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "@(abc\\.)?abstractmethod",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+[tool.coverage.xml]
+output = "coverage.xml"


### PR DESCRIPTION
## Summary

- `pyproject.toml` had no `[tool.coverage]` section, so `pytest --cov` had no configured source paths, omit list, or minimum threshold.
- Added `[tool.coverage.run]` covering `modules/` and `src/`, with `branch = true` for branch coverage.
- Added `[tool.coverage.report]` with `fail_under = 60` as an initial floor — enforced whenever CI runs `pytest --cov`. Raise this incrementally as coverage improves.
- Added HTML (`htmlcov/`) and XML (`coverage.xml`) report destinations for CI artifact upload.

## Test plan

- [ ] `pytest --cov --cov-report=term-missing -m unit` respects the source/omit config
- [ ] `pytest --cov` fails if overall coverage drops below 60%
- [ ] `coverage report` shows missing lines correctly

Fixes #790

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_