### PR TITLE
feat: harden MCP connector bridge — fail-closed auth, retries, headers, sanitized errors

### DIFF
--- a/connector/transport/bridge.py
+++ b/connector/transport/bridge.py
@@ -17,6 +17,7 @@ Usage:
     data = await bridge.post("/memory/node", payload={...})
 """
 
+import asyncio
 import os
 import logging
 from typing import Any
@@ -29,6 +30,8 @@ except ImportError:
 log = logging.getLogger("aurora.connector.bridge")
 
 DEFAULT_TIMEOUT = 10.0  # seconds
+_CONNECTOR_VERSION = "0.1.0"
+_MAX_GET_RETRIES = 3
 
 
 class BridgeError(Exception):
@@ -40,8 +43,9 @@ class CloudbankBridge:
     Thin async HTTP client wrapping the Aurora API.
 
     Reads configuration from environment:
-      AURORA_API_BASE_URL   -- base URL of aurora_api_server.py
-      AURORA_CONNECTOR_TOKEN -- Bearer token for auth
+      AURORA_API_BASE_URL              -- base URL of aurora_api_server.py
+      AURORA_CONNECTOR_TOKEN           -- Bearer token for auth (required; fails closed if absent)
+      AURORA_CONNECTOR_TIMEOUT_SECONDS -- per-request timeout in seconds (default 10)
     """
 
     def __init__(self) -> None:
@@ -52,13 +56,24 @@ class CloudbankBridge:
         self.token = os.getenv("AURORA_CONNECTOR_TOKEN", "")
 
         if not self.token:
-            log.warning(
-                "AURORA_CONNECTOR_TOKEN not set. Requests will be unauthenticated."
+            raise RuntimeError(
+                "AURORA_CONNECTOR_TOKEN is required. "
+                "Set it before starting the MCP connector."
             )
+
+        self._timeout = float(
+            os.getenv("AURORA_CONNECTOR_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT))
+        )
 
     @property
     def _headers(self) -> dict[str, str]:
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": f"aurora-mcp-connector/{_CONNECTOR_VERSION}",
+            "X-Source-Client": "aurora-mcp-connector",
+            "X-Connector-Version": _CONNECTOR_VERSION,
+        }
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
         return headers
@@ -66,6 +81,9 @@ class CloudbankBridge:
     async def get(self, path: str, params: dict | None = None) -> Any:
         """
         Perform a GET request against the Aurora API.
+
+        Retries up to _MAX_GET_RETRIES times on connection errors and 5xx responses
+        with exponential backoff. Does not retry on 4xx (client errors).
 
         Args:
             path: API path (e.g. "/state", "/agents")
@@ -75,33 +93,39 @@ class CloudbankBridge:
             Parsed JSON response body
 
         Raises:
-            BridgeError: On HTTP error or connection failure
+            BridgeError: On HTTP error or connection failure after all retries
         """
         url = f"{self.base_url}{path}"
         log.debug("GET %s params=%s", url, params)
 
-        # TODO: Map Aurora API endpoint paths to match aurora_api_server.py routes.
-        # Current aurora_api.py endpoints need audit to confirm exact path names.
-        # See api/aurora_api_server.py for route definitions.
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_GET_RETRIES):
+            if attempt:
+                await asyncio.sleep(0.5 * (2 ** (attempt - 1)))
 
-        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
-            try:
-                response = await client.get(url, headers=self._headers, params=params)
-                response.raise_for_status()
-                return response.json()
-            except httpx.HTTPStatusError as exc:
-                raise BridgeError(
-                    f"Aurora API returned {exc.response.status_code} for GET {path}: "
-                    f"{exc.response.text[:200]}"
-                ) from exc
-            except httpx.RequestError as exc:
-                raise BridgeError(
-                    f"Cannot reach Aurora API at {self.base_url}: {exc}"
-                ) from exc
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                try:
+                    response = await client.get(url, headers=self._headers, params=params)
+                    response.raise_for_status()
+                    return response.json()
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code < 500:
+                        raise BridgeError(
+                            f"Aurora API returned {exc.response.status_code} for GET {path}"
+                        ) from exc
+                    last_exc = exc
+                except httpx.RequestError as exc:
+                    last_exc = exc
+
+        raise BridgeError(
+            f"Aurora API unreachable at {self.base_url} after {_MAX_GET_RETRIES} attempts"
+        ) from last_exc
 
     async def post(self, path: str, payload: dict | None = None) -> Any:
         """
         Perform a POST request against the Aurora API.
+
+        No automatic retry (non-idempotent operation).
 
         Args:
             path: API path (e.g. "/memory/node", "/anomaly/flag")
@@ -114,19 +138,18 @@ class CloudbankBridge:
             BridgeError: On HTTP error or connection failure
         """
         url = f"{self.base_url}{path}"
-        log.debug("POST %s payload=%s", url, payload)
+        log.debug("POST %s", url)
 
-        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
             try:
                 response = await client.post(url, headers=self._headers, json=payload or {})
                 response.raise_for_status()
                 return response.json()
             except httpx.HTTPStatusError as exc:
                 raise BridgeError(
-                    f"Aurora API returned {exc.response.status_code} for POST {path}: "
-                    f"{exc.response.text[:200]}"
+                    f"Aurora API returned {exc.response.status_code} for POST {path}"
                 ) from exc
             except httpx.RequestError as exc:
                 raise BridgeError(
-                    f"Cannot reach Aurora API at {self.base_url}: {exc}"
+                    f"Cannot reach Aurora API at {self.base_url}"
                 ) from exc

--- a/tests/connector/test_transport.py
+++ b/tests/connector/test_transport.py
@@ -1,0 +1,159 @@
+"""
+Tests for connector/transport/bridge.py — fail-closed auth, identifying headers,
+configurable timeout, retries with backoff, and sanitized error messages.
+
+Covers issues #823 (sanitize BridgeError), #824 (fail-closed, retries, timeout),
+and #826 (User-Agent / X-Source-Client headers).
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bridge(monkeypatch, token="test-token", base_url="http://localhost:8000", **extra_env):
+    monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", token)
+    monkeypatch.setenv("AURORA_API_BASE_URL", base_url)
+    for k, v in extra_env.items():
+        monkeypatch.setenv(k, v)
+    # Re-import so env changes take effect on module-level reads inside __init__
+    import importlib
+    import connector.transport.bridge as mod
+    importlib.reload(mod)
+    return mod.CloudbankBridge(), mod.BridgeError
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed auth (#824)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_missing_token_raises(monkeypatch):
+    """Bridge must fail closed when AURORA_CONNECTOR_TOKEN is not set."""
+    monkeypatch.delenv("AURORA_CONNECTOR_TOKEN", raising=False)
+    monkeypatch.setenv("AURORA_API_BASE_URL", "http://localhost:8000")
+    import importlib
+    import connector.transport.bridge as mod
+    importlib.reload(mod)
+    with pytest.raises(RuntimeError, match="AURORA_CONNECTOR_TOKEN is required"):
+        mod.CloudbankBridge()
+
+
+@pytest.mark.unit
+def test_empty_token_raises(monkeypatch):
+    """Empty string token should also fail closed."""
+    monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", "")
+    monkeypatch.setenv("AURORA_API_BASE_URL", "http://localhost:8000")
+    import importlib
+    import connector.transport.bridge as mod
+    importlib.reload(mod)
+    with pytest.raises(RuntimeError):
+        mod.CloudbankBridge()
+
+
+# ---------------------------------------------------------------------------
+# Identifying headers (#826)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_headers_include_user_agent(monkeypatch):
+    """Bridge headers must include User-Agent, X-Source-Client, X-Connector-Version."""
+    bridge, _ = _make_bridge(monkeypatch)
+    headers = bridge._headers
+    assert "User-Agent" in headers
+    assert headers["User-Agent"].startswith("aurora-mcp-connector/")
+    assert headers["X-Source-Client"] == "aurora-mcp-connector"
+    assert "X-Connector-Version" in headers
+
+
+@pytest.mark.unit
+def test_authorization_header_present(monkeypatch):
+    """Authorization header must be present when token is configured."""
+    bridge, _ = _make_bridge(monkeypatch, token="my-secret-token")
+    assert bridge._headers["Authorization"] == "Bearer my-secret-token"
+
+
+# ---------------------------------------------------------------------------
+# Configurable timeout (#824)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_configurable_timeout(monkeypatch):
+    """Bridge timeout should be configurable via AURORA_CONNECTOR_TIMEOUT_SECONDS."""
+    bridge, _ = _make_bridge(monkeypatch, AURORA_CONNECTOR_TIMEOUT_SECONDS="5")
+    assert bridge._timeout == 5.0
+
+
+@pytest.mark.unit
+def test_default_timeout(monkeypatch):
+    """Default timeout should be 10 seconds when env var not set."""
+    monkeypatch.delenv("AURORA_CONNECTOR_TIMEOUT_SECONDS", raising=False)
+    bridge, _ = _make_bridge(monkeypatch)
+    assert bridge._timeout == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Sanitized error messages (#823)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_get_bridge_error_omits_response_body(monkeypatch):
+    """BridgeError for 4xx GET must not include upstream response body text."""
+    bridge, BridgeError = _make_bridge(monkeypatch)
+
+    import httpx
+
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.text = "secret-internal-detail-should-not-appear-in-error"
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "error", request=MagicMock(), response=mock_response
+    )
+
+    async def _mock_get(*args, **kwargs):
+        return mock_response
+
+    with patch("httpx.AsyncClient") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_cls.return_value = mock_client
+
+        with pytest.raises(BridgeError) as exc_info:
+            asyncio.run(bridge.get("/test"))
+
+    assert "secret-internal-detail" not in str(exc_info.value)
+    assert "400" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_post_bridge_error_omits_response_body(monkeypatch):
+    """BridgeError for POST must not include upstream response body text."""
+    bridge, BridgeError = _make_bridge(monkeypatch)
+
+    import httpx
+
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.text = "confidential-error-detail-must-not-leak"
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "error", request=MagicMock(), response=mock_response
+    )
+
+    with patch("httpx.AsyncClient") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_cls.return_value = mock_client
+
+        with pytest.raises(BridgeError) as exc_info:
+            asyncio.run(bridge.post("/test"))
+
+    assert "confidential-error-detail" not in str(exc_info.value)
+    assert "503" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- **Fail-closed auth**: `CloudbankBridge.__init__` now raises `RuntimeError` when `AURORA_CONNECTOR_TOKEN` is missing or empty, instead of logging a warning and continuing unauthenticated.
- **Configurable timeout**: timeout is now driven by `AURORA_CONNECTOR_TIMEOUT_SECONDS` env var (default 10s).
- **Retries with backoff**: GET operations retry up to 3× on connection errors and 5xx responses, with exponential backoff (0.5s, 1s). 4xx errors are not retried.
- **Identifying headers**: all requests now include `User-Agent: aurora-mcp-connector/0.1.0`, `X-Source-Client: aurora-mcp-connector`, `X-Connector-Version: 0.1.0`.
- **Sanitized BridgeError messages**: upstream response body text (the `{exc.response.text[:200]}` echo) is removed from error messages; only status code and path are included.

## Test plan

- [ ] Missing token → `RuntimeError` at bridge construction
- [ ] Empty token → `RuntimeError` at bridge construction
- [ ] `AURORA_CONNECTOR_TIMEOUT_SECONDS=5` → `_timeout == 5.0`
- [ ] Headers include `User-Agent`, `X-Source-Client`, `X-Connector-Version`
- [ ] 4xx GET → BridgeError with status code, no response body
- [ ] 5xx POST → BridgeError with status code, no response body

Fixes #824
Fixes #826
Partially fixes #823 (bridge portion; `connector/server.py` catch block is addressed in a separate PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_