### PR TITLE
feat: verify InsightLedger chain integrity on startup

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -560,7 +560,22 @@ if INSIGHT_LEDGER_AVAILABLE and INSIGHT_LEDGER_ROUTER:
     try:
         app.include_router(INSIGHT_LEDGER_ROUTER)
         if initialize_ledger:
-            initialize_ledger(storage_path="./data/insight_ledger")
+            _ledger_instance = initialize_ledger(storage_path="./data/insight_ledger")
+            try:
+                _integrity = _ledger_instance.verify_integrity()
+                if _integrity.get("chain_intact"):
+                    logger.info(
+                        "Ledger integrity verified on startup: %d entries",
+                        _integrity.get("verified_entries", 0),
+                    )
+                else:
+                    logger.warning(
+                        "Ledger integrity check FAILED on startup: %d failed entries; errors: %s",
+                        len(_integrity.get("failed_entries", [])),
+                        _integrity.get("errors", []),
+                    )
+            except Exception as _integrity_err:
+                logger.warning("Ledger integrity check raised an exception on startup: %s", _integrity_err)
         logger.info("Insight Ledger API routes integrated successfully")
     except Exception as e:
         logger.error("Failed to integrate Insight Ledger API routes: %s", e)


### PR DESCRIPTION
## Summary

`InsightLedger.verify_integrity()` existed but was never called during startup, meaning a tampered or partially-written ledger file would be silently loaded without any indication.

This change wires the call into the module-level initialization block in `api/aurora_api.py`:
- On success: logs the entry count at INFO level
- On failure: logs failed entry count and error list at WARNING level (non-fatal — server continues, but operators can act)
- Exceptions from `verify_integrity` itself are caught and logged as WARNING so a broken ledger never crashes startup

## Why non-fatal?

Crashing the server on integrity failure would be a DoS vector — an attacker who can write to the ledger directory could take down the API on restart. Logging a warning lets the operator investigate and take action without taking down the service.

## Test plan
- [ ] Fresh ledger (no data file) → startup log shows `Ledger integrity verified on startup: 0 entries`
- [ ] Ledger with valid entries → startup log shows correct entry count
- [ ] Tampered entries file (manually corrupt a line) → startup log shows `FAILED` warning with error details

Fixes #806

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_