### PR TITLE
feat(ai_core): add memory-augmented RAG chat endpoint over AuMemManager

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -1521,6 +1521,52 @@ async def execute_gemini_agent_tool(
 
 
 # ==============================================================================
+# MEMORY-AUGMENTED CHAT (RAG) ENDPOINT
+# ==============================================================================
+
+
+class RAGChatRequest(BaseModel):
+    """Request body for the memory-augmented RAG chat endpoint."""
+
+    message: str
+    context_id: str
+    user_id: str = "default"
+    top_k: int = Field(default=5, ge=1, le=20)
+    model: Optional[str] = None
+
+
+@app.post("/api/chat/rag")
+@limiter.limit("20/minute")  # AI inference - stricter rate limit per IP
+async def rag_chat_endpoint(req: RAGChatRequest, request: Request):
+    """Memory-augmented chat endpoint (RAG over AuMemManager).
+
+    Retrieves relevant memories for the given context before calling the LLM,
+    giving the model context from past conversations. The Q&A pair is stored
+    back to memory after a successful response.
+
+    Args:
+        req: RAGChatRequest containing message, context_id, user_id, top_k, model.
+
+    Returns:
+        JSON with ``response``, ``memories_used``, and ``context_id``.
+    """
+    try:
+        from modules.ai_core.rag_chat import rag_chat
+
+        result = await rag_chat(
+            req.message,
+            context_id=req.context_id,
+            user_id=req.user_id,
+            top_k=req.top_k,
+            model=req.model,
+        )
+        return result
+    except Exception as exc:
+        logger.exception("RAG chat endpoint error: %s", exc)
+        raise HTTPException(status_code=500, detail="RAG chat failed")
+
+
+# ==============================================================================
 # THREAD TRANSFER BRIDGE ENDPOINTS
 # ==============================================================================
 
@@ -3042,6 +3088,50 @@ async def get_performance_budgets(request: Request):
         "budgets": list_budgets(),
         "note": "p95/p99 latency targets in ms; error rate in percent",
     }
+
+
+# ---------------------------------------------------------------------------
+# RAG Chat endpoint (issue #775) — memory-augmented chat over AuMemManager
+# ---------------------------------------------------------------------------
+
+class RAGChatRequest(BaseModel):
+    """Request model for the memory-augmented RAG chat endpoint."""
+
+    message: str
+    context_id: str
+    user_id: str = "default"
+    top_k: int = Field(default=5, ge=1, le=20)
+    model: Optional[str] = None
+
+
+@app.post("/api/chat/rag")
+@limiter.limit("20/minute")
+async def rag_chat_endpoint(req: RAGChatRequest, request: Request):
+    """
+    Memory-augmented chat endpoint (RAG over AuMemManager).
+
+    Retrieves relevant memories for the given ``context_id``/``message`` pair,
+    injects them as context, calls the unified AI interface, and stores the
+    Q&A exchange back to memory for future retrieval.
+
+    Returns:
+        - ``response``: LLM response text.
+        - ``memories_used``: Number of memory entries injected.
+        - ``context_id``: Echo of the supplied context_id.
+    """
+    try:
+        from modules.ai_core.rag_chat import rag_chat
+        result = await rag_chat(
+            req.message,
+            context_id=req.context_id,
+            user_id=req.user_id,
+            top_k=req.top_k,
+            model=req.model,
+        )
+        return result
+    except Exception:
+        logger.exception("RAG chat endpoint failed")
+        raise HTTPException(status_code=500, detail="RAG chat failed")
 
 
 if __name__ == "__main__":

--- a/modules/ai_core/rag_chat.py
+++ b/modules/ai_core/rag_chat.py
@@ -1,0 +1,119 @@
+"""Memory-augmented chat: retrieves relevant memories before LLM call."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def rag_chat(
+    message: str,
+    *,
+    context_id: str,
+    user_id: str = "default",
+    top_k: int = 5,
+    max_memory_tokens: int = 2000,
+    model: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Chat with memory augmentation.
+
+    1. Retrieves relevant memories for the context_id/message pair
+    2. Prepends memory context to the system prompt
+    3. Calls the unified AI interface
+    4. Stores the response back to memory
+
+    Args:
+        message: The current user message.
+        context_id: Session / agent context identifier used to scope memories.
+        user_id: Tenant / user identifier for cache isolation.
+        top_k: Maximum number of memory snippets to retrieve.
+        max_memory_tokens: Rough upper-bound on injected memory text (characters).
+        model: Optional model name passed through as ``model_preference``.
+            Must be a valid ``AIModel`` value; ignored if not recognised.
+        metadata: Extra key/value pairs forwarded to the AI request metadata.
+
+    Returns:
+        dict with keys:
+            - ``response`` (str): LLM response text.
+            - ``memories_used`` (int): Number of memories retrieved.
+            - ``context_id`` (str): Echo of the supplied context_id.
+    """
+    # ------------------------------------------------------------------
+    # Step 1: Retrieve relevant memories
+    # ------------------------------------------------------------------
+    memories: List[Dict] = []
+    memory_context = ""
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        core = MemoryRetrievalCore.get_instance()
+        memories = core.retrieve_memories(
+            context_id, message, top_k=top_k, user_id=user_id
+        )
+        if memories:
+            snippets = [m.get("content", "") for m in memories[:top_k]]
+            # Truncate total injected context to stay within max_memory_tokens
+            joined = "\n---\n".join(snippets)
+            if len(joined) > max_memory_tokens:
+                joined = joined[:max_memory_tokens]
+            memory_context = "\n\n[Relevant context from memory]\n" + joined
+    except Exception as exc:
+        logger.warning("Memory retrieval failed for RAG chat: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Step 2: Build augmented prompt
+    # ------------------------------------------------------------------
+    if memory_context:
+        augmented_message = f"{memory_context}\n\n[Current message]\n{message}"
+    else:
+        augmented_message = message
+
+    # ------------------------------------------------------------------
+    # Step 3: Call LLM via UnifiedAIInterface
+    # ------------------------------------------------------------------
+    response_text = ""
+    try:
+        from modules.ai_core.unified_ai_interface import AIModel, AIRequest, UnifiedAIInterface
+
+        # Resolve optional model string to AIModel enum value
+        model_preference: Optional[AIModel] = None
+        if model:
+            try:
+                model_preference = AIModel(model)
+            except ValueError:
+                logger.debug("Unrecognised model %r; letting UnifiedAIInterface choose", model)
+
+        interface = UnifiedAIInterface()
+        req = AIRequest(
+            prompt=augmented_message,
+            model_preference=model_preference,
+            context_tag=f"rag_chat:{context_id}",
+        )
+        ai_response = await interface.execute_request(req)
+        response_text = ai_response.content
+    except Exception:
+        logger.exception("LLM call failed in RAG chat")
+        raise
+
+    # ------------------------------------------------------------------
+    # Step 4: Store the Q&A exchange back to memory
+    # ------------------------------------------------------------------
+    try:
+        from modules.memory_retrieval.core import MemoryRetrievalCore
+
+        core = MemoryRetrievalCore.get_instance()
+        core.add_memory(
+            context_id,
+            f"Q: {message[:500]}\nA: {response_text[:500]}",
+            {"importance": 0.6, "tags": ["rag_chat"], "user_id": user_id},
+        )
+    except Exception as exc:
+        logger.debug("Failed to store RAG chat to memory: %s", exc)
+
+    return {
+        "response": response_text,
+        "memories_used": len(memories),
+        "context_id": context_id,
+    }

--- a/tests/test_rag_chat.py
+++ b/tests/test_rag_chat.py
@@ -1,0 +1,266 @@
+"""Tests for memory-augmented RAG chat (issue #775)."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so we can import rag_chat without real backend deps
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeAIResponse:
+    content: str
+    model_used: object = None
+    provider: object = None
+    tokens_used: int = 0
+    latency_ms: float = 0.0
+    success: bool = True
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    context_tag: str = "test"
+    timestamp: str = "2026-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_memories(n: int) -> List[Dict]:
+    return [{"id": f"mem-{i}", "content": f"memory snippet {i}", "score": 1.0 - i * 0.1} for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_retrieve_memories_called_with_correct_args():
+    """rag_chat should call retrieve_memories with context_id, message and top_k."""
+    fake_memories = _make_memories(3)
+    fake_core = MagicMock()
+    fake_core.retrieve_memories.return_value = fake_memories
+    fake_core.add_memory.return_value = "mem-new"
+
+    fake_ai_response = _FakeAIResponse(content="Hello from LLM")
+    fake_interface = MagicMock()
+    fake_interface.execute_request = AsyncMock(return_value=fake_ai_response)
+
+    with (
+        patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", return_value=fake_core),
+        patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+    ):
+        from modules.ai_core.rag_chat import rag_chat
+
+        await rag_chat("test question", context_id="ctx-1", user_id="user-A", top_k=7)
+
+    fake_core.retrieve_memories.assert_called_once_with("ctx-1", "test question", top_k=7, user_id="user-A")
+
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_llm_receives_augmented_prompt_with_memory_context():
+    """When memories exist, the prompt sent to the LLM should contain memory context."""
+    fake_memories = _make_memories(2)
+    fake_core = MagicMock()
+    fake_core.retrieve_memories.return_value = fake_memories
+    fake_core.add_memory.return_value = "mem-new"
+
+    captured_requests = []
+
+    fake_ai_response = _FakeAIResponse(content="LLM answer")
+
+    async def _capture_execute(req):
+        captured_requests.append(req)
+        return fake_ai_response
+
+    fake_interface = MagicMock()
+    fake_interface.execute_request = _capture_execute
+
+    with (
+        patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", return_value=fake_core),
+        patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+    ):
+        from modules.ai_core import rag_chat as _module
+        import importlib
+        importlib.reload(_module)
+        from modules.ai_core.rag_chat import rag_chat
+
+        await rag_chat("user message", context_id="ctx-2")
+
+    assert captured_requests, "execute_request was never called"
+    prompt_sent = captured_requests[0].prompt
+    assert "[Relevant context from memory]" in prompt_sent
+    assert "memory snippet 0" in prompt_sent
+    assert "[Current message]" in prompt_sent
+    assert "user message" in prompt_sent
+
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_memory_failure_does_not_prevent_llm_call():
+    """If memory retrieval raises, the LLM call should still proceed."""
+    fake_ai_response = _FakeAIResponse(content="LLM answer despite memory failure")
+    fake_interface = MagicMock()
+    fake_interface.execute_request = AsyncMock(return_value=fake_ai_response)
+
+    fake_core_for_add = MagicMock()
+    fake_core_for_add.add_memory.return_value = "mem-new"
+
+    def _side_effect_get_instance():
+        # First call (retrieve) raises; second call (add) succeeds
+        m = MagicMock()
+        m.retrieve_memories.side_effect = RuntimeError("store unavailable")
+        m.add_memory.return_value = "mem-new"
+        return m
+
+    with (
+        patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", side_effect=_side_effect_get_instance),
+        patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+    ):
+        from modules.ai_core.rag_chat import rag_chat
+
+        result = await rag_chat("question", context_id="ctx-3")
+
+    assert result["response"] == "LLM answer despite memory failure"
+    fake_interface.execute_request.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_llm_response_stored_back_to_memory():
+    """The Q&A exchange should be written back to memory after a successful LLM call."""
+    fake_memories = _make_memories(1)
+    fake_core = MagicMock()
+    fake_core.retrieve_memories.return_value = fake_memories
+    fake_core.add_memory.return_value = "mem-stored"
+
+    fake_ai_response = _FakeAIResponse(content="stored answer")
+    fake_interface = MagicMock()
+    fake_interface.execute_request = AsyncMock(return_value=fake_ai_response)
+
+    with (
+        patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", return_value=fake_core),
+        patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+    ):
+        from modules.ai_core.rag_chat import rag_chat
+
+        await rag_chat("my question", context_id="ctx-4", user_id="user-B")
+
+    fake_core.add_memory.assert_called_once()
+    call_args = fake_core.add_memory.call_args
+    context_arg, content_arg, metadata_arg = call_args[0]
+    assert context_arg == "ctx-4"
+    assert "my question" in content_arg
+    assert "stored answer" in content_arg
+    assert metadata_arg.get("user_id") == "user-B"
+
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_memory_store_failure_does_not_raise():
+    """A failure to store the Q&A to memory should be swallowed, not re-raised."""
+    fake_core = MagicMock()
+    fake_core.retrieve_memories.return_value = []
+    fake_core.add_memory.side_effect = RuntimeError("store write failed")
+
+    fake_ai_response = _FakeAIResponse(content="some answer")
+    fake_interface = MagicMock()
+    fake_interface.execute_request = AsyncMock(return_value=fake_ai_response)
+
+    with (
+        patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", return_value=fake_core),
+        patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+    ):
+        from modules.ai_core.rag_chat import rag_chat
+
+        # Should NOT raise
+        result = await rag_chat("question", context_id="ctx-5")
+
+    assert result["response"] == "some answer"
+
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_empty_memories_message_sent_unchanged():
+    """When no memories are found, the message is sent verbatim to the LLM."""
+    fake_core = MagicMock()
+    fake_core.retrieve_memories.return_value = []
+    fake_core.add_memory.return_value = "mem-new"
+
+    captured_requests = []
+
+    async def _capture(req):
+        captured_requests.append(req)
+        return _FakeAIResponse(content="direct answer")
+
+    fake_interface = MagicMock()
+    fake_interface.execute_request = _capture
+
+    with (
+        patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", return_value=fake_core),
+        patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+    ):
+        from modules.ai_core.rag_chat import rag_chat
+
+        await rag_chat("plain question", context_id="ctx-6")
+
+    assert captured_requests[0].prompt == "plain question"
+
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_return_dict_has_required_keys():
+    """Return value must contain 'response', 'memories_used', and 'context_id' keys."""
+    fake_memories = _make_memories(3)
+    fake_core = MagicMock()
+    fake_core.retrieve_memories.return_value = fake_memories
+    fake_core.add_memory.return_value = "mem-new"
+
+    fake_ai_response = _FakeAIResponse(content="answer text")
+    fake_interface = MagicMock()
+    fake_interface.execute_request = AsyncMock(return_value=fake_ai_response)
+
+    with (
+        patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", return_value=fake_core),
+        patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+    ):
+        from modules.ai_core.rag_chat import rag_chat
+
+        result = await rag_chat("hello", context_id="ctx-7")
+
+    assert "response" in result
+    assert "memories_used" in result
+    assert "context_id" in result
+    assert result["response"] == "answer text"
+    assert result["memories_used"] == 3
+    assert result["context_id"] == "ctx-7"
+
+
+@pytest.mark.unit
+@pytest.mark.ai
+async def test_memories_used_count_matches_retrieved():
+    """memories_used in the result must equal the number of memories returned."""
+    for n in (0, 1, 5):
+        fake_memories = _make_memories(n)
+        fake_core = MagicMock()
+        fake_core.retrieve_memories.return_value = fake_memories
+        fake_core.add_memory.return_value = "mem-new"
+
+        fake_interface = MagicMock()
+        fake_interface.execute_request = AsyncMock(return_value=_FakeAIResponse(content="ok"))
+
+        with (
+            patch("modules.memory_retrieval.core.MemoryRetrievalCore.get_instance", return_value=fake_core),
+            patch("modules.ai_core.unified_ai_interface.UnifiedAIInterface", return_value=fake_interface),
+        ):
+            from modules.ai_core.rag_chat import rag_chat
+
+            result = await rag_chat("q", context_id=f"ctx-n{n}")
+
+        assert result["memories_used"] == n, f"expected {n}, got {result['memories_used']}"


### PR DESCRIPTION
## Summary

- Adds `modules/ai_core/rag_chat.py` — `rag_chat()` async function implementing a 4-step RAG pipeline:
  1. Retrieve top-k relevant memories from `MemoryRetrievalCore` (with token cap)
  2. Prepend memory snippets to the prompt as context
  3. Call `UnifiedAIInterface.execute_request()` with the augmented prompt
  4. Store the Q&A pair back to memory (best-effort, never raises)
- Adds `POST /api/chat/rag` endpoint in `aurora_api.py` with `20/minute` rate limit
- `RAGChatRequest` model: `message`, `context_id`, `user_id`, `top_k` (1-20), `model`
- Memory retrieval failure is non-blocking — degrades to plain chat without context

## Test plan

- [ ] `tests/test_rag_chat.py` — 8 tests: correct `retrieve_memories` args, augmented prompt contains snippets, memory failure doesn't block LLM, response stored back, store failure doesn't raise, empty memories → unchanged message, return dict shape, `memories_used` count — all pass
- [ ] CI syntax check passes

Fixes #775

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_