### PR TITLE
fix: correct ETHICS_RULES_PATH default in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ METRIC_SUCCESS_RATE=
 COMPONENT_LABEL_KEY=component
 
 # Ethics rules (path used by ethics modules)
-ETHICS_RULES_PATH=./config/ethics_rules.json
+ETHICS_RULES_PATH=./ethics/validation_engine/validation_rules.json
 
 # Memory Retrieval Module (MRM)
 MRM_VECTOR_DIM=1536


### PR DESCRIPTION
## Summary

`.env.example` documented `ETHICS_RULES_PATH=./config/ethics_rules.json` but `config/ethics_rules.json` does not exist. The actual rules file lives at `./ethics/validation_engine/validation_rules.json`, which is also the default the code falls back to when the env var is absent.

This one-line fix aligns the documented default with the real file, so developers who copy `.env.example` get a working path out of the box.

**Root cause**: The `src/monitoring/dashboard_api.py` loader already uses the correct path as its hardcoded default (`os.getenv("ETHICS_RULES_PATH", "./ethics/validation_engine/validation_rules.json")`), but `.env.example` was pointing to a nonexistent location.

## Test plan
- [ ] Copy `.env.example` to `.env`, start the server — no ethics rules load warning
- [ ] `grep ETHICS_RULES_PATH .env.example` returns the corrected path

Fixes #782

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_