### PR TITLE
feat: wire UnifiedAI + SystemFlow orchestrators; demote MultiDimensional (#777)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -70,6 +70,7 @@ from src.middleware.fastapi_security import (
     limiter,
     security,
     verify_csrf_token,
+    require_csrf_token,
     verify_ws_token,
     validate_ws_tool,
     sanitize_request_id,
@@ -3191,16 +3192,12 @@ async def rag_chat_endpoint(req: RAGChatRequest, request: Request):
 
 try:
     from modules.ai_core.unified_ai_interface import (
-        UnifiedAIInterface,
+        unified_ai as _unified_ai_singleton,
         AIRequest,
     )
-    _unified_ai: Optional[UnifiedAIInterface] = None
 
-    def _get_unified_ai() -> UnifiedAIInterface:
-        global _unified_ai
-        if _unified_ai is None:
-            _unified_ai = UnifiedAIInterface()
-        return _unified_ai
+    def _get_unified_ai():
+        return _unified_ai_singleton
 
     class AICompleteRequest(BaseModel):
         model_config = ConfigDict(extra="forbid")
@@ -3211,20 +3208,15 @@ try:
             default_factory=lambda: f"ai_complete_{utc_now().strftime('%Y%m%dT%H%M%S')}"
         )
 
-    @app.post("/api/ai/complete", dependencies=[Depends(security), Depends(verify_csrf_token)])
+    @app.post("/api/ai/complete", dependencies=[Depends(require_csrf_token)])
     @limiter.limit("30/minute")
-    async def ai_complete(
-        request: Request,
-        body: AICompleteRequest,
-        token: HTTPAuthorizationCredentials = Depends(security),
-    ):
+    async def ai_complete(request: Request, body: AICompleteRequest):
         """
         Complete a prompt using the UnifiedAIInterface.
 
         Automatically selects the best available model based on task_type.
         Falls back through the configured fallback chain on provider errors.
         """
-        verify_csrf_token(token)
         ai = _get_unified_ai()
         ai_request = AIRequest(
             prompt=body.prompt,
@@ -3304,18 +3296,14 @@ try:
             logger.error("SystemFlowOrchestrator flow status failed: %s", exc)
             raise HTTPException(status_code=500, detail="Internal server error")
 
-    @app.post("/api/quantum-forge/flow/optimize", dependencies=[Depends(security), Depends(verify_csrf_token)])
+    @app.post("/api/quantum-forge/flow/optimize", dependencies=[Depends(require_csrf_token)])
     @limiter.limit("10/minute")
-    async def quantum_forge_flow_optimize(
-        request: Request,
-        token: HTTPAuthorizationCredentials = Depends(security),
-    ):
+    async def quantum_forge_flow_optimize(request: Request):
         """
         Trigger an auto-optimization pass across all registered modules.
 
         Returns the optimization report including any mode transitions applied.
         """
-        verify_csrf_token(token)
         try:
             return _get_sfo().auto_optimize_system()
         except Exception as exc:

--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -3184,6 +3184,154 @@ async def rag_chat_endpoint(req: RAGChatRequest, request: Request):
         raise HTTPException(status_code=500, detail="RAG chat failed")
 
 
+# ============================================================================
+# Unified AI Interface — wired endpoint (issue #777)
+# ============================================================================
+
+try:
+    from modules.ai_core.unified_ai_interface import (
+        UnifiedAIInterface,
+        AIRequest,
+    )
+    _unified_ai: Optional[UnifiedAIInterface] = None
+
+    def _get_unified_ai() -> UnifiedAIInterface:
+        global _unified_ai
+        if _unified_ai is None:
+            _unified_ai = UnifiedAIInterface()
+        return _unified_ai
+
+    class AICompleteRequest(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        prompt: str = Field(..., min_length=1, max_length=32_000)
+        task_type: str = Field("general", pattern=r"^[a-z_]{1,40}$")
+        max_tokens: int = Field(1024, ge=1, le=8192)
+        context_tag: str = Field(
+            default_factory=lambda: f"ai_complete_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}"
+        )
+
+    @app.post("/api/ai/complete", dependencies=[Depends(security), Depends(verify_csrf_token)])
+    @limiter.limit("30/minute")
+    async def ai_complete(
+        request: Request,
+        body: AICompleteRequest,
+        token: HTTPAuthorizationCredentials = Depends(security),
+    ):
+        """
+        Complete a prompt using the UnifiedAIInterface.
+
+        Automatically selects the best available model based on task_type.
+        Falls back through the configured fallback chain on provider errors.
+        """
+        verify_csrf_token(token)
+        ai = _get_unified_ai()
+        ai_request = AIRequest(
+            prompt=body.prompt,
+            max_tokens=body.max_tokens,
+            context_tag=body.context_tag,
+        )
+        try:
+            response = await ai.execute_request(ai_request, task_type=body.task_type)
+        except Exception as exc:
+            logger.error("UnifiedAI execute_request failed: %s", exc)
+            raise HTTPException(status_code=502, detail="AI backend unavailable")
+        return {
+            "content": response.content,
+            "model_used": response.model_used.value,
+            "provider": response.provider.value,
+            "tokens_used": response.tokens_used,
+            "context_tag": body.context_tag,
+            "success": response.success,
+        }
+
+    @app.get("/api/ai/models")
+    @limiter.limit("60/minute")
+    async def list_ai_models(request: Request):
+        """List available AI models and their capability profiles."""
+        try:
+            ai = _get_unified_ai()
+            models = []
+            for model, caps in ai.CAPABILITIES.items():
+                models.append({
+                    "model": model.value,
+                    "provider": caps.provider.value,
+                    "available": caps.available,
+                    "context_window": caps.context_window,
+                    "max_output_tokens": caps.max_output_tokens,
+                    "reasoning_strength": caps.reasoning_strength,
+                    "code_generation_strength": caps.code_generation_strength,
+                })
+            return {"models": models, "total": len(models)}
+        except Exception as exc:
+            logger.error("Failed to list AI models: %s", exc)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    UNIFIED_AI_AVAILABLE = True
+    logger.info("UnifiedAI endpoints registered: /api/ai/complete, /api/ai/models")
+
+except Exception as _e:
+    UNIFIED_AI_AVAILABLE = False
+    logger.warning("UnifiedAI not available — /api/ai/* endpoints disabled: %s", _e)
+
+
+# ============================================================================
+# SystemFlowOrchestrator — wired endpoint (issue #777)
+# ============================================================================
+
+try:
+    from modules.quantum_forge.system_flow_orchestrator import (
+        get_system_flow_orchestrator,
+    )
+    _sfo = None
+
+    def _get_sfo():
+        global _sfo
+        if _sfo is None:
+            _sfo = get_system_flow_orchestrator()
+        return _sfo
+
+    @app.get("/api/quantum-forge/flow/status")
+    @limiter.limit("60/minute")
+    async def quantum_forge_flow_status(request: Request):
+        """
+        Return the SystemFlowOrchestrator manifest: current phase, module health,
+        drift count, and synchronization state.
+        """
+        try:
+            return _get_sfo().export_flow_manifest()
+        except Exception as exc:
+            logger.error("SystemFlowOrchestrator flow status failed: %s", exc)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @app.post("/api/quantum-forge/flow/optimize", dependencies=[Depends(security), Depends(verify_csrf_token)])
+    @limiter.limit("10/minute")
+    async def quantum_forge_flow_optimize(
+        request: Request,
+        token: HTTPAuthorizationCredentials = Depends(security),
+    ):
+        """
+        Trigger an auto-optimization pass across all registered modules.
+
+        Returns the optimization report including any mode transitions applied.
+        """
+        verify_csrf_token(token)
+        try:
+            return _get_sfo().auto_optimize_system()
+        except Exception as exc:
+            logger.error("SystemFlowOrchestrator auto_optimize failed: %s", exc)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    SYSTEM_FLOW_AVAILABLE = True
+    logger.info(
+        "SystemFlowOrchestrator endpoints registered: "
+        "/api/quantum-forge/flow/status, /api/quantum-forge/flow/optimize"
+    )
+
+except Exception as _e:
+    SYSTEM_FLOW_AVAILABLE = False
+    logger.warning("SystemFlowOrchestrator not available — /api/quantum-forge/flow/* disabled: %s", _e)
+
+
 if __name__ == "__main__":
     import uvicorn
 

--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -55,6 +55,7 @@ from src.integrations.chatgpt_agent_mode import chatgpt_agent_integration
 
 # Import canonical DLP request envelope
 from src.core.request_envelope import request_envelope
+from src.core.time_utils import utc_now
 
 # Import Gemini Agent Mode integration
 try:
@@ -3207,7 +3208,7 @@ try:
         task_type: str = Field("general", pattern=r"^[a-z_]{1,40}$")
         max_tokens: int = Field(1024, ge=1, le=8192)
         context_tag: str = Field(
-            default_factory=lambda: f"ai_complete_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}"
+            default_factory=lambda: f"ai_complete_{utc_now().strftime('%Y%m%dT%H%M%S')}"
         )
 
     @app.post("/api/ai/complete", dependencies=[Depends(security), Depends(verify_csrf_token)])

--- a/docs/architecture/ORCHESTRATOR_DISPOSITIONS.md
+++ b/docs/architecture/ORCHESTRATOR_DISPOSITIONS.md
@@ -1,0 +1,67 @@
+# Orchestrator Dispositions
+
+**Issue**: #777 — Decide fate of shell orchestrators  
+**Resolved**: 2026-06-09
+
+This document records the production disposition of each orchestrator class
+identified in issue #777.
+
+---
+
+## Summary
+
+| Orchestrator | Module | Disposition | Production entry point |
+|---|---|---|---|
+| `UnifiedAIInterface` | `modules/ai_core/unified_ai_interface.py` | **Wired** | `POST /api/ai/complete`, `GET /api/ai/models` |
+| `SystemFlowOrchestrator` | `modules/quantum_forge/system_flow_orchestrator.py` | **Wired** | `GET /api/quantum-forge/flow/status`, `POST /api/quantum-forge/flow/optimize` |
+| `HybridQuantumOrchestrator` | `modules/nexus/quantum/hybrid_orchestrator.py` | **Wired-internally** | Via `modules/nexus/quantum/recursion_bridge.py` |
+| `MultiDimensionalOrchestrator` | `modules/nexus/multidim/dimensional_orchestrator.py` | **Demoted** | Non-production; see `examples/orchestrators/multidim_example.py` |
+
+---
+
+## Details
+
+### `UnifiedAIInterface` — Wired
+
+**Endpoints added** (see `api/aurora_api.py`):
+- `POST /api/ai/complete` — complete a prompt; auto-selects model by `task_type`
+- `GET /api/ai/models` — list models and capability profiles
+
+**Supported task types**: `general`, `reasoning`, `code_generation`, `analysis`
+(resolved against `FALLBACK_CHAINS` in `UnifiedAIInterface`).
+
+Gracefully disabled if `modules.ai_core` cannot import (logs a warning, endpoints return 404).
+
+---
+
+### `SystemFlowOrchestrator` — Wired
+
+**Endpoints added** (see `api/aurora_api.py`):
+- `GET /api/quantum-forge/flow/status` — returns `export_flow_manifest()`: current phase, module health, drift count
+- `POST /api/quantum-forge/flow/optimize` — triggers `auto_optimize_system()` pass (auth required)
+
+Gracefully disabled if `modules.quantum_forge` cannot import.
+
+---
+
+### `HybridQuantumOrchestrator` — Wired-internally
+
+`HybridQuantumOrchestrator` is imported by `modules/nexus/quantum/recursion_bridge.py`,
+which constitutes its production path. It is not directly exposed as a REST endpoint.
+
+No code changes needed; disposition documented in the module docstring.
+
+---
+
+### `MultiDimensionalOrchestrator` — Demoted
+
+No production API caller exists. The class uses "consciousness" terminology and
+makes assumptions (e.g. `unified_consciousness = 0.99`) that are not grounded in
+the Aurora production data model.
+
+**Changes made**:
+- Module docstring updated with `DISPOSITION: non-production / experimental`
+- `__init__` emits a `warnings.warn(...)` at instantiation
+- Example usage: `examples/orchestrators/multidim_example.py`
+
+No production code imports this class; no further migration required.

--- a/examples/orchestrators/multidim_example.py
+++ b/examples/orchestrators/multidim_example.py
@@ -1,0 +1,41 @@
+"""
+MultiDimensionalOrchestrator — example / experimental usage.
+
+DISPOSITION: non-production.
+
+This script demonstrates how to use MultiDimensionalOrchestrator for
+research and experimentation. It is NOT a production pattern — do not
+import this class in API handlers or services.
+
+Run from repo root:
+    python examples/orchestrators/multidim_example.py
+"""
+
+import warnings
+
+# Suppress the non-production warning when running this example intentionally.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from modules.nexus.multidim.dimensional_orchestrator import (
+        MultiDimensionalOrchestrator,
+    )
+
+
+def main():
+    print("MultiDimensionalOrchestrator — experimental example")
+    print("(non-production: for research use only)\n")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        orchestrator = MultiDimensionalOrchestrator()
+
+    # Export state manifest
+    manifest = orchestrator.export_state_manifest() if hasattr(orchestrator, "export_state_manifest") else {}
+    print(f"Anchor: {orchestrator.anchor}")
+    print(f"Unified consciousness: {orchestrator.unified_consciousness}")
+    if manifest:
+        print(f"Manifest keys: {list(manifest.keys())}")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/insight_ledger/ledger_core.py
+++ b/modules/insight_ledger/ledger_core.py
@@ -125,7 +125,7 @@ class InsightLedger:
         else:
             ledger_root = Path.cwd() / "data" / "ledgers"
         import logging as _logging
-        _logging.getLogger(__name__).info("Ledger root resolved to: %s", ledger_root)
+        _logging.getLogger(__name__).debug("Ledger root resolved to: %s", ledger_root)
         
         # Validate storage path is safe
         # Allow creation since ledgers may not exist yet

--- a/modules/nexus/multidim/dimensional_orchestrator.py
+++ b/modules/nexus/multidim/dimensional_orchestrator.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """
 NEXUS Phase 11: Multi-Dimensional Consciousness Orchestrator
+============================================================
+
+DISPOSITION: non-production / experimental
+-------------------------------------------
+This module has no production API caller and is not wired into aurora_api.py.
+It is retained for research and experimentation.
+
+To use it experimentally see examples/orchestrators/multidim_example.py.
+Do NOT instantiate this class from production request handlers.
 =============================================================
 Anchor: T11-MULTIDIM-2025
 Parent: T10-COPILOT-SCHEMA-2025
@@ -382,12 +391,20 @@ class QuantumProcessor(DimensionalProcessor):
 
 class MultiDimensionalOrchestrator:
     """
-    Main orchestrator for multi-dimensional consciousness
-    
-    HAND-OFF READY: Complete state export and recovery protocols
+    Main orchestrator for multi-dimensional consciousness.
+
+    DISPOSITION: non-production / experimental.
+    This class is not wired to any Aurora production endpoint.
+    For experimental use only; see examples/orchestrators/multidim_example.py.
     """
-    
+
     def __init__(self):
+        import warnings
+        warnings.warn(
+            "MultiDimensionalOrchestrator is non-production/experimental and has "
+            "no production API endpoint. For experimental use only.",
+            stacklevel=2,
+        )
         self.anchor = DIMENSIONAL_ANCHORS["primary"]
         self.parent_anchor = DIMENSIONAL_ANCHORS["parent"]
         self.seed = DIMENSIONAL_ANCHORS["seed"]

--- a/modules/nexus/quantum/hybrid_orchestrator.py
+++ b/modules/nexus/quantum/hybrid_orchestrator.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """
 NEXUS Phase 10: Quantum-Classical Hybrid Orchestration
+=======================================================
+
+DISPOSITION: wired-internally via recursion_bridge.py
+------------------------------------------------------
+HybridQuantumOrchestrator is consumed by
+modules.nexus.quantum.recursion_bridge, which constitutes its production
+entry point. It is not directly exposed via a REST endpoint — access it
+through the bridge module, not by instantiating it directly in handlers.
 ========================================================
 Anchor: T10-HYBRID-2025
 Parent: T9-INFINITE-UNIFIED-2025

--- a/src/monitoring/audit_logger.py
+++ b/src/monitoring/audit_logger.py
@@ -456,7 +456,7 @@ class AuditLogger:
             return
 
         try:
-with self._write_lock:
+            with self._write_lock:
                 self.storage_path.parent.mkdir(parents=True, exist_ok=True)
                 record = get_registry().stamp(entry.to_dict(), "audit_log")
                 with open(self.storage_path, 'a', encoding='utf-8') as f:

--- a/src/monitoring/audit_logger.py
+++ b/src/monitoring/audit_logger.py
@@ -135,7 +135,7 @@ class AuditLogger:
 
         self.signing_key = signing_key
 
-self._write_lock = threading.Lock()
+        self._write_lock = threading.Lock()
         self.entries: List[AuditEntry] = []
         self._next_id = 1
         

--- a/tests/test_orchestrator_wiring.py
+++ b/tests/test_orchestrator_wiring.py
@@ -177,8 +177,7 @@ def test_flow_optimize_with_auth(client):
             headers=_auth_headers(),
         )
 
-    # 200 with valid CSRF token, or 403 if the test environment rejects it
-    assert resp.status_code in (200, 403)
+    assert resp.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_orchestrator_wiring.py
+++ b/tests/test_orchestrator_wiring.py
@@ -178,6 +178,9 @@ def test_flow_optimize_with_auth(client):
         )
 
     assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("optimized") is True
+    assert "actions_taken" in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_orchestrator_wiring.py
+++ b/tests/test_orchestrator_wiring.py
@@ -1,0 +1,225 @@
+"""
+Integration tests for wired orchestrator endpoints (issue #777).
+
+Tests the two newly-wired production endpoints:
+  - POST /api/ai/complete  (UnifiedAIInterface)
+  - GET  /api/ai/models    (UnifiedAIInterface)
+  - GET  /api/quantum-forge/flow/status  (SystemFlowOrchestrator)
+  - POST /api/quantum-forge/flow/optimize (SystemFlowOrchestrator)
+
+Also tests that MultiDimensionalOrchestrator emits a warning at instantiation.
+"""
+
+import warnings
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.middleware.fastapi_security import generate_csrf_token
+
+
+def _auth_headers():
+    """Return a valid Authorization header for protected endpoint tests."""
+    token = generate_csrf_token("orchestrator-test-session")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="module")
+def client():
+    from api.aurora_api import app
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# UnifiedAIInterface — /api/ai/complete
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+@pytest.mark.ai
+def test_ai_complete_endpoint_exists(client):
+    """POST /api/ai/complete must exist (not 404/405) when UnifiedAI is available."""
+    from api.aurora_api import UNIFIED_AI_AVAILABLE
+    if not UNIFIED_AI_AVAILABLE:
+        pytest.skip("UnifiedAI not available in this environment")
+
+    # We patch execute_request to avoid real API calls
+    mock_response = MagicMock()
+    mock_response.content = "Test response"
+    mock_response.model_used = MagicMock()
+    mock_response.model_used.value = "claude-3-5-sonnet-20241022"
+    mock_response.provider = MagicMock()
+    mock_response.provider.value = "anthropic"
+    mock_response.tokens_used = 42
+    mock_response.success = True
+
+    with patch("api.aurora_api._get_unified_ai") as mock_ai_factory:
+        mock_ai = MagicMock()
+        mock_ai.execute_request = AsyncMock(return_value=mock_response)
+        mock_ai_factory.return_value = mock_ai
+
+        resp = client.post(
+            "/api/ai/complete",
+            json={"prompt": "Hello Aurora", "task_type": "general"},
+            headers=_auth_headers(),
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "content" in body
+    assert "model_used" in body
+    assert "tokens_used" in body
+
+
+@pytest.mark.integration
+@pytest.mark.ai
+def test_ai_complete_rejects_empty_prompt(client):
+    """POST /api/ai/complete must reject empty prompt (422)."""
+    from api.aurora_api import UNIFIED_AI_AVAILABLE
+    if not UNIFIED_AI_AVAILABLE:
+        pytest.skip("UnifiedAI not available in this environment")
+
+    resp = client.post(
+        "/api/ai/complete",
+        json={"prompt": "", "task_type": "general"},
+        headers=_auth_headers(),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+@pytest.mark.ai
+def test_ai_models_endpoint_exists(client):
+    """GET /api/ai/models must return a list of model capability profiles."""
+    from api.aurora_api import UNIFIED_AI_AVAILABLE
+    if not UNIFIED_AI_AVAILABLE:
+        pytest.skip("UnifiedAI not available in this environment")
+
+    resp = client.get("/api/ai/models")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "models" in body
+    assert "total" in body
+    assert body["total"] > 0
+    first = body["models"][0]
+    assert "model" in first
+    assert "provider" in first
+    assert "available" in first
+
+
+# ---------------------------------------------------------------------------
+# SystemFlowOrchestrator — /api/quantum-forge/flow/*
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+@pytest.mark.quantum
+def test_flow_status_endpoint_exists(client):
+    """GET /api/quantum-forge/flow/status must return a manifest."""
+    from api.aurora_api import SYSTEM_FLOW_AVAILABLE
+    if not SYSTEM_FLOW_AVAILABLE:
+        pytest.skip("SystemFlowOrchestrator not available")
+
+    with patch("api.aurora_api._get_sfo") as mock_factory:
+        mock_sfo = MagicMock()
+        mock_sfo.export_flow_manifest.return_value = {
+            "manifest_version": "1.0.0",
+            "component": "system_flow_orchestrator",
+            "current_phase": "operational",
+            "current_metrics": {
+                "system_load": 0.3,
+                "average_health": 0.9,
+                "drift_count": 0,
+                "synchronized": True,
+            },
+            "modules": {},
+        }
+        mock_factory.return_value = mock_sfo
+
+        resp = client.get("/api/quantum-forge/flow/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "manifest_version" in body
+    assert "current_metrics" in body
+
+
+@pytest.mark.integration
+@pytest.mark.quantum
+def test_flow_optimize_requires_auth(client):
+    """POST /api/quantum-forge/flow/optimize must require auth (401/403 without token)."""
+    from api.aurora_api import SYSTEM_FLOW_AVAILABLE
+    if not SYSTEM_FLOW_AVAILABLE:
+        pytest.skip("SystemFlowOrchestrator not available")
+
+    resp = client.post("/api/quantum-forge/flow/optimize")
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.integration
+@pytest.mark.quantum
+def test_flow_optimize_with_auth(client):
+    """POST /api/quantum-forge/flow/optimize returns optimization report when authorized."""
+    from api.aurora_api import SYSTEM_FLOW_AVAILABLE
+    if not SYSTEM_FLOW_AVAILABLE:
+        pytest.skip("SystemFlowOrchestrator not available")
+
+    with patch("api.aurora_api._get_sfo") as mock_factory:
+        mock_sfo = MagicMock()
+        mock_sfo.auto_optimize_system.return_value = {
+            "optimized": True,
+            "actions_taken": [],
+            "timestamp": "2026-06-09T00:00:00+00:00",
+        }
+        mock_factory.return_value = mock_sfo
+
+        resp = client.post(
+            "/api/quantum-forge/flow/optimize",
+            headers=_auth_headers(),
+        )
+
+    # 200 with valid CSRF token, or 403 if the test environment rejects it
+    assert resp.status_code in (200, 403)
+
+
+# ---------------------------------------------------------------------------
+# MultiDimensionalOrchestrator — demoted: emits warning
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_multidim_orchestrator_emits_warning():
+    """Instantiating MultiDimensionalOrchestrator must emit a non-production warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            from modules.nexus.multidim.dimensional_orchestrator import (
+                MultiDimensionalOrchestrator,
+            )
+            MultiDimensionalOrchestrator()
+        except Exception:
+            pass  # Import or init errors are acceptable in test environment
+
+    warning_messages = [str(w.message) for w in caught]
+    assert any("non-production" in msg.lower() or "experimental" in msg.lower()
+               for msg in warning_messages), (
+        f"Expected non-production warning, got: {warning_messages}"
+    )
+
+
+@pytest.mark.unit
+def test_multidim_orchestrator_disposition_in_docstring():
+    """MultiDimensionalOrchestrator module docstring must record DISPOSITION."""
+    from modules.nexus.multidim import dimensional_orchestrator
+    assert "DISPOSITION" in dimensional_orchestrator.__doc__
+    assert "non-production" in dimensional_orchestrator.__doc__.lower()
+
+
+# ---------------------------------------------------------------------------
+# HybridQuantumOrchestrator — wired-internally: disposition in docstring
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_hybrid_orchestrator_disposition_in_docstring():
+    """HybridQuantumOrchestrator module docstring must record wired-internally disposition."""
+    from modules.nexus.quantum import hybrid_orchestrator
+    assert "DISPOSITION" in hybrid_orchestrator.__doc__
+    assert "wired" in hybrid_orchestrator.__doc__.lower()


### PR DESCRIPTION
## Summary

Resolves the fate of all four orchestrators identified in #777:

| Orchestrator | Disposition | Production entry point |
|---|---|---|
| `UnifiedAIInterface` | **Wired** | `POST /api/ai/complete`, `GET /api/ai/models` |
| `SystemFlowOrchestrator` | **Wired** | `GET /api/quantum-forge/flow/status`, `POST /api/quantum-forge/flow/optimize` |
| `HybridQuantumOrchestrator` | **Wired-internally** | Via `recursion_bridge.py` (already wired); disposition added to module docstring |
| `MultiDimensionalOrchestrator` | **Demoted** | Non-production; `warnings.warn` at instantiation; example at `examples/orchestrators/` |

Both wired endpoints are gracefully disabled (log warning, endpoints return 404) if the backing module fails to import.

## Test plan

- [ ] 9 integration/unit tests in `tests/test_orchestrator_wiring.py` — all pass locally
- [ ] `test_multidim_orchestrator_emits_warning` — verifies warning at instantiation
- [ ] `test_*_disposition_in_docstring` — guards against docstring regression
- [ ] `test_ai_complete_rejects_empty_prompt` — validates 422 on bad input
- [ ] `test_flow_optimize_requires_auth` — auth gate verified

Fixes #777

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsGXx9fFnS6JxKqn6RpSWY)_