### PR TITLE
fix(persistence): add threading.Lock write guards to AuditLogger, DriftDetector, EthicsEngine, MonitoringSystem

### DIFF
--- a/src/monitoring/audit_logger.py
+++ b/src/monitoring/audit_logger.py
@@ -10,6 +10,7 @@ import hmac
 import json
 import logging
 import os
+import threading
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from enum import Enum
@@ -134,6 +135,7 @@ class AuditLogger:
 
         self.signing_key = signing_key
 
+        self._write_lock = threading.Lock()
         self.entries: List[AuditEntry] = []
         self._next_id = 1
         
@@ -454,12 +456,13 @@ class AuditLogger:
             return
 
         try:
-            self.storage_path.parent.mkdir(parents=True, exist_ok=True)
-            record = get_registry().stamp(entry.to_dict(), "audit_log")
-            with open(self.storage_path, 'a', encoding='utf-8') as f:
-                f.write(json.dumps(record, sort_keys=True) + "\n")
-                f.flush()
-                os.fsync(f.fileno())
+            with self._write_lock:
+                self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+                record = get_registry().stamp(entry.to_dict(), "audit_log")
+                with open(self.storage_path, 'a', encoding='utf-8') as f:
+                    f.write(json.dumps(record, sort_keys=True) + "\n")
+                    f.flush()
+                    os.fsync(f.fileno())
         except Exception as e:
             logger.error("Failed to append audit entry: %s", e)
     

--- a/src/monitoring/drift_detector.py
+++ b/src/monitoring/drift_detector.py
@@ -7,6 +7,7 @@ Detects deviations from baseline patterns using multiple algorithms.
 
 import json
 import logging
+import threading
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -113,7 +114,9 @@ class DriftDetector:
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
         self.alerts_path = alerts_path
-        
+
+        self._write_lock = threading.Lock()
+
         # Storage for baselines and alerts
         self.baselines: Dict[str, BaselineMetrics] = {}
         self.alerts: List[DriftAlert] = []
@@ -353,9 +356,10 @@ class DriftDetector:
                 alert_dict["metadata"] = redact_for_persistence(
                     alert_dict["metadata"], context_tag=alert.context_tag or ""
                 )
-            record = get_registry().stamp(alert_dict, "drift_alert")
-            with open(self.alerts_path, 'a') as f:
-                f.write(json.dumps(record, sort_keys=True) + "\n")
+            with self._write_lock:
+                record = get_registry().stamp(alert_dict, "drift_alert")
+                with open(self.alerts_path, 'a') as f:
+                    f.write(json.dumps(record, sort_keys=True) + "\n")
         except Exception as e:
             logger.error("Failed to persist drift alert: %s", e)
 
@@ -382,9 +386,10 @@ class DriftDetector:
 
         try:
             self.alerts_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.alerts_path, 'w') as f:
-                for alert in self.alerts:
-                    f.write(json.dumps(alert.to_dict(), sort_keys=True) + "\n")
+            with self._write_lock:
+                with open(self.alerts_path, 'w') as f:
+                    for alert in self.alerts:
+                        f.write(json.dumps(alert.to_dict(), sort_keys=True) + "\n")
         except Exception as e:
             logger.error("Failed to rewrite drift alerts: %s", e)
 

--- a/src/monitoring/ethics_engine.py
+++ b/src/monitoring/ethics_engine.py
@@ -7,6 +7,7 @@ and safety boundaries. Supports configurable rules and automated enforcement.
 
 import json
 import logging
+import threading
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from src.core.time_utils import utc_iso
@@ -113,6 +114,7 @@ class EthicsEngine:
         self.violations: List[EthicsViolation] = []
         self.custom_evaluators: Dict[str, Callable] = {}
         self.violations_path = violations_path
+        self._write_lock = threading.Lock()
         
         # Load default rules if available
         if rules_path and rules_path.exists():
@@ -446,8 +448,9 @@ class EthicsEngine:
 
         try:
             self.violations_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.violations_path, 'a') as f:
-                f.write(json.dumps(violation.to_dict(), sort_keys=True) + "\n")
+            with self._write_lock:
+                with open(self.violations_path, 'a') as f:
+                    f.write(json.dumps(violation.to_dict(), sort_keys=True) + "\n")
         except Exception as e:
             logger.error("Failed to persist ethics violation: %s", e)
 
@@ -474,9 +477,10 @@ class EthicsEngine:
 
         try:
             self.violations_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.violations_path, 'w') as f:
-                for violation in self.violations:
-                    f.write(json.dumps(violation.to_dict(), sort_keys=True) + "\n")
+            with self._write_lock:
+                with open(self.violations_path, 'w') as f:
+                    for violation in self.violations:
+                        f.write(json.dumps(violation.to_dict(), sort_keys=True) + "\n")
         except Exception as e:
             logger.error("Failed to rewrite ethics violations: %s", e)
 

--- a/src/monitoring/monitoring_system.py
+++ b/src/monitoring/monitoring_system.py
@@ -8,6 +8,7 @@ and alerting for comprehensive agent oversight.
 import logging
 import json
 import os
+import threading
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 from src.core.time_utils import utc_now, utc_iso
@@ -144,6 +145,7 @@ class MonitoringSystem:
         self.interventions: List[Intervention] = []
         self.last_intervention_time: Dict[str, datetime] = {}
         self._enforcement_handlers: Dict[InterventionType, Callable] = {}
+        self._write_lock = threading.Lock()
         
         # Alert handlers
         self.alert_handlers: Dict[AlertLevel, List[Callable]] = {
@@ -658,21 +660,22 @@ class MonitoringSystem:
     def _persist_state(self):
         """Persist intervention state needed for restart-safe cooldowns."""
         try:
-            self._state_path.parent.mkdir(parents=True, exist_ok=True)
-            state = get_registry().stamp(
-                {
-                    'interventions': [
-                        intervention.to_dict()
-                        for intervention in self.interventions
-                    ],
-                    'last_intervention_time': {
-                        agent_id: timestamp.isoformat()
-                        for agent_id, timestamp in self.last_intervention_time.items()
-                    }
-                },
-                "monitoring_state",
-            )
-            with open(self._state_path, 'w') as f:
-                json.dump(state, f, indent=2, sort_keys=True)
+            with self._write_lock:
+                self._state_path.parent.mkdir(parents=True, exist_ok=True)
+                state = get_registry().stamp(
+                    {
+                        'interventions': [
+                            intervention.to_dict()
+                            for intervention in self.interventions
+                        ],
+                        'last_intervention_time': {
+                            agent_id: timestamp.isoformat()
+                            for agent_id, timestamp in self.last_intervention_time.items()
+                        }
+                    },
+                    "monitoring_state",
+                )
+                with open(self._state_path, 'w') as f:
+                    json.dump(state, f, indent=2, sort_keys=True)
         except Exception as e:
             logger.error("Failed to persist monitoring state: %s", e)

--- a/tests/test_write_locks.py
+++ b/tests/test_write_locks.py
@@ -1,0 +1,301 @@
+"""
+Concurrency tests for write-lock guards on persistence classes.
+
+Verifies that AuditLogger, DriftDetector, EthicsEngine, and MonitoringSystem
+can handle concurrent writes from multiple threads without raising exceptions
+and that the final on-disk state is consistent (not partial/corrupted).
+"""
+
+import json
+import os
+import threading
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SIGNING_KEY = "test-write-lock-signing-key-00000000"
+_N_THREADS = 10
+
+
+def _run_threads(target, args_list):
+    """Launch threads concurrently and join them all."""
+    errors = []
+
+    def safe_target(*args, **kwargs):
+        try:
+            target(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=safe_target, args=a) for a in args_list]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# AuditLogger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_audit_logger_concurrent_writes_no_exception(tmp_path):
+    """Multiple threads appending audit entries must not raise."""
+    from src.monitoring.audit_logger import AuditLogger
+
+    storage = tmp_path / "audit.jsonl"
+    logger = AuditLogger(storage_path=storage, signing_key=_SIGNING_KEY)
+
+    def write_entry(i):
+        logger.log_manual_override(
+            agent_id=f"agent-{i}",
+            operator="tester",
+            action="approve",
+            justification=f"thread {i}",
+        )
+
+    errors = _run_threads(write_entry, [(i,) for i in range(_N_THREADS)])
+    assert errors == [], f"Concurrent writes raised: {errors}"
+
+
+@pytest.mark.unit
+def test_audit_logger_concurrent_writes_consistent_state(tmp_path):
+    """All audit entries written concurrently must appear on disk."""
+    from src.monitoring.audit_logger import AuditLogger
+
+    storage = tmp_path / "audit.jsonl"
+    logger = AuditLogger(storage_path=storage, signing_key=_SIGNING_KEY)
+
+    errors = _run_threads(
+        lambda i: logger.log_manual_override(
+            agent_id=f"agent-{i}",
+            operator="tester",
+            action="approve",
+            justification=f"thread {i}",
+        ),
+        [(i,) for i in range(_N_THREADS)],
+    )
+    assert errors == []
+
+    lines = [l for l in storage.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == _N_THREADS, (
+        f"Expected {_N_THREADS} entries on disk, got {len(lines)}"
+    )
+    # Every line must be valid JSON
+    for line in lines:
+        entry = json.loads(line)
+        assert "event_type" in entry
+
+
+# ---------------------------------------------------------------------------
+# DriftDetector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_drift_detector_concurrent_persist_no_exception(tmp_path):
+    """Multiple threads persisting drift alerts must not raise."""
+    from src.monitoring.drift_detector import DriftDetector, DriftLevel, DriftMethod, DriftAlert
+    from datetime import datetime, timezone
+
+    alerts_path = tmp_path / "alerts.jsonl"
+    detector = DriftDetector(alerts_path=alerts_path)
+
+    # Pre-populate a baseline so detect_drift works
+    detector.establish_baseline("agent-0", "cpu", [0.5] * 20)
+
+    def write_alert(i):
+        alert = DriftAlert(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            agent_id=f"agent-{i}",
+            metric_name="cpu",
+            level=DriftLevel.WARNING,
+            method=DriftMethod.THRESHOLD,
+            current_value=0.9,
+            baseline_value=0.5,
+            deviation=0.8,
+            description=f"thread {i}",
+        )
+        detector._persist_alert(alert)
+
+    errors = _run_threads(write_alert, [(i,) for i in range(_N_THREADS)])
+    assert errors == [], f"Concurrent writes raised: {errors}"
+
+
+@pytest.mark.unit
+def test_drift_detector_concurrent_persist_consistent_state(tmp_path):
+    """All drift alerts written concurrently must appear on disk."""
+    from src.monitoring.drift_detector import DriftDetector, DriftLevel, DriftMethod, DriftAlert
+    from datetime import datetime, timezone
+
+    alerts_path = tmp_path / "alerts.jsonl"
+    detector = DriftDetector(alerts_path=alerts_path)
+
+    def write_alert(i):
+        alert = DriftAlert(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            agent_id=f"agent-{i}",
+            metric_name="cpu",
+            level=DriftLevel.INFO,
+            method=DriftMethod.THRESHOLD,
+            current_value=0.7,
+            baseline_value=0.5,
+            deviation=0.4,
+            description=f"thread {i}",
+        )
+        detector._persist_alert(alert)
+
+    errors = _run_threads(write_alert, [(i,) for i in range(_N_THREADS)])
+    assert errors == []
+
+    lines = [l for l in alerts_path.read_text().splitlines() if l.strip()]
+    assert len(lines) == _N_THREADS, (
+        f"Expected {_N_THREADS} alert lines, got {len(lines)}"
+    )
+    for line in lines:
+        entry = json.loads(line)
+        assert "agent_id" in entry
+
+
+# ---------------------------------------------------------------------------
+# EthicsEngine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_ethics_engine_concurrent_persist_no_exception(tmp_path):
+    """Multiple threads persisting ethics violations must not raise."""
+    from src.monitoring.ethics_engine import (
+        EthicsEngine,
+        EthicsViolation,
+        ViolationSeverity,
+        RuleCategory,
+    )
+    from src.core.time_utils import utc_iso
+
+    violations_path = tmp_path / "violations.jsonl"
+    engine = EthicsEngine(violations_path=violations_path)
+
+    def write_violation(i):
+        violation = EthicsViolation(
+            timestamp=utc_iso(),
+            agent_id=f"agent-{i}",
+            rule_id="TEST_001",
+            rule_name="Test Rule",
+            severity=ViolationSeverity.LOW,
+            category=RuleCategory.AI_ETHICS,
+            description=f"thread {i}",
+            blocked=False,
+            context={},
+        )
+        engine._persist_violation(violation)
+
+    errors = _run_threads(write_violation, [(i,) for i in range(_N_THREADS)])
+    assert errors == [], f"Concurrent writes raised: {errors}"
+
+
+@pytest.mark.unit
+def test_ethics_engine_concurrent_persist_consistent_state(tmp_path):
+    """All ethics violations written concurrently must appear on disk."""
+    from src.monitoring.ethics_engine import (
+        EthicsEngine,
+        EthicsViolation,
+        ViolationSeverity,
+        RuleCategory,
+    )
+    from src.core.time_utils import utc_iso
+
+    violations_path = tmp_path / "violations.jsonl"
+    engine = EthicsEngine(violations_path=violations_path)
+
+    def write_violation(i):
+        violation = EthicsViolation(
+            timestamp=utc_iso(),
+            agent_id=f"agent-{i}",
+            rule_id="TEST_001",
+            rule_name="Test Rule",
+            severity=ViolationSeverity.LOW,
+            category=RuleCategory.AI_ETHICS,
+            description=f"thread {i}",
+            blocked=False,
+            context={},
+        )
+        engine._persist_violation(violation)
+
+    errors = _run_threads(write_violation, [(i,) for i in range(_N_THREADS)])
+    assert errors == []
+
+    lines = [l for l in violations_path.read_text().splitlines() if l.strip()]
+    assert len(lines) == _N_THREADS, (
+        f"Expected {_N_THREADS} violation lines, got {len(lines)}"
+    )
+    for line in lines:
+        entry = json.loads(line)
+        assert "rule_id" in entry
+
+
+# ---------------------------------------------------------------------------
+# MonitoringSystem
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_monitoring_system_concurrent_persist_no_exception(tmp_path, monkeypatch):
+    """Multiple threads calling _persist_state must not raise."""
+    monkeypatch.setenv("MONITORING_SIGNING_KEY", _SIGNING_KEY)
+
+    from src.monitoring.monitoring_system import MonitoringSystem
+
+    system = MonitoringSystem(storage_dir=tmp_path / "monitoring")
+
+    errors = _run_threads(
+        lambda: system._persist_state(),
+        [() for _ in range(_N_THREADS)],
+    )
+    assert errors == [], f"Concurrent writes raised: {errors}"
+
+
+@pytest.mark.unit
+def test_monitoring_system_concurrent_persist_consistent_state(tmp_path, monkeypatch):
+    """State file written concurrently must remain valid JSON."""
+    monkeypatch.setenv("MONITORING_SIGNING_KEY", _SIGNING_KEY)
+
+    from src.monitoring.monitoring_system import MonitoringSystem
+
+    state_dir = tmp_path / "monitoring"
+    system = MonitoringSystem(storage_dir=state_dir)
+
+    errors = _run_threads(
+        lambda: system._persist_state(),
+        [() for _ in range(_N_THREADS)],
+    )
+    assert errors == []
+
+    state_file = state_dir / "monitoring_state.json"
+    assert state_file.exists(), "State file must exist after persist"
+    data = json.loads(state_file.read_text())
+    assert "interventions" in data
+    assert "last_intervention_time" in data
+
+
+# ---------------------------------------------------------------------------
+# InsightLedger (already locked — regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_insight_ledger_already_has_write_lock():
+    """InsightLedger._lock must be a threading.Lock (regression guard)."""
+    import threading
+    from modules.insight_ledger.ledger_core import InsightLedger
+
+    ledger = InsightLedger(storage_path="/tmp/test_lock_ledger_regression")
+    assert hasattr(ledger, "_lock"), "InsightLedger must have a _lock attribute"
+    assert isinstance(ledger._lock, type(threading.Lock())), (
+        "InsightLedger._lock must be a threading.Lock instance"
+    )


### PR DESCRIPTION
## Summary

- Adds `threading.Lock` write guards to four persistence classes that were writing to disk without any locking: `AuditLogger`, `DriftDetector`, `EthicsEngine`, `MonitoringSystem`
- `InsightLedger` already had a `threading.Lock` — left untouched
- Total new lock sites: 6 (audit append, drift persist/rewrite, ethics persist/rewrite, monitoring persist)
- Prevents file corruption when multiple threads call `save`/`persist` methods concurrently

## Test plan

- [ ] `tests/test_write_locks.py` — 9 tests: no-exception under concurrent writes + consistent on-disk state for each class, plus regression guard for existing InsightLedger lock — all pass
- [ ] CI syntax check passes

Fixes #808

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_