### PR TITLE
fix(storage): make ledger and monitoring paths configurable via env vars (issue #813)

### DIFF
--- a/modules/insight_ledger/ledger_core.py
+++ b/modules/insight_ledger/ledger_core.py
@@ -112,9 +112,18 @@ class InsightLedger:
         Raises:
             ValueError: If storage_path is invalid or outside safe directory
         """
-        # Define safe root for ledger storage
-        # In production, this should come from config
-        ledger_root = Path.cwd() / "data" / "ledgers"
+        # Resolve ledger root from env vars; fall back to cwd-relative for local dev.
+        # Priority: AURORA_LEDGER_PATH → AURORA_STATE_ROOT/ledgers → cwd/data/ledgers
+        _state_root = os.environ.get("AURORA_STATE_ROOT", "")
+        _ledger_env = os.environ.get("AURORA_LEDGER_PATH", "")
+        if _ledger_env:
+            ledger_root = Path(_ledger_env)
+        elif _state_root:
+            ledger_root = Path(_state_root) / "ledgers"
+        else:
+            ledger_root = Path.cwd() / "data" / "ledgers"
+        import logging as _logging
+        _logging.getLogger(__name__).info("Ledger root resolved to: %s", ledger_root)
         
         # Validate storage path is safe
         # Allow creation since ledgers may not exist yet

--- a/src/monitoring/monitoring_system.py
+++ b/src/monitoring/monitoring_system.py
@@ -7,6 +7,7 @@ and alerting for comprehensive agent oversight.
 
 import logging
 import json
+import os
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 from src.core.time_utils import utc_now, utc_iso
@@ -110,7 +111,18 @@ class MonitoringSystem:
             ethics_rules_path: Path to ethics rules configuration
             config: Alert configuration
         """
-        self.storage_dir = Path(storage_dir or "./monitoring_data")
+        if storage_dir is not None:
+            self.storage_dir = Path(storage_dir)
+        else:
+            # Priority: AURORA_MONITORING_PATH → AURORA_STATE_ROOT/monitoring → ./monitoring_data
+            _state_root = os.environ.get("AURORA_STATE_ROOT", "")
+            _mon_env = os.environ.get("AURORA_MONITORING_PATH", "")
+            if _mon_env:
+                self.storage_dir = Path(_mon_env)
+            elif _state_root:
+                self.storage_dir = Path(_state_root) / "monitoring"
+            else:
+                self.storage_dir = Path("./monitoring_data")
         self._state_path = self.storage_dir / "monitoring_state.json"
         self.config = config or AlertConfig()
         
@@ -141,7 +153,7 @@ class MonitoringSystem:
 
         self.import_state()
         
-        logger.info("Monitoring system initialized (storage=%s)", storage_dir)
+        logger.info("Monitoring system initialized (storage=%s)", self.storage_dir)
 
     def register_enforcement_handler(
         self,

--- a/tests/test_configurable_storage_paths.py
+++ b/tests/test_configurable_storage_paths.py
@@ -1,0 +1,118 @@
+"""
+Tests for configurable storage paths via env vars (issue #813).
+
+Covers:
+ - MonitoringSystem: AURORA_MONITORING_PATH, AURORA_STATE_ROOT, default fallback
+ - InsightLedger:    AURORA_LEDGER_PATH, AURORA_STATE_ROOT, default fallback
+"""
+
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# MonitoringSystem
+# ---------------------------------------------------------------------------
+
+_FAKE_SIGNING_KEY = "a" * 64  # valid hex for MONITORING_SIGNING_KEY
+
+
+@pytest.mark.unit
+def test_monitoring_system_respects_aurora_monitoring_path(tmp_path):
+    """AURORA_MONITORING_PATH is used as storage_dir when set."""
+    monitoring_dir = tmp_path / "custom_monitoring"
+    monitoring_dir.mkdir()
+
+    env = {
+        "AURORA_MONITORING_PATH": str(monitoring_dir),
+        "AURORA_STATE_ROOT": "",
+        "MONITORING_SIGNING_KEY": _FAKE_SIGNING_KEY,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from src.monitoring.monitoring_system import MonitoringSystem
+        ms = MonitoringSystem()
+        assert ms.storage_dir == monitoring_dir
+
+
+@pytest.mark.unit
+def test_monitoring_system_respects_aurora_state_root(tmp_path):
+    """AURORA_STATE_ROOT/monitoring is used when AURORA_MONITORING_PATH is absent."""
+    env = {
+        "AURORA_MONITORING_PATH": "",
+        "AURORA_STATE_ROOT": str(tmp_path),
+        "MONITORING_SIGNING_KEY": _FAKE_SIGNING_KEY,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from src.monitoring.monitoring_system import MonitoringSystem
+        ms = MonitoringSystem()
+        assert ms.storage_dir == tmp_path / "monitoring"
+
+
+@pytest.mark.unit
+def test_monitoring_system_falls_back_to_cwd_relative(tmp_path, monkeypatch):
+    """Without env vars, storage_dir defaults to ./monitoring_data (cwd-relative)."""
+    monkeypatch.chdir(tmp_path)
+    env = {
+        "AURORA_MONITORING_PATH": "",
+        "AURORA_STATE_ROOT": "",
+        "MONITORING_SIGNING_KEY": _FAKE_SIGNING_KEY,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from src.monitoring.monitoring_system import MonitoringSystem
+        ms = MonitoringSystem()
+        assert ms.storage_dir == Path("./monitoring_data")
+
+
+@pytest.mark.unit
+def test_monitoring_system_explicit_storage_dir_overrides_env(tmp_path):
+    """Explicitly passed storage_dir takes precedence over all env vars."""
+    explicit_dir = tmp_path / "explicit"
+    explicit_dir.mkdir()
+    env = {
+        "AURORA_MONITORING_PATH": str(tmp_path / "env_path"),
+        "AURORA_STATE_ROOT": str(tmp_path / "state_root"),
+        "MONITORING_SIGNING_KEY": _FAKE_SIGNING_KEY,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from src.monitoring.monitoring_system import MonitoringSystem
+        ms = MonitoringSystem(storage_dir=explicit_dir)
+        assert ms.storage_dir == explicit_dir
+
+
+# ---------------------------------------------------------------------------
+# InsightLedger root resolution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_ledger_root_respects_aurora_ledger_path(tmp_path):
+    """AURORA_LEDGER_PATH sets the ledger safe root."""
+    ledger_root = tmp_path / "custom_ledgers"
+    ledger_root.mkdir()
+
+    env = {
+        "AURORA_LEDGER_PATH": str(ledger_root),
+        "AURORA_STATE_ROOT": "",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from modules.insight_ledger.ledger_core import InsightLedger
+        ledger = InsightLedger("mystore")
+        assert ledger.storage_path.parent == ledger_root
+        import shutil
+        shutil.rmtree(ledger.storage_path)
+
+
+@pytest.mark.unit
+def test_ledger_root_respects_aurora_state_root(tmp_path):
+    """AURORA_STATE_ROOT/ledgers is used when AURORA_LEDGER_PATH is absent."""
+    env = {
+        "AURORA_LEDGER_PATH": "",
+        "AURORA_STATE_ROOT": str(tmp_path),
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from modules.insight_ledger.ledger_core import InsightLedger
+        ledger = InsightLedger("mystore")
+        assert ledger.storage_path.parent == tmp_path / "ledgers"
+        import shutil
+        shutil.rmtree(ledger.storage_path)


### PR DESCRIPTION
## Summary

- **`InsightLedger`** (`modules/insight_ledger/ledger_core.py`): the safe ledger root is now resolved in priority order: `AURORA_LEDGER_PATH` → `AURORA_STATE_ROOT/ledgers` → `cwd/data/ledgers` (backward-compatible default). The resolved path is logged at `INFO` on every instantiation.
- **`MonitoringSystem`** (`src/monitoring/monitoring_system.py`): the default `storage_dir` is now resolved in priority order: `AURORA_MONITORING_PATH` → `AURORA_STATE_ROOT/monitoring` → `./monitoring_data` (backward-compatible default). Resolved path is logged at `INFO`. Explicit `storage_dir` parameter still takes precedence over all env vars.
- Adds `tests/test_configurable_storage_paths.py` with 6 unit tests: `AURORA_MONITORING_PATH`, `AURORA_STATE_ROOT` fallback, cwd fallback, explicit override for `MonitoringSystem`; `AURORA_LEDGER_PATH` and `AURORA_STATE_ROOT` for `InsightLedger`.

## Deployment

Set `AURORA_STATE_ROOT=/var/lib/aurora` (or the relevant volume mount) to redirect all state to a persistent path:
- Ledger files → `$AURORA_STATE_ROOT/ledgers/`
- Monitoring state → `$AURORA_STATE_ROOT/monitoring/`

Or set `AURORA_LEDGER_PATH` / `AURORA_MONITORING_PATH` individually for fine-grained control.

## Test plan

- [ ] `pytest tests/test_configurable_storage_paths.py -v` → 6 passed
- [ ] `AURORA_STATE_ROOT=/tmp/test pytest tests/test_configurable_storage_paths.py` → verifies env resolution

Fixes #813

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_