### PR TITLE
feat(runtime): add ShutdownCoordinator and wire into API lifespan (issue #816)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -30,6 +30,7 @@ from src.observability import get_telemetry, get_r2_telemetry
 from src.middleware.body_size import MaxBodySizeMiddleware, _default_max_bytes
 from src.middleware.exception_handler import validation_handler
 from src.middleware.request_id import RequestIDMiddleware
+from src.runtime.shutdown import ShutdownCoordinator
 
 from modules.symbolic_core.geometric_algebra import GeometricAlgebra
 try:
@@ -273,7 +274,7 @@ except Exception as e:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Manage application lifecycle with startup and shutdown logic"""
+    """Manage application lifecycle with startup and shutdown logic."""
     # Startup
     logger.info("Aurora API starting up...")
     logger.info("Rate limiter active: AI=20/min, crew=30/min, quantum=10/min, memory_write=60/min")
@@ -288,6 +289,8 @@ async def lifespan(app: FastAPI):
             "state divergence. See docs/operations/single-worker-constraint.md for details.",
             _worker_count,
         )
+
+    shutdown_coordinator = ShutdownCoordinator()
 
     # Initialize telemetry systems
     try:
@@ -306,48 +309,54 @@ async def lifespan(app: FastAPI):
         try:
             await HALO_PAS_CONTROLLER.start()
             logger.info("✅ HALO/PAS Drift Controller started")
+            shutdown_coordinator.register_flush(HALO_PAS_CONTROLLER.stop, name="HALO/PAS stop")
         except Exception as e:
             logger.error("❌ Failed to start HALO/PAS Controller: %s", e)
 
+    # Register telemetry snapshot as a shutdown flush
+    def _telemetry_flush() -> None:
+        try:
+            telemetry = get_telemetry()
+            snapshot = telemetry.get_metrics_snapshot(context_tag="shutdown_metrics")
+            logger.info(
+                "📊 Final telemetry: %d operations, %d features tracked",
+                len(snapshot.performance_metrics),
+                len(snapshot.adoption_metrics),
+            )
+        except Exception as exc:
+            logger.debug("Telemetry snapshot failed: %s", exc)
+
+    shutdown_coordinator.register_flush(_telemetry_flush, name="telemetry snapshot")
+
+    # Register shutdown manifest as a flush
+    def _manifest_flush() -> None:
+        try:
+            import json as _json
+            manifest = build_shutdown_manifest()
+            manifest_path = os.path.join(os.getcwd(), "shutdown_manifest.json")
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                _json.dump(manifest, f, ensure_ascii=False, indent=2)
+            logger.info(
+                "🧾 Shutdown manifest written (%s components, hash=%s)",
+                len(manifest.get("components", {})),
+                manifest.get("hash"),
+            )
+        except Exception as exc:
+            logger.warning("⚠️ Failed to generate shutdown manifest: %s", exc)
+
+    shutdown_coordinator.register_flush(_manifest_flush, name="shutdown manifest")
+
     yield
 
-    # Shutdown
-    logger.info("Aurora API shutting down...")
-
-    # Export final telemetry snapshot
-    try:
-        aurora_telemetry = get_telemetry()
-        snapshot = aurora_telemetry.get_metrics_snapshot(context_tag="shutdown_metrics")
-        logger.info(
-            "📊 Final telemetry: %d operations, %d features tracked",
-            len(snapshot.performance_metrics),
-            len(snapshot.adoption_metrics),
-        )
-    except Exception as e:
-        logger.debug("Telemetry snapshot failed: %s", e)
-
-    # Stop HALO/PAS drift controller if running
-    if HALO_PAS_AVAILABLE and HALO_PAS_CONTROLLER:
-        try:
-            await HALO_PAS_CONTROLLER.stop()
-            logger.info("✅ HALO/PAS Drift Controller stopped")
-        except Exception as e:
-            logger.error("❌ Failed to stop HALO/PAS Controller: %s", e)
-
-    # Build and persist shutdown manifest (Phase 1 implementation)
-    try:
-        import json  # local import to avoid mid-file import lint warnings
-        manifest = build_shutdown_manifest()
-        manifest_path = os.path.join(os.getcwd(), "shutdown_manifest.json")
-        with open(manifest_path, "w", encoding="utf-8") as f:
-            json.dump(manifest, f, ensure_ascii=False, indent=2)
-        logger.info(
-            "🧾 Shutdown manifest written (%s components, hash=%s)",
-            len(manifest.get("components", {})),
-            manifest.get("hash"),
-        )
-    except Exception as e:
-        logger.warning("⚠️ Failed to generate shutdown manifest: %s", e)
+    # Shutdown — coordinator cancels tasks, shuts down executors, runs flushes
+    logger.info(
+        "Aurora API shutting down (tasks=%d flushes=%d executors=%d)...",
+        shutdown_coordinator.pending_task_count,
+        shutdown_coordinator.registered_flush_count,
+        shutdown_coordinator.registered_executor_count,
+    )
+    await shutdown_coordinator.shutdown(timeout=10.0)
+    logger.info("Aurora API shutdown complete.")
 
 
 def build_shutdown_manifest() -> Dict[str, Any]:

--- a/src/runtime/shutdown.py
+++ b/src/runtime/shutdown.py
@@ -1,0 +1,125 @@
+"""
+Shutdown Coordinator
+=====================
+Centralises graceful-shutdown logic for the Aurora API process.
+
+Usage (in lifespan):
+
+    coordinator = ShutdownCoordinator()
+
+    # During startup, register anything that needs cleanup:
+    bg_task = asyncio.create_task(my_background_loop())
+    coordinator.register(bg_task, name="my_background_loop")
+
+    coordinator.register_executor(thread_pool)
+
+    coordinator.register_flush(monitoring_system.export_state)
+
+    yield  # serve requests
+
+    # On shutdown:
+    await coordinator.shutdown(timeout=10.0)
+"""
+
+import asyncio
+import concurrent.futures
+import logging
+from typing import Any, Callable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class ShutdownCoordinator:
+    """
+    Coordinates graceful shutdown of background tasks, thread-pool executors,
+    and async/sync flush callables.
+
+    Registration order matters: tasks are cancelled in reverse order so
+    higher-level dependents are stopped before lower-level producers.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: List[Tuple[asyncio.Task, str]] = []
+        self._executors: List[concurrent.futures.Executor] = []
+        self._flushes: List[Tuple[Callable[[], Any], str]] = []
+
+    # ------------------------------------------------------------------
+    # Registration API
+    # ------------------------------------------------------------------
+
+    def register(self, task: "asyncio.Task[Any]", name: str = "") -> None:
+        """Register a background asyncio Task for cancellation on shutdown."""
+        self._tasks.append((task, name or repr(task)))
+
+    def register_executor(self, executor: concurrent.futures.Executor, name: str = "") -> None:
+        """Register a ThreadPoolExecutor (or any Executor) for orderly shutdown."""
+        self._executors.append(executor)
+
+    def register_flush(self, fn: Callable[[], Any], name: str = "") -> None:
+        """Register a zero-argument callable (sync or async) to run before exit."""
+        self._flushes.append((fn, name or getattr(fn, "__name__", repr(fn))))
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    async def shutdown(self, timeout: float = 10.0) -> None:
+        """
+        Cancel registered tasks, wait for them, shutdown executors, run flushes.
+
+        Args:
+            timeout: Per-task cancellation wait timeout in seconds.
+        """
+        await self._cancel_tasks(timeout)
+        self._shutdown_executors()
+        await self._run_flushes()
+
+    async def _cancel_tasks(self, timeout: float) -> None:
+        for task, name in reversed(self._tasks):
+            if task.done():
+                continue
+            logger.info("Cancelling background task: %s", name)
+            task.cancel()
+            done, _ = await asyncio.wait([task], timeout=timeout)
+            if task in done:
+                exc = task.exception() if not task.cancelled() else None
+                if exc:
+                    logger.warning("Task raised on cancellation (%s): %s", name, exc)
+                else:
+                    logger.debug("Task cancelled cleanly: %s", name)
+            else:
+                logger.warning("Task did not stop within %.1fs: %s", timeout, name)
+
+    def _shutdown_executors(self) -> None:
+        for executor in self._executors:
+            try:
+                executor.shutdown(wait=True)
+                logger.debug("Executor shut down: %s", repr(executor))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Executor shutdown raised: %s", exc)
+
+    async def _run_flushes(self) -> None:
+        for fn, name in self._flushes:
+            logger.debug("Running flush: %s", name)
+            try:
+                result = fn()
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Flush callable raised (%s): %s", name, exc)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def pending_task_count(self) -> int:
+        return sum(1 for t, _ in self._tasks if not t.done())
+
+    @property
+    def registered_flush_count(self) -> int:
+        return len(self._flushes)
+
+    @property
+    def registered_executor_count(self) -> int:
+        return len(self._executors)

--- a/tests/test_shutdown_coordinator.py
+++ b/tests/test_shutdown_coordinator.py
@@ -1,0 +1,147 @@
+"""
+Tests for src/runtime/shutdown.py — ShutdownCoordinator (issue #816).
+"""
+
+import asyncio
+import concurrent.futures
+import pytest
+
+from src.runtime.shutdown import ShutdownCoordinator
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_registered_task_is_cancelled_on_shutdown():
+    """Background tasks registered with the coordinator are cancelled on shutdown."""
+    cancelled = asyncio.Event()
+
+    async def long_runner():
+        try:
+            await asyncio.sleep(9999)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    coordinator = ShutdownCoordinator()
+    task = asyncio.create_task(long_runner())
+    await asyncio.sleep(0)  # let long_runner reach its first await before cancelling
+    coordinator.register(task, name="long_runner")
+
+    await coordinator.shutdown(timeout=2.0)
+
+    assert cancelled.is_set(), "Task should have received CancelledError"
+    assert task.cancelled(), "Task should be in cancelled state"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_already_done_task_is_skipped():
+    """Tasks that have already completed are not re-cancelled."""
+    async def quick():
+        return 42
+
+    coordinator = ShutdownCoordinator()
+    task = asyncio.create_task(quick())
+    await asyncio.sleep(0)  # let it complete
+    coordinator.register(task, name="quick")
+
+    # Should not raise
+    await coordinator.shutdown(timeout=1.0)
+    assert task.done()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flush_callable_is_invoked_on_shutdown():
+    """Flush callables registered with the coordinator are called during shutdown."""
+    called = []
+
+    def flush_fn():
+        called.append("flushed")
+
+    coordinator = ShutdownCoordinator()
+    coordinator.register_flush(flush_fn, name="test flush")
+    await coordinator.shutdown(timeout=1.0)
+
+    assert called == ["flushed"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_flush_callable_is_awaited():
+    """Async flush callables are properly awaited."""
+    called = []
+
+    async def async_flush():
+        called.append("async_flushed")
+
+    coordinator = ShutdownCoordinator()
+    coordinator.register_flush(async_flush, name="async flush")
+    await coordinator.shutdown(timeout=1.0)
+
+    assert called == ["async_flushed"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flush_exception_does_not_abort_shutdown():
+    """A failing flush callable logs a warning but does not stop other flushes."""
+    results = []
+
+    def bad_flush():
+        raise RuntimeError("flush failed")
+
+    def good_flush():
+        results.append("ok")
+
+    coordinator = ShutdownCoordinator()
+    coordinator.register_flush(bad_flush, name="bad")
+    coordinator.register_flush(good_flush, name="good")
+
+    # Should not raise
+    await coordinator.shutdown(timeout=1.0)
+    assert results == ["ok"], "Good flush should still run after bad flush"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_executor_is_shut_down():
+    """Registered ThreadPoolExecutors are shut down during coordinator shutdown."""
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    work_done = []
+
+    def work():
+        work_done.append(True)
+        return True
+
+    future = executor.submit(work)
+    future.result()  # ensure it completed
+
+    coordinator = ShutdownCoordinator()
+    coordinator.register_executor(executor)
+    await coordinator.shutdown(timeout=2.0)
+
+    # After shutdown, submitting new work should raise
+    with pytest.raises(RuntimeError):
+        executor.submit(lambda: None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_introspection_properties():
+    """pending_task_count and registered_flush_count reflect actual state."""
+    coordinator = ShutdownCoordinator()
+
+    async def runner():
+        await asyncio.sleep(9999)
+
+    task = asyncio.create_task(runner())
+    coordinator.register(task, name="t1")
+    coordinator.register_flush(lambda: None, name="f1")
+    coordinator.register_flush(lambda: None, name="f2")
+
+    assert coordinator.pending_task_count == 1
+    assert coordinator.registered_flush_count == 2
+
+    await coordinator.shutdown(timeout=1.0)
+    assert coordinator.pending_task_count == 0


### PR DESCRIPTION
## Summary

- Adds `src/runtime/shutdown.py` — `ShutdownCoordinator` with a clean registration API:
  - `register(task, name)` — asyncio Task for cancellation
  - `register_executor(executor)` — ThreadPoolExecutor for orderly shutdown
  - `register_flush(fn, name)` — sync or async zero-arg callable to run before exit
  - `shutdown(timeout)` — cancels tasks in reverse order (via `asyncio.wait`), shuts down executors (`shutdown(wait=True)`), runs flush callables; flush exceptions are logged but do not abort remaining flushes
  - Introspection: `pending_task_count`, `registered_flush_count`, `registered_executor_count`
- Refactors the `lifespan` handler in `api/aurora_api.py`:
  - Creates a `ShutdownCoordinator` at startup
  - HALO/PAS `.stop()`, telemetry snapshot, and shutdown manifest write are now registered as flush callables
  - The ad-hoc shutdown sequence is replaced by `await coordinator.shutdown(timeout=10.0)`
  - Startup logs task/flush/executor counts before delegating
- New background tasks and executors added in future PRs can be registered with the coordinator rather than adding more ad-hoc cleanup code.
- Adds `tests/test_shutdown_coordinator.py` with 7 unit tests covering all major paths.

## Test plan

- [ ] `pytest tests/test_shutdown_coordinator.py -v` → 7 passed
- [ ] Start server, send SIGTERM, confirm "shutdown complete" log line appears and manifest is written

Fixes #816

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_