### PR TITLE
feat(core): add canonical DLP request envelope — context_tag, audit log, memory chain

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -53,6 +53,9 @@ from modules.symbolic_core.sonnet4_integration_hub import enable_sonnet4_globall
 # Import ChatGPT Agent Mode integration
 from src.integrations.chatgpt_agent_mode import chatgpt_agent_integration
 
+# Import canonical DLP request envelope
+from src.core.request_envelope import request_envelope
+
 # Import Gemini Agent Mode integration
 try:
     from src.integrations.gemini_agent_integration import gemini_agent_integration
@@ -1340,11 +1343,13 @@ async def execute_agent_tool(
     verify_csrf_token(token, session_id=bound_session_id)
 
     try:
-        result = await chatgpt_agent_integration.execute_tool(
-            tool_name=req.tool_name,
-            parameters=req.parameters,
-            session_id=req.session_id
-        )
+        with request_envelope("agent_execute", agent_id="api", store_to_memory=True) as ctx:
+            result = await chatgpt_agent_integration.execute_tool(
+                tool_name=req.tool_name,
+                parameters=req.parameters,
+                session_id=req.session_id
+            )
+            ctx["result_summary"] = str(result)[:200]
         _evaluate_response(
             "agent_execute",
             result,

--- a/src/core/request_envelope.py
+++ b/src/core/request_envelope.py
@@ -1,0 +1,108 @@
+"""Canonical request envelope: DLP context_tag, audit log, optional memory storage."""
+from __future__ import annotations
+
+import logging
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def generate_context_tag(operation: str, agent_id: str = "api") -> str:
+    """Generate a unique DLP context tag for an operation."""
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+    return f"aurora:{agent_id}:{operation}:{ts}:{uuid.uuid4().hex[:8]}"
+
+
+@contextmanager
+def request_envelope(
+    operation: str,
+    *,
+    agent_id: str = "api",
+    metadata: Optional[Dict[str, Any]] = None,
+    store_to_memory: bool = False,
+    memory_context_id: Optional[str] = None,
+):
+    """Wrap an operation with DLP tracking, audit logging, and optional memory storage.
+
+    Yields a dict ``ctx`` that callers can populate with result metadata.
+    All failures in DLP/audit/memory are swallowed (logged at DEBUG) so that
+    observability plumbing never breaks the business logic it wraps.
+
+    Args:
+        operation: Short name for the operation (e.g. ``"chat_response"``).
+        agent_id: Identifies the calling agent/service; baked into the context tag.
+        metadata: Optional extra key-value pairs merged into ctx at entry.
+        store_to_memory: When True, store ctx[``"result_summary"``] to the memory
+            retrieval module after the body exits.
+        memory_context_id: Context ID passed to ``MemoryRetrievalCore.add_memory``.
+            Defaults to *agent_id* when not provided.
+
+    Yields:
+        Dict[str, Any]: mutable context dict containing at minimum
+        ``context_tag``, ``operation``, ``agent_id``, and ``started_at``.
+    """
+    context_tag = generate_context_tag(operation, agent_id)
+    ctx: Dict[str, Any] = {
+        "context_tag": context_tag,
+        "operation": operation,
+        "agent_id": agent_id,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if metadata:
+        ctx.update(metadata)
+
+    # DLP tracking — create a provenance tag before the body runs
+    try:
+        from src.core.native_dlp_export import NativeDLPTracker
+
+        tracker = NativeDLPTracker()
+        tracker.create_tag(operation, {"context_tag": context_tag, "agent_id": agent_id})
+    except Exception as exc:
+        logger.debug("DLP tracking unavailable: %s", exc)
+
+    try:
+        yield ctx
+    finally:
+        ctx["completed_at"] = datetime.now(timezone.utc).isoformat()
+
+        # Audit log — use AuditLogger._create_entry with SYSTEM_CHANGE event type.
+        # AuditLogger requires a signing key; if the env-var is absent this will raise
+        # ValueError during construction — that is swallowed here intentionally.
+        try:
+            from src.monitoring.audit_logger import AuditLogger, AuditEventType
+
+            auditor = AuditLogger()
+            auditor._create_entry(
+                event_type=AuditEventType.SYSTEM_CHANGE,
+                agent_id=agent_id,
+                severity="low",
+                description=f"request_envelope: {operation}",
+                data=ctx,
+                context_tag=context_tag,
+            )
+        except Exception as exc:
+            logger.debug("Audit logging failed: %s", exc)
+
+        # Optional memory storage
+        if store_to_memory:
+            try:
+                from modules.memory_retrieval.core import MemoryRetrievalCore
+
+                core = MemoryRetrievalCore.get_instance()
+                cid = memory_context_id or agent_id
+                content = ctx.get("result_summary", operation)
+                core.add_memory(
+                    cid,
+                    str(content),
+                    {
+                        "context_tag": context_tag,
+                        "operation": operation,
+                        "agent_id": agent_id,
+                        "importance": 0.5,
+                    },
+                )
+            except Exception as exc:
+                logger.debug("Memory storage failed: %s", exc)

--- a/tests/test_request_envelope.py
+++ b/tests/test_request_envelope.py
@@ -1,0 +1,190 @@
+"""Tests for src/core/request_envelope.py — canonical DLP request envelope."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helper: import the module under test
+# ---------------------------------------------------------------------------
+from src.core.request_envelope import generate_context_tag, request_envelope
+
+# Patch targets — the lazy imports live inside the envelope function body
+_DLP_TARGET = "src.core.native_dlp_export.NativeDLPTracker"
+_AUDIT_TARGET = "src.monitoring.audit_logger.AuditLogger"
+_MEMORY_TARGET = "modules.memory_retrieval.core.MemoryRetrievalCore"
+
+
+# ===========================================================================
+# generate_context_tag
+# ===========================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_generate_context_tag_format():
+    """Tag follows the expected aurora:<agent>:<op>:<ts>:<rand> pattern."""
+    tag = generate_context_tag("my_op", "agent1")
+    parts = tag.split(":")
+    assert parts[0] == "aurora"
+    assert parts[1] == "agent1"
+    assert parts[2] == "my_op"
+    assert len(parts) == 5, f"Expected 5 colon-separated parts, got {len(parts)}"
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_generate_context_tag_unique():
+    """Two consecutive calls must produce distinct tags."""
+    tag1 = generate_context_tag("op")
+    tag2 = generate_context_tag("op")
+    assert tag1 != tag2
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_generate_context_tag_default_agent_id():
+    """Default agent_id is 'api'."""
+    tag = generate_context_tag("op")
+    assert tag.startswith("aurora:api:op:")
+
+
+# ===========================================================================
+# request_envelope — basic context dict
+# ===========================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_request_envelope_yields_dict_with_context_tag():
+    """request_envelope yields a dict containing 'context_tag'."""
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET):
+        with request_envelope("test_op", agent_id="svc") as ctx:
+            assert "context_tag" in ctx
+            assert ctx["context_tag"].startswith("aurora:svc:test_op:")
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_request_envelope_completed_at_set_after_exit():
+    """'completed_at' key is absent inside the body but set after exit."""
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET):
+        with request_envelope("test_op") as ctx:
+            assert "completed_at" not in ctx
+        assert "completed_at" in ctx
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_request_envelope_metadata_merged():
+    """Extra metadata is merged into ctx before yield."""
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET):
+        with request_envelope("test_op", metadata={"user_id": "u42", "priority": 1}) as ctx:
+            assert ctx["user_id"] == "u42"
+            assert ctx["priority"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_request_envelope_caller_updates_visible():
+    """Updates made to ctx inside the body are present in the final ctx."""
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET):
+        with request_envelope("test_op") as ctx:
+            ctx["result_summary"] = "hello world"
+        assert ctx["result_summary"] == "hello world"
+
+
+# ===========================================================================
+# request_envelope — failure resilience
+# ===========================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_dlp_failure_does_not_raise():
+    """DLP tracker construction failure must not propagate to caller."""
+    with patch(_DLP_TARGET, side_effect=RuntimeError("dlp boom")):
+        # Should not raise
+        with request_envelope("test_op") as ctx:
+            assert "context_tag" in ctx
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_audit_failure_does_not_raise():
+    """Audit logger failure must not propagate to caller."""
+    with patch(_DLP_TARGET), \
+         patch(_AUDIT_TARGET, side_effect=ValueError("no signing key")):
+        with request_envelope("test_op") as ctx:
+            pass  # must not raise
+        assert "completed_at" in ctx
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_exception_in_body_propagates():
+    """An exception raised inside the with-block must propagate normally."""
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET):
+        with pytest.raises(ValueError, match="oops"):
+            with request_envelope("test_op"):
+                raise ValueError("oops")
+
+
+# ===========================================================================
+# request_envelope — memory storage
+# ===========================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_memory_storage_called_when_enabled():
+    """MemoryRetrievalCore.add_memory is called when store_to_memory=True."""
+    mock_core = MagicMock()
+    mock_cls = MagicMock()
+    mock_cls.get_instance.return_value = mock_core
+
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET, mock_cls):
+        with request_envelope("test_op", agent_id="a1", store_to_memory=True) as ctx:
+            ctx["result_summary"] = "summary text"
+
+    mock_core.add_memory.assert_called_once()
+    args = mock_core.add_memory.call_args[0]
+    assert args[0] == "a1"                # context_id defaults to agent_id
+    assert "summary text" in args[1]      # content
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_memory_storage_not_called_when_disabled():
+    """MemoryRetrievalCore.add_memory is NOT called when store_to_memory=False."""
+    mock_core = MagicMock()
+    mock_cls = MagicMock()
+    mock_cls.get_instance.return_value = mock_core
+
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET, mock_cls):
+        with request_envelope("test_op", store_to_memory=False):
+            pass
+
+    mock_core.add_memory.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_memory_storage_uses_custom_context_id():
+    """memory_context_id overrides the default agent_id bucket."""
+    mock_core = MagicMock()
+    mock_cls = MagicMock()
+    mock_cls.get_instance.return_value = mock_core
+
+    with patch(_DLP_TARGET), patch(_AUDIT_TARGET), patch(_MEMORY_TARGET, mock_cls):
+        with request_envelope(
+            "test_op",
+            agent_id="agent-x",
+            store_to_memory=True,
+            memory_context_id="custom-bucket",
+        ):
+            pass
+
+    args = mock_core.add_memory.call_args[0]
+    assert args[0] == "custom-bucket"


### PR DESCRIPTION
## Summary

- Adds `src/core/request_envelope.py` with `generate_context_tag()` and `request_envelope()` context manager
- Every operation wrapped in the envelope gets: a unique DLP context_tag (`aurora:{agent_id}:{operation}:{ts}:{hex}`), an audit log entry via `AuditLogger._create_entry(AuditEventType.SYSTEM_CHANGE)`, and optional memory storage via `MemoryRetrievalCore.add_memory()`
- All three integrations fail silently at DEBUG level — envelope never raises even if DLP/audit/memory are unavailable or misconfigured
- Wired into `POST /agent/execute` in `aurora_api.py` with `store_to_memory=True`

## Test plan

- [ ] `tests/test_request_envelope.py` — 13 tests: tag uniqueness, ctx dict shape, `completed_at` set, metadata merge, caller-update visibility, DLP/audit failure isolation, body exception propagates, memory called/not-called based on flag — all pass
- [ ] CI syntax check passes

Fixes #774

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_