### PR TITLE
feat(persistence): add schema versioning and migration registry for state files

### DIFF
--- a/src/monitoring/audit_logger.py
+++ b/src/monitoring/audit_logger.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any
 from src.core.time_utils import utc_now
 from src.utils.persist_redact import redact_for_persistence
+from src.utils.schema_migrations import get_registry
 
 logger = logging.getLogger(__name__)
 
@@ -454,8 +455,9 @@ class AuditLogger:
 
         try:
             self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+            record = get_registry().stamp(entry.to_dict(), "audit_log")
             with open(self.storage_path, 'a', encoding='utf-8') as f:
-                f.write(json.dumps(entry.to_dict(), sort_keys=True) + "\n")
+                f.write(json.dumps(record, sort_keys=True) + "\n")
                 f.flush()
                 os.fsync(f.fileno())
         except Exception as e:

--- a/src/monitoring/drift_detector.py
+++ b/src/monitoring/drift_detector.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any
 import statistics
 from src.utils.persist_redact import redact_for_persistence
+from src.utils.schema_migrations import get_registry
 
 logger = logging.getLogger(__name__)
 
@@ -352,8 +353,9 @@ class DriftDetector:
                 alert_dict["metadata"] = redact_for_persistence(
                     alert_dict["metadata"], context_tag=alert.context_tag or ""
                 )
+            record = get_registry().stamp(alert_dict, "drift_alert")
             with open(self.alerts_path, 'a') as f:
-                f.write(json.dumps(alert_dict, sort_keys=True) + "\n")
+                f.write(json.dumps(record, sort_keys=True) + "\n")
         except Exception as e:
             logger.error("Failed to persist drift alert: %s", e)
 

--- a/src/monitoring/monitoring_system.py
+++ b/src/monitoring/monitoring_system.py
@@ -11,6 +11,7 @@ import os
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 from src.core.time_utils import utc_now, utc_iso
+from src.utils.schema_migrations import get_registry
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Callable
@@ -658,21 +659,20 @@ class MonitoringSystem:
         """Persist intervention state needed for restart-safe cooldowns."""
         try:
             self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            state = get_registry().stamp(
+                {
+                    'interventions': [
+                        intervention.to_dict()
+                        for intervention in self.interventions
+                    ],
+                    'last_intervention_time': {
+                        agent_id: timestamp.isoformat()
+                        for agent_id, timestamp in self.last_intervention_time.items()
+                    }
+                },
+                "monitoring_state",
+            )
             with open(self._state_path, 'w') as f:
-                json.dump(
-                    {
-                        'interventions': [
-                            intervention.to_dict()
-                            for intervention in self.interventions
-                        ],
-                        'last_intervention_time': {
-                            agent_id: timestamp.isoformat()
-                            for agent_id, timestamp in self.last_intervention_time.items()
-                        }
-                    },
-                    f,
-                    indent=2,
-                    sort_keys=True
-                )
+                json.dump(state, f, indent=2, sort_keys=True)
         except Exception as e:
             logger.error("Failed to persist monitoring state: %s", e)

--- a/src/utils/schema_migrations.py
+++ b/src/utils/schema_migrations.py
@@ -1,0 +1,109 @@
+"""Schema versioning and migration registry for Aurora persisted state files.
+
+Usage:
+    registry = MigrationRegistry()
+    registry.register("audit_log", 1, migrate_v0_to_v1)
+
+    # When loading a file:
+    data = registry.upgrade(data, schema="audit_log")  # upgrades to latest version
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION_KEY = "_schema_version"
+CURRENT_VERSION = 1  # bump whenever a schema changes
+
+MigrationFn = Callable[[Dict[str, Any]], Dict[str, Any]]
+
+
+class MigrationRegistry:
+    """Registry of schema migrations keyed by (schema_name, from_version)."""
+
+    def __init__(self) -> None:
+        # {schema_name: {from_version: migration_fn}}
+        self._migrations: Dict[str, Dict[int, MigrationFn]] = {}
+        self._latest: Dict[str, int] = {}
+
+    def register(
+        self,
+        schema: str,
+        from_version: int,
+        fn: MigrationFn,
+        to_version: Optional[int] = None,
+    ) -> None:
+        """Register a migration from `from_version` to `from_version+1` (or `to_version` if given)."""
+        target = to_version if to_version is not None else from_version + 1
+        self._migrations.setdefault(schema, {})[from_version] = fn
+        self._latest[schema] = max(self._latest.get(schema, 0), target)
+
+    def upgrade(self, data: Dict[str, Any], schema: str) -> Dict[str, Any]:
+        """Apply migrations until data is at the latest version for this schema."""
+        if not isinstance(data, dict):
+            return data
+        current = data.get(SCHEMA_VERSION_KEY, 0)
+        latest = self._latest.get(schema, CURRENT_VERSION)
+        while current < latest:
+            fn = self._migrations.get(schema, {}).get(current)
+            if fn is None:
+                logger.warning(
+                    "No migration for %s v%d→v%d, skipping remaining upgrades",
+                    schema,
+                    current,
+                    current + 1,
+                )
+                break
+            try:
+                data = fn(data)
+                current = data.get(SCHEMA_VERSION_KEY, current + 1)
+                logger.info("Migrated %s schema to v%d", schema, current)
+            except Exception as exc:
+                logger.error("Migration failed for %s v%d: %s", schema, current, exc)
+                break
+        return data
+
+    def stamp(self, data: Dict[str, Any], schema: str) -> Dict[str, Any]:
+        """Add/update the schema version key on a record before writing."""
+        data = dict(data)
+        data[SCHEMA_VERSION_KEY] = self._latest.get(schema, CURRENT_VERSION)
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Process-global default registry
+# ---------------------------------------------------------------------------
+
+_default_registry = MigrationRegistry()
+
+
+def get_registry() -> MigrationRegistry:
+    """Return the process-global migration registry."""
+    return _default_registry
+
+
+# ---------------------------------------------------------------------------
+# Initial no-op migrations (v0 → v1) for the three core persistence schemas.
+# These establish the baseline version so that future structural changes can
+# be expressed as v1 → v2 migrations rather than having to handle unversioned
+# (v0) records forever.
+# ---------------------------------------------------------------------------
+
+
+def _noop_v0_to_v1(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Stamp an unversioned record as v1 without altering any fields."""
+    data = dict(data)
+    data[SCHEMA_VERSION_KEY] = 1
+    return data
+
+
+# audit_log schema  (src/monitoring/audit_logger.py — JSONL append)
+_default_registry.register("audit_log", 0, _noop_v0_to_v1)
+
+# drift_alert schema  (src/monitoring/drift_detector.py — JSONL append)
+_default_registry.register("drift_alert", 0, _noop_v0_to_v1)
+
+# monitoring_state schema  (src/monitoring/monitoring_system.py — JSON snapshot)
+_default_registry.register("monitoring_state", 0, _noop_v0_to_v1)

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -1,0 +1,247 @@
+"""Tests for src/utils/schema_migrations.py
+
+Covers:
+- Registry with no migrations registered
+- Single v0→v1 migration applied
+- Chained migrations (v0→v1→v2)
+- Missing intermediate migration: logs warning and stops
+- stamp() adds _schema_version key
+- Non-dict data returned unchanged by upgrade()
+- Data already at latest version is returned unchanged
+- to_version parameter in register()
+- Default registry / get_registry()
+- Stamp reflects latest registered version for schema
+"""
+
+import logging
+import pytest
+
+from src.utils.schema_migrations import (
+    MigrationRegistry,
+    SCHEMA_VERSION_KEY,
+    CURRENT_VERSION,
+    get_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _add_v(data, version):
+    """Return a copy of data with _schema_version set."""
+    return {**data, SCHEMA_VERSION_KEY: version}
+
+
+# ---------------------------------------------------------------------------
+# Tests: upgrade()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_upgrade_no_migrations_returns_data_unchanged():
+    """Registry with no migrations: upgrade returns data unchanged."""
+    registry = MigrationRegistry()
+    data = {"foo": "bar"}
+    result = registry.upgrade(data, schema="nonexistent")
+    # Data should be returned as-is; no _schema_version injected
+    assert result["foo"] == "bar"
+
+
+@pytest.mark.unit
+def test_upgrade_single_migration_v0_to_v1():
+    """Single registered migration transforms data from v0 to v1."""
+    registry = MigrationRegistry()
+
+    def migrate(d):
+        d = dict(d)
+        d["migrated"] = True
+        d[SCHEMA_VERSION_KEY] = 1
+        return d
+
+    registry.register("test_schema", 0, migrate)
+    data = {"value": 42}  # no _schema_version → treated as v0
+    result = registry.upgrade(data, schema="test_schema")
+
+    assert result[SCHEMA_VERSION_KEY] == 1
+    assert result["migrated"] is True
+    assert result["value"] == 42
+
+
+@pytest.mark.unit
+def test_upgrade_chain_v0_to_v1_to_v2():
+    """Chain of two migrations applied in order: v0→v1→v2."""
+    registry = MigrationRegistry()
+
+    def v0_to_v1(d):
+        d = dict(d)
+        d["step1"] = True
+        d[SCHEMA_VERSION_KEY] = 1
+        return d
+
+    def v1_to_v2(d):
+        d = dict(d)
+        d["step2"] = True
+        d[SCHEMA_VERSION_KEY] = 2
+        return d
+
+    registry.register("chain_schema", 0, v0_to_v1)
+    registry.register("chain_schema", 1, v1_to_v2)
+
+    data = {"original": True}
+    result = registry.upgrade(data, schema="chain_schema")
+
+    assert result[SCHEMA_VERSION_KEY] == 2
+    assert result["step1"] is True
+    assert result["step2"] is True
+    assert result["original"] is True
+
+
+@pytest.mark.unit
+def test_upgrade_missing_intermediate_stops_and_warns(caplog):
+    """Missing intermediate migration logs a warning and stops upgrading."""
+    registry = MigrationRegistry()
+
+    # Only register v1→v2; leave v0→v1 missing so the loop can't start
+    def v1_to_v2(d):
+        d = dict(d)
+        d[SCHEMA_VERSION_KEY] = 2
+        return d
+
+    # Manually set latest to 2 by registering v1 migration with to_version=2
+    registry.register("gap_schema", 1, v1_to_v2, to_version=2)
+
+    # Data at v0 — the registry has no v0 migration
+    data = {"payload": "x"}  # v0 (no _schema_version key)
+
+    with caplog.at_level(logging.WARNING, logger="src.utils.schema_migrations"):
+        result = registry.upgrade(data, schema="gap_schema")
+
+    # Should stop at v0 because no migration found
+    assert result.get(SCHEMA_VERSION_KEY, 0) == 0
+    assert any("No migration" in record.message for record in caplog.records)
+
+
+@pytest.mark.unit
+def test_upgrade_already_at_latest_returns_unchanged():
+    """Data already at the latest version is returned without modification."""
+    registry = MigrationRegistry()
+    call_count = {"n": 0}
+
+    def v0_to_v1(d):
+        call_count["n"] += 1
+        d = dict(d)
+        d[SCHEMA_VERSION_KEY] = 1
+        return d
+
+    registry.register("stamped_schema", 0, v0_to_v1)
+
+    data = {"already": True, SCHEMA_VERSION_KEY: 1}
+    result = registry.upgrade(data, schema="stamped_schema")
+
+    assert result[SCHEMA_VERSION_KEY] == 1
+    assert call_count["n"] == 0  # migration was never called
+
+
+@pytest.mark.unit
+def test_upgrade_non_dict_returned_unchanged():
+    """Non-dict values passed to upgrade() are returned as-is."""
+    registry = MigrationRegistry()
+    registry.register("any_schema", 0, lambda d: d)
+
+    for value in [None, "string", 42, [1, 2, 3]]:
+        assert registry.upgrade(value, schema="any_schema") is value
+
+
+# ---------------------------------------------------------------------------
+# Tests: stamp()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_stamp_adds_schema_version_key():
+    """stamp() adds _schema_version to the returned dict."""
+    registry = MigrationRegistry()
+    registry.register("my_schema", 0, lambda d: d)
+
+    record = {"event": "login"}
+    stamped = registry.stamp(record, schema="my_schema")
+
+    assert SCHEMA_VERSION_KEY in stamped
+    assert stamped[SCHEMA_VERSION_KEY] == 1
+
+
+@pytest.mark.unit
+def test_stamp_does_not_mutate_original():
+    """stamp() returns a new dict and does not mutate the input."""
+    registry = MigrationRegistry()
+    registry.register("immutable_schema", 0, lambda d: d)
+
+    original = {"data": "value"}
+    stamped = registry.stamp(original, schema="immutable_schema")
+
+    assert SCHEMA_VERSION_KEY not in original
+    assert SCHEMA_VERSION_KEY in stamped
+
+
+@pytest.mark.unit
+def test_stamp_reflects_latest_registered_version():
+    """stamp() uses the latest known version for the schema."""
+    registry = MigrationRegistry()
+
+    def noop(d):
+        d = dict(d)
+        d[SCHEMA_VERSION_KEY] = 3
+        return d
+
+    registry.register("versioned_schema", 2, noop, to_version=3)
+    stamped = registry.stamp({"x": 1}, schema="versioned_schema")
+    assert stamped[SCHEMA_VERSION_KEY] == 3
+
+
+@pytest.mark.unit
+def test_stamp_unknown_schema_uses_current_version():
+    """stamp() falls back to CURRENT_VERSION for unregistered schemas."""
+    registry = MigrationRegistry()
+    stamped = registry.stamp({"y": 2}, schema="unknown_schema")
+    assert stamped[SCHEMA_VERSION_KEY] == CURRENT_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Tests: default registry / get_registry()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_registry_returns_migration_registry_instance():
+    """get_registry() returns a MigrationRegistry."""
+    registry = get_registry()
+    assert isinstance(registry, MigrationRegistry)
+
+
+@pytest.mark.unit
+def test_default_registry_stamps_audit_log():
+    """Default registry can stamp an audit_log record."""
+    registry = get_registry()
+    record = {"id": "AUDIT-00000001", "event_type": "drift_alert"}
+    stamped = registry.stamp(record, schema="audit_log")
+    assert stamped[SCHEMA_VERSION_KEY] == 1
+
+
+@pytest.mark.unit
+def test_default_registry_upgrades_unversioned_drift_alert():
+    """Default registry upgrades an unversioned drift_alert record to v1."""
+    registry = get_registry()
+    old_record = {"agent_id": "agent-001", "level": "warning"}
+    upgraded = registry.upgrade(old_record, schema="drift_alert")
+    assert upgraded[SCHEMA_VERSION_KEY] == 1
+    assert upgraded["agent_id"] == "agent-001"
+
+
+@pytest.mark.unit
+def test_default_registry_upgrades_unversioned_monitoring_state():
+    """Default registry upgrades an unversioned monitoring_state record to v1."""
+    registry = get_registry()
+    old_state = {"interventions": [], "last_intervention_time": {}}
+    upgraded = registry.upgrade(old_state, schema="monitoring_state")
+    assert upgraded[SCHEMA_VERSION_KEY] == 1


### PR DESCRIPTION
## Summary

- Adds `src/utils/schema_migrations.py` with `MigrationRegistry` — a lightweight schema versioning system for persisted state files
- `MigrationRegistry.register()` maps `(schema_name, from_version) → migration_fn`
- `MigrationRegistry.upgrade(data, schema)` walks a record from its current `_schema_version` up to the latest, applying each migration in sequence; logs a warning and stops gracefully if an intermediate step is missing
- `MigrationRegistry.stamp(data, schema)` stamps a `_schema_version` key before each write, establishing a v1 baseline
- Pre-registers no-op v0→v1 migrations for `audit_log`, `drift_alert`, and `monitoring_state` schemas
- Wires `stamp()` into `AuditLogger._append_entry_to_disk()`, `DriftDetector._persist_alert()`, and `MonitoringSystem._persist_state()`

## Test plan

- [ ] `tests/test_schema_migrations.py` — 14 tests: no-op registry, single migration, migration chain, missing intermediate (stops with warning), `stamp()` adds key, non-dict passthrough, already-at-latest unchanged — all pass
- [ ] CI syntax check passes

Fixes #811

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_