### PR TITLE
deps: update psutil requirement from >=5.9.0 to >=7.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -95,4 +95,4 @@ urllib3>=2.7.0                      # HTTP connection pooling
 certifi>=2026.5.20                   # SSL certificates
 charset-normalizer>=3.4.3           # Character encoding detection
 idna>=3.15                          # Internationalized domain names
-psutil>=5.9.0                       # Process and system monitoring (for R-2 telemetry)
+psutil>=7.2.2                       # Process and system monitoring (for R-2 telemetry)


### PR DESCRIPTION
Rebased version of #851 — Dependabot's branch had conflicts after recent requirements.txt changes. Applies only the psutil floor bump to the current main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_