### PR TITLE
docs: document cookie-not-used policy in SECURITY.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,6 @@ reports/analysis/gitwiz/
 runtime/mesh/*.db
 runtime/mesh/*.log
 runtime/mesh/transcripts/*.jsonl
+
+# Claude Code internal directory
+.claude/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,36 @@ system integrity, and ensure secure operations across all components.
 - **Incident Response**: Automated alert system
 - **Audit Logging**: Complete security event logging
 
+## 🍪 Authentication & Cookie Policy
+
+### Authentication Architecture
+
+Aurora CloudBank uses **stateless, token-based authentication** exclusively. The API does not
+set HTTP cookies for any purpose.
+
+- **Primary auth**: `Authorization: Bearer <JWT>` header
+- **Session management**: Cryptographically-signed JWT tokens with configurable expiry
+- **CSRF protection**: Token-based CSRF verification (`X-CSRF-Token` header), not cookie-based
+
+### Cookie Usage
+
+**The Aurora CloudBank API backend does not issue `Set-Cookie` headers.**
+
+No cookies are created, read, or required by any API endpoint. This means HTTP cookie flags
+(`Secure`, `HttpOnly`, `SameSite`) are not applicable to the backend itself.
+
+**Rationale:**
+- Stateless token-based auth is better suited for REST APIs and microservices
+- Eliminates cookie-related attack surfaces (session fixation, cross-site cookie leakage)
+- Enables horizontal scaling without shared session state
+- Simplifies CORS configuration (no `credentials: true` needed)
+
+### Guidance for Web Clients
+
+If a web frontend stores JWT tokens in cookies (a valid hardening option), it should enforce
+`Secure; HttpOnly; SameSite=Strict` on those cookies. The backend enforces no opinion on
+client-side token storage.
+
 ## 🚨 Vulnerability Reporting
 
 ### Responsible Disclosure


### PR DESCRIPTION
## Summary

Issue #788 asked to either standardize `Secure/HttpOnly/SameSite` cookie flags globally, or document that cookies are not used.

**Verdict: cookies are not used.** A codebase-wide search found:
- Zero `response.set_cookie()` calls
- Zero `Set-Cookie` header writes
- No session middleware
- Authentication is fully token-based (`Authorization: Bearer <JWT>`)

This PR adds a new **"Authentication & Cookie Policy"** section to `SECURITY.md` that:
- Explains the stateless JWT/Bearer architecture
- States explicitly that no `Set-Cookie` headers are issued
- Documents why cookie flags are not applicable to the backend
- Provides guidance for web clients that choose to store JWTs in cookies

## Test plan
- [ ] `grep -r "set_cookie" api/ modules/ src/` returns no results
- [ ] SECURITY.md renders correctly in GitHub markdown preview

Fixes #788

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_