### PR TITLE
test: scope conftest env-var fixtures to prevent test bleed (fixes #794)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,26 +2,37 @@
 Pytest configuration for Aurora CloudBank test suite.
 
 Sets up test environment variables and fixtures.
+
+Security note: CSRF_SECRET_KEY, WS_AUTH_SECRET, and JWT_SECRET_KEY are checked
+at module import time by src/middleware/fastapi_security.py. They must therefore
+be present in os.environ before any test module is collected (i.e. here at the
+module level, guarded so real environment values are never overwritten).
+Cleanup is handled by the session-scoped ``test_env_vars`` autouse fixture below.
+
+AURORA_ALLOW_DEV_AUTH_FIXTURE and the associated password variables are NOT set
+globally. Tests that require the dev-auth fixture user store must explicitly
+request the ``dev_auth_fixture_env`` fixture.
 """
 import os
 
-# CRITICAL: Set environment variables BEFORE any test imports
-# Security middleware checks these secrets at import time
-if "CSRF_SECRET_KEY" not in os.environ:
-    os.environ["CSRF_SECRET_KEY"] = "test-csrf-secret-key-do-not-use-in-production-32chars"
+# ---------------------------------------------------------------------------
+# Import-time guards – required so security middleware can be imported safely.
+# These only write to os.environ when the variable is not already set, so real
+# secrets in a CI/CD environment are never clobbered.
+# ---------------------------------------------------------------------------
+_TEST_ENV_DEFAULTS = {
+    "CSRF_SECRET_KEY": "test-csrf-secret-key-do-not-use-in-production-32chars",
+    "WS_AUTH_SECRET": "test-websocket-auth-secret-do-not-use-in-production-val",
+    "JWT_SECRET_KEY": "test-jwt-secret-key-do-not-use-in-production-hex32",
+}
 
-if "WS_AUTH_SECRET" not in os.environ:
-    os.environ["WS_AUTH_SECRET"] = "test-websocket-auth-secret-do-not-use-in-production-val"
+# Track which keys were injected by this conftest so they can be cleaned up.
+_INJECTED_BY_CONFTEST: set = set()
 
-# Provide a deterministic JWT secret for tests so authentication components can import safely.
-if "JWT_SECRET_KEY" not in os.environ:
-    os.environ["JWT_SECRET_KEY"] = "test-jwt-secret-key-do-not-use-in-production-hex32"
-
-# Auth route tests use an explicitly gated dev-only fixture user store.
-os.environ.setdefault("AURORA_ALLOW_DEV_AUTH_FIXTURE", "true")
-os.environ.setdefault("AURORA_DEV_ADMIN_PASSWORD", "test-" + "admin-secret")
-os.environ.setdefault("AURORA_DEV_OPERATOR_PASSWORD", "test-" + "operator-secret")
-os.environ.setdefault("AURORA_DEV_OBSERVER_PASSWORD", "test-" + "observer-secret")
+for _key, _value in _TEST_ENV_DEFAULTS.items():
+    if _key not in os.environ:
+        os.environ[_key] = _value
+        _INJECTED_BY_CONFTEST.add(_key)
 
 import pytest  # noqa: E402 - import must happen after env setup
 from fastapi.testclient import TestClient  # noqa: E402
@@ -31,6 +42,51 @@ try:
 except Exception:  # pragma: no cover - fallback if import fails
     core_app = None
 
+
+# ---------------------------------------------------------------------------
+# Session-scoped autouse fixture: owns the lifecycle of the security env vars
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def test_env_vars():
+    """Ensure core security env vars are present for the test session and
+    remove any values that were injected by this conftest upon teardown.
+
+    Variables that already existed in the environment before the session
+    started are left untouched at teardown.
+    """
+    # Values were already written at module-import time above.  Yield to let
+    # the entire test session run.
+    yield
+
+    # Teardown: remove only the variables that this conftest injected.
+    for key in _INJECTED_BY_CONFTEST:
+        os.environ.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Narrow, non-autouse fixture for the dev-auth fixture user store
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def dev_auth_fixture_env(monkeypatch):
+    """Activate the dev/test auth fixture user store for a single test.
+
+    Sets AURORA_ALLOW_DEV_AUTH_FIXTURE and the three dev password variables.
+    These values are automatically removed after the requesting test finishes
+    thanks to monkeypatch's built-in teardown.
+
+    Only tests that explicitly request this fixture receive the dev-auth bypass.
+    """
+    monkeypatch.setenv("AURORA_ALLOW_DEV_AUTH_FIXTURE", "true")
+    monkeypatch.setenv("AURORA_DEV_ADMIN_PASSWORD", "test-admin-secret")
+    monkeypatch.setenv("AURORA_DEV_OPERATOR_PASSWORD", "test-operator-secret")
+    monkeypatch.setenv("AURORA_DEV_OBSERVER_PASSWORD", "test-observer-secret")
+
+
+# ---------------------------------------------------------------------------
+# General-purpose fixtures
+# ---------------------------------------------------------------------------
 
 @pytest.fixture(scope="session")
 def client():
@@ -57,9 +113,3 @@ def cmd():
         return proc.returncode, proc.stdout, proc.stderr
 
     return _run
-
-
-@pytest.fixture(scope="session", autouse=True)
-def setup_test_environment():
-    """Placeholder for additional test environment setup if needed."""
-    yield

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -14,6 +14,17 @@ from slowapi.middleware import SlowAPIMiddleware
 from src.middleware.fastapi_security import limiter
 
 
+@pytest.fixture(autouse=True)
+def _require_dev_auth_env(dev_auth_fixture_env):  # noqa: PT004
+    """Activate the dev-auth fixture environment for every test in this module.
+
+    All tests here exercise authentication routes that depend on the dev/test
+    fixture user store (AURORA_ALLOW_DEV_AUTH_FIXTURE + password secrets).
+    Using autouse=True within this file avoids repetitive per-test requests
+    while keeping the variables absent from modules that do not request them.
+    """
+
+
 @pytest.fixture
 def app():
     """Create a test FastAPI application."""

--- a/tests/test_conftest_env_isolation.py
+++ b/tests/test_conftest_env_isolation.py
@@ -1,0 +1,84 @@
+"""
+Tests that verify conftest.py env-var fixture scoping (issue #794).
+
+Ensures:
+- Core security variables (CSRF_SECRET_KEY etc.) are available during the session.
+- AURORA_ALLOW_DEV_AUTH_FIXTURE is NOT set unless dev_auth_fixture_env is requested.
+- dev_auth_fixture_env injects and cleans up the dev-auth variables correctly.
+"""
+import os
+
+import pytest
+
+
+@pytest.mark.unit
+def test_csrf_secret_key_is_set():
+    """CSRF_SECRET_KEY must be present for every test (security middleware relies on it)."""
+    assert os.environ.get("CSRF_SECRET_KEY") is not None, (
+        "CSRF_SECRET_KEY should be set by the test_env_vars session fixture"
+    )
+
+
+@pytest.mark.unit
+def test_ws_auth_secret_is_set():
+    """WS_AUTH_SECRET must be present for every test."""
+    assert os.environ.get("WS_AUTH_SECRET") is not None, (
+        "WS_AUTH_SECRET should be set by the test_env_vars session fixture"
+    )
+
+
+@pytest.mark.unit
+def test_jwt_secret_key_is_set():
+    """JWT_SECRET_KEY must be present for every test."""
+    assert os.environ.get("JWT_SECRET_KEY") is not None, (
+        "JWT_SECRET_KEY should be set by the test_env_vars session fixture"
+    )
+
+
+@pytest.mark.unit
+def test_dev_auth_fixture_env_not_set_by_default():
+    """AURORA_ALLOW_DEV_AUTH_FIXTURE must NOT be set unless dev_auth_fixture_env is requested.
+
+    This is the core regression check for issue #794: the dev-auth bypass must not
+    bleed into tests that do not explicitly request it.
+    """
+    assert os.environ.get("AURORA_ALLOW_DEV_AUTH_FIXTURE") is None, (
+        "AURORA_ALLOW_DEV_AUTH_FIXTURE should only be set when dev_auth_fixture_env "
+        "is explicitly requested by a test — it must not leak into other tests."
+    )
+
+
+@pytest.mark.unit
+def test_dev_auth_passwords_not_set_by_default():
+    """Dev password variables must NOT be set unless dev_auth_fixture_env is requested."""
+    for var in (
+        "AURORA_DEV_ADMIN_PASSWORD",
+        "AURORA_DEV_OPERATOR_PASSWORD",
+        "AURORA_DEV_OBSERVER_PASSWORD",
+    ):
+        assert os.environ.get(var) is None, (
+            f"{var} should only be present when dev_auth_fixture_env is active"
+        )
+
+
+@pytest.mark.unit
+def test_dev_auth_fixture_env_sets_vars(dev_auth_fixture_env):  # noqa: ARG001
+    """When dev_auth_fixture_env is requested the bypass variables are present."""
+    assert os.environ.get("AURORA_ALLOW_DEV_AUTH_FIXTURE") == "true"
+    assert os.environ.get("AURORA_DEV_ADMIN_PASSWORD") is not None
+    assert os.environ.get("AURORA_DEV_OPERATOR_PASSWORD") is not None
+    assert os.environ.get("AURORA_DEV_OBSERVER_PASSWORD") is not None
+
+
+@pytest.mark.unit
+def test_dev_auth_fixture_env_cleaned_up_after_use():
+    """After a test that used dev_auth_fixture_env the variables must be absent again.
+
+    This test intentionally does NOT request dev_auth_fixture_env.  Because pytest
+    runs tests in declaration order within a module, this test runs after
+    test_dev_auth_fixture_env_sets_vars, proving that monkeypatch cleaned up.
+    """
+    assert os.environ.get("AURORA_ALLOW_DEV_AUTH_FIXTURE") is None, (
+        "AURORA_ALLOW_DEV_AUTH_FIXTURE leaked from a prior test — monkeypatch "
+        "teardown did not run correctly."
+    )


### PR DESCRIPTION
## Summary

Fixes #794 — removes module-level `os.environ` writes that caused env-var bleed between tests and prevented parallel test runs.

## Changes

- **`conftest.py`**: The three mandatory security secrets (`CSRF_SECRET_KEY`, `WS_AUTH_SECRET`, `JWT_SECRET_KEY`) are still written at import time (required so security middleware can be imported), but now tracked via `_INJECTED_BY_CONFTEST` and cleaned up by a session-scoped autouse `test_env_vars` fixture. `AURORA_ALLOW_DEV_AUTH_FIXTURE` and the dev password vars are **no longer set globally** — they now live in a narrow `dev_auth_fixture_env` fixture that only runs when a test explicitly requests it.
- **`tests/test_auth_routes.py`**: Added a module-level autouse fixture that requests `dev_auth_fixture_env`, so all auth-route tests still get the bypass without changing each test signature.
- **`tests/test_conftest_env_isolation.py`** (new): Regression tests that verify `AURORA_ALLOW_DEV_AUTH_FIXTURE` is absent by default and present only when `dev_auth_fixture_env` is active.

## Test plan

- [ ] `pytest tests/test_conftest_env_isolation.py -v` passes
- [ ] `pytest tests/test_auth_routes.py -v` passes
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_