### PR TITLE
feat(api): expose memory retrieval module as REST endpoints

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -150,6 +150,16 @@ except ImportError:
     AUMEMMANAGER_AVAILABLE = False
     AUMEMMANAGER_ROUTER = None
 
+# Import Memory Retrieval API integration
+try:
+    from modules.memory_retrieval.api import router as memory_retrieval_router
+    MEMORY_RETRIEVAL_AVAILABLE = True
+    MEMORY_RETRIEVAL_ROUTER = memory_retrieval_router
+except ImportError:
+    logging.getLogger("aurora_api").warning("Memory Retrieval not available - memory retrieval features disabled")
+    MEMORY_RETRIEVAL_AVAILABLE = False
+    MEMORY_RETRIEVAL_ROUTER = None
+
 # Import Data Guardian API integration
 try:
     from modules.data_guardian.api import router as data_guardian_router
@@ -250,6 +260,16 @@ except ImportError:
     RELAY_MANAGER_ROUTER = None
 
 # from modules.symbolic_core.quantum_vsa import QuantumVSA  # Uncomment if available
+
+# Import Memory Retrieval API router
+try:
+    from modules.memory_retrieval.router import router as memory_retrieval_router
+    MEMORY_RETRIEVAL_AVAILABLE = True
+    MEMORY_RETRIEVAL_ROUTER = memory_retrieval_router
+except ImportError:
+    logging.getLogger("aurora_api").warning("Memory Retrieval not available - memory retrieval features disabled")
+    MEMORY_RETRIEVAL_AVAILABLE = False
+    MEMORY_RETRIEVAL_ROUTER = None
 
 # Structured logger (avoids f-string interpolation for security)
 logger = logging.getLogger("aurora_api")
@@ -631,6 +651,15 @@ if AUMEMMANAGER_AVAILABLE and AUMEMMANAGER_ROUTER:
         logger.error("Failed to integrate AuMemManager API routes: %s", e)
         AUMEMMANAGER_AVAILABLE = False
 
+# Include Memory Retrieval API routes if available
+if MEMORY_RETRIEVAL_AVAILABLE and MEMORY_RETRIEVAL_ROUTER:
+    try:
+        app.include_router(MEMORY_RETRIEVAL_ROUTER)
+        logger.info("Memory Retrieval API routes integrated successfully")
+    except Exception as e:
+        logger.error("Failed to integrate Memory Retrieval API routes: %s", e)
+        MEMORY_RETRIEVAL_AVAILABLE = False
+
 # Include Data Guardian API routes if available
 if DATA_GUARDIAN_AVAILABLE and DATA_GUARDIAN_ROUTER:
     try:
@@ -674,6 +703,15 @@ if QUANTUM_SIMULATOR_AVAILABLE and QUANTUM_SIMULATOR_ROUTER:
     except Exception as e:
         logger.error("Failed to integrate Quantum Simulator API routes: %s", e)
         QUANTUM_SIMULATOR_AVAILABLE = False
+
+# Include Memory Retrieval API routes if available
+if MEMORY_RETRIEVAL_AVAILABLE and MEMORY_RETRIEVAL_ROUTER:
+    try:
+        app.include_router(MEMORY_RETRIEVAL_ROUTER)
+        logger.info("Memory Retrieval API routes integrated successfully")
+    except Exception as e:
+        logger.error("Failed to integrate Memory Retrieval API routes: %s", e)
+        MEMORY_RETRIEVAL_AVAILABLE = False
 
 # Include RD Productization Pipeline API routes if available
 if RD_PIPELINE_AVAILABLE:

--- a/modules/memory_retrieval/__init__.py
+++ b/modules/memory_retrieval/__init__.py
@@ -1,6 +1,6 @@
 """Memory Retrieval Module (MRM) for AuroraOS."""
 
-from modules.memory_retrieval.api import add_memory, delete_memory, get_memory, query_memory
+from modules.memory_retrieval.api import add_memory, delete_memory, get_memory, query_memory, router
 
 __version__ = "0.2.0"
-__all__ = ["add_memory", "query_memory", "get_memory", "delete_memory"]
+__all__ = ["add_memory", "query_memory", "get_memory", "delete_memory", "router"]

--- a/modules/memory_retrieval/api.py
+++ b/modules/memory_retrieval/api.py
@@ -1,9 +1,139 @@
-"""Memory Retrieval Module - API Interface."""
+"""Memory Retrieval Module - API Interface.
 
-from typing import Dict, Optional
+Provides both a FastAPI router (``router``) for HTTP exposure and plain
+Python helper functions for in-process use.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
 import logging
 
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# FastAPI Router
+# ---------------------------------------------------------------------------
+
+router = APIRouter(prefix="/api/memory-retrieval", tags=["MemoryRetrieval"])
+
+
+class AddMemoryRequest(BaseModel):
+    context_id: str
+    content: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AddMemoryResponse(BaseModel):
+    memory_id: str
+    status: str = "ok"
+
+
+class RetrieveMemoriesRequest(BaseModel):
+    context_id: str
+    query: str
+    top_k: int = Field(default=10, ge=1, le=100)
+    user_id: str = "default"
+    max_tokens: Optional[int] = Field(default=None, ge=1)
+
+
+class RetrieveMemoriesResponse(BaseModel):
+    memories: List[Dict[str, Any]]
+    count: int
+
+
+@router.post("/memories", response_model=AddMemoryResponse)
+async def add_memory_endpoint(request: AddMemoryRequest):
+    """Add a memory entry to the retrieval store."""
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        core = MemoryRetrievalCore.get_instance()
+        memory_id = core.add_memory(request.context_id, request.content, request.metadata)
+        return AddMemoryResponse(memory_id=memory_id)
+    except Exception as exc:
+        logger.exception("Failed to add memory")
+        raise HTTPException(status_code=500, detail="Failed to add memory") from exc
+
+
+@router.post("/retrieve", response_model=RetrieveMemoriesResponse)
+async def retrieve_memories_endpoint(request: RetrieveMemoriesRequest):
+    """Retrieve relevant memories for a context/query pair."""
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        core = MemoryRetrievalCore.get_instance()
+        kwargs: Dict[str, Any] = {}
+        if request.max_tokens is not None:
+            kwargs["max_tokens"] = request.max_tokens
+        memories = core.retrieve_memories(
+            request.context_id,
+            request.query,
+            top_k=request.top_k,
+            user_id=request.user_id,
+            **kwargs,
+        )
+        return RetrieveMemoriesResponse(memories=memories, count=len(memories))
+    except Exception as exc:
+        logger.exception("Failed to retrieve memories")
+        raise HTTPException(status_code=500, detail="Failed to retrieve memories") from exc
+
+
+@router.get("/memories/{memory_id}", response_model=Dict[str, Any])
+async def get_memory_endpoint(memory_id: str):
+    """Fetch a single memory entry by ID."""
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        core = MemoryRetrievalCore.get_instance()
+        memory = core.get_memory(memory_id)
+        if memory is None:
+            raise HTTPException(status_code=404, detail=f"Memory {memory_id!r} not found")
+        return memory
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to get memory %s", memory_id)
+        raise HTTPException(status_code=500, detail="Failed to get memory") from exc
+
+
+@router.delete("/memories/{memory_id}")
+async def delete_memory_endpoint(memory_id: str):
+    """Delete a memory entry."""
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        core = MemoryRetrievalCore.get_instance()
+        deleted = core.delete_memory(memory_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail=f"Memory {memory_id!r} not found")
+        return {"status": "deleted", "memory_id": memory_id}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to delete memory %s", memory_id)
+        raise HTTPException(status_code=500, detail="Failed to delete memory") from exc
+
+
+@router.get("/cache-stats")
+async def get_cache_stats_endpoint():
+    """Get memory cache statistics."""
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        core = MemoryRetrievalCore.get_instance()
+        return core.get_cache_stats()
+    except Exception as exc:
+        logger.exception("Failed to get cache stats")
+        raise HTTPException(status_code=500, detail="Failed to get cache stats") from exc
+
+
+# ---------------------------------------------------------------------------
+# Plain Python helpers (in-process use / backward compatibility)
+# ---------------------------------------------------------------------------
 
 
 def add_memory(context_id: str, content: str, metadata: Optional[dict] = None) -> Dict:

--- a/tests/test_memory_retrieval_api.py
+++ b/tests/test_memory_retrieval_api.py
@@ -1,0 +1,191 @@
+"""Tests for the Memory Retrieval REST API router."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from modules.memory_retrieval.api import router
+
+
+@pytest.fixture()
+def app():
+    """Minimal FastAPI app with the memory retrieval router mounted."""
+    _app = FastAPI()
+    _app.include_router(router)
+    return _app
+
+
+@pytest.fixture()
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture()
+def mock_core():
+    """Return a mock MemoryRetrievalCore instance."""
+    core = MagicMock()
+    core.add_memory.return_value = "mem-abc-123"
+    core.retrieve_memories.return_value = [
+        {"id": "mem-abc-123", "score": 0.95, "content": "hello world", "metadata": {}}
+    ]
+    core.get_memory.return_value = {
+        "id": "mem-abc-123",
+        "content": "hello world",
+        "context_id": "ctx-1",
+        "metadata": {},
+    }
+    core.delete_memory.return_value = True
+    core.get_cache_stats.return_value = {"hits": 5, "misses": 2, "size": 7}
+    return core
+
+
+# ---------------------------------------------------------------------------
+# POST /api/memory-retrieval/memories
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_add_memory_success(client, mock_core):
+    """Adding a memory returns 200 with a memory_id."""
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.post(
+            "/api/memory-retrieval/memories",
+            json={"context_id": "ctx-1", "content": "hello world", "metadata": {"tag": "test"}},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["memory_id"] == "mem-abc-123"
+    assert data["status"] == "ok"
+    mock_core.add_memory.assert_called_once_with("ctx-1", "hello world", {"tag": "test"})
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_add_memory_server_error(client, mock_core):
+    """A core exception is surfaced as a 500."""
+    mock_core.add_memory.side_effect = RuntimeError("store failure")
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.post(
+            "/api/memory-retrieval/memories",
+            json={"context_id": "ctx-1", "content": "hello world"},
+        )
+    assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# POST /api/memory-retrieval/retrieve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_retrieve_memories_success(client, mock_core):
+    """Retrieve returns memories list and count."""
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.post(
+            "/api/memory-retrieval/retrieve",
+            json={"context_id": "ctx-1", "query": "hello", "top_k": 5},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert data["memories"][0]["id"] == "mem-abc-123"
+    mock_core.retrieve_memories.assert_called_once_with("ctx-1", "hello", top_k=5, user_id="default")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory-retrieval/memories/{memory_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_get_memory_found(client, mock_core):
+    """A known memory_id returns 200 with the memory dict."""
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.get("/api/memory-retrieval/memories/mem-abc-123")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == "mem-abc-123"
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_get_memory_not_found(client, mock_core):
+    """An unknown memory_id returns 404."""
+    mock_core.get_memory.return_value = None
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.get("/api/memory-retrieval/memories/nonexistent")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/memory-retrieval/memories/{memory_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_delete_memory_success(client, mock_core):
+    """Deleting an existing memory returns 200 with status=deleted."""
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.delete("/api/memory-retrieval/memories/mem-abc-123")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "deleted"
+    assert data["memory_id"] == "mem-abc-123"
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_delete_memory_not_found(client, mock_core):
+    """Deleting a non-existent memory returns 404."""
+    mock_core.delete_memory.return_value = False
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.delete("/api/memory-retrieval/memories/nonexistent")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory-retrieval/cache-stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_get_cache_stats(client, mock_core):
+    """Cache-stats endpoint returns 200 with stats dict."""
+    with patch(
+        "modules.memory_retrieval.core.MemoryRetrievalCore.get_instance",
+        return_value=mock_core,
+    ):
+        response = client.get("/api/memory-retrieval/cache-stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["hits"] == 5
+    assert data["misses"] == 2
+    assert data["size"] == 7


### PR DESCRIPTION
## Summary

- Adds a proper FastAPI `APIRouter` to `modules/memory_retrieval/api.py` (prefix `/api/memory-retrieval`, tag `MemoryRetrieval`) with 5 endpoints:
  - `POST /memories` — add a memory entry to the retrieval store
  - `POST /retrieve` — semantic search with scoring (relevance × importance × recency × cultural)
  - `GET /memories/{memory_id}` — fetch a single memory by ID (404 if missing)
  - `DELETE /memories/{memory_id}` — delete a memory (404 if missing)
  - `GET /cache-stats` — live cache hit/miss statistics
- Backward-compatible: original helper functions preserved in `api.py`
- Exports `router` from `modules/memory_retrieval/__init__.py`
- Registers the router in `api/aurora_api.py` (try/except pattern matching all other routers)

## Test plan

- [ ] `tests/test_memory_retrieval_api.py` — 8 tests: add/retrieve/get/delete/cache-stats endpoints, 404 on missing memory — all pass
- [ ] CI syntax check passes

Fixes #773

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_