### PR TITLE
feat: add SanitizingLogFilter to prevent log injection

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -9,6 +9,14 @@ Enhanced with Claude Sonnet 4 capabilities and ChatGPT Agent Mode integration.
 import logging
 import os
 from contextlib import asynccontextmanager
+
+# Install log-injection filter as early as possible so all subsequent loggers
+# inherit it.  Import is guarded so a missing data_guardian doesn't crash startup.
+try:
+    from modules.data_guardian.log_sanitizer import SanitizingLogFilter as _SanitizingLogFilter
+    logging.getLogger().addFilter(_SanitizingLogFilter())
+except Exception:  # pragma: no cover - graceful degradation
+    pass
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Literal
 

--- a/modules/data_guardian/log_sanitizer.py
+++ b/modules/data_guardian/log_sanitizer.py
@@ -1,0 +1,82 @@
+"""
+Log Sanitizer — data_guardian sub-module
+
+Provides sanitize_log_output() and SanitizingLogFilter to prevent log injection.
+
+Log injection occurs when user-controlled input containing newline or carriage-
+return characters is written to a log file: the injected characters split the
+line, letting an attacker forge arbitrary log entries that appear to come from
+the application itself.
+
+sanitize_log_output():
+  - Replaces \\n / \\r with the literal escape sequences so the meaning is
+    preserved but the log line stays intact.
+  - Strips other C0/C1 control characters (except ordinary \\t) that have no
+    printable representation and serve no purpose in a log message.
+  - Truncates to MAX_LOG_MSG_LENGTH characters to guard against DoS from
+    giant payloads.
+
+SanitizingLogFilter:
+  - A logging.Filter subclass that applies sanitize_log_output to every
+    LogRecord's msg and args so the protection is transparent to all loggers
+    in the process once the filter is installed on the root logger or a handler.
+"""
+
+import logging
+import re
+from typing import Any
+
+# C0/C1 control characters except \\t (0x09) — printable tab is acceptable.
+# Covers 0x00–0x08, 0x0A–0x1F, 0x7F–0x9F.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+# Maximum length before truncation; keeps individual log lines bounded.
+MAX_LOG_MSG_LENGTH = 4096
+
+
+def sanitize_log_output(text: Any) -> str:
+    """
+    Sanitize a value before it is written to a log record.
+
+    Args:
+        text: Any value — typically a str, but may be anything that a logger
+              receives as a message or argument.  Non-string values are cast
+              to str first.
+
+    Returns:
+        A sanitized string safe to write to log output.
+    """
+    if not isinstance(text, str):
+        text = str(text)
+
+    # Replace newlines/carriage-returns with their visible escape sequences.
+    text = text.replace("\r\n", "\\r\\n").replace("\n", "\\n").replace("\r", "\\r")
+
+    # Strip remaining control characters that have no printable representation.
+    text = _CONTROL_CHARS_RE.sub("", text)
+
+    # Truncate to prevent DoS via extremely long log messages.
+    if len(text) > MAX_LOG_MSG_LENGTH:
+        text = text[:MAX_LOG_MSG_LENGTH] + " [truncated]"
+
+    return text
+
+
+class SanitizingLogFilter(logging.Filter):
+    """
+    logging.Filter that sanitizes LogRecord.msg and LogRecord.args in-place.
+
+    Install on the root logger (or any handler) to automatically protect all
+    log output in the process:
+
+        logging.getLogger().addFilter(SanitizingLogFilter())
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = sanitize_log_output(record.msg)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {k: sanitize_log_output(v) for k, v in record.args.items()}
+            elif isinstance(record.args, tuple):
+                record.args = tuple(sanitize_log_output(a) for a in record.args)
+        return True

--- a/tests/test_log_sanitizer.py
+++ b/tests/test_log_sanitizer.py
@@ -1,0 +1,112 @@
+"""Tests for modules/data_guardian/log_sanitizer.py (Issue #781)."""
+
+import logging
+
+import pytest
+
+from modules.data_guardian.log_sanitizer import (
+    MAX_LOG_MSG_LENGTH,
+    SanitizingLogFilter,
+    sanitize_log_output,
+)
+
+
+@pytest.mark.unit
+class TestSanitizeLogOutput:
+    """sanitize_log_output strips injection vectors from arbitrary input."""
+
+    def test_clean_string_unchanged(self):
+        assert sanitize_log_output("hello world") == "hello world"
+
+    def test_newline_escaped(self):
+        result = sanitize_log_output("line1\nline2")
+        assert "\n" not in result
+        assert "\\n" in result
+
+    def test_carriage_return_escaped(self):
+        result = sanitize_log_output("line1\rline2")
+        assert "\r" not in result
+        assert "\\r" in result
+
+    def test_crlf_escaped(self):
+        result = sanitize_log_output("line1\r\nline2")
+        assert "\r\n" not in result
+        assert "\\r\\n" in result
+
+    def test_control_chars_stripped(self):
+        # NUL, BEL, ESC should all disappear
+        result = sanitize_log_output("a\x00b\x07c\x1bc")
+        assert "\x00" not in result
+        assert "\x07" not in result
+        assert "\x1b" not in result
+        assert "abc" in result
+
+    def test_tab_preserved(self):
+        # Tabs are printable and should NOT be stripped
+        assert "\t" in sanitize_log_output("col1\tcol2")
+
+    def test_long_string_truncated(self):
+        long_msg = "x" * (MAX_LOG_MSG_LENGTH + 100)
+        result = sanitize_log_output(long_msg)
+        assert len(result) <= MAX_LOG_MSG_LENGTH + len(" [truncated]")
+        assert result.endswith("[truncated]")
+
+    def test_non_string_cast(self):
+        assert sanitize_log_output(42) == "42"
+        assert sanitize_log_output(None) == "None"
+        assert sanitize_log_output(["a", "b"]) == "['a', 'b']"
+
+    def test_injection_attempt(self):
+        payload = "normal\n[CRITICAL] forged entry"
+        result = sanitize_log_output(payload)
+        # The forged entry is still there as text but not on its own line
+        assert "\n" not in result
+        assert "forged entry" in result
+
+
+@pytest.mark.unit
+class TestSanitizingLogFilter:
+    """SanitizingLogFilter sanitizes record.msg and record.args in-place."""
+
+    def _make_record(self, msg, *args) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="test", level=logging.INFO,
+            pathname="", lineno=0,
+            msg=msg, args=args, exc_info=None,
+        )
+
+    def test_filter_returns_true(self):
+        f = SanitizingLogFilter()
+        record = self._make_record("hello")
+        assert f.filter(record) is True
+
+    def test_msg_sanitized(self):
+        f = SanitizingLogFilter()
+        record = self._make_record("user said: \ninjected")
+        f.filter(record)
+        assert "\n" not in record.msg
+
+    def test_tuple_args_sanitized(self):
+        f = SanitizingLogFilter()
+        record = self._make_record("val=%s", "evil\nvalue")
+        f.filter(record)
+        assert isinstance(record.args, tuple)
+        assert "\n" not in record.args[0]
+
+    def test_dict_args_sanitized(self):
+        f = SanitizingLogFilter()
+        # Construct the record and set args directly to avoid LogRecord
+        # constructor's internal validation of the args/msg combo.
+        record = self._make_record("val=%(k)s")
+        record.args = {"k": "bad\nval"}
+        f.filter(record)
+        assert isinstance(record.args, dict)
+        assert "\n" not in record.args["k"]
+
+    def test_no_args_unchanged(self):
+        f = SanitizingLogFilter()
+        record = self._make_record("plain message")
+        record.args = None
+        f.filter(record)
+        assert record.msg == "plain message"
+        assert record.args is None


### PR DESCRIPTION
## Summary

- Log injection attacks embed `\n`/`\r` in user-supplied strings to forge new log lines. This PR closes that gap by installing a `logging.Filter` on the root logger at startup.
- `modules/data_guardian/log_sanitizer.py` (new file):
  - `sanitize_log_output(text)`: escapes `\n`/`\r` to their visible literals, strips C0/C1 control chars (except `\t`), truncates to 4096 chars.
  - `SanitizingLogFilter`: `logging.Filter` that sanitizes `record.msg` and all args (tuple + dict styles) in-place — transparent to every logger once installed.
- `api/aurora_api.py`: installs the filter on `logging.getLogger()` (root) as early as possible, guarded with `try/except` so a missing module doesn't block startup.
- 14 unit tests covering: clean pass-through, `\n`/`\r`/CRLF escaping, control-char stripping, tab preservation, truncation, non-string casting, injection attempt, filter return value, msg sanitization, tuple/dict arg sanitization.

## Test plan

- [ ] `pytest tests/test_log_sanitizer.py -v` — 14 tests all pass
- [ ] `python -c "import logging; logging.warning('test\\ninjected')"` shows `\\n` not a real newline

Fixes #781

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_