### PR TITLE
feat(security): redact PII before persisting to ledger and monitoring stores

### DIFF
--- a/modules/insight_ledger/ledger_core.py
+++ b/modules/insight_ledger/ledger_core.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 
 from .crypto_signatures import SignatureManager
 from .schemas import AuditQuery, InsightRecord, InsightType, LedgerEntry, LedgerStats
+from src.utils.persist_redact import redact_for_persistence
 
 # Try to import secure storage for encrypted key persistence
 try:
@@ -275,6 +276,13 @@ class InsightLedger:
             entry_id = self._generate_entry_id(entry_type)
             timestamp = datetime.now(timezone.utc)
 
+            # Redact PII from context metadata before persisting
+            safe_context = (
+                redact_for_persistence(insight.context, context_tag=entry_id)
+                if isinstance(insight.context, dict)
+                else insight.context
+            )
+
             # Prepare signable data (without signature/hash fields)
             signable_data = {
                 "entry_id": entry_id,
@@ -282,7 +290,7 @@ class InsightLedger:
                 "entry_type": entry_type.value,
                 "insight_type": insight.insight_type.value,
                 "content": insight.content,
-                "context": insight.context,
+                "context": safe_context,
                 "source": insight.source,
                 "tags": sorted(list(set(insight.tags or []))),  # Ensure tags are sorted and unique
                 "severity": insight.severity,

--- a/src/monitoring/audit_logger.py
+++ b/src/monitoring/audit_logger.py
@@ -16,6 +16,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 from src.core.time_utils import utc_now
+from src.utils.persist_redact import redact_for_persistence
 
 logger = logging.getLogger(__name__)
 
@@ -310,9 +311,12 @@ class AuditLogger:
         context_tag: Optional[str]
     ) -> AuditEntry:
         """Create and sign a new audit entry"""
+        # Redact PII from context/metadata before persisting
+        safe_data = redact_for_persistence(data, context_tag=context_tag or "")
+
         # Get previous hash for chain
         previous_hash = self.entries[-1].compute_hash() if self.entries else None
-        
+
         entry = AuditEntry(
             id=f"AUDIT-{self._next_id:08d}",
             timestamp=utc_now().isoformat(),
@@ -320,7 +324,7 @@ class AuditLogger:
             agent_id=agent_id,
             severity=severity,
             description=description,
-            data=data,
+            data=safe_data,
             context_tag=context_tag,
             previous_hash=previous_hash
         )

--- a/src/monitoring/drift_detector.py
+++ b/src/monitoring/drift_detector.py
@@ -13,6 +13,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 import statistics
+from src.utils.persist_redact import redact_for_persistence
 
 logger = logging.getLogger(__name__)
 
@@ -345,8 +346,14 @@ class DriftDetector:
 
         try:
             self.alerts_path.parent.mkdir(parents=True, exist_ok=True)
+            alert_dict = alert.to_dict()
+            # Redact PII from metadata before persisting
+            if "metadata" in alert_dict and isinstance(alert_dict["metadata"], dict):
+                alert_dict["metadata"] = redact_for_persistence(
+                    alert_dict["metadata"], context_tag=alert.context_tag or ""
+                )
             with open(self.alerts_path, 'a') as f:
-                f.write(json.dumps(alert.to_dict(), sort_keys=True) + "\n")
+                f.write(json.dumps(alert_dict, sort_keys=True) + "\n")
         except Exception as e:
             logger.error("Failed to persist drift alert: %s", e)
 

--- a/src/utils/persist_redact.py
+++ b/src/utils/persist_redact.py
@@ -1,0 +1,147 @@
+"""
+PII Redaction Utilities for Persistence
+
+Provides helper functions that redact personally identifiable information (PII)
+from dicts and lists before they are written to any persistent store (ledger,
+monitoring files, audit logs, etc.).
+
+Anchor: T1-EDG-001-PERSIST
+"""
+
+import copy
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+# Attempt to import data_guardian redaction components.
+# Graceful degradation: if the module is unavailable, redaction is skipped and
+# a warning is emitted so that callers keep working without crashing.
+try:
+    from modules.data_guardian.detection_rules import PIIDetector
+    from modules.data_guardian.redaction import RedactionEngine, RedactionStrategy
+
+    _DETECTOR = PIIDetector()
+    _REDACTOR = RedactionEngine(default_strategy=RedactionStrategy.MASK)
+    _DATA_GUARDIAN_AVAILABLE = True
+except ImportError:  # pragma: no cover – tested via monkeypatch
+    _DATA_GUARDIAN_AVAILABLE = False
+    logger.warning(
+        "data_guardian module not available; PII redaction before persistence is disabled."
+    )
+
+
+def _redact_value(value: str) -> str:
+    """Redact PII from a single string value.
+
+    Returns the redacted string.  If data_guardian is not available the
+    original string is returned unchanged.
+    """
+    if not _DATA_GUARDIAN_AVAILABLE:
+        return value
+
+    detections = _DETECTOR.detect(value)
+    if not detections:
+        return value
+
+    # Use a fresh engine instance per call to avoid cross-call token counter
+    # bleed while still leveraging the module-level detector for efficiency.
+    engine = RedactionEngine(default_strategy=RedactionStrategy.MASK)
+    return engine.redact_text(value, detections)
+
+
+def _redact_dict_recursive(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep copy of *data* with PII strings redacted recursively."""
+    redacted: Dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            redacted[key] = _redact_value(value)
+        elif isinstance(value, dict):
+            redacted[key] = _redact_dict_recursive(value)
+        elif isinstance(value, list):
+            redacted[key] = _redact_list_items(value)
+        else:
+            # ints, floats, bools, None – pass through unchanged
+            redacted[key] = value
+    return redacted
+
+
+def _redact_list_items(items: list) -> list:
+    """Redact PII from each item in a list (strings or nested dicts)."""
+    result = []
+    for item in items:
+        if isinstance(item, str):
+            result.append(_redact_value(item))
+        elif isinstance(item, dict):
+            result.append(_redact_dict_recursive(item))
+        elif isinstance(item, list):
+            result.append(_redact_list_items(item))
+        else:
+            result.append(item)
+    return result
+
+
+def redact_for_persistence(data: Dict[str, Any], context_tag: str = "") -> Dict[str, Any]:
+    """Redact PII from *data* dict before it is written to any persistent store.
+
+    Performs a recursive scan of all string values in the dict and replaces
+    detected PII (email, phone, SSN, credit-card number, IP address, etc.)
+    with masked representations using the ``data_guardian`` module.
+
+    If ``data_guardian`` is not importable (graceful degradation) the original
+    dict is returned **unchanged** and a warning is logged.
+
+    Args:
+        data:        Dictionary to redact.  Must not be ``None``.
+        context_tag: Optional DLP context tag for audit traceability.
+
+    Returns:
+        A new dictionary that is safe to write to disk.  The original *data*
+        argument is never mutated.
+    """
+    if not isinstance(data, dict):
+        logger.warning(
+            "redact_for_persistence received non-dict value (type=%s); returning as-is. "
+            "context_tag=%s",
+            type(data).__name__,
+            context_tag,
+        )
+        return data  # type: ignore[return-value]
+
+    if not data:
+        return {}
+
+    if not _DATA_GUARDIAN_AVAILABLE:
+        logger.warning(
+            "PII redaction skipped (data_guardian unavailable). context_tag=%s",
+            context_tag,
+        )
+        return copy.deepcopy(data)
+
+    try:
+        redacted = _redact_dict_recursive(data)
+        logger.debug("PII redaction applied before persistence. context_tag=%s", context_tag)
+        return redacted
+    except Exception as exc:
+        # Never crash a write path — log and return original data.
+        logger.error(
+            "PII redaction failed (%s); returning original data. context_tag=%s",
+            exc,
+            context_tag,
+        )
+        return copy.deepcopy(data)
+
+
+def redact_list_for_persistence(
+    records: List[Dict[str, Any]], context_tag: str = ""
+) -> List[Dict[str, Any]]:
+    """Apply :func:`redact_for_persistence` to every item in *records*.
+
+    Args:
+        records:     List of dicts to redact.
+        context_tag: Optional DLP context tag for audit traceability.
+
+    Returns:
+        A new list where each dict has been redacted.
+    """
+    return [redact_for_persistence(record, context_tag=context_tag) for record in records]

--- a/tests/test_persist_redact.py
+++ b/tests/test_persist_redact.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for src/utils/persist_redact.py
+
+Covers:
+- Email, phone, SSN redaction from flat dict
+- Recursive redaction in nested dicts
+- Graceful degradation when data_guardian is not importable
+- Empty dict edge case
+- Non-string scalar values pass through unchanged
+- List values are redacted recursively
+- context_tag parameter is accepted without error
+- redact_list_for_persistence helper
+- Original dict is not mutated
+
+Anchor: T1-EDG-001-PERSIST
+"""
+
+import importlib
+import sys
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reimport_module():
+    """Force a fresh import of persist_redact (needed after monkeypatching sys.modules)."""
+    mod_name = "src.utils.persist_redact"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+    return importlib.import_module(mod_name)
+
+
+# ---------------------------------------------------------------------------
+# Basic redaction tests (data_guardian available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_redact_email_in_flat_dict():
+    """Email addresses in string values are masked."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {"user": "alice@example.com", "action": "login"}
+    result = redact_for_persistence(data)
+
+    assert "alice@example.com" not in result["user"], "Email should be redacted"
+    assert result["action"] == "login", "Non-PII field should be unchanged"
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_redact_ssn_in_flat_dict():
+    """US Social Security Numbers are masked."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {"ssn": "123-45-6789", "category": "medical"}
+    result = redact_for_persistence(data)
+
+    assert "123-45-6789" not in result["ssn"], "SSN should be redacted"
+    assert result["category"] == "medical"
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_redact_phone_in_flat_dict():
+    """US phone numbers are masked."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {"contact": "Call me at 555-867-5309", "priority": "high"}
+    result = redact_for_persistence(data)
+
+    assert "555-867-5309" not in result["contact"], "Phone number should be redacted"
+    assert result["priority"] == "high"
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_redact_nested_dict_recursively():
+    """PII inside nested dicts is redacted recursively."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {
+        "outer": "ok",
+        "inner": {
+            "email": "bob@domain.org",
+            "deep": {
+                "ssn": "987-65-4321"
+            }
+        }
+    }
+    result = redact_for_persistence(data)
+
+    assert "bob@domain.org" not in result["inner"]["email"]
+    assert "987-65-4321" not in result["inner"]["deep"]["ssn"]
+    assert result["outer"] == "ok"
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_non_string_values_pass_through_unchanged():
+    """Integers, booleans, and None are returned unchanged."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {
+        "count": 42,
+        "active": True,
+        "ratio": 3.14,
+        "missing": None,
+    }
+    result = redact_for_persistence(data)
+
+    assert result["count"] == 42
+    assert result["active"] is True
+    assert result["ratio"] == 3.14
+    assert result["missing"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_empty_dict_returns_empty_dict():
+    """Empty input yields an empty output dict."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    result = redact_for_persistence({})
+    assert result == {}
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_original_dict_not_mutated():
+    """redact_for_persistence must not mutate the input dict."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {"email": "carol@test.com", "score": 99}
+    original_email = data["email"]
+    redact_for_persistence(data)
+
+    assert data["email"] == original_email, "Input dict should not be mutated"
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_context_tag_accepted():
+    """context_tag keyword argument is accepted without raising."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {"note": "no pii here"}
+    result = redact_for_persistence(data, context_tag="test-tag-001")
+    assert result["note"] == "no pii here"
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_redact_list_for_persistence():
+    """redact_list_for_persistence applies redaction to each item in a list."""
+    from src.utils.persist_redact import redact_list_for_persistence
+
+    records = [
+        {"email": "dave@example.com", "action": "read"},
+        {"note": "clean record", "value": 7},
+    ]
+    results = redact_list_for_persistence(records, context_tag="batch-001")
+
+    assert "dave@example.com" not in results[0]["email"]
+    assert results[0]["action"] == "read"
+    assert results[1]["note"] == "clean record"
+    assert results[1]["value"] == 7
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_graceful_degradation_when_data_guardian_unavailable(monkeypatch):
+    """When data_guardian is not importable, data is returned unchanged."""
+    # Remove any cached import of data_guardian components
+    to_remove = [k for k in sys.modules if "data_guardian" in k]
+    for key in to_remove:
+        monkeypatch.delitem(sys.modules, key, raising=False)
+
+    # Also remove cached persist_redact so it re-executes the import block
+    monkeypatch.delitem(sys.modules, "src.utils.persist_redact", raising=False)
+
+    # Patch the data_guardian detection_rules import to raise ImportError
+    import builtins
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if "data_guardian" in name:
+            raise ImportError(f"Simulated missing data_guardian: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+
+    module = _reimport_module()
+
+    data = {"email": "eve@example.com", "value": 5}
+    result = module.redact_for_persistence(data)
+
+    # Without data_guardian the data must come back intact (graceful degradation)
+    assert result["email"] == "eve@example.com"
+    assert result["value"] == 5
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_string_list_values_are_redacted():
+    """PII in string list items is redacted."""
+    from src.utils.persist_redact import redact_for_persistence
+
+    data = {"contacts": ["frank@corp.io", "plain text", "555-321-0987"]}
+    result = redact_for_persistence(data)
+
+    assert "frank@corp.io" not in result["contacts"][0]
+    assert result["contacts"][1] == "plain text"
+    assert "555-321-0987" not in result["contacts"][2]


### PR DESCRIPTION
## Summary

- Adds `src/utils/persist_redact.py` with `redact_for_persistence()` and `redact_list_for_persistence()` utilities that use `data_guardian`'s `PIIDetector` + `RedactionEngine` (MASK strategy) to strip emails, SSNs, phone numbers, IPs, and credit-card patterns from all string values in a dict before it hits disk
- Gracefully degrades if `data_guardian` is unavailable (returns data unchanged with a warning)
- Wires redaction into `src/monitoring/audit_logger.py`, `src/monitoring/drift_detector.py`, and `modules/insight_ledger/ledger_core.py` — the three main callsites that write raw context/metadata to JSONL stores

## Test plan

- [ ] `tests/test_persist_redact.py` — 11 unit tests: flat-dict email/phone/SSN redaction, recursive nested-dict, graceful degradation (ImportError monkeypatch), empty dict, non-string passthrough — all pass
- [ ] CI syntax check passes

Fixes #812

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_