### PR TITLE
fix(api): fail closed when build-phase placeholder secrets reach runtime (issue #766)

### DIFF
--- a/api/_guard.py
+++ b/api/_guard.py
@@ -1,0 +1,34 @@
+"""Runtime guard: reject BUILD_PHASE_PLACEHOLDER_* secrets outside build phase."""
+
+import os
+
+_PLACEHOLDER_PREFIX = "BUILD_PHASE_PLACEHOLDER_"
+_GUARDED_VARS = (
+    "CSRF_SECRET_KEY",
+    "AURORA_SECRET_KEY",
+    "WS_AUTH_SECRET",
+    "AES_KEY_256_HEX",
+)
+
+
+def assert_no_placeholder_secrets() -> None:
+    """Raise RuntimeError if any guarded secret holds a build-phase placeholder.
+
+    No-op when AURORA_BUILD_PHASE=1 (Vercel import / catalog-generation phase).
+    """
+    if os.getenv("AURORA_BUILD_PHASE", "").strip() == "1":
+        return
+
+    offenders = [
+        var
+        for var in _GUARDED_VARS
+        if os.getenv(var, "").startswith(_PLACEHOLDER_PREFIX)
+    ]
+
+    if offenders:
+        raise RuntimeError(
+            f"Runtime started with build-phase placeholder secret(s): "
+            f"{', '.join(offenders)}. "
+            "Configure real values in Vercel environment settings before deployment. "
+            "Set AURORA_BUILD_PHASE=1 only during Vercel build/import."
+        )

--- a/api/index.py
+++ b/api/index.py
@@ -27,6 +27,11 @@ if not os.getenv("WS_AUTH_SECRET"):
 if not os.getenv("AES_KEY_256_HEX"):
     os.environ["AES_KEY_256_HEX"] = "BUILD_PHASE_PLACEHOLDER_" + "0" * 48
 
+# Fail closed: raise at runtime if placeholder secrets are still in effect.
+# This is a no-op when AURORA_BUILD_PHASE=1 (Vercel import/build phase).
+from api._guard import assert_no_placeholder_secrets
+assert_no_placeholder_secrets()
+
 # Now import the app (will use placeholders during build, real values at runtime)
 # Import directly from aurora_api since Vercel runs from the api/ directory context
 from aurora_api import app

--- a/tests/test_placeholder_secret_guard.py
+++ b/tests/test_placeholder_secret_guard.py
@@ -1,0 +1,117 @@
+"""
+Tests for api/_guard.py — runtime placeholder-secret guard (issue #766).
+"""
+
+import os
+import pytest
+from unittest.mock import patch
+
+
+def _run_guard(**env_overrides):
+    """Import and call assert_no_placeholder_secrets with the given env overrides."""
+    import importlib
+    import api._guard as guard_module
+    importlib.reload(guard_module)  # ensure fresh import after env mutation
+
+    with patch.dict(os.environ, env_overrides, clear=False):
+        guard_module.assert_no_placeholder_secrets()
+
+
+_PLACEHOLDER = "BUILD_PHASE_PLACEHOLDER_" + "0" * 48
+_REAL = "a" * 64
+
+
+@pytest.mark.unit
+def test_raises_when_placeholder_present():
+    """Guard raises RuntimeError if any secret is a placeholder at runtime."""
+    env = {
+        "CSRF_SECRET_KEY": _PLACEHOLDER,
+        "AURORA_SECRET_KEY": _REAL,
+        "WS_AUTH_SECRET": _REAL,
+        "AES_KEY_256_HEX": _REAL,
+        "AURORA_BUILD_PHASE": "",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from api._guard import assert_no_placeholder_secrets
+        with pytest.raises(RuntimeError, match="CSRF_SECRET_KEY"):
+            assert_no_placeholder_secrets()
+
+
+@pytest.mark.unit
+def test_raises_lists_all_offenders():
+    """RuntimeError message lists every offending variable."""
+    env = {
+        "CSRF_SECRET_KEY": _PLACEHOLDER,
+        "AURORA_SECRET_KEY": _PLACEHOLDER,
+        "WS_AUTH_SECRET": _REAL,
+        "AES_KEY_256_HEX": _REAL,
+        "AURORA_BUILD_PHASE": "",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from api._guard import assert_no_placeholder_secrets
+        with pytest.raises(RuntimeError) as exc_info:
+            assert_no_placeholder_secrets()
+        msg = str(exc_info.value)
+        assert "CSRF_SECRET_KEY" in msg
+        assert "AURORA_SECRET_KEY" in msg
+
+
+@pytest.mark.unit
+def test_build_phase_flag_suppresses_guard():
+    """Guard is silent when AURORA_BUILD_PHASE=1, even with placeholder secrets."""
+    env = {
+        "CSRF_SECRET_KEY": _PLACEHOLDER,
+        "AURORA_SECRET_KEY": _PLACEHOLDER,
+        "WS_AUTH_SECRET": _PLACEHOLDER,
+        "AES_KEY_256_HEX": _PLACEHOLDER,
+        "AURORA_BUILD_PHASE": "1",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from api._guard import assert_no_placeholder_secrets
+        assert_no_placeholder_secrets()  # must not raise
+
+
+@pytest.mark.unit
+def test_passes_when_all_real_secrets_configured():
+    """Guard is silent when all guarded vars have non-placeholder values."""
+    env = {
+        "CSRF_SECRET_KEY": _REAL,
+        "AURORA_SECRET_KEY": _REAL,
+        "WS_AUTH_SECRET": _REAL,
+        "AES_KEY_256_HEX": _REAL,
+        "AURORA_BUILD_PHASE": "",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from api._guard import assert_no_placeholder_secrets
+        assert_no_placeholder_secrets()  # must not raise
+
+
+@pytest.mark.unit
+def test_missing_env_var_does_not_raise():
+    """Absent env vars (empty string) are not placeholders — guard stays silent."""
+    env = {
+        "CSRF_SECRET_KEY": "",
+        "AURORA_SECRET_KEY": "",
+        "WS_AUTH_SECRET": "",
+        "AES_KEY_256_HEX": "",
+        "AURORA_BUILD_PHASE": "",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from api._guard import assert_no_placeholder_secrets
+        # Empty strings do not start with the placeholder prefix
+        assert_no_placeholder_secrets()  # must not raise
+
+
+@pytest.mark.unit
+def test_only_exact_prefix_triggers_guard():
+    """Strings that merely contain the prefix substring but don't start with it are safe."""
+    env = {
+        "CSRF_SECRET_KEY": "prefix_BUILD_PHASE_PLACEHOLDER_000",
+        "AURORA_SECRET_KEY": _REAL,
+        "WS_AUTH_SECRET": _REAL,
+        "AES_KEY_256_HEX": _REAL,
+        "AURORA_BUILD_PHASE": "",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from api._guard import assert_no_placeholder_secrets
+        assert_no_placeholder_secrets()  # must not raise — prefix is in middle


### PR DESCRIPTION
## Summary

- Adds `api/_guard.py` — a standalone `assert_no_placeholder_secrets()` helper that raises `RuntimeError` listing every offending variable name if any of the four guarded secrets (`CSRF_SECRET_KEY`, `AURORA_SECRET_KEY`, `WS_AUTH_SECRET`, `AES_KEY_256_HEX`) still holds a `BUILD_PHASE_PLACEHOLDER_*` value at startup.
- The guard is a no-op when `AURORA_BUILD_PHASE=1` (Vercel build / catalog-generation phase), so the existing build-time import flow is unaffected.
- Wires the guard into `api/index.py` immediately after placeholder defaults are applied and before the FastAPI app is imported, ensuring fail-closed behavior before any request can be served.
- Adds `tests/test_placeholder_secret_guard.py` with 6 unit tests covering: placeholder raises, all offenders listed in message, `AURORA_BUILD_PHASE=1` suppresses guard, real secrets pass, empty/missing vars pass, substring-only prefix does not trigger.

## Test plan

- [ ] `pytest tests/test_placeholder_secret_guard.py -v` → 6 passed
- [ ] Deploy without real env vars → `RuntimeError` at import time, request never served
- [ ] Deploy with `AURORA_BUILD_PHASE=1` and placeholders → no error (Vercel build phase)
- [ ] Deploy with real env vars and no `AURORA_BUILD_PHASE` → no error

Fixes #766

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_