### PR TITLE
feat: wire R2AgentTelemetry into FastAPI middleware (issue #769)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -581,6 +581,49 @@ async def telemetry_middleware(request: Request, call_next):
             raise
 
 
+# ================================
+# R2 Agent Telemetry Middleware
+# ================================
+
+# Paths that produce noisy or circular telemetry if traced at this level
+_R2_SKIP_PATHS = frozenset({"/health", "/metrics", "/docs", "/openapi.json", "/redoc", "/"})
+
+
+@app.middleware("http")
+async def r2_telemetry_middleware(request: Request, call_next):
+    """Wrap every API request in an R2AgentTelemetry span for distributed tracing.
+
+    Records http_method, http_path, and http_status_code per span, enabling
+    downstream anomaly detection and Prometheus counters for every route.
+
+    DLP: r2_request_tracing_middleware
+    """
+    if request.url.path in _R2_SKIP_PATHS or request.url.path.startswith("/static"):
+        return await call_next(request)
+
+    try:
+        r2 = get_r2_telemetry()
+    except Exception:  # pragma: no cover - graceful degradation
+        return await call_next(request)
+
+    context_tag = (
+        f"http_{request.url.path.replace('/', '_').strip('_')}_"
+        f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}"
+    )
+    with r2.trace_agent_operation(
+        f"http_{request.method.lower()}",
+        context_tag=context_tag,
+        http_method=request.method,
+        http_path=str(request.url.path),
+    ) as op:
+        try:
+            response = await call_next(request)
+            op.metadata["http_status_code"] = response.status_code
+            return response
+        except Exception:
+            raise
+
+
 # HIGH-5: NoSQL Injection Prevention - Input Validation Helper
 def validate_identifier(identifier: str, param_name: str) -> str:
     """
@@ -1172,8 +1215,14 @@ def prometheus_metrics(request: Request):
     from fastapi.responses import PlainTextResponse
     try:
         telemetry = get_telemetry()
-        prometheus_data = telemetry.export_prometheus_format()
-        return PlainTextResponse(content=prometheus_data, media_type="text/plain; version=0.0.4")
+        parts = [telemetry.export_prometheus_format()]
+        try:
+            r2 = get_r2_telemetry()
+            parts.append(r2.export_prometheus_metrics())
+        except Exception as r2_err:
+            logger.warning("R2 metrics export partial failure: %s", r2_err)
+        combined = "\n".join(p for p in parts if p)
+        return PlainTextResponse(content=combined, media_type="text/plain; version=0.0.4")
     except Exception as e:
         logger.error("Failed to export Prometheus metrics: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -166,3 +166,53 @@ def test_telemetry_initialized_in_lifespan():
     # Service names may vary if initialized before lifespan runs
     assert aurora_telemetry.service_name in ["aurora-cloudbank", "aurora-cloudbank-api"]
     assert r2_telemetry.service_name in ["aurora-r2-agent", "r2-agent"]
+
+
+@pytest.mark.integration
+@pytest.mark.observability
+def test_r2_middleware_records_span_per_request():
+    """R2AgentTelemetry middleware must produce at least one span per non-skip request.
+
+    This is the acceptance-criteria test for issue #769: removing the middleware
+    causes this test to fail because no operations are recorded.
+    """
+    from api.aurora_api import app
+    from src.observability import get_r2_telemetry, reset_r2_telemetry
+
+    reset_r2_telemetry()
+
+    client = TestClient(app)
+    # /telemetry/snapshot is a real API path (not in _R2_SKIP_PATHS) so the
+    # middleware must wrap it and record an operation.
+    response = client.get("/telemetry/snapshot")
+    assert response.status_code == 200
+
+    r2 = get_r2_telemetry()
+    summary = r2.get_metrics_summary()
+    # At least one operation must have been recorded by the middleware.
+    assert summary.get("total_operations", 0) >= 1, (
+        "R2AgentTelemetry middleware did not record any spans — "
+        "check that r2_telemetry_middleware is registered in aurora_api.py"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.observability
+def test_metrics_endpoint_includes_r2_counters():
+    """The /metrics endpoint must expose R2 Prometheus counters after a traced request."""
+    from api.aurora_api import app
+    from src.observability import reset_r2_telemetry
+
+    reset_r2_telemetry()
+
+    client = TestClient(app)
+    # Trigger a span by hitting a real endpoint first
+    client.get("/telemetry/snapshot")
+
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    content = response.text
+    # R2 Prometheus counters should appear after at least one span is recorded
+    assert "r2_agent_operations_total" in content, (
+        "/metrics is not exporting R2AgentTelemetry counters"
+    )


### PR DESCRIPTION
## Summary

Closes #769 — R2AgentTelemetry was fully implemented but never called from production API paths. This PR wires it in so every request is traced.

- **New middleware `r2_telemetry_middleware`** in `api/aurora_api.py`: wraps every non-infra HTTP request in a `trace_agent_operation` span, recording `http_method`, `http_path`, and `http_status_code` per operation. Infra/noise paths (`/health`, `/metrics`, `/docs`, `/openapi.json`, `/redoc`, `/`) are skipped. Middleware is guarded — if R2 telemetry init fails, requests still pass through.
- **Updated `/metrics` endpoint**: now merges R2AgentTelemetry Prometheus counters (`r2_agent_operations_total`, `r2_agent_operations_success`, `r2_agent_anomalies_detected`) alongside existing Aurora telemetry output.
- **Two new integration tests** in `tests/test_telemetry_integration.py`:
  - `test_r2_middleware_records_span_per_request` — fails if the middleware is removed (acceptance criterion from issue)
  - `test_metrics_endpoint_includes_r2_counters` — verifies R2 counters appear in `/metrics` after a traced request

## Test plan

- [ ] `pytest tests/test_telemetry_integration.py -v -m integration` — all tests pass
- [ ] `pytest tests/test_r2_telemetry.py -v` — existing R2 unit tests unaffected
- [ ] Hit `/telemetry/snapshot`, then `/metrics` — `r2_agent_operations_total` counter appears

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_