### PR TITLE
feat(memory): token-cap and content-hash dedup for retrieve_memories

### DIFF
--- a/modules/memory_retrieval/core.py
+++ b/modules/memory_retrieval/core.py
@@ -17,6 +17,44 @@ except ImportError:
     logger.warning("NativeDLPTracker not available, DLP tracking disabled")
 
 
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count using a 4-chars-per-token heuristic (no tiktoken required)."""
+    try:
+        import tiktoken
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    except (ImportError, Exception):
+        return max(1, len(text) // 4)
+
+
+def _dedup_memories(memories: list) -> list:
+    """Remove duplicate memories by content hash, keeping highest-scored."""
+    import hashlib
+    seen: dict = {}
+    for mem in memories:
+        content_hash = hashlib.sha256(
+            str(mem.get("content", "")).encode("utf-8", errors="replace")
+        ).hexdigest()
+        if content_hash not in seen:
+            seen[content_hash] = mem
+    return list(seen.values())
+
+
+def _apply_cap(memories: list, max_tokens: Optional[int]) -> list:
+    """Apply a token budget cap, returning only memories that fit within max_tokens."""
+    if max_tokens is None:
+        return memories
+    capped: List[Dict] = []
+    running = 0
+    for mem in memories:
+        t = _estimate_tokens(str(mem.get("content", "")))
+        if running + t > max_tokens:
+            break
+        capped.append(mem)
+        running += t
+    return capped
+
+
 class MemoryRetrievalCore:
     """Core orchestration layer for memory retrieval."""
 
@@ -69,7 +107,13 @@ class MemoryRetrievalCore:
         return memory_id
 
     def retrieve_memories(
-        self, context_id: str, query: str, top_k: int = 10, *, user_id: str = "default"
+        self,
+        context_id: str,
+        query: str,
+        top_k: int = 10,
+        *,
+        user_id: str = "default",
+        max_tokens: Optional[int] = None,
     ) -> List[Dict]:
         """Retrieve scored memories for a context/query pair.
 
@@ -80,6 +124,9 @@ class MemoryRetrievalCore:
             user_id: Tenant / user identifier used for cache isolation.
                 Pass the authenticated user's ID; use ``"default"`` only in
                 single-tenant deployments where cross-user leakage is impossible.
+            max_tokens: Optional token budget cap. When set, returned memories
+                are truncated so that their cumulative estimated token count
+                does not exceed this value.
         """
         context_tag = f"mrm:query:{context_id}"
         if self._dlp_tracker:
@@ -90,7 +137,7 @@ class MemoryRetrievalCore:
         )
         cached_results = self._cache.get(cache_key)
         if cached_results is not None:
-            return cached_results
+            return _apply_cap(cached_results, max_tokens)
 
         raw_results = self._store.query_memory(context_id, query, top_k)
         scored_results: List[Dict] = []
@@ -111,8 +158,11 @@ class MemoryRetrievalCore:
                 }
             )
         scored_results.sort(key=lambda item: item["score"], reverse=True)
+
+        # Dedup by content hash before caching (dedup is stable across calls)
+        scored_results = _dedup_memories(scored_results)
         self._cache.set(cache_key, scored_results)
-        return scored_results
+        return _apply_cap(scored_results, max_tokens)
 
     def get_memory(self, memory_id: str) -> Optional[Dict]:
         """Fetch a single memory entry."""

--- a/tests/test_memory_retrieval_cap.py
+++ b/tests/test_memory_retrieval_cap.py
@@ -1,0 +1,60 @@
+"""Tests for memory token cap and dedup in retrieve_memories."""
+import pytest
+from modules.memory_retrieval.core import _dedup_memories, _estimate_tokens, _apply_cap
+
+
+@pytest.mark.unit
+def test_estimate_tokens_heuristic():
+    # 40 chars → ~10 tokens
+    text = "a" * 40
+    assert _estimate_tokens(text) >= 1
+
+
+@pytest.mark.unit
+def test_estimate_tokens_nonempty():
+    assert _estimate_tokens("Hello world") > 0
+
+
+@pytest.mark.unit
+def test_dedup_removes_identical_content():
+    memories = [
+        {"id": "1", "score": 0.9, "content": "same content"},
+        {"id": "2", "score": 0.5, "content": "same content"},
+    ]
+    result = _dedup_memories(memories)
+    assert len(result) == 1
+    # Keeps first occurrence (highest score comes first from sort)
+    assert result[0]["id"] == "1"
+
+
+@pytest.mark.unit
+def test_dedup_keeps_different_content():
+    memories = [
+        {"id": "1", "score": 0.9, "content": "content A"},
+        {"id": "2", "score": 0.5, "content": "content B"},
+    ]
+    result = _dedup_memories(memories)
+    assert len(result) == 2
+
+
+@pytest.mark.unit
+def test_apply_cap_limits_by_tokens():
+    # 10 memories each of 1000 chars (~250 tokens each), cap at 300 tokens
+    memories = [
+        {"id": str(i), "score": float(i), "content": "x" * 1000}
+        for i in range(10)
+    ]
+    result = _apply_cap(memories, max_tokens=300)
+    assert len(result) <= 2  # at most 2 fit under 300 tokens
+
+
+@pytest.mark.unit
+def test_apply_cap_none_returns_all():
+    memories = [{"id": str(i), "content": "x" * 100} for i in range(5)]
+    result = _apply_cap(memories, max_tokens=None)
+    assert len(result) == 5
+
+
+@pytest.mark.unit
+def test_apply_cap_empty_input():
+    assert _apply_cap([], max_tokens=1000) == []


### PR DESCRIPTION
## Summary\n\n- Adds `_estimate_tokens(text)` — 4-chars/token heuristic with optional tiktoken fallback\n- Adds `_dedup_memories(memories)` — SHA-256 content-hash dedup keeping highest-scored occurrence\n- Adds `_apply_cap(memories, max_tokens)` — stops appending once running token estimate exceeds budget\n- Updates `retrieve_memories` with `max_tokens: Optional[int] = None` keyword arg; dedup applied before cache set, cap applied on both cache-hit and fresh-retrieval paths\n- 7 new unit tests; all 59 pre-existing `test_memory_retrieval_full.py` tests continue to pass\n\n## Test plan\n\n- [x] `pytest tests/test_memory_retrieval_cap.py -v` — 7/7 passed\n- [x] `pytest tests/ -k memory_retrieval -q` — 66/66 passed (no regressions)\n- [ ] Full CI\n\nFixes #799\n\nhttps://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_