### PR TITLE
fix(monitoring): add retention TTL and periodic cleanup for unbounded in-memory stores (issue #809)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -6,6 +6,7 @@ Exposes endpoints for quantum and geometric algebra modules.
 Enhanced with Claude Sonnet 4 capabilities and ChatGPT Agent Mode integration.
 """
 
+import asyncio
 import logging
 import os
 import time
@@ -342,6 +343,22 @@ async def lifespan(app: FastAPI):
             shutdown_coordinator.register_flush(HALO_PAS_CONTROLLER.stop, name="HALO/PAS stop")
         except Exception as e:
             logger.error("❌ Failed to start HALO/PAS Controller: %s", e)
+
+    # Periodic retention cleanup: evict old violations/alerts/interventions from memory
+    _cleanup_interval = int(os.getenv("AURORA_RETENTION_CLEANUP_INTERVAL_SECONDS", "3600"))
+
+    async def _retention_cleanup_loop() -> None:
+        from src.monitoring.dashboard_api import run_monitoring_cleanup
+        while True:
+            await asyncio.sleep(_cleanup_interval)
+            try:
+                run_monitoring_cleanup()
+            except Exception as _exc:  # noqa: BLE001
+                logger.debug("Retention cleanup cycle error: %s", _exc)
+
+    _cleanup_task = asyncio.create_task(_retention_cleanup_loop(), name="retention_cleanup")
+    shutdown_coordinator.register(_cleanup_task, name="retention_cleanup")
+    logger.info("✅ Retention cleanup task started (interval=%ds)", _cleanup_interval)
 
     # Register telemetry snapshot as a shutdown flush
     def _telemetry_flush() -> None:

--- a/src/monitoring/dashboard_api.py
+++ b/src/monitoring/dashboard_api.py
@@ -97,6 +97,12 @@ def get_monitoring_system(
     return _monitoring_system
 
 
+def run_monitoring_cleanup() -> None:
+    """Run retention cleanup on the active MonitoringSystem instance (no-op if not yet created)."""
+    if _monitoring_system is not None:
+        _monitoring_system.run_retention_cleanup()
+
+
 def create_monitoring_router(
     storage_dir: Optional[Path] = None,
     ethics_rules_path: Optional[Path] = None

--- a/src/monitoring/drift_detector.py
+++ b/src/monitoring/drift_detector.py
@@ -95,11 +95,12 @@ class DriftDetector:
         info_threshold: float = 0.2,
         warning_threshold: float = 0.5,
         critical_threshold: float = 0.8,
-        alerts_path: Optional[Path] = None
+        alerts_path: Optional[Path] = None,
+        retention_hours: int = 168,
     ):
         """
         Initialize drift detector
-        
+
         Args:
             z_score_threshold: Standard deviations for z-score alerts (default: 3.0)
             moving_avg_window: Window size for moving average (default: 10)
@@ -107,6 +108,7 @@ class DriftDetector:
             warning_threshold: Relative change threshold for warning alerts (default: 0.5 = 50%)
             critical_threshold: Relative change threshold for critical alerts (default: 0.8 = 80%)
             alerts_path: Append-only JSONL path for persisted alerts
+            retention_hours: Retain in-memory alerts for this many hours (default: 168 = 7 days)
         """
         self.z_score_threshold = z_score_threshold
         self.moving_avg_window = moving_avg_window
@@ -114,6 +116,7 @@ class DriftDetector:
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
         self.alerts_path = alerts_path
+        self.retention_hours = retention_hours
 
         self._write_lock = threading.Lock()
 
@@ -121,7 +124,7 @@ class DriftDetector:
         self.baselines: Dict[str, BaselineMetrics] = {}
         self.alerts: List[DriftAlert] = []
         self._load_alerts()
-        
+
         logger.info("Drift detector initialized with z_threshold=%.1f", z_score_threshold)
     
     def establish_baseline(
@@ -409,6 +412,16 @@ class DriftDetector:
             metadata=data.get('metadata', {})
         )
     
+    def purge_old_alerts(self) -> int:
+        """Drop in-memory alerts older than *retention_hours*. Returns count removed."""
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=self.retention_hours)
+        before_count = len(self.alerts)
+        self.clear_alerts(before=cutoff)
+        removed = before_count - len(self.alerts)
+        if removed:
+            logger.info("Drift detector: purged %d alerts older than %dh", removed, self.retention_hours)
+        return removed
+
     def clear_alerts(self, before: Optional[datetime] = None):
         """
         Clear old alerts

--- a/src/monitoring/ethics_engine.py
+++ b/src/monitoring/ethics_engine.py
@@ -101,19 +101,22 @@ class EthicsEngine:
     def __init__(
         self,
         rules_path: Optional[Path] = None,
-        violations_path: Optional[Path] = None
+        violations_path: Optional[Path] = None,
+        retention_hours: int = 168,
     ):
         """
         Initialize ethics engine
-        
+
         Args:
             rules_path: Path to rules configuration file (JSON)
             violations_path: Append-only JSONL path for persisted violations
+            retention_hours: Retain in-memory violations for this many hours (default: 168 = 7 days)
         """
         self.rules: Dict[str, EthicsRule] = {}
         self.violations: List[EthicsViolation] = []
         self.custom_evaluators: Dict[str, Callable] = {}
         self.violations_path = violations_path
+        self.retention_hours = retention_hours
         self._write_lock = threading.Lock()
         
         # Load default rules if available
@@ -539,6 +542,17 @@ class EthicsEngine:
             for rule_id, rule in self.rules.items()
         }
     
+    def purge_old_violations(self) -> int:
+        """Drop in-memory violations older than *retention_hours*. Returns count removed."""
+        from datetime import timedelta, timezone
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=self.retention_hours)
+        before_count = len(self.violations)
+        self.clear_violations(before=cutoff)
+        removed = before_count - len(self.violations)
+        if removed:
+            logger.info("Ethics engine: purged %d violations older than %dh", removed, self.retention_hours)
+        return removed
+
     def clear_violations(self, before: Optional[datetime] = None):
         """
         Clear old violations

--- a/src/monitoring/monitoring_system.py
+++ b/src/monitoring/monitoring_system.py
@@ -103,16 +103,19 @@ class MonitoringSystem:
         self,
         storage_dir: Optional[Path] = None,
         ethics_rules_path: Optional[Path] = None,
-        config: Optional[AlertConfig] = None
+        config: Optional[AlertConfig] = None,
+        retention_hours: int = 168,
     ):
         """
         Initialize monitoring system
-        
+
         Args:
             storage_dir: Directory for persistent storage
             ethics_rules_path: Path to ethics rules configuration
             config: Alert configuration
+            retention_hours: Retain in-memory state for this many hours (default: 168 = 7 days)
         """
+        self.retention_hours = retention_hours
         if storage_dir is not None:
             self.storage_dir = Path(storage_dir)
         else:
@@ -127,15 +130,17 @@ class MonitoringSystem:
                 self.storage_dir = Path("./monitoring_data")
         self._state_path = self.storage_dir / "monitoring_state.json"
         self.config = config or AlertConfig()
-        
-        # Initialize subsystems
-        self.behavior_monitor = BehaviorMonitor(retention_hours=168)
+
+        # Initialize subsystems with matching retention window
+        self.behavior_monitor = BehaviorMonitor(retention_hours=retention_hours)
         self.drift_detector = DriftDetector(
-            alerts_path=self.storage_dir / "drift_alerts.jsonl"
+            alerts_path=self.storage_dir / "drift_alerts.jsonl",
+            retention_hours=retention_hours,
         )
         self.ethics_engine = EthicsEngine(
             rules_path=ethics_rules_path,
-            violations_path=self.storage_dir / "ethics_violations.jsonl"
+            violations_path=self.storage_dir / "ethics_violations.jsonl",
+            retention_hours=retention_hours,
         )
         
         audit_storage = self.storage_dir / "audit_log.jsonl"
@@ -182,7 +187,37 @@ class MonitoringSystem:
         """
         self.alert_handlers[level].append(handler)
         logger.info("Registered alert handler for %s level", level.value)
-    
+
+    def purge_old_interventions(self) -> int:
+        """Trim interventions and last_intervention_time entries older than retention_hours."""
+        from datetime import timedelta, timezone
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=self.retention_hours)
+        before_count = len(self.interventions)
+        self.interventions = [
+            iv for iv in self.interventions
+            if datetime.fromisoformat(iv.timestamp) >= cutoff
+        ]
+        # Evict stale cooldown entries
+        stale_agents = [
+            agent_id for agent_id, ts in self.last_intervention_time.items()
+            if ts < cutoff
+        ]
+        for agent_id in stale_agents:
+            del self.last_intervention_time[agent_id]
+        removed = before_count - len(self.interventions)
+        if removed or stale_agents:
+            logger.info(
+                "MonitoringSystem: purged %d interventions and %d cooldown entries older than %dh",
+                removed, len(stale_agents), self.retention_hours,
+            )
+        return removed
+
+    def run_retention_cleanup(self) -> None:
+        """Run all retention cleanup methods across every subsystem."""
+        self.drift_detector.purge_old_alerts()
+        self.ethics_engine.purge_old_violations()
+        self.purge_old_interventions()
+
     def establish_agent_baseline(
         self,
         agent_id: str,

--- a/tests/test_retention_ttl.py
+++ b/tests/test_retention_ttl.py
@@ -1,0 +1,206 @@
+"""
+Tests for retention TTL on monitoring subsystems (issue #809).
+
+Verifies that violations, drift alerts, interventions, and cooldown maps
+are bounded by the retention window and purged on demand.
+"""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from src.monitoring.drift_detector import DriftDetector, DriftAlert, DriftLevel, DriftMethod
+from src.monitoring.ethics_engine import EthicsEngine, EthicsViolation, ViolationSeverity, RuleCategory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _old_ts(hours: int = 200) -> str:
+    """ISO timestamp older than 168 h (default retention)."""
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+
+def _fresh_ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# DriftDetector
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_drift_detector_accepts_retention_hours():
+    """DriftDetector can be initialised with a custom retention_hours."""
+    dd = DriftDetector(retention_hours=48)
+    assert dd.retention_hours == 48
+
+
+@pytest.mark.unit
+def test_purge_old_alerts_removes_expired(tmp_path):
+    """purge_old_alerts drops alerts older than retention_hours."""
+    dd = DriftDetector(retention_hours=168, alerts_path=tmp_path / "alerts.jsonl")
+
+    # Plant two synthetic alerts: one old, one fresh
+    old_alert = DriftAlert(
+        timestamp=_old_ts(200),
+        agent_id="a1", metric_name="m",
+        level=DriftLevel.CRITICAL, method=DriftMethod.Z_SCORE,
+        current_value=5.0, baseline_value=1.0, deviation=4.0,
+        description="old alert",
+    )
+    fresh_alert = DriftAlert(
+        timestamp=_fresh_ts(),
+        agent_id="a1", metric_name="m",
+        level=DriftLevel.INFO, method=DriftMethod.Z_SCORE,
+        current_value=1.1, baseline_value=1.0, deviation=0.1,
+        description="fresh alert",
+    )
+    dd.alerts = [old_alert, fresh_alert]
+
+    removed = dd.purge_old_alerts()
+
+    assert removed == 1
+    assert len(dd.alerts) == 1
+    assert dd.alerts[0].level == DriftLevel.INFO
+
+
+@pytest.mark.unit
+def test_purge_old_alerts_noop_when_all_fresh(tmp_path):
+    """purge_old_alerts does nothing when all alerts are within retention window."""
+    dd = DriftDetector(retention_hours=168, alerts_path=tmp_path / "alerts.jsonl")
+    fresh_alert = DriftAlert(
+        timestamp=_fresh_ts(),
+        agent_id="a1", metric_name="m",
+        level=DriftLevel.INFO, method=DriftMethod.Z_SCORE,
+        current_value=1.1, baseline_value=1.0, deviation=0.1,
+        description="fresh alert",
+    )
+    dd.alerts = [fresh_alert]
+
+    removed = dd.purge_old_alerts()
+
+    assert removed == 0
+    assert len(dd.alerts) == 1
+
+
+# ---------------------------------------------------------------------------
+# EthicsEngine
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_ethics_engine_accepts_retention_hours():
+    """EthicsEngine can be initialised with a custom retention_hours."""
+    ee = EthicsEngine(retention_hours=24)
+    assert ee.retention_hours == 24
+
+
+@pytest.mark.unit
+def test_purge_old_violations_removes_expired(tmp_path):
+    """purge_old_violations drops violations older than retention_hours."""
+    ee = EthicsEngine(
+        violations_path=tmp_path / "violations.jsonl",
+        retention_hours=168,
+    )
+
+    old_v = EthicsViolation(
+        timestamp=_old_ts(200),
+        agent_id="a1",
+        rule_id="r1", rule_name="Test Rule",
+        severity=ViolationSeverity.CRITICAL, category=RuleCategory.SAFETY,
+        description="old violation", blocked=False, context={},
+    )
+    fresh_v = EthicsViolation(
+        timestamp=_fresh_ts(),
+        agent_id="a1",
+        rule_id="r2", rule_name="Other Rule",
+        severity=ViolationSeverity.LOW, category=RuleCategory.SAFETY,
+        description="fresh violation", blocked=False, context={},
+    )
+    ee.violations = [old_v, fresh_v]
+
+    removed = ee.purge_old_violations()
+
+    assert removed == 1
+    assert len(ee.violations) == 1
+    assert ee.violations[0].rule_id == "r2"
+
+
+# ---------------------------------------------------------------------------
+# MonitoringSystem
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_monitoring_system_accepts_retention_hours(tmp_path):
+    """MonitoringSystem propagates retention_hours to subsystems."""
+    import os
+    with patch.dict(os.environ, {"MONITORING_SIGNING_KEY": "a" * 64}):
+        from src.monitoring.monitoring_system import MonitoringSystem
+        ms = MonitoringSystem(storage_dir=tmp_path, retention_hours=48)
+        assert ms.retention_hours == 48
+        assert ms.drift_detector.retention_hours == 48
+        assert ms.ethics_engine.retention_hours == 48
+
+
+@pytest.mark.unit
+def test_purge_old_interventions_removes_stale(tmp_path):
+    """purge_old_interventions trims old entries from interventions and cooldown map."""
+    import os
+    from src.monitoring.monitoring_system import MonitoringSystem, Intervention, InterventionType
+
+    with patch.dict(os.environ, {"MONITORING_SIGNING_KEY": "a" * 64}):
+        ms = MonitoringSystem(storage_dir=tmp_path, retention_hours=168)
+
+    old_iv = Intervention(
+        timestamp=_old_ts(200),
+        agent_id="agent-old",
+        type=InterventionType.NOTIFY_OPERATOR,
+        reason="old",
+        context={},
+        success=True,
+    )
+    fresh_iv = Intervention(
+        timestamp=_fresh_ts(),
+        agent_id="agent-new",
+        type=InterventionType.NOTIFY_OPERATOR,
+        reason="fresh",
+        context={},
+        success=True,
+    )
+    ms.interventions = [old_iv, fresh_iv]
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=200)
+    ms.last_intervention_time = {
+        "agent-old": cutoff - timedelta(hours=1),
+        "agent-new": datetime.now(timezone.utc),
+    }
+
+    removed = ms.purge_old_interventions()
+
+    assert removed == 1
+    assert len(ms.interventions) == 1
+    assert ms.interventions[0].agent_id == "agent-new"
+    assert "agent-old" not in ms.last_intervention_time
+    assert "agent-new" in ms.last_intervention_time
+
+
+@pytest.mark.unit
+def test_run_retention_cleanup_calls_all_subsystems(tmp_path):
+    """run_retention_cleanup delegates to all three purge methods."""
+    import os
+    from unittest.mock import MagicMock
+    from src.monitoring.monitoring_system import MonitoringSystem
+
+    with patch.dict(os.environ, {"MONITORING_SIGNING_KEY": "a" * 64}):
+        ms = MonitoringSystem(storage_dir=tmp_path, retention_hours=168)
+
+    ms.drift_detector.purge_old_alerts = MagicMock(return_value=0)
+    ms.ethics_engine.purge_old_violations = MagicMock(return_value=0)
+    ms.purge_old_interventions = MagicMock(return_value=0)
+
+    ms.run_retention_cleanup()
+
+    ms.drift_detector.purge_old_alerts.assert_called_once()
+    ms.ethics_engine.purge_old_violations.assert_called_once()
+    ms.purge_old_interventions.assert_called_once()


### PR DESCRIPTION
## Summary

Unbounded `self.violations`, `self.alerts`, `self.interventions`, and `self.last_intervention_time` dicts grew forever. This PR adds a `retention_hours` parameter and scheduled cleanup across all three monitoring subsystems.

### Changes

- **`DriftDetector`**: `retention_hours` parameter (default 168 h = 7 days); new `purge_old_alerts()` that calls the existing `clear_alerts(before=cutoff)`.
- **`EthicsEngine`**: `retention_hours` parameter; new `purge_old_violations()` that calls `clear_violations(before=cutoff)`.
- **`MonitoringSystem`**: `retention_hours` parameter propagated to all subsystems; `purge_old_interventions()` trims `self.interventions` and evicts stale `last_intervention_time` entries; `run_retention_cleanup()` delegates to all three.
- **`dashboard_api.py`**: module-level `run_monitoring_cleanup()` helper — calls `run_retention_cleanup()` on the active singleton, no-op if not yet created.
- **`aurora_api.py`**: starts a `_retention_cleanup_loop()` background asyncio task in `lifespan` that calls `run_monitoring_cleanup()` every `AURORA_RETENTION_CLEANUP_INTERVAL_SECONDS` seconds (default 3600). Task is cancelled cleanly on shutdown.

### Default retention

All stores default to **168 hours (7 days)**. Override individually via the `retention_hours` parameter or globally via the `AURORA_RETENTION_CLEANUP_INTERVAL_SECONDS` env var (controls cleanup frequency, not window length — adjust `retention_hours` at instantiation for the window).

## Test plan

- [ ] `pytest tests/test_retention_ttl.py -v` → 8 passed
- [ ] Plant old + fresh entries; call `run_retention_cleanup()`; assert only fresh remain
- [ ] Long-running process: memory usage stays bounded after cleanup cycle

Fixes #809

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_