### PR TITLE
feat(middleware,utils): global CSRF enforcement + instance-level dir locks

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -63,6 +63,7 @@ from src.middleware.fastapi_security import (
     sanitize_request_id,
     sanitize_session_id
 )
+from src.middleware.csrf_middleware import GlobalCsrfMiddleware
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from fastapi import APIRouter
@@ -465,6 +466,11 @@ app.add_middleware(MaxBodySizeMiddleware, max_bytes=_default_max_bytes())
 # requests that carry an Idempotency-Key header. Registered before
 # RequestIDMiddleware so the ID is already set when idempotency logic fires.
 app.add_middleware(IdempotencyMiddleware)
+
+# Global CSRF enforcement: applies to all state-changing routes except the
+# allowlist defined in csrf_middleware._CSRF_ALLOWLIST.
+app.add_middleware(GlobalCsrfMiddleware)
+logger.info("✅ Global CSRF middleware registered")
 
 # Request-ID middleware: must be registered last so it wraps everything and
 # its ContextVar is set before any inner middleware runs.

--- a/src/middleware/csrf_middleware.py
+++ b/src/middleware/csrf_middleware.py
@@ -1,0 +1,173 @@
+"""Global CSRF enforcement middleware.
+
+Enforces CSRF token validation on all state-changing HTTP methods
+(POST, PUT, PATCH, DELETE) except for paths in the allowlist.
+
+The token must be present as the X-CSRF-Token (or X-Csrf-Token) request header.
+Token format mirrors src/middleware/fastapi_security.py:
+    session_id.timestamp.signature  (HMAC-SHA256, 5-minute TTL)
+
+Pair with: src/middleware/fastapi_security.py generate_csrf_token /
+           verify_csrf_token for per-endpoint use; this middleware enforces
+           the same rule globally so individual routes need not repeat it.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import time
+from typing import FrozenSet, Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+# HTTP methods that mutate state — CSRF applies to these
+_UNSAFE_METHODS: FrozenSet[str] = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Paths exempt from CSRF (machine-to-machine, read-only, or own-auth flows)
+_CSRF_ALLOWLIST: FrozenSet[str] = frozenset({
+    "/health",
+    "/metrics",
+    "/docs",
+    "/openapi.json",
+    "/redoc",
+    "/api/auth/token",      # OAuth token endpoint — has its own auth
+    "/api/auth/refresh",
+    "/api/csrf-token",      # Token issuance endpoint itself
+    "/csrf-token",
+    "/api/webhooks/",       # Webhook callbacks verified by their own signature
+})
+
+# Token freshness window — must match fastapi_security.py CSRF_TOKEN_EXPIRY_SECONDS
+_TOKEN_EXPIRY_SECONDS: int = 300
+_CLOCK_SKEW_GRACE_SECONDS: int = 30
+
+
+def _is_exempt(path: str) -> bool:
+    """Return True if *path* is on the CSRF allowlist."""
+    if path in _CSRF_ALLOWLIST:
+        return True
+    # Prefix match for path families (docs, redoc, openapi, webhooks)
+    for prefix in ("/api/webhooks/", "/docs", "/redoc", "/openapi"):
+        if path.startswith(prefix):
+            return True
+    return False
+
+
+def _validate_csrf_token(token: str, secret: str) -> bool:
+    """Validate a CSRF token using inline HMAC-SHA256 with timestamp check.
+
+    Expected token format: ``session_id.timestamp.signature``
+    This matches the format produced by
+    ``src.middleware.fastapi_security.generate_csrf_token``.
+
+    Args:
+        token:  Raw token string from the X-CSRF-Token header.
+        secret: CSRF secret key (CSRF_SECRET_KEY env var).
+
+    Returns:
+        True if signature is valid and token has not expired.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return False
+
+        session_id, timestamp_str, signature = parts
+
+        # Verify timestamp freshness with clock-skew grace period
+        token_time = int(timestamp_str)
+        current_time = int(time.time())
+        age = current_time - token_time
+        if age < -_CLOCK_SKEW_GRACE_SECONDS:
+            # Token timestamp is too far in the future
+            return False
+        if age > _TOKEN_EXPIRY_SECONDS + _CLOCK_SKEW_GRACE_SECONDS:
+            # Token has expired
+            return False
+
+        # Recompute expected HMAC signature
+        message = f"{session_id}.{timestamp_str}"
+        expected_sig = hmac.new(
+            secret.encode(),
+            message.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+
+        return hmac.compare_digest(signature, expected_sig)
+
+    except Exception:
+        return False
+
+
+class GlobalCsrfMiddleware(BaseHTTPMiddleware):
+    """Enforce CSRF token on all unsafe (non-idempotent) routes.
+
+    Reads the CSRF secret from the CSRF_SECRET_KEY env var at init time.
+    When no secret is configured the middleware degrades gracefully: it logs
+    a warning and passes requests through so the application can still start
+    in development environments where the env var is absent.
+
+    Args:
+        app:        The ASGI application to wrap.
+        secret_key: Override CSRF secret (defaults to CSRF_SECRET_KEY env var).
+    """
+
+    def __init__(self, app: ASGIApp, *, secret_key: str = "") -> None:
+        super().__init__(app)
+        self._secret_key: str = secret_key or os.getenv("CSRF_SECRET_KEY", "")
+        if not self._secret_key:
+            logger.warning(
+                "GlobalCsrfMiddleware: CSRF_SECRET_KEY not set — CSRF enforcement disabled"
+            )
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        # Safe / idempotent methods don't need CSRF protection
+        if request.method not in _UNSAFE_METHODS:
+            return await call_next(request)
+
+        # Allowlisted paths bypass the check
+        if _is_exempt(request.url.path):
+            return await call_next(request)
+
+        # No secret configured — degrade gracefully
+        if not self._secret_key:
+            logger.debug(
+                "CSRF check skipped (no secret configured) for %s %s",
+                request.method,
+                request.url.path,
+            )
+            return await call_next(request)
+
+        # Extract token from header (case-insensitive common variants)
+        token: Optional[str] = (
+            request.headers.get("X-CSRF-Token")
+            or request.headers.get("X-Csrf-Token")
+            or request.query_params.get("csrf_token")
+        )
+
+        if not token:
+            logger.warning(
+                "CSRF token missing: %s %s", request.method, request.url.path
+            )
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "CSRF token missing. Include X-CSRF-Token header."},
+            )
+
+        if not _validate_csrf_token(token, self._secret_key):
+            logger.warning(
+                "CSRF token invalid: %s %s", request.method, request.url.path
+            )
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "CSRF token invalid or expired."},
+            )
+
+        return await call_next(request)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+# Aurora CloudBank Symbolic — shared utilities package

--- a/src/utils/file_lock.py
+++ b/src/utils/file_lock.py
@@ -1,0 +1,171 @@
+"""Instance-level advisory file locks to prevent two processes sharing a state dir.
+
+Uses ``fcntl.flock`` on POSIX (Linux/macOS) with a best-effort PID-file fallback
+on Windows (where ``fcntl`` is not available).  The lock sentinel is a hidden file
+``<storage_dir>/.aurora.lock`` that contains the owning process's PID.
+
+Usage (explicit acquire/release)::
+
+    lock = DirLock(storage_dir)
+    lock.acquire()          # raises DirLockError if already held
+    try:
+        # ... exclusive access ...
+    finally:
+        lock.release()
+
+Usage (context manager, preferred)::
+
+    with DirLock(storage_dir):
+        # exclusive access guaranteed
+
+Emergency override::
+
+    Set the environment variable ``AURORA_FORCE_RELEASE_LOCK=1`` to forcibly
+    remove a stale lock file before attempting to acquire.  Use only when you
+    are certain the previous holder has crashed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import IO, Optional
+
+logger = logging.getLogger(__name__)
+
+_LOCK_FILENAME: str = ".aurora.lock"
+_FORCE_ENV: str = "AURORA_FORCE_RELEASE_LOCK"
+
+
+class DirLockError(RuntimeError):
+    """Raised when a directory lock cannot be acquired."""
+
+
+class DirLock:
+    """Advisory exclusive lock on a storage directory.
+
+    Args:
+        storage_dir: Path to the directory that should be exclusively owned.
+    """
+
+    def __init__(self, storage_dir: "Path | str") -> None:
+        self._dir: Path = Path(storage_dir)
+        self._fh: Optional[IO[str]] = None
+        self._pid_file_path: Optional[Path] = None  # Windows fallback sentinel
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    @property
+    def lock_path(self) -> Path:
+        """Full path to the sentinel lock file."""
+        return self._dir / _LOCK_FILENAME
+
+    def acquire(self) -> None:
+        """Acquire exclusive lock on the storage directory.
+
+        Raises:
+            DirLockError: If the lock is already held by another process.
+        """
+        force = os.getenv(_FORCE_ENV, "").strip() == "1"
+        if force:
+            logger.warning(
+                "%s=1 — forcibly releasing existing lock on %s",
+                _FORCE_ENV,
+                self._dir,
+            )
+            try:
+                self.lock_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            import fcntl  # noqa: PLC0415  (POSIX-only)
+            self._fh = open(self.lock_path, "w")  # noqa: WPS515 — intentional keep-open
+            self._fh.write(str(os.getpid()))
+            self._fh.flush()
+            fcntl.flock(self._fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            logger.debug("Acquired dir lock: %s (pid=%d)", self._dir, os.getpid())
+        except ImportError:
+            # Windows — fcntl unavailable; use best-effort PID file
+            self._acquire_pid_file()
+        except OSError as exc:
+            if self._fh is not None:
+                self._fh.close()
+                self._fh = None
+            pid_hint = self._read_lock_pid()
+            raise DirLockError(
+                f"Cannot acquire lock on {self._dir} — already held by pid {pid_hint}. "
+                f"If the holder crashed, set {_FORCE_ENV}=1 to override."
+            ) from exc
+
+    def release(self) -> None:
+        """Release the lock and remove the sentinel file.
+
+        Safe to call even if the lock was never successfully acquired.
+        """
+        # POSIX path: unlock via fcntl then close the file handle
+        if self._fh is not None:
+            try:
+                import fcntl
+                fcntl.flock(self._fh, fcntl.LOCK_UN)
+            except Exception:
+                pass
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+            self._fh = None
+
+        # Remove the lock sentinel
+        try:
+            self.lock_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+        # Windows path: remove the PID file sentinel
+        if self._pid_file_path is not None:
+            try:
+                self._pid_file_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            self._pid_file_path = None
+
+        logger.debug("Released dir lock: %s", self._dir)
+
+    # ------------------------------------------------------------------
+    # Context-manager protocol
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "DirLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.release()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _acquire_pid_file(self) -> None:
+        """Windows fallback: best-effort PID file (not atomic)."""
+        if self.lock_path.exists():
+            pid_hint = self._read_lock_pid()
+            raise DirLockError(
+                f"Lock file exists at {self.lock_path} (pid={pid_hint}). "
+                f"Set {_FORCE_ENV}=1 to override."
+            )
+        self._pid_file_path = self.lock_path
+        self._pid_file_path.write_text(str(os.getpid()))
+        logger.debug("Acquired dir lock (pid-file): %s (pid=%d)", self._dir, os.getpid())
+
+    def _read_lock_pid(self) -> str:
+        """Read the PID stored in the lock file, or return 'unknown'."""
+        try:
+            return self.lock_path.read_text().strip()
+        except Exception:
+            return "unknown"

--- a/tests/test_csrf_middleware.py
+++ b/tests/test_csrf_middleware.py
@@ -1,0 +1,243 @@
+"""Tests for src/middleware/csrf_middleware — issue #784.
+
+Verifies that GlobalCsrfMiddleware:
+  - passes safe (GET/HEAD) methods without a token
+  - blocks unsafe methods (POST/PUT/PATCH/DELETE) when no token is supplied
+  - allows requests on the path allowlist even without a token
+  - degrades gracefully when no CSRF_SECRET_KEY is configured
+  - accepts a well-formed, in-date HMAC token
+  - rejects an invalid / tampered HMAC token
+"""
+import hashlib
+import hmac
+import time
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.middleware.csrf_middleware import (
+    GlobalCsrfMiddleware,
+    _is_exempt,
+    _validate_csrf_token,
+)
+
+_SECRET = "test-csrf-secret-key"
+
+
+# ---------------------------------------------------------------------------
+# Helper: generate a valid token
+# ---------------------------------------------------------------------------
+
+def _make_token(secret: str = _SECRET, session_id: str = "sess-abc", offset: int = 0) -> str:
+    """Build a well-formed HMAC-SHA256 CSRF token."""
+    timestamp = str(int(time.time()) + offset)
+    message = f"{session_id}.{timestamp}"
+    sig = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+    return f"{session_id}.{timestamp}.{sig}"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _is_exempt
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_is_exempt_known_allowlist_paths():
+    assert _is_exempt("/health")
+    assert _is_exempt("/metrics")
+    assert _is_exempt("/docs")
+    assert _is_exempt("/openapi.json")
+    assert _is_exempt("/redoc")
+    assert _is_exempt("/api/auth/token")
+    assert _is_exempt("/api/auth/refresh")
+    assert _is_exempt("/api/csrf-token")
+    assert _is_exempt("/csrf-token")
+
+
+@pytest.mark.unit
+def test_is_exempt_prefix_matches():
+    assert _is_exempt("/api/webhooks/github")
+    assert _is_exempt("/api/webhooks/stripe")
+    assert _is_exempt("/docs/swagger")
+    assert _is_exempt("/openapi/v3")
+    assert _is_exempt("/redoc/v2")
+
+
+@pytest.mark.unit
+def test_is_exempt_non_allowlisted_paths():
+    assert not _is_exempt("/api/memory/store")
+    assert not _is_exempt("/api/quantum/simulate")
+    assert not _is_exempt("/api/monitoring/status")
+    assert not _is_exempt("/data")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _validate_csrf_token
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_validate_csrf_token_valid():
+    token = _make_token()
+    assert _validate_csrf_token(token, _SECRET) is True
+
+
+@pytest.mark.unit
+def test_validate_csrf_token_wrong_secret():
+    token = _make_token(secret=_SECRET)
+    assert _validate_csrf_token(token, "wrong-secret") is False
+
+
+@pytest.mark.unit
+def test_validate_csrf_token_tampered_signature():
+    token = _make_token()
+    parts = token.rsplit(".", 1)
+    tampered = parts[0] + ".deadbeefdeadbeef"
+    assert _validate_csrf_token(tampered, _SECRET) is False
+
+
+@pytest.mark.unit
+def test_validate_csrf_token_expired():
+    # Create token 400 seconds in the past (beyond 300 s TTL + 30 s grace)
+    token = _make_token(offset=-400)
+    assert _validate_csrf_token(token, _SECRET) is False
+
+
+@pytest.mark.unit
+def test_validate_csrf_token_future_skew():
+    # Slightly future token within grace period should be accepted
+    token = _make_token(offset=20)
+    assert _validate_csrf_token(token, _SECRET) is True
+
+
+@pytest.mark.unit
+def test_validate_csrf_token_too_far_future():
+    # Token with timestamp > 30 s in future is rejected
+    token = _make_token(offset=60)
+    assert _validate_csrf_token(token, _SECRET) is False
+
+
+@pytest.mark.unit
+def test_validate_csrf_token_wrong_format():
+    assert _validate_csrf_token("not-a-valid-token", _SECRET) is False
+    assert _validate_csrf_token("", _SECRET) is False
+    assert _validate_csrf_token("a.b", _SECRET) is False
+
+
+# ---------------------------------------------------------------------------
+# Middleware integration tests via Starlette test app
+# ---------------------------------------------------------------------------
+
+def _make_app(secret: str = _SECRET) -> Starlette:
+    async def view(request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    routes = [
+        Route("/data", view, methods=["GET", "POST", "PUT", "PATCH", "DELETE"]),
+        Route("/health", view, methods=["POST"]),
+        Route("/api/auth/token", view, methods=["POST"]),
+        Route("/api/webhooks/gh", view, methods=["POST"]),
+    ]
+    app = Starlette(routes=routes)
+    app.add_middleware(GlobalCsrfMiddleware, secret_key=secret)
+    return app
+
+
+@pytest.mark.unit
+def test_get_request_bypasses_csrf():
+    client = TestClient(_make_app(), raise_server_exceptions=True)
+    assert client.get("/data").status_code == 200
+
+
+@pytest.mark.unit
+def test_post_without_token_is_403():
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    resp = client.post("/data", json={})
+    assert resp.status_code == 403
+    assert "CSRF token missing" in resp.json()["detail"]
+
+
+@pytest.mark.unit
+def test_put_without_token_is_403():
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    assert client.put("/data", json={}).status_code == 403
+
+
+@pytest.mark.unit
+def test_patch_without_token_is_403():
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    assert client.patch("/data", json={}).status_code == 403
+
+
+@pytest.mark.unit
+def test_delete_without_token_is_403():
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    assert client.delete("/data").status_code == 403
+
+
+@pytest.mark.unit
+def test_post_with_valid_token_succeeds():
+    client = TestClient(_make_app(), raise_server_exceptions=True)
+    token = _make_token()
+    resp = client.post("/data", json={}, headers={"X-CSRF-Token": token})
+    assert resp.status_code == 200
+
+
+@pytest.mark.unit
+def test_post_with_invalid_token_is_403():
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    resp = client.post("/data", json={}, headers={"X-CSRF-Token": "bad.token.value"})
+    assert resp.status_code == 403
+    assert "invalid" in resp.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_post_on_health_allowlisted_path_succeeds():
+    client = TestClient(_make_app(), raise_server_exceptions=True)
+    assert client.post("/health", json={}).status_code == 200
+
+
+@pytest.mark.unit
+def test_post_on_auth_token_allowlisted_path_succeeds():
+    client = TestClient(_make_app(), raise_server_exceptions=True)
+    assert client.post("/api/auth/token", json={}).status_code == 200
+
+
+@pytest.mark.unit
+def test_post_on_webhook_prefix_succeeds():
+    client = TestClient(_make_app(), raise_server_exceptions=True)
+    assert client.post("/api/webhooks/gh", json={}).status_code == 200
+
+
+@pytest.mark.unit
+def test_no_secret_key_degrades_gracefully(monkeypatch):
+    """When CSRF_SECRET_KEY is absent the middleware allows all requests.
+
+    The middleware constructor falls back to os.getenv("CSRF_SECRET_KEY").
+    We must ensure that env var is absent for this test so the middleware
+    truly enters graceful-degradation mode.
+    """
+    monkeypatch.delenv("CSRF_SECRET_KEY", raising=False)
+
+    async def view(request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    from starlette.applications import Starlette as _Starlette
+    from starlette.routing import Route as _Route
+
+    app = _Starlette(routes=[_Route("/data", view, methods=["POST"])])
+    app.add_middleware(GlobalCsrfMiddleware, secret_key="")
+    client = TestClient(app, raise_server_exceptions=True)
+    resp = client.post("/data", json={})
+    assert resp.status_code == 200
+
+
+@pytest.mark.unit
+def test_csrf_token_accepted_via_lowercase_header():
+    """X-Csrf-Token header variant should also be accepted."""
+    client = TestClient(_make_app(), raise_server_exceptions=True)
+    token = _make_token()
+    resp = client.post("/data", json={}, headers={"X-Csrf-Token": token})
+    assert resp.status_code == 200

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -1,0 +1,189 @@
+"""Tests for src/utils/file_lock — issue #820.
+
+Verifies that DirLock:
+  - creates the sentinel file on acquire and removes it on release
+  - works as a context manager
+  - raises DirLockError when a second instance tries to acquire the same dir
+    (two DirLock objects → two distinct open() calls → two file-descriptions;
+     fcntl.flock is per open-file-description so the second is blocked)
+  - honours AURORA_FORCE_RELEASE_LOCK=1 to clear a stale lock file
+  - is safe to release multiple times
+  - creates the storage directory if it does not exist
+"""
+import os
+import pytest
+
+from src.utils.file_lock import DirLock, DirLockError, _LOCK_FILENAME, _FORCE_ENV
+
+
+# ---------------------------------------------------------------------------
+# Basic acquire / release
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_acquire_creates_sentinel_file(tmp_path):
+    lock = DirLock(tmp_path)
+    lock.acquire()
+    try:
+        assert lock.lock_path.exists(), "Lock sentinel should exist after acquire()"
+    finally:
+        lock.release()
+
+
+@pytest.mark.unit
+def test_release_removes_sentinel_file(tmp_path):
+    lock = DirLock(tmp_path)
+    lock.acquire()
+    lock.release()
+    assert not lock.lock_path.exists(), "Lock sentinel should be removed after release()"
+
+
+@pytest.mark.unit
+def test_lock_path_uses_expected_filename(tmp_path):
+    lock = DirLock(tmp_path)
+    assert lock.lock_path.name == _LOCK_FILENAME
+
+
+@pytest.mark.unit
+def test_lock_sentinel_contains_pid(tmp_path):
+    lock = DirLock(tmp_path)
+    lock.acquire()
+    try:
+        content = lock.lock_path.read_text().strip()
+        assert content == str(os.getpid()), "Sentinel should contain current PID"
+    finally:
+        lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_context_manager_acquires_on_enter(tmp_path):
+    with DirLock(tmp_path):
+        assert (tmp_path / _LOCK_FILENAME).exists()
+
+
+@pytest.mark.unit
+def test_context_manager_releases_on_exit(tmp_path):
+    with DirLock(tmp_path):
+        pass
+    assert not (tmp_path / _LOCK_FILENAME).exists()
+
+
+@pytest.mark.unit
+def test_context_manager_releases_on_exception(tmp_path):
+    try:
+        with DirLock(tmp_path):
+            raise RuntimeError("oops")
+    except RuntimeError:
+        pass
+    assert not (tmp_path / _LOCK_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# Contention: two DirLock instances on the same directory
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_double_acquire_raises_dir_lock_error(tmp_path):
+    """Two DirLock objects on the same dir must contend.
+
+    fcntl.flock locking is per open-file-description (not per-process), so
+    two distinct open() calls in the same process DO contend with each other.
+    """
+    lock1 = DirLock(tmp_path)
+    lock1.acquire()
+    try:
+        lock2 = DirLock(tmp_path)
+        with pytest.raises(DirLockError, match="already held"):
+            lock2.acquire()
+    finally:
+        lock1.release()
+
+
+@pytest.mark.unit
+def test_second_acquire_succeeds_after_first_is_released(tmp_path):
+    lock1 = DirLock(tmp_path)
+    lock1.acquire()
+    lock1.release()
+
+    lock2 = DirLock(tmp_path)
+    lock2.acquire()  # Should succeed — no one holds the lock
+    lock2.release()
+
+
+# ---------------------------------------------------------------------------
+# Force-release via env var
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_force_release_env_var_overrides_stale_lock(tmp_path, monkeypatch):
+    """AURORA_FORCE_RELEASE_LOCK=1 should clear a stale lock file."""
+    # Simulate a stale lock file left by a crashed process
+    stale_pid = "99999"
+    (tmp_path / _LOCK_FILENAME).write_text(stale_pid)
+
+    monkeypatch.setenv(_FORCE_ENV, "1")
+
+    lock = DirLock(tmp_path)
+    lock.acquire()  # Should succeed after force-clearing the stale file
+    try:
+        assert lock.lock_path.exists()
+        pid_in_file = lock.lock_path.read_text().strip()
+        assert pid_in_file == str(os.getpid()), "File should now hold the current PID"
+    finally:
+        lock.release()
+
+
+@pytest.mark.unit
+def test_force_release_not_set_does_not_clear_lock(tmp_path, monkeypatch):
+    """Without AURORA_FORCE_RELEASE_LOCK the second acquire must still fail."""
+    monkeypatch.delenv(_FORCE_ENV, raising=False)
+
+    lock1 = DirLock(tmp_path)
+    lock1.acquire()
+    try:
+        lock2 = DirLock(tmp_path)
+        with pytest.raises(DirLockError):
+            lock2.acquire()
+    finally:
+        lock1.release()
+
+
+# ---------------------------------------------------------------------------
+# Directory creation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_acquire_creates_nonexistent_directory(tmp_path):
+    new_dir = tmp_path / "deep" / "nested" / "dir"
+    assert not new_dir.exists()
+
+    lock = DirLock(new_dir)
+    lock.acquire()
+    try:
+        assert new_dir.exists()
+        assert lock.lock_path.exists()
+    finally:
+        lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Idempotent release
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_release_without_acquire_is_safe(tmp_path):
+    """Calling release() without prior acquire() should not raise."""
+    lock = DirLock(tmp_path)
+    lock.release()  # Must not raise
+
+
+@pytest.mark.unit
+def test_double_release_is_safe(tmp_path):
+    lock = DirLock(tmp_path)
+    lock.acquire()
+    lock.release()
+    lock.release()  # Second release must not raise


### PR DESCRIPTION
## Summary\n\n### #784 — Global CSRF enforcement\n- Adds `src/middleware/csrf_middleware.py` with `GlobalCsrfMiddleware` (Starlette `BaseHTTPMiddleware`)\n- Blocks `POST/PUT/PATCH/DELETE` without a valid `X-CSRF-Token` header (HMAC-SHA256 with 300s TTL)\n- Allowlist covers `/health`, `/metrics`, `/docs`, `/api/auth/token`, `/api/auth/refresh`, `/api/webhooks/*`, and other machine-to-machine paths\n- Gracefully degrades (pass-through + warning) when `CSRF_SECRET_KEY` is unset\n- Registered in `api/aurora_api.py` immediately after SlowAPI rate-limit middleware\n- 22 unit tests\n\n### #820 — Instance-level file locks\n- Adds `src/utils/file_lock.py` with `DirLock` / `DirLockError`\n- Uses `fcntl.flock(LOCK_EX | LOCK_NB)` on POSIX; best-effort PID-file fallback on Windows\n- `AURORA_FORCE_RELEASE_LOCK=1` env var for recovery from stale locks\n- Context-manager and explicit `acquire/release` API\n- 14 unit tests (including double-acquire contention)\n\n## Test plan\n\n- [x] `pytest tests/test_csrf_middleware.py tests/test_file_lock.py -v` — 36/36 passed\n- [ ] Full CI\n\nFixes #784, Fixes #820\n\nhttps://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_