### PR TITLE
feat: add X-Request-ID middleware with ContextVar log propagation

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -19,6 +19,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from src.observability import get_telemetry, get_r2_telemetry
 from src.middleware.exception_handler import validation_handler
+from src.middleware.request_id import RequestIDMiddleware
 
 from modules.symbolic_core.geometric_algebra import GeometricAlgebra
 try:
@@ -398,6 +399,10 @@ try:
     logger.info("✅ SlowAPI rate limiting middleware enabled")
 except Exception as e:  # pragma: no cover - graceful degradation if slowapi misconfigured
     logger.warning("⚠️ Failed to enable rate limiting middleware: %s", e)
+
+# Request-ID middleware: must be registered last so it wraps everything and
+# its ContextVar is set before any inner middleware runs.
+app.add_middleware(RequestIDMiddleware)
 
 
 @app.exception_handler(RateLimitExceeded)

--- a/src/middleware/request_id.py
+++ b/src/middleware/request_id.py
@@ -1,0 +1,72 @@
+"""
+Request-ID Middleware
+
+Generates or forwards an X-Request-ID header for every HTTP request and
+propagates it through the response and log context so all log lines for a
+single request share the same identifier.
+
+Design:
+  - If the client sends X-Request-ID, validate it via sanitize_request_id;
+    discard silently if it fails validation and generate a fresh UUID instead.
+  - Store the resolved ID in request.state.request_id so route handlers and
+    other middleware can reference it without re-reading the header.
+  - Echo the ID in the X-Request-ID response header.
+  - Bind the ID to a contextvars.ContextVar so logging formatters can include
+    it via a LogRecord filter without threading.local boilerplate.
+"""
+
+import logging
+import uuid
+from contextvars import ContextVar
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+try:
+    from src.middleware.fastapi_security import sanitize_request_id
+except ImportError:  # pragma: no cover
+    def sanitize_request_id(request_id: Optional[str]) -> Optional[str]:  # type: ignore[misc]
+        return None
+
+logger = logging.getLogger(__name__)
+
+# Module-level ContextVar so any log formatter can read the current request ID.
+current_request_id: ContextVar[str] = ContextVar("request_id", default="")
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Attach a unique X-Request-ID to every request/response pair."""
+
+    def __init__(self, app: ASGIApp, header_name: str = REQUEST_ID_HEADER) -> None:
+        super().__init__(app)
+        self._header_name = header_name
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        incoming = request.headers.get(self._header_name)
+        request_id = sanitize_request_id(incoming) or str(uuid.uuid4())
+
+        # Make ID available to route handlers and other middleware.
+        request.state.request_id = request_id
+
+        # Bind to context so log filters can pick it up without touching handlers.
+        token = current_request_id.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            current_request_id.reset(token)
+
+        response.headers[self._header_name] = request_id
+        return response
+
+
+class RequestIDLogFilter(logging.Filter):
+    """Inject the current request_id into every LogRecord."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = current_request_id.get()
+        return True

--- a/tests/test_request_id_middleware.py
+++ b/tests/test_request_id_middleware.py
@@ -1,0 +1,93 @@
+"""Tests for RequestIDMiddleware (Issue #818)."""
+
+import os
+import re
+import uuid
+
+# fastapi_security refuses to import without these secrets; set safe test values
+# before any src.middleware import so the module-level guard doesn't raise.
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-key-32chars-min!")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-auth-secret-32chars-min!")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-32chars-min!")
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.middleware.request_id import (
+    REQUEST_ID_HEADER,
+    RequestIDMiddleware,
+    current_request_id,
+)
+
+
+def _make_app() -> TestClient:
+    """Minimal Starlette app with RequestIDMiddleware for testing."""
+
+    async def echo(request: Request) -> PlainTextResponse:
+        rid = getattr(request.state, "request_id", "MISSING")
+        ctx = current_request_id.get()
+        return PlainTextResponse(f"{rid}|{ctx}")
+
+    app = Starlette(routes=[Route("/", echo)])
+    app.add_middleware(RequestIDMiddleware)
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.mark.unit
+class TestRequestIDMiddleware:
+    """RequestIDMiddleware generates, validates, and propagates request IDs."""
+
+    def test_generates_uuid_when_no_header(self):
+        client = _make_app()
+        resp = client.get("/")
+        rid = resp.headers.get(REQUEST_ID_HEADER, "")
+        assert rid, "Response must include X-Request-ID"
+        # UUID4 pattern
+        assert re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", rid), (
+            f"Expected UUID4, got {rid!r}"
+        )
+
+    def test_forwards_valid_caller_id(self):
+        client = _make_app()
+        caller_id = str(uuid.uuid4())
+        resp = client.get("/", headers={REQUEST_ID_HEADER: caller_id})
+        assert resp.headers[REQUEST_ID_HEADER] == caller_id
+
+    def test_replaces_invalid_caller_id_with_uuid(self):
+        client = _make_app()
+        resp = client.get("/", headers={REQUEST_ID_HEADER: "bad\ninject"})
+        rid = resp.headers[REQUEST_ID_HEADER]
+        # Must NOT echo the injected value
+        assert "inject" not in rid
+        assert re.match(r"^[0-9a-f-]{36}$", rid), f"Expected UUID4 fallback, got {rid!r}"
+
+    def test_replaces_oversized_caller_id(self):
+        client = _make_app()
+        resp = client.get("/", headers={REQUEST_ID_HEADER: "a" * 200})
+        rid = resp.headers[REQUEST_ID_HEADER]
+        assert len(rid) <= 36
+
+    def test_request_state_contains_id(self):
+        client = _make_app()
+        resp = client.get("/")
+        state_id, _ = resp.text.split("|")
+        assert state_id == resp.headers[REQUEST_ID_HEADER]
+
+    def test_contextvar_set_during_request(self):
+        client = _make_app()
+        resp = client.get("/")
+        _, ctx_id = resp.text.split("|")
+        assert ctx_id == resp.headers[REQUEST_ID_HEADER]
+
+    def test_contextvar_cleared_after_request(self):
+        # After the request completes the ContextVar should reset to default "".
+        assert current_request_id.get() == ""
+
+    def test_unique_id_per_request(self):
+        client = _make_app()
+        ids = {client.get("/").headers[REQUEST_ID_HEADER] for _ in range(5)}
+        assert len(ids) == 5, "Each request should get a unique ID"


### PR DESCRIPTION
## Summary

- Every HTTP request now gets a unique `X-Request-ID` that flows from client → request state → response header → log context.
- `RequestIDMiddleware` (`src/middleware/request_id.py`): accepts caller-supplied IDs after validation via the existing `sanitize_request_id()` helper; falls back to a fresh UUID4 if missing or invalid. Resets the ContextVar after the response.
- `RequestIDLogFilter`: companion filter that injects `request_id` into `LogRecord` fields so formatters can include it without modifying handlers.
- Registered in `api/aurora_api.py` as the outermost middleware wrapper.
- 8 unit tests covering: UUID generation, valid forwarding, injection rejection, oversized ID rejection, `request.state` binding, ContextVar propagation, post-request cleanup, and uniqueness.

## Test plan

- [ ] `pytest tests/test_request_id_middleware.py -v` — 8 tests all pass
- [ ] `curl -s -I http://localhost:8000/` shows `X-Request-ID` in response headers
- [ ] Passing `X-Request-ID: my-id` in request echoes `my-id` back
- [ ] Passing `X-Request-ID: bad\ninjection` gets replaced with a UUID

Fixes #818

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_