### PR TITLE
feat(api): add Idempotency-Key middleware to prevent duplicate state changes (issue #819)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel, Field, field_validator, ConfigDict
 from src.observability import get_telemetry, get_r2_telemetry
 from src.middleware.body_size import MaxBodySizeMiddleware, _default_max_bytes
 from src.middleware.exception_handler import validation_handler
+from src.middleware.idempotency import IdempotencyMiddleware
 from src.middleware.request_id import RequestIDMiddleware
 from src.runtime.shutdown import ShutdownCoordinator
 
@@ -438,6 +439,11 @@ except Exception as e:  # pragma: no cover - graceful degradation if slowapi mis
 # Body-size guard: registered before RequestIDMiddleware so oversized requests
 # are rejected before ID assignment and inner middleware run.
 app.add_middleware(MaxBodySizeMiddleware, max_bytes=_default_max_bytes())
+
+# Idempotency middleware: caches and replays responses for state-changing
+# requests that carry an Idempotency-Key header. Registered before
+# RequestIDMiddleware so the ID is already set when idempotency logic fires.
+app.add_middleware(IdempotencyMiddleware)
 
 # Request-ID middleware: must be registered last so it wraps everything and
 # its ContextVar is set before any inner middleware runs.

--- a/src/middleware/idempotency.py
+++ b/src/middleware/idempotency.py
@@ -1,0 +1,181 @@
+"""
+Idempotency-Key Middleware
+===========================
+Prevents duplicate execution of state-changing requests by caching
+responses keyed on the client-supplied Idempotency-Key header.
+
+Behaviour:
+  - No header → pass through unchanged (key is optional by default).
+  - Header present, UUID-invalid → HTTP 422.
+  - Header present, first request → execute route, cache response, return it.
+  - Header present, same key in-flight → HTTP 409 (retry later).
+  - Header present, same key already done → replay cached response, no route call.
+
+Cache is in-process (dict); TTL defaults to 24 h via AURORA_IDEMPOTENCY_TTL_SECONDS.
+For multi-process deployments, replace _IdempotencyStore with a Redis backend.
+
+Key uniqueness scope: (HTTP method, URL path, Idempotency-Key value).
+This prevents a single key value from accidentally de-duplicating requests
+to different endpoints.
+"""
+
+import logging
+import os
+import re
+import time
+from typing import Dict, Optional, Tuple
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+_DEFAULT_TTL = 86_400  # 24 hours
+
+
+def _ttl() -> float:
+    try:
+        return float(os.getenv("AURORA_IDEMPOTENCY_TTL_SECONDS", str(_DEFAULT_TTL)))
+    except ValueError:
+        return _DEFAULT_TTL
+
+
+# ---------------------------------------------------------------------------
+# In-process cache (swap this class for a Redis-backed one in production)
+# ---------------------------------------------------------------------------
+
+class _CacheRecord:
+    __slots__ = ("status", "status_code", "body", "media_type", "headers", "expires_at")
+
+    def __init__(
+        self,
+        *,
+        status: str,
+        status_code: int = 0,
+        body: bytes = b"",
+        media_type: Optional[str] = None,
+        headers: Optional[dict] = None,
+        expires_at: float = 0.0,
+    ) -> None:
+        self.status = status          # "in_flight" | "done"
+        self.status_code = status_code
+        self.body = body
+        self.media_type = media_type
+        self.headers = headers or {}
+        self.expires_at = expires_at
+
+
+_CacheKey = Tuple[str, str, str]  # (method, path, idempotency_key)
+
+_store: Dict[_CacheKey, _CacheRecord] = {}
+
+
+def _purge_expired() -> None:
+    now = time.monotonic()
+    expired = [k for k, v in _store.items() if v.expires_at < now]
+    for k in expired:
+        del _store[k]
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+class IdempotencyMiddleware(BaseHTTPMiddleware):
+    """Cache and replay responses for requests carrying an Idempotency-Key header."""
+
+    def __init__(self, app: ASGIApp, ttl_seconds: Optional[float] = None) -> None:
+        super().__init__(app)
+        self._ttl = ttl_seconds if ttl_seconds is not None else _ttl()
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        raw_key = request.headers.get("Idempotency-Key")
+        if not raw_key:
+            return await call_next(request)
+
+        # Validate UUID format
+        if not _UUID_RE.match(raw_key.strip()):
+            return JSONResponse(
+                {"detail": "Idempotency-Key must be a UUID (e.g. xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)."},
+                status_code=422,
+            )
+
+        key = raw_key.strip().lower()
+        cache_key: _CacheKey = (request.method, request.url.path, key)
+
+        # Periodically evict expired entries (simple O(n) scan is fine at low volume)
+        _purge_expired()
+
+        record = _store.get(cache_key)
+
+        if record is not None:
+            if record.status == "in_flight":
+                logger.info("Idempotency: key %s in-flight for %s %s", key, request.method, request.url.path)
+                return JSONResponse(
+                    {"detail": "A request with this Idempotency-Key is already in progress. Retry after it completes."},
+                    status_code=409,
+                    headers={"Retry-After": "5"},
+                )
+
+            if record.status == "done" and record.expires_at > time.monotonic():
+                logger.debug("Idempotency: replaying cached response for key %s", key)
+                # Strip hop-by-hop headers that must not be forwarded
+                headers = {k: v for k, v in record.headers.items() if k.lower() not in ("content-length",)}
+                return Response(
+                    content=record.body,
+                    status_code=record.status_code,
+                    headers=headers,
+                    media_type=record.media_type,
+                )
+
+        # First request with this key — mark in-flight
+        _store[cache_key] = _CacheRecord(
+            status="in_flight",
+            expires_at=time.monotonic() + self._ttl,
+        )
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            # Route raised — remove in-flight marker so client can retry
+            _store.pop(cache_key, None)
+            raise
+
+        # Buffer the response body so we can both cache and return it
+        body_chunks = []
+        async for chunk in response.body_iterator:
+            body_chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode())
+        body = b"".join(body_chunks)
+
+        _store[cache_key] = _CacheRecord(
+            status="done",
+            status_code=response.status_code,
+            body=body,
+            media_type=response.media_type,
+            headers=dict(response.headers),
+            expires_at=time.monotonic() + self._ttl,
+        )
+
+        logger.info(
+            "Idempotency: stored response (status=%d) for key %s on %s %s",
+            response.status_code, key, request.method, request.url.path,
+        )
+
+        return Response(
+            content=body,
+            status_code=response.status_code,
+            headers={k: v for k, v in response.headers.items() if k.lower() != "content-length"},
+            media_type=response.media_type,
+        )
+
+
+def clear_idempotency_cache() -> None:
+    """Remove all entries from the in-process cache (useful in tests)."""
+    _store.clear()

--- a/tests/test_idempotency_middleware.py
+++ b/tests/test_idempotency_middleware.py
@@ -1,0 +1,148 @@
+"""
+Tests for src/middleware/idempotency.py — IdempotencyMiddleware (issue #819).
+"""
+
+import uuid
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.middleware.idempotency import IdempotencyMiddleware, clear_idempotency_cache
+
+_VALID_KEY = str(uuid.uuid4())
+_VALID_KEY_2 = str(uuid.uuid4())
+
+
+def _make_app(ttl: float = 3600) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(IdempotencyMiddleware, ttl_seconds=ttl)
+
+    call_count = {"n": 0}
+
+    @app.post("/state")
+    async def create_state():
+        call_count["n"] += 1
+        return {"count": call_count["n"]}
+
+    app.state.call_count = call_count
+    return app
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """Clear the idempotency cache before every test."""
+    clear_idempotency_cache()
+    yield
+    clear_idempotency_cache()
+
+
+@pytest.mark.unit
+def test_request_without_idempotency_key_passes_through():
+    """Requests without Idempotency-Key are forwarded normally on every call."""
+    client = TestClient(_make_app())
+    r1 = client.post("/state")
+    r2 = client.post("/state")
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json()["count"] == 1
+    assert r2.json()["count"] == 2  # called twice, not cached
+
+
+@pytest.mark.unit
+def test_same_key_replays_cached_response():
+    """Second request with the same Idempotency-Key returns the cached response."""
+    app = _make_app()
+    client = TestClient(app)
+
+    r1 = client.post("/state", headers={"Idempotency-Key": _VALID_KEY})
+    r2 = client.post("/state", headers={"Idempotency-Key": _VALID_KEY})
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # Route was called only once
+    assert r1.json() == r2.json()
+    assert app.state.call_count["n"] == 1
+
+
+@pytest.mark.unit
+def test_different_keys_are_independent():
+    """Two different keys each execute the route independently."""
+    app = _make_app()
+    client = TestClient(app)
+
+    r1 = client.post("/state", headers={"Idempotency-Key": _VALID_KEY})
+    r2 = client.post("/state", headers={"Idempotency-Key": _VALID_KEY_2})
+
+    assert r1.json()["count"] == 1
+    assert r2.json()["count"] == 2
+    assert app.state.call_count["n"] == 2
+
+
+@pytest.mark.unit
+def test_invalid_key_format_returns_422():
+    """Non-UUID Idempotency-Key values are rejected with HTTP 422."""
+    client = TestClient(_make_app())
+    response = client.post("/state", headers={"Idempotency-Key": "not-a-uuid"})
+    assert response.status_code == 422
+    assert "UUID" in response.json()["detail"]
+
+
+@pytest.mark.unit
+def test_expired_cache_entry_allows_re_execution():
+    """After TTL expires, the same key triggers a fresh route execution."""
+    app = _make_app(ttl=0.0)  # immediate expiry
+    client = TestClient(app)
+
+    r1 = client.post("/state", headers={"Idempotency-Key": _VALID_KEY})
+    assert r1.json()["count"] == 1
+
+    # Force-clear so expiry-based eviction fires on next request
+    clear_idempotency_cache()
+
+    r2 = client.post("/state", headers={"Idempotency-Key": _VALID_KEY})
+    assert r2.json()["count"] == 2  # executed again
+    assert app.state.call_count["n"] == 2
+
+
+@pytest.mark.unit
+def test_different_paths_with_same_key_are_independent():
+    """Same Idempotency-Key on different paths does not cross-contaminate."""
+    app = FastAPI()
+    app.add_middleware(IdempotencyMiddleware, ttl_seconds=3600)
+
+    @app.post("/a")
+    async def route_a():
+        return {"route": "a"}
+
+    @app.post("/b")
+    async def route_b():
+        return {"route": "b"}
+
+    client = TestClient(app)
+
+    ra = client.post("/a", headers={"Idempotency-Key": _VALID_KEY})
+    rb = client.post("/b", headers={"Idempotency-Key": _VALID_KEY})
+
+    assert ra.json()["route"] == "a"
+    assert rb.json()["route"] == "b"
+
+
+@pytest.mark.unit
+def test_cached_response_preserves_status_code():
+    """Cached replay returns the original HTTP status code (not always 200)."""
+    app = FastAPI()
+    app.add_middleware(IdempotencyMiddleware, ttl_seconds=3600)
+
+    @app.post("/created")
+    async def create():
+        from fastapi.responses import JSONResponse
+        return JSONResponse({"msg": "ok"}, status_code=201)
+
+    client = TestClient(app)
+    key = str(uuid.uuid4())
+
+    r1 = client.post("/created", headers={"Idempotency-Key": key})
+    r2 = client.post("/created", headers={"Idempotency-Key": key})
+
+    assert r1.status_code == 201
+    assert r2.status_code == 201


### PR DESCRIPTION
## Summary

- Adds `src/middleware/idempotency.py` — `IdempotencyMiddleware` (Starlette `BaseHTTPMiddleware`) that caches and replays HTTP responses keyed on `(HTTP method, URL path, Idempotency-Key)`:
  - **No header** → pass through unchanged (key is optional).
  - **Invalid format** (non-UUID) → HTTP 422 with descriptive message.
  - **First request** → execute route, buffer and store response, return it.
  - **Repeat request** within TTL → replay cached response; route handler is NOT invoked again.
  - **In-flight collision** (same key already processing) → HTTP 409 with `Retry-After: 5`.
  - TTL configurable via `AURORA_IDEMPOTENCY_TTL_SECONDS` (default 24 hours).
  - `clear_idempotency_cache()` helper for test isolation.
  - Evicts expired entries on each keyed request (O(n) scan, acceptable at low store size).
- Wires `IdempotencyMiddleware` into `aurora_api.py` ahead of `RequestIDMiddleware` so every route is protected without requiring per-route changes.
- Adds `tests/test_idempotency_middleware.py` with 7 unit tests.

## Deployment note

For multi-process / multi-node deployments, the in-process dict cache is not shared. Replace the `_store` dict in `src/middleware/idempotency.py` with a Redis-backed adapter (use `AURORA_IDEMPOTENCY_REDIS_URL` or similar) when running more than one worker.

## Test plan

- [ ] `pytest tests/test_idempotency_middleware.py -v` → 7 passed
- [ ] `curl -X POST /state -H "Idempotency-Key: $(uuidgen)"` twice → second returns cached body, route not called
- [ ] Invalid key format → 422
- [ ] Same key twice in rapid succession → first returns result, second replays cached

Fixes #819

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_