### PR TITLE
fix(api): harden uvicorn config and add body-size limit middleware (issue #817)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -26,6 +26,7 @@ from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from src.observability import get_telemetry, get_r2_telemetry
+from src.middleware.body_size import MaxBodySizeMiddleware, _default_max_bytes
 from src.middleware.exception_handler import validation_handler
 from src.middleware.request_id import RequestIDMiddleware
 
@@ -412,6 +413,10 @@ try:
     logger.info("✅ SlowAPI rate limiting middleware enabled")
 except Exception as e:  # pragma: no cover - graceful degradation if slowapi misconfigured
     logger.warning("⚠️ Failed to enable rate limiting middleware: %s", e)
+
+# Body-size guard: registered before RequestIDMiddleware so oversized requests
+# are rejected before ID assignment and inner middleware run.
+app.add_middleware(MaxBodySizeMiddleware, max_bytes=_default_max_bytes())
 
 # Request-ID middleware: must be registered last so it wraps everything and
 # its ContextVar is set before any inner middleware runs.
@@ -2904,4 +2909,14 @@ async def verify_patchweaver_state(
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    uvicorn.run(
+        app,
+        host=os.getenv("AURORA_HOST", "0.0.0.0"),
+        port=int(os.getenv("AURORA_PORT", "8000")),
+        timeout_keep_alive=int(os.getenv("AURORA_KEEPALIVE", "30")),
+        limit_concurrency=int(os.getenv("AURORA_MAX_CONCURRENCY", "256")),
+        limit_max_requests=int(os.getenv("AURORA_MAX_REQUESTS", "10000")),
+        proxy_headers=True,
+        forwarded_allow_ips=os.getenv("AURORA_TRUSTED_PROXIES", "127.0.0.1"),
+    )

--- a/src/middleware/body_size.py
+++ b/src/middleware/body_size.py
@@ -1,0 +1,61 @@
+"""
+Max Body Size Middleware
+========================
+Rejects HTTP requests whose body exceeds a configurable byte limit.
+
+Fast-path: checks the Content-Length header before the body is read.
+Any request where Content-Length is declared and exceeds the limit is
+rejected immediately with HTTP 413, without touching the body.
+
+Default limit: 10 MiB (AURORA_MAX_BODY_BYTES env var overrides).
+"""
+
+import logging
+import os
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+_10_MIB = 10 * 1024 * 1024
+
+
+def _default_max_bytes() -> int:
+    try:
+        return int(os.getenv("AURORA_MAX_BODY_BYTES", str(_10_MIB)))
+    except ValueError:
+        return _10_MIB
+
+
+class MaxBodySizeMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose declared Content-Length exceeds *max_bytes*."""
+
+    def __init__(self, app: ASGIApp, max_bytes: int = _10_MIB) -> None:
+        super().__init__(app)
+        self._max_bytes = max_bytes
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        content_length_header = request.headers.get("Content-Length")
+        if content_length_header is not None:
+            try:
+                content_length = int(content_length_header)
+            except ValueError:
+                content_length = None
+
+            if content_length is not None and content_length > self._max_bytes:
+                logger.warning(
+                    "Rejected oversized request: Content-Length=%d limit=%d path=%s",
+                    content_length,
+                    self._max_bytes,
+                    request.url.path,
+                )
+                return Response(
+                    content=f"Request body too large (limit {self._max_bytes} bytes).",
+                    status_code=413,
+                    media_type="text/plain",
+                )
+
+        return await call_next(request)

--- a/tests/test_body_size_middleware.py
+++ b/tests/test_body_size_middleware.py
@@ -1,0 +1,94 @@
+"""
+Tests for src/middleware/body_size.py — MaxBodySizeMiddleware (issue #817).
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.middleware.body_size import MaxBodySizeMiddleware
+
+
+def _make_app(max_bytes: int) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(MaxBodySizeMiddleware, max_bytes=max_bytes)
+
+    @app.post("/upload")
+    async def upload():
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.unit
+def test_request_within_limit_passes():
+    """Body smaller than limit is forwarded normally."""
+    client = TestClient(_make_app(max_bytes=100))
+    response = client.post(
+        "/upload",
+        content=b"x" * 50,
+        headers={"Content-Length": "50", "Content-Type": "application/octet-stream"},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.unit
+def test_request_exactly_at_limit_passes():
+    """Body exactly at the limit is accepted."""
+    client = TestClient(_make_app(max_bytes=100))
+    response = client.post(
+        "/upload",
+        content=b"x" * 100,
+        headers={"Content-Length": "100", "Content-Type": "application/octet-stream"},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.unit
+def test_request_over_limit_returns_413():
+    """Body declared larger than the limit is rejected with HTTP 413."""
+    client = TestClient(_make_app(max_bytes=100))
+    response = client.post(
+        "/upload",
+        content=b"x" * 101,
+        headers={"Content-Length": "101", "Content-Type": "application/octet-stream"},
+    )
+    assert response.status_code == 413
+
+
+@pytest.mark.unit
+def test_413_response_is_plain_text():
+    """413 response body is plain text describing the limit."""
+    client = TestClient(_make_app(max_bytes=100))
+    response = client.post(
+        "/upload",
+        content=b"x" * 200,
+        headers={"Content-Length": "200", "Content-Type": "application/octet-stream"},
+    )
+    assert response.status_code == 413
+    assert "100" in response.text  # limit mentioned in body
+
+
+@pytest.mark.unit
+def test_missing_content_length_not_rejected():
+    """Requests without Content-Length header are not rejected by fast-path guard."""
+    client = TestClient(_make_app(max_bytes=10))
+    # TestClient sends Content-Length automatically; simulate absence by using
+    # chunked-style transfer. A GET request has no body, so Content-Length is absent.
+    response = client.get("/upload")
+    # 405 Method Not Allowed (not 413) — guard didn't fire
+    assert response.status_code in (200, 405, 422)
+    assert response.status_code != 413
+
+
+@pytest.mark.unit
+def test_malformed_content_length_not_rejected():
+    """A malformed (non-integer) Content-Length header does not cause a 413 or 500."""
+    client = TestClient(_make_app(max_bytes=100))
+    response = client.post(
+        "/upload",
+        content=b"hello",
+        headers={"Content-Length": "not-a-number", "Content-Type": "application/octet-stream"},
+    )
+    # Should pass through to the route (200) or hit Starlette's own handling
+    assert response.status_code != 413


### PR DESCRIPTION
## Summary

- Replaces the bare `uvicorn.run(app, host="0.0.0.0", port=8000)` with a documented production config block reading from env vars: `AURORA_HOST`, `AURORA_PORT`, `AURORA_KEEPALIVE` (default 30 s), `AURORA_MAX_CONCURRENCY` (default 256), `AURORA_MAX_REQUESTS` (default 10 000), `proxy_headers=True`, `AURORA_TRUSTED_PROXIES` (default `127.0.0.1`).
- Adds `src/middleware/body_size.py`: `MaxBodySizeMiddleware` checks the `Content-Length` header at request intake and rejects oversized requests with **HTTP 413** before any body bytes are read. Default limit is 10 MiB, overridable via `AURORA_MAX_BODY_BYTES`. Wired into `aurora_api.py` ahead of `RequestIDMiddleware`.
- Adds `tests/test_body_size_middleware.py` with 6 unit tests covering: within-limit passes, exact-limit passes, over-limit → 413, 413 body mentions the limit value, missing `Content-Length` passes (no false positives), malformed `Content-Length` passes without error.

## Test plan

- [ ] `pytest tests/test_body_size_middleware.py -v` → 6 passed
- [ ] `curl -X POST http://localhost:8000/... -H "Content-Length: 20971520" ...` → 413
- [ ] Start server; verify proxy IP appears in logs correctly with `X-Forwarded-For`

Fixes #817

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_