### PR TITLE
feat(config): centralized settings validation and startup-complete signal

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -278,6 +278,13 @@ async def lifespan(app: FastAPI):
     """Manage application lifecycle with startup and shutdown logic."""
     # Startup
     logger.info("Aurora API starting up...")
+
+    # Validate application configuration — exits non-zero if critical vars missing
+    from src.config.settings import load_settings
+    _settings = load_settings(exit_on_error=True)
+    if _settings:
+        logger.info("Configuration validated (build_phase=%s)", _settings.aurora_build_phase)
+
     logger.info("Rate limiter active: AI=20/min, crew=30/min, quantum=10/min, memory_write=60/min")
 
     # Warn when in-process monitoring state cannot be shared across workers.
@@ -346,6 +353,20 @@ async def lifespan(app: FastAPI):
             logger.warning("⚠️ Failed to generate shutdown manifest: %s", exc)
 
     shutdown_coordinator.register_flush(_manifest_flush, name="shutdown manifest")
+
+    # ── Structured startup-complete record ──────────────────────────────────────
+    _optional_modules = {
+        "aumemmanager": AUMEMMANAGER_AVAILABLE,
+        "data_guardian": DATA_GUARDIAN_AVAILABLE,
+        "insight_ledger": INSIGHT_LEDGER_AVAILABLE,
+        "quantum_simulator": QUANTUM_SIMULATOR_AVAILABLE,
+        "halo_pas": HALO_PAS_AVAILABLE,
+    }
+    logger.info(
+        "Aurora API startup complete — routes=%d optional_modules=%s",
+        len(app.routes),
+        {k: v for k, v in _optional_modules.items() if not v},  # log only degraded ones
+    )
 
     yield
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,0 +1,87 @@
+"""Centralized application settings validated at startup."""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Optional
+
+from pydantic import model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+# Env vars that MUST be non-empty for the app to boot correctly.
+_CRITICAL_VARS = ("CSRF_SECRET_KEY", "AURORA_SECRET_KEY")
+
+# Env vars that are used but for which a warning (not a hard failure) is sufficient.
+_IMPORTANT_VARS = ("JWT_SECRET_KEY", "WS_AUTH_SECRET", "AES_KEY_256_HEX")
+
+
+class AuroraSettings(BaseSettings):
+    """Validated environment configuration for Aurora CloudBank API.
+
+    Critical vars raise ValueError on validation if empty; important vars
+    emit warnings. Instantiate once at startup; do not re-instantiate.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="allow",
+    )
+
+    # --- Critical (fail-closed) ---
+    csrf_secret_key: str = ""
+    aurora_secret_key: str = ""
+
+    # --- Important (warn-only) ---
+    jwt_secret_key: str = ""
+    ws_auth_secret: str = ""
+    aes_key_256_hex: str = ""
+
+    # --- Optional / operational ---
+    aurora_build_phase: str = "0"
+    monitoring_storage_dir: Optional[str] = None
+    aurora_state_root: Optional[str] = None
+    aurora_monitoring_path: Optional[str] = None
+    aurora_ledger_path: Optional[str] = None
+    openai_api_key: str = ""
+    mesh_openai_model: str = "gpt-4.1-mini"
+
+    @model_validator(mode="after")
+    def check_critical_vars(self) -> "AuroraSettings":
+        build_phase = self.aurora_build_phase.strip() == "1"
+        if build_phase:
+            return self
+        missing = [v for v in _CRITICAL_VARS if not getattr(self, v.lower(), "")]
+        if missing:
+            raise ValueError(
+                f"Critical env var(s) missing or empty at startup: {', '.join(missing)}. "
+                "Set them before starting the API."
+            )
+        for v in _IMPORTANT_VARS:
+            if not getattr(self, v.lower(), ""):
+                logger.warning(
+                    "Important env var %s is not set — related features may be degraded.", v
+                )
+        return self
+
+
+def load_settings(exit_on_error: bool = True) -> Optional[AuroraSettings]:
+    """Load and validate application settings.
+
+    Args:
+        exit_on_error: When True (default), call sys.exit(1) on validation failure
+                       so container orchestrators detect a bad boot.
+
+    Returns:
+        AuroraSettings on success; None if exit_on_error=False and validation fails.
+    """
+    try:
+        return AuroraSettings()
+    except Exception as exc:
+        logger.critical("Aurora startup failed — invalid configuration: %s", exc)
+        if exit_on_error:
+            sys.exit(1)
+        return None

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -1,0 +1,55 @@
+"""Tests for src/config/settings.py."""
+import importlib
+import sys
+import pytest
+
+
+def _reload_settings():
+    """Force-reload settings module to avoid cached validation state."""
+    for mod_name in list(sys.modules.keys()):
+        if "src.config" in mod_name:
+            del sys.modules[mod_name]
+
+
+@pytest.mark.unit
+def test_settings_load_with_critical_vars(monkeypatch):
+    monkeypatch.setenv("CSRF_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("AURORA_SECRET_KEY", "y" * 32)
+    monkeypatch.setenv("AURORA_BUILD_PHASE", "0")
+    _reload_settings()
+    from src.config.settings import AuroraSettings
+    s = AuroraSettings()
+    assert s.csrf_secret_key == "x" * 32
+
+
+@pytest.mark.unit
+def test_settings_fails_without_critical_vars(monkeypatch):
+    monkeypatch.delenv("CSRF_SECRET_KEY", raising=False)
+    monkeypatch.delenv("AURORA_SECRET_KEY", raising=False)
+    monkeypatch.setenv("AURORA_BUILD_PHASE", "0")
+    _reload_settings()
+    from src.config.settings import AuroraSettings
+    with pytest.raises(Exception):
+        AuroraSettings()
+
+
+@pytest.mark.unit
+def test_settings_build_phase_suppresses_check(monkeypatch):
+    monkeypatch.delenv("CSRF_SECRET_KEY", raising=False)
+    monkeypatch.delenv("AURORA_SECRET_KEY", raising=False)
+    monkeypatch.setenv("AURORA_BUILD_PHASE", "1")
+    _reload_settings()
+    from src.config.settings import AuroraSettings
+    s = AuroraSettings()  # should not raise
+    assert s.aurora_build_phase == "1"
+
+
+@pytest.mark.unit
+def test_load_settings_returns_none_without_exit(monkeypatch):
+    monkeypatch.delenv("CSRF_SECRET_KEY", raising=False)
+    monkeypatch.delenv("AURORA_SECRET_KEY", raising=False)
+    monkeypatch.setenv("AURORA_BUILD_PHASE", "0")
+    _reload_settings()
+    from src.config.settings import load_settings
+    result = load_settings(exit_on_error=False)
+    assert result is None


### PR DESCRIPTION
## Summary\n\n- Adds `src/config/settings.py` with `pydantic_settings.BaseSettings` — validates all critical env vars (`CSRF_SECRET_KEY`, `AURORA_SECRET_KEY`) at startup and calls `sys.exit(1)` if missing, so container orchestrators detect bad boots\n- Warns (but does not fail) on important-but-optional vars (`JWT_SECRET_KEY`, `WS_AUTH_SECRET`, `AES_KEY_256_HEX`)\n- Build-phase bypass via `AURORA_BUILD_PHASE=1` (consistent with the placeholder guard from #766)\n- Emits a structured "startup complete" log line listing route count and any degraded optional modules\n\n## Test plan\n\n- [x] `pytest tests/test_config_settings.py -v` — 4/4 passed\n- [ ] Full CI\n\nFixes #815\n\nhttps://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_