### PR TITLE
feat(monitoring): feed DriftDetector with live request metrics from production endpoints

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -34,6 +34,12 @@ from src.middleware.idempotency import IdempotencyMiddleware
 from src.middleware.pii_middleware import PIIMiddleware
 from src.middleware.request_id import RequestIDMiddleware
 from src.runtime.shutdown import ShutdownCoordinator
+try:
+    from src.middleware.telemetry_middleware import MetricsMiddleware
+    _METRICS_MIDDLEWARE_AVAILABLE = True
+except Exception as _mm_exc:  # pragma: no cover - graceful degradation
+    logging.getLogger("aurora_api").warning("MetricsMiddleware unavailable: %s", _mm_exc)
+    _METRICS_MIDDLEWARE_AVAILABLE = False
 
 from modules.symbolic_core.geometric_algebra import GeometricAlgebra
 try:
@@ -353,6 +359,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("⚠️ Failed to initialize telemetry: %s", e)
 
+    # Start background metrics pusher for live DriftDetector feeds
+    try:
+        from src.monitoring.metrics_pusher import start_background_pusher
+        start_background_pusher(interval_seconds=30)
+        logger.info("Background metrics pusher started (feeds DriftDetector every 30s)")
+    except Exception as e:
+        logger.warning("Failed to start background metrics pusher: %s", e)
+
     # Start HALO/PAS drift controller if available
     if HALO_PAS_AVAILABLE and HALO_PAS_CONTROLLER:
         try:
@@ -535,6 +549,12 @@ app.add_middleware(PIIMiddleware)
 # Request-ID middleware: must be registered last so it wraps everything and
 # its ContextVar is set before any inner middleware runs.
 app.add_middleware(RequestIDMiddleware)
+
+# Metrics middleware: record per-request latency/status for DriftDetector.
+# Registered after RequestIDMiddleware so request-ID context is available.
+if _METRICS_MIDDLEWARE_AVAILABLE:
+    app.add_middleware(MetricsMiddleware)
+    logger.info("MetricsMiddleware registered for live drift detection")
 
 
 @app.exception_handler(RateLimitExceeded)

--- a/src/middleware/telemetry_middleware.py
+++ b/src/middleware/telemetry_middleware.py
@@ -1,0 +1,57 @@
+"""Telemetry Middleware
+
+Records per-request latency and HTTP status code into the MetricsPusher so
+that live production traffic feeds the DriftDetector for behavioral drift
+detection (see src/monitoring/metrics_pusher.py).
+
+The middleware measures wall-clock time between request receipt and response
+completion, then calls ``get_pusher().record(duration_ms, status_code)``.
+
+Design notes:
+- Uses Starlette BaseHTTPMiddleware for consistency with RequestIDMiddleware.
+- Falls back gracefully if MetricsPusher is unavailable (import error, etc.).
+- Only HTTP requests are instrumented; WebSocket connections are skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+try:
+    from src.monitoring.metrics_pusher import get_pusher as _get_pusher
+    _PUSHER_AVAILABLE = True
+except Exception as _import_exc:  # pragma: no cover - graceful degradation
+    logger.warning("MetricsPusher unavailable: %s", _import_exc)
+    _PUSHER_AVAILABLE = False
+    _get_pusher = None  # type: ignore[assignment]
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Capture per-request duration and status code for drift detection."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.monotonic()
+        response = await call_next(request)
+        duration_ms = (time.monotonic() - start) * 1000.0
+
+        if _PUSHER_AVAILABLE:
+            try:
+                _get_pusher().record(
+                    duration_ms=duration_ms,
+                    status_code=response.status_code,
+                )
+            except Exception as exc:  # pragma: no cover - safety net
+                logger.debug("MetricsMiddleware: record error: %s", exc)
+
+        return response

--- a/src/monitoring/metrics_pusher.py
+++ b/src/monitoring/metrics_pusher.py
@@ -1,0 +1,240 @@
+"""Pushes live request metrics to DriftDetector for behavioral drift detection.
+
+Collects per-request observations from the MetricsMiddleware and periodically
+pushes aggregated window statistics (avg latency, p95 latency, error rate,
+request count) into the DriftDetector via its ``detect_drift`` method.
+
+Baseline bootstrapping: the first ``_MIN_BASELINE_SAMPLES`` observations are
+used to establish an initial baseline so the detector has reference data before
+it starts emitting drift alerts.
+"""
+from __future__ import annotations
+
+import collections
+import logging
+import threading
+import time
+from typing import Deque, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_WINDOW_SECONDS = 60  # rolling aggregation window
+_MIN_BASELINE_SAMPLES = 20  # samples required before handing off to detector
+_AGENT_ID = "aurora-api"  # logical agent identifier used in drift keys
+
+
+class MetricsPusher:
+    """Collects per-request stats and pushes aggregated metrics to DriftDetector.
+
+    Thread-safe. Designed to be called from FastAPI middleware on every request.
+
+    Usage::
+
+        pusher = get_pusher()
+        pusher.record(duration_ms=42.3, status_code=200)
+
+    A background daemon thread calls :meth:`push_to_detector` on a regular
+    interval via :func:`start_background_pusher`.
+    """
+
+    def __init__(self, window_seconds: int = _WINDOW_SECONDS) -> None:
+        self._window = window_seconds
+        self._lock = threading.Lock()
+        # Each entry: (monotonic_timestamp, duration_ms, status_code)
+        self._samples: Deque[tuple] = collections.deque()
+        # Warm-up buffer: accumulate until we have enough for a baseline
+        self._warmup: list[tuple[str, float]] = []  # (metric_name, value)
+        self._detector = None
+        self._baseline_established: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Internal: DriftDetector access
+    # ------------------------------------------------------------------
+
+    def _get_detector(self):
+        """Lazy-init DriftDetector; returns None when unavailable."""
+        if self._detector is None:
+            try:
+                from src.monitoring.drift_detector import DriftDetector
+                self._detector = DriftDetector()
+                logger.info("DriftDetector initialised for MetricsPusher")
+            except Exception as exc:
+                logger.warning("DriftDetector unavailable: %s", exc)
+        return self._detector
+
+    # ------------------------------------------------------------------
+    # Public: observation recording
+    # ------------------------------------------------------------------
+
+    def record(self, duration_ms: float, status_code: int) -> None:
+        """Record a single request observation (called from middleware).
+
+        Args:
+            duration_ms: End-to-end request duration in milliseconds.
+            status_code: HTTP response status code.
+        """
+        now = time.monotonic()
+        with self._lock:
+            self._samples.append((now, duration_ms, status_code))
+            # Evict samples outside the rolling window
+            cutoff = now - self._window
+            while self._samples and self._samples[0][0] < cutoff:
+                self._samples.popleft()
+
+    # ------------------------------------------------------------------
+    # Public: aggregation
+    # ------------------------------------------------------------------
+
+    def get_metrics(self) -> Dict[str, float]:
+        """Return aggregated metrics for the current rolling window.
+
+        Returns an empty dict when no samples are present.
+
+        Keys:
+            ``request_count``, ``avg_latency_ms``, ``p95_latency_ms``,
+            ``error_rate``
+        """
+        with self._lock:
+            if not self._samples:
+                return {}
+            now = time.monotonic()
+            cutoff = now - self._window
+            recent = [(d, s) for ts, d, s in self._samples if ts >= cutoff]
+
+        if not recent:
+            return {}
+
+        durations = [d for d, _ in recent]
+        error_count = sum(1 for _, s in recent if s >= 500)
+        sorted_durations = sorted(durations)
+        p95_idx = max(0, int(len(sorted_durations) * 0.95) - 1)
+
+        return {
+            "request_count": float(len(recent)),
+            "avg_latency_ms": sum(durations) / len(durations),
+            "p95_latency_ms": sorted_durations[p95_idx],
+            "error_rate": error_count / len(recent),
+        }
+
+    # ------------------------------------------------------------------
+    # Public: push to detector
+    # ------------------------------------------------------------------
+
+    def push_to_detector(self) -> None:
+        """Push current aggregated metrics to DriftDetector.
+
+        On the first ``_MIN_BASELINE_SAMPLES`` pushes the values are used to
+        establish the detector baseline; subsequent pushes call
+        ``detect_drift`` for each metric so the detector can issue alerts.
+        """
+        detector = self._get_detector()
+        if detector is None:
+            return
+
+        metrics = self.get_metrics()
+        if not metrics:
+            logger.debug("MetricsPusher: no samples yet, skipping push")
+            return
+
+        for metric_name, value in metrics.items():
+            key = f"{_AGENT_ID}:{metric_name}"
+            if key not in self._baseline_established:
+                # Accumulate warm-up values for this metric
+                self._warmup.append((metric_name, value))
+                warmup_values = [v for n, v in self._warmup if n == metric_name]
+                if len(warmup_values) >= _MIN_BASELINE_SAMPLES:
+                    try:
+                        detector.establish_baseline(
+                            agent_id=_AGENT_ID,
+                            metric_name=metric_name,
+                            values=warmup_values,
+                        )
+                        self._baseline_established.add(key)
+                        logger.info(
+                            "Baseline established for %s:%s from %d samples",
+                            _AGENT_ID, metric_name, len(warmup_values),
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to establish baseline for %s:%s: %s",
+                            _AGENT_ID, metric_name, exc,
+                        )
+            else:
+                try:
+                    alert = detector.detect_drift(
+                        agent_id=_AGENT_ID,
+                        metric_name=metric_name,
+                        current_value=value,
+                        context_tag=f"metrics_pusher_{metric_name}_{int(time.time())}",
+                    )
+                    if alert:
+                        logger.warning(
+                            "Drift alert [%s] %s=%s (baseline=%.3f)",
+                            alert.level.value, metric_name, value, alert.baseline_value,
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to push metric %s to DriftDetector: %s",
+                        metric_name, exc,
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_pusher: Optional[MetricsPusher] = None
+_pusher_lock = threading.Lock()
+
+
+def get_pusher() -> MetricsPusher:
+    """Return the process-wide MetricsPusher singleton."""
+    global _pusher
+    if _pusher is None:
+        with _pusher_lock:
+            if _pusher is None:
+                _pusher = MetricsPusher()
+    return _pusher
+
+
+# ---------------------------------------------------------------------------
+# Background flush thread
+# ---------------------------------------------------------------------------
+
+_bg_thread: Optional[threading.Thread] = None
+_bg_lock = threading.Lock()
+
+
+def start_background_pusher(interval_seconds: int = 30) -> None:
+    """Start a daemon thread that calls ``push_to_detector`` every *interval_seconds*.
+
+    Safe to call multiple times; only one background thread is ever started.
+
+    Args:
+        interval_seconds: How often (in seconds) to push aggregated metrics.
+    """
+    global _bg_thread
+
+    with _bg_lock:
+        if _bg_thread is not None and _bg_thread.is_alive():
+            logger.debug("Background metrics pusher already running")
+            return
+
+        def _loop() -> None:
+            logger.info(
+                "Background metrics pusher started (interval=%ds)", interval_seconds
+            )
+            while True:
+                time.sleep(interval_seconds)
+                try:
+                    get_pusher().push_to_detector()
+                except Exception as exc:  # pragma: no cover - safety net
+                    logger.error("Background metrics pusher error: %s", exc)
+
+        _bg_thread = threading.Thread(
+            target=_loop,
+            name="metrics-pusher-bg",
+            daemon=True,
+        )
+        _bg_thread.start()
+        logger.info("Background metrics pusher thread started")

--- a/tests/test_metrics_pusher.py
+++ b/tests/test_metrics_pusher.py
@@ -1,0 +1,236 @@
+"""Tests for src/monitoring/metrics_pusher.py
+
+Covers:
+- record() adds samples to the rolling window
+- Old samples outside the window are evicted
+- get_metrics() returns correct avg_latency_ms, p95_latency_ms, error_rate,
+  and request_count
+- push_to_detector() calls DriftDetector.detect_drift for each metric
+- push_to_detector() is a no-op when DriftDetector is unavailable
+- Empty window returns empty dict from get_metrics()
+- start_background_pusher() starts exactly one daemon thread
+- get_pusher() returns a consistent singleton
+"""
+from __future__ import annotations
+
+import threading
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.monitoring.metrics_pusher import MetricsPusher, get_pusher, start_background_pusher
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pusher_with_samples(*status_duration_pairs) -> MetricsPusher:
+    """Return a MetricsPusher pre-loaded with (status_code, duration_ms) samples."""
+    pusher = MetricsPusher(window_seconds=60)
+    for status_code, duration_ms in status_duration_pairs:
+        pusher.record(duration_ms=duration_ms, status_code=status_code)
+    return pusher
+
+
+# ---------------------------------------------------------------------------
+# Tests: record() and rolling window
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_record_adds_samples():
+    """record() should add a sample that get_metrics() can see."""
+    pusher = MetricsPusher(window_seconds=60)
+    assert pusher.get_metrics() == {}
+
+    pusher.record(duration_ms=100.0, status_code=200)
+    metrics = pusher.get_metrics()
+
+    assert metrics["request_count"] == 1.0
+    assert metrics["avg_latency_ms"] == pytest.approx(100.0)
+
+
+@pytest.mark.unit
+def test_record_multiple_samples():
+    """record() for multiple requests accumulates correctly."""
+    pusher = _pusher_with_samples(
+        (200, 50.0),
+        (200, 150.0),
+        (200, 100.0),
+    )
+    metrics = pusher.get_metrics()
+
+    assert metrics["request_count"] == 3.0
+    assert metrics["avg_latency_ms"] == pytest.approx(100.0)
+
+
+@pytest.mark.unit
+def test_old_samples_evicted_from_window():
+    """Samples older than window_seconds are evicted on the next record()."""
+    pusher = MetricsPusher(window_seconds=1)  # 1-second window for speed
+
+    # Inject an old sample by manipulating the internal deque directly
+    old_ts = time.monotonic() - 10  # 10 seconds ago — well outside window
+    with pusher._lock:
+        pusher._samples.append((old_ts, 999.0, 200))
+
+    # Record a fresh sample; this triggers eviction
+    pusher.record(duration_ms=10.0, status_code=200)
+    metrics = pusher.get_metrics()
+
+    # Only the fresh sample should survive
+    assert metrics["request_count"] == 1.0
+    assert metrics["avg_latency_ms"] == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_metrics() aggregation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_get_metrics_empty_window():
+    """get_metrics() returns empty dict when no samples exist."""
+    pusher = MetricsPusher(window_seconds=60)
+    assert pusher.get_metrics() == {}
+
+
+@pytest.mark.unit
+def test_get_metrics_avg_latency():
+    """avg_latency_ms is the mean of recorded durations."""
+    pusher = _pusher_with_samples(
+        (200, 20.0),
+        (200, 40.0),
+        (200, 60.0),
+    )
+    metrics = pusher.get_metrics()
+    assert metrics["avg_latency_ms"] == pytest.approx(40.0)
+
+
+@pytest.mark.unit
+def test_get_metrics_p95_latency():
+    """p95_latency_ms is the 95th-percentile duration in the window."""
+    # 20 samples: 19 at 10 ms, 1 at 1000 ms
+    samples = [(200, 10.0)] * 19 + [(200, 1000.0)]
+    pusher = _pusher_with_samples(*samples)
+    metrics = pusher.get_metrics()
+
+    # p95 index = int(20 * 0.95) - 1 = 18 → sorted[18] = 10.0
+    # The spike lands at index 19, above the p95 cut
+    assert metrics["p95_latency_ms"] == pytest.approx(10.0)
+
+
+@pytest.mark.unit
+def test_get_metrics_error_rate():
+    """error_rate counts HTTP 5xx responses divided by total requests."""
+    pusher = _pusher_with_samples(
+        (200, 10.0),
+        (200, 10.0),
+        (200, 10.0),
+        (500, 10.0),  # one error
+    )
+    metrics = pusher.get_metrics()
+    assert metrics["error_rate"] == pytest.approx(0.25)  # 1/4
+
+
+@pytest.mark.unit
+def test_get_metrics_no_errors():
+    """error_rate is 0.0 when all requests succeed."""
+    pusher = _pusher_with_samples((200, 10.0), (201, 10.0), (204, 10.0))
+    metrics = pusher.get_metrics()
+    assert metrics["error_rate"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: push_to_detector()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_push_to_detector_calls_detect_drift():
+    """push_to_detector() calls DriftDetector.detect_drift once per metric
+    after the baseline warm-up period (_MIN_BASELINE_SAMPLES pushes) completes."""
+    import src.monitoring.metrics_pusher as mp_module
+
+    min_samples = mp_module._MIN_BASELINE_SAMPLES  # typically 20
+
+    pusher = MetricsPusher(window_seconds=60)
+    pusher.record(duration_ms=50.0, status_code=200)  # ensure window is non-empty
+
+    mock_detector = MagicMock()
+    mock_detector.establish_baseline = MagicMock()
+    mock_detector.detect_drift = MagicMock(return_value=None)
+
+    with patch.object(pusher, "_get_detector", return_value=mock_detector):
+        # Push min_samples times to build up warm-up values per metric
+        for _ in range(min_samples):
+            pusher.push_to_detector()
+
+        # One more push should now trigger detect_drift (baseline is established)
+        pusher.push_to_detector()
+
+    # detect_drift should have been called at least once (one call per metric)
+    assert mock_detector.detect_drift.called
+    called_metric_names = {call.kwargs["metric_name"] for call in mock_detector.detect_drift.call_args_list}
+    expected_metrics = {"request_count", "avg_latency_ms", "p95_latency_ms", "error_rate"}
+    assert called_metric_names == expected_metrics
+
+
+@pytest.mark.unit
+def test_push_to_detector_noop_when_detector_unavailable():
+    """push_to_detector() is a no-op when DriftDetector cannot be imported."""
+    pusher = MetricsPusher(window_seconds=60)
+    pusher.record(duration_ms=10.0, status_code=200)
+
+    with patch.object(pusher, "_get_detector", return_value=None):
+        # Should not raise
+        pusher.push_to_detector()
+
+
+@pytest.mark.unit
+def test_push_to_detector_noop_when_no_samples():
+    """push_to_detector() is a no-op when the window is empty."""
+    pusher = MetricsPusher(window_seconds=60)
+    mock_detector = MagicMock()
+
+    with patch.object(pusher, "_get_detector", return_value=mock_detector):
+        pusher.push_to_detector()
+
+    mock_detector.detect_drift.assert_not_called()
+    mock_detector.establish_baseline.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: singleton and background thread
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_get_pusher_returns_singleton():
+    """get_pusher() should return the same instance on repeated calls."""
+    p1 = get_pusher()
+    p2 = get_pusher()
+    assert p1 is p2
+
+
+@pytest.mark.unit
+def test_start_background_pusher_starts_daemon_thread():
+    """start_background_pusher() should start exactly one daemon thread."""
+    import src.monitoring.metrics_pusher as mp_module
+
+    # Reset background thread state for isolation
+    original_thread = mp_module._bg_thread
+    mp_module._bg_thread = None
+
+    try:
+        start_background_pusher(interval_seconds=60)
+        thread = mp_module._bg_thread
+        assert thread is not None
+        assert thread.is_alive()
+        assert thread.daemon is True
+
+        # Calling again should NOT start a second thread
+        start_background_pusher(interval_seconds=60)
+        assert mp_module._bg_thread is thread  # same object
+    finally:
+        # Restore original state (the thread is daemon so it will die with the process)
+        mp_module._bg_thread = original_thread


### PR DESCRIPTION
## Summary

- Adds `src/monitoring/metrics_pusher.py` — `MetricsPusher` collects per-request `(duration_ms, status_code)` observations in a 60-second rolling window and pushes aggregated `request_count`, `avg_latency_ms`, `p95_latency_ms`, `error_rate` to `DriftDetector.detect_drift()`
- 20-sample warm-up period seeds baselines via `DriftDetector.establish_baseline()` before drift detection begins
- Background daemon thread flushes metrics to DriftDetector every 30 seconds (started in API lifespan)
- Adds `MetricsMiddleware(BaseHTTPMiddleware)` in `src/middleware/telemetry_middleware.py` that calls `get_pusher().record(duration_ms, status_code)` on every request
- Registered in `api/aurora_api.py` with `app.add_middleware(MetricsMiddleware)` and `start_background_pusher()` wired into lifespan startup
- Gracefully degrades when `DriftDetector` is unavailable

## Test plan

- [ ] `tests/test_metrics_pusher.py` — 13 tests: record/eviction, aggregation correctness, push calls detect_drift, no-op when unavailable, empty window returns `{}` — all pass
- [ ] CI syntax check passes

Fixes #779

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_