### PR TITLE
feat: replace substring pilot seal with HMAC-SHA256

### DIFF
--- a/connector/auth/token.py
+++ b/connector/auth/token.py
@@ -7,31 +7,146 @@ Two levels of auth:
   1. AURORA_CONNECTOR_TOKEN  -- Bearer token for Aurora API access (required)
   2. AURORA_PILOT_SEAL       -- Pilot continuity seal for elevated write ops (optional)
 
-The Pilot seal is validated against the known continuity signature:
-  'Continuity flows through coherence. The system remembers because we chose to align.'
+The Pilot seal is validated using HMAC-SHA256.  Seals are generated with
+``generate_pilot_seal()`` and consist of a structured payload plus an HMAC
+tag:
 
-Write operations (v0.2+) will require a valid Pilot seal in addition
-to the bearer token.
+    {operator_id}:{scope}:{exp_unix}:{hmac_hex}
+
+The HMAC is computed over ``{operator_id}:{scope}:{exp_unix}`` using the
+secret stored in ``AURORA_PILOT_SEAL_SECRET``.
+
+Write operations (v0.2+) require a valid Pilot seal in addition to the
+bearer token.
 """
 
+import functools
+import hashlib
+import hmac
 import logging
 import os
 import sys
+import time
 
 log = logging.getLogger("aurora.connector.auth")
 
 REQUIRED_ENV_VARS = ["AURORA_CONNECTOR_TOKEN", "AURORA_API_BASE_URL"]
 
-# Pilot continuity seal -- elevates to write-operation access
-PILOT_SEAL_SIGNATURE = (
-    "Continuity flows through coherence. "
-    "The system remembers because we chose to align."
-)
+
+# ---------------------------------------------------------------------------
+# Seal generation
+# ---------------------------------------------------------------------------
+
+
+def generate_pilot_seal(
+    operator_id: str,
+    scope: str = "read",
+    exp_seconds: int = 3600,
+) -> str:
+    """Generate a time-limited, HMAC-SHA256-signed Pilot seal.
+
+    The returned seal has the form::
+
+        {operator_id}:{scope}:{exp_unix}:{hmac_hex}
+
+    where ``hmac_hex`` is the HMAC-SHA256 of the string
+    ``{operator_id}:{scope}:{exp_unix}`` keyed with the value of the
+    ``AURORA_PILOT_SEAL_SECRET`` environment variable.
+
+    Args:
+        operator_id: Identifier for the operator requesting elevated access.
+        scope: Access scope, e.g. ``"read"`` or ``"write"``.
+        exp_seconds: Lifetime of the seal in seconds (default 3600).
+
+    Returns:
+        A signed seal string.
+
+    Raises:
+        RuntimeError: If ``AURORA_PILOT_SEAL_SECRET`` is not set.
+    """
+    secret = os.getenv("AURORA_PILOT_SEAL_SECRET", "")
+    if not secret:
+        raise RuntimeError(
+            "AURORA_PILOT_SEAL_SECRET must be set to generate a Pilot seal."
+        )
+
+    exp_unix = int(time.time()) + exp_seconds
+    payload = f"{operator_id}:{scope}:{exp_unix}"
+    mac = _compute_hmac(secret, payload)
+    return f"{payload}:{mac}"
+
+
+# ---------------------------------------------------------------------------
+# Seal validation
+# ---------------------------------------------------------------------------
+
+
+def is_valid_pilot_seal(seal: str) -> bool:
+    """Validate a Pilot seal using HMAC-SHA256 and expiry check.
+
+    Expects the seal in the format produced by :func:`generate_pilot_seal`::
+
+        {operator_id}:{scope}:{exp_unix}:{hmac_hex}
+
+    Validation steps:
+
+    1. ``AURORA_PILOT_SEAL_SECRET`` must be configured; if it is not, the
+       function logs a warning and returns ``False``.
+    2. The seal must contain exactly four colon-separated fields.
+    3. The HMAC tag must match the recomputed tag (constant-time comparison).
+    4. The ``exp_unix`` timestamp must be in the future.
+
+    Old substring-style seals (v0.1) do not match this format and are
+    therefore rejected.
+
+    Args:
+        seal: The seal string to validate.
+
+    Returns:
+        ``True`` if the seal is cryptographically valid and unexpired,
+        ``False`` otherwise.
+    """
+    secret = os.getenv("AURORA_PILOT_SEAL_SECRET", "")
+    if not secret:
+        log.warning(
+            "AURORA_PILOT_SEAL_SECRET is not configured; "
+            "no Pilot seal can be validated."
+        )
+        return False
+
+    parts = seal.split(":")
+    if len(parts) != 4:
+        return False
+
+    operator_id, scope, exp_unix_str, provided_mac = parts
+
+    # Verify HMAC first (timing-safe), then check expiry so we don't leak
+    # timing information about which check failed.
+    payload = f"{operator_id}:{scope}:{exp_unix_str}"
+    expected_mac = _compute_hmac(secret, payload)
+
+    if not hmac.compare_digest(expected_mac, provided_mac):
+        return False
+
+    try:
+        exp_unix = int(exp_unix_str)
+    except ValueError:
+        return False
+
+    if time.time() > exp_unix:
+        return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Environment validation
+# ---------------------------------------------------------------------------
 
 
 def validate_environment() -> None:
-    """
-    Validate required environment variables are present.
+    """Validate required environment variables are present.
+
     Logs warnings for missing optional vars.
     Exits with code 1 if required vars are absent.
     """
@@ -53,7 +168,7 @@ def validate_environment() -> None:
             log.info("Pilot seal validated. Elevated operations available (v0.2+).")
         else:
             log.warning(
-                "AURORA_PILOT_SEAL provided but does not match known signature. "
+                "AURORA_PILOT_SEAL provided but failed HMAC validation. "
                 "Elevated operations will be unavailable."
             )
     else:
@@ -65,27 +180,22 @@ def validate_environment() -> None:
     )
 
 
-def is_valid_pilot_seal(seal: str) -> bool:
-    """
-    Validate a Pilot seal string.
-
-    Currently checks for the known continuity signature substring.
-    TODO: Replace with cryptographic signature verification in v0.2.
-    """
-    return PILOT_SEAL_SIGNATURE.lower() in seal.lower()
+# ---------------------------------------------------------------------------
+# Decorator
+# ---------------------------------------------------------------------------
 
 
 def requires_pilot_seal(fn):
-    """
-    Decorator for tool handlers that require a valid Pilot seal.
+    """Decorator for tool handlers that require a valid Pilot seal.
+
     Applied to write operations in v0.2+.
 
-    Usage:
+    Usage::
+
         @requires_pilot_seal
         async def run(self, arguments: dict) -> str:
             ...
     """
-    import functools
 
     @functools.wraps(fn)
     async def wrapper(self, arguments: dict) -> str:
@@ -99,3 +209,17 @@ def requires_pilot_seal(fn):
         return await fn(self, arguments)
 
     return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_hmac(secret: str, message: str) -> str:
+    """Return the lowercase hex HMAC-SHA256 of *message* keyed with *secret*."""
+    return hmac.new(
+        secret.encode(),
+        message.encode(),
+        hashlib.sha256,
+    ).hexdigest()

--- a/tests/connector/test_hmac_seal.py
+++ b/tests/connector/test_hmac_seal.py
@@ -1,0 +1,72 @@
+"""
+Tests for HMAC-SHA256-based Pilot seal validation (issue #822).
+"""
+
+import time
+
+import pytest
+
+from connector.auth.token import generate_pilot_seal, is_valid_pilot_seal
+
+_SECRET = "test-secret-do-not-use-in-production"
+
+
+@pytest.mark.unit
+def test_valid_seal_accepted(monkeypatch):
+    """A freshly generated seal should pass validation."""
+    monkeypatch.setenv("AURORA_PILOT_SEAL_SECRET", _SECRET)
+
+    seal = generate_pilot_seal(operator_id="alice", scope="write", exp_seconds=3600)
+    assert is_valid_pilot_seal(seal) is True
+
+
+@pytest.mark.unit
+def test_tampered_seal_rejected(monkeypatch):
+    """Altering any part of the payload must invalidate the seal."""
+    monkeypatch.setenv("AURORA_PILOT_SEAL_SECRET", _SECRET)
+
+    seal = generate_pilot_seal(operator_id="alice", scope="write", exp_seconds=3600)
+
+    # Tamper with the operator_id field
+    parts = seal.split(":")
+    parts[0] = "mallory"
+    tampered = ":".join(parts)
+
+    assert is_valid_pilot_seal(tampered) is False
+
+
+@pytest.mark.unit
+def test_expired_seal_rejected(monkeypatch):
+    """A seal whose expiry timestamp is in the past must be rejected."""
+    monkeypatch.setenv("AURORA_PILOT_SEAL_SECRET", _SECRET)
+
+    # Generate a seal that expires immediately (0 seconds into the future).
+    seal = generate_pilot_seal(operator_id="bob", scope="read", exp_seconds=0)
+
+    # Wait just long enough for the timestamp to be in the past.
+    time.sleep(0.05)
+
+    assert is_valid_pilot_seal(seal) is False
+
+
+@pytest.mark.unit
+def test_no_secret_configured_returns_false(monkeypatch):
+    """Without AURORA_PILOT_SEAL_SECRET set, validation must return False."""
+    monkeypatch.delenv("AURORA_PILOT_SEAL_SECRET", raising=False)
+
+    # Craft a syntactically valid-looking seal to confirm the secret check
+    # is what causes rejection, not a format error.
+    fake_seal = "alice:write:9999999999:deadbeefdeadbeef"
+    assert is_valid_pilot_seal(fake_seal) is False
+
+
+@pytest.mark.unit
+def test_old_substring_seal_rejected(monkeypatch):
+    """Legacy v0.1 substring-style seals must be rejected."""
+    monkeypatch.setenv("AURORA_PILOT_SEAL_SECRET", _SECRET)
+
+    old_seal = (
+        "Continuity flows through coherence. "
+        "The system remembers because we chose to align."
+    )
+    assert is_valid_pilot_seal(old_seal) is False


### PR DESCRIPTION
Fixes #822

## Summary

- Replaces the insecure substring-based `is_valid_pilot_seal` in `connector/auth/token.py` with HMAC-SHA256 validation using `hmac.compare_digest` for timing-safe comparison.
- Adds `generate_pilot_seal(operator_id, scope, exp_seconds)` that produces a structured, time-limited seal: `{operator_id}:{scope}:{exp_unix}:{hmac_hex}`.
- Seal secret is read from the `AURORA_PILOT_SEAL_SECRET` env var; validation returns `False` (with a warning log) if the secret is not configured.
- Removes the hardcoded `PILOT_SEAL_SIGNATURE` literal from source code; old substring-style seals are rejected because they do not match the `operator_id:scope:exp_unix:hmac_hex` format.
- Keeps `validate_environment()` and `requires_pilot_seal()` fully backward-compatible with the new validator.
- Adds `tests/connector/test_hmac_seal.py` (5 `@pytest.mark.unit` tests, all passing) covering: valid seal, tampered payload, expired seal, missing secret, and legacy substring seal.

## Test plan

- [ ] `pytest tests/connector/test_hmac_seal.py -v` — all 5 tests pass
- [ ] `make lint` passes on `connector/auth/token.py`
- [ ] Confirm `AURORA_PILOT_SEAL_SECRET` is documented in `.env.example` (follow-up task if needed)

https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_