### PR TITLE
refactor(api): consolidate crew endpoints — adopt modules/crew_agents/api.py router, fix stale imports

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -77,9 +77,8 @@ from src.middleware.fastapi_security import (
 from src.middleware.csrf_middleware import GlobalCsrfMiddleware
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from fastapi import APIRouter
 from src.security.oauth2 import get_current_active_user, User  # authentication dependency
-from src.agents.crew.base_agent import get_crew_agent, get_all_crew_agents
+from src.agents.crew.base_agent import get_all_crew_agents
 
 # Action Guard: fire-and-forget ethics/compliance evaluation on response paths
 try:
@@ -91,80 +90,6 @@ except Exception as _action_guard_exc:  # pragma: no cover - graceful degradatio
 
     def _evaluate_response(*_args, **_kwargs) -> None:  # type: ignore[misc]
         """No-op fallback when action_guard cannot be imported."""
-
-# Crew Agents API Router (Phase 3 minimal implementation)
-crew_router = APIRouter(prefix="/api/crew", tags=["crew"])
-
-
-@crew_router.get("/all")
-async def list_all_crew(user: User = Depends(get_current_active_user)):
-    """List all registered crew agents with condensed status.
-
-    Security: Requires active user (OAuth2 token).
-    """
-    agents = get_all_crew_agents().values()
-    return {
-        "count": len(list(agents)),
-        "agents": [
-            {
-                "surname": a.surname,
-                "role": a.role.value,
-                "status": a.status,
-                "clearance": a.clearance.value,
-                "t1_state": a.t1_state,
-                "srb_resolution": a.srb_resolution,
-            }
-            for a in agents
-        ],
-    }
-
-
-@crew_router.post("/{surname}/process")
-@limiter.limit("30/minute")  # Crew collaboration - moderate rate per IP
-async def process_agent_task(
-    surname: str,
-    task: Dict[str, Any],
-    request: Request,
-    user: User = Depends(get_current_active_user),
-):
-    """Process a task with a specific crew agent.
-
-    Body: {"task_type": str, "context": {}, "priority": str}
-    Returns task execution including DLP placeholders.
-    """
-    agent = get_crew_agent(surname)
-    if not agent:
-        raise HTTPException(status_code=404, detail=f"Crew agent '{surname}' not found")
-    result = await agent.process_request(task)
-    _evaluate_response(
-        "agent_task",
-        result,
-        metadata={"endpoint": f"/api/crew/{surname}/process", "surname": surname},
-        agent_id=surname,
-        context_tag=f"crew_agent_{surname}",
-    )
-    return result
-
-
-@crew_router.post("/collaborate")
-@limiter.limit("30/minute")  # Crew collaboration - moderate rate per IP
-async def collaborate_agents(
-    payload: Dict[str, Any],
-    request: Request,
-    user: User = Depends(get_current_active_user),
-):
-    """Collaborate two agents on a task.
-
-    Body: {"primary": "Thorne", "secondary": "Markov", "task": {...}}
-    Returns collaboration result combining contributions.
-    """
-    primary = get_crew_agent(payload.get("primary"))
-    secondary = get_crew_agent(payload.get("secondary"))
-    if not primary or not secondary:
-        raise HTTPException(status_code=404, detail="One or both agents not found")
-    task_def = payload.get("task", {})
-    result = await primary.collaborate_with(secondary, task_def)
-    return result
 
 # (Moved time/hash imports into helper to satisfy lint ordering)
 
@@ -899,14 +824,21 @@ except Exception as e:
 try:
     from api.r2_telemetry_routes import router as r2_telemetry_router
     app.include_router(r2_telemetry_router)
-
-    # Crew Agents router inclusion (Phase 3)
-    app.include_router(crew_router)
     logger.info("✅ R2 Telemetry API routes integrated successfully")
 except ImportError as e:
     logger.warning("⚠️ R2 Telemetry routes not available: %s", e)
 except Exception as e:
     logger.error("❌ Failed to integrate R2 Telemetry routes: %s", e)
+
+# Include Crew Agents API routes (modules/crew_agents)
+try:
+    from modules.crew_agents.api import router as crew_agents_router
+    app.include_router(crew_agents_router)
+    logger.info("✅ Crew Agents API routes integrated successfully")
+except ImportError as e:
+    logger.warning("⚠️ Crew Agents module not available: %s", e)
+except Exception as e:
+    logger.error("❌ Failed to integrate Crew Agents routes: %s", e)
 
 # Include L2 Meta-Agent Bridge API routes
 try:

--- a/modules/crew_agents/api.py
+++ b/modules/crew_agents/api.py
@@ -65,9 +65,6 @@ from src.agents.crew import (
     get_nguyen,
     get_lee,
     get_el_sayegh,
-    get_kim,
-    get_okafor,
-    get_santos,
 )
 
 router = APIRouter(prefix="/api/crew", tags=["Crew Agents"])
@@ -108,9 +105,6 @@ get_vatra()
 get_nguyen()
 get_lee()
 get_el_sayegh()
-get_kim()
-get_okafor()
-get_santos()
 
 
 # Pydantic models for requests/responses

--- a/tests/test_crew_agents_api.py
+++ b/tests/test_crew_agents_api.py
@@ -23,16 +23,19 @@ def test_list_all_crew_agents():
     if resp.status_code == 200:
         data = resp.json()
         assert "agents" in data
-        assert isinstance(data["agents"], list)
+        # Module router returns agents as a dict keyed by surname
+        assert isinstance(data["agents"], dict)
         # Ensure at least one known current agent (e.g., lin) present
-        assert any(a["surname"].lower() == "lin" for a in data["agents"])  # present
+        assert "lin" in data["agents"] or any(
+            v.get("surname", "").lower() == "lin" for v in data["agents"].values()
+        )
 
 
 @pytest.mark.unit
 def test_process_agent_task_success():
     get_noor()
     payload = {"task_type": "reflexivity_analysis", "context": {"target_system": "aurora_core"}, "priority": "low"}
-    resp = client.post("/api/crew/Noor/process", json=payload, headers=_auth_headers())
+    resp = client.post("/api/crew/noor/process", json=payload, headers=_auth_headers())
     assert resp.status_code in (200, 401)
     if resp.status_code == 200:
         data = resp.json()
@@ -47,7 +50,7 @@ def test_process_agent_task_success():
 def test_process_agent_task_invalid():
     get_noor()
     payload = {"task_type": "__invalid__", "context": {}, "priority": "low"}
-    resp = client.post("/api/crew/Noor/process", json=payload, headers=_auth_headers())
+    resp = client.post("/api/crew/noor/process", json=payload, headers=_auth_headers())
     assert resp.status_code in (200, 401)
     if resp.status_code == 200:
         data = resp.json()
@@ -59,9 +62,9 @@ def test_process_agent_task_invalid():
 def test_collaboration_endpoint():
     get_noor()
     get_lin()
+    # Module router CollaborationRequest: {"agents": [...], "task": {...}}
     payload = {
-        "primary": "Noor",
-        "secondary": "Noor",  # same agent instance type ensures shared task support
+        "agents": ["noor", "lin"],
         "task": {"task_type": "reflexivity_analysis", "context": {}, "priority": "low"}
     }
     resp = client.post("/api/crew/collaborate", json=payload, headers=_auth_headers())
@@ -69,7 +72,6 @@ def test_collaboration_endpoint():
     if resp.status_code == 200:
         data = resp.json()
         assert data["success"] is True
-        assert "my_contribution" in data and "their_contribution" in data
-        assert data["my_contribution"]["task_type"] == payload["task"]["task_type"]
-        assert "context_tag" in data["my_contribution"]
-        assert "symbolic_hash" in data["my_contribution"]
+        assert "results" in data
+        assert "primary_agent" in data
+        assert "collaborators" in data


### PR DESCRIPTION
## Summary

- Removes 3 duplicate inline crew route handlers from `aurora_api.py` (`GET /api/crew/all`, `POST /api/crew/{surname}/process`, `POST /api/crew/collaborate`) — ~68 lines removed
- Replaces the buried `app.include_router(crew_router)` inside the R2 Telemetry try/except with a proper standalone try/except import block for `modules/crew_agents/api.py`'s router
- Fixes a pre-existing import bug in `modules/crew_agents/api.py`: stale imports of `get_kim`, `get_okafor`, `get_santos` (referencing non-existent `src/agents/crew/` files) were causing the entire crew module to fail to load at startup
- Updates `tests/test_crew_agents_api.py` to match the module router's actual API contract (`/all` returns `agents` as dict, `/collaborate` uses `CollaborationRequest`)

## Test plan

- [ ] `tests/test_crew_agents_api.py` — 30 crew tests pass (4 were previously failing due to the stale import bug), 2 skipped
- [ ] CI syntax check passes

Fixes #772

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_