### PR TITLE
fix(ci): repair corrupted action SHA pins (github-script + 9 others)

### DIFF
--- a/.github/workflows/auto-assign-and-review.yml
+++ b/.github/workflows/auto-assign-and-review.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign issue or PR to repository owner
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const owner = context.repo.owner;
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign based on label
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/auto-assign-and-review.yml
+++ b/.github/workflows/auto-assign-and-review.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto assign reviewers
-        uses: kentaro-m/auto-assign-action@6f0f42e47d4d24a3f5dd3a5e92c5bfab4f3a9f41  # v2.0.0
+        uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e  # v2.0.0
         with:
           configuration-path: '.github/auto_assign.yml'
 

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels
-        uses: actions/labeler@b1c87a9db1de53e81b27b2bb5e3f5a4f0e7da020  # v3.0.0
+        uses: actions/labeler@9794b1493b6f1fa7b006c5f8635a19c76c98be95  # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/labeler.yml

--- a/.github/workflows/auto-merge-admin.yml
+++ b/.github/workflows/auto-merge-admin.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Check PR status
         id: pr-status
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -41,7 +41,7 @@ jobs:
       
       - name: Auto-approve PR
         if: github.actor == 'AUo959'
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -59,7 +59,7 @@ jobs:
             }
       
       - name: Enable auto-merge
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -75,7 +75,7 @@ jobs:
       
       - name: Delete branch
         if: success()
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci-status-project-automation.yml
+++ b/.github/workflows/ci-status-project-automation.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Get PR or Issue Info
         id: get-info
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const context_name = context.eventName;
@@ -78,7 +78,7 @@ jobs:
       - name: Check CI Status
         id: check-ci
         if: steps.get-info.outputs.sha
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const sha = '${{ steps.get-info.outputs.sha }}';
@@ -150,7 +150,7 @@ jobs:
     if: github.event.pull_request || github.event.issue
     steps:
       - name: Add CI Status Label (Silent)
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const item_number = context.payload.pull_request?.number || context.payload.issue?.number;

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Codacy Analysis
-        uses: codacy/codacy-analysis-cli-action@33d455949345bdff05aa32e1eff9b37536b01e68  # v4.4.0
+        uses: codacy/codacy-analysis-cli-action@33d455949345bddfdb845fba76b57b70cc83754b  # v4.4.0
         with:
           codacy-repo-token: ${{ secrets.CODACY_REPO_TOKEN }}

--- a/.github/workflows/constellation-ci.yml
+++ b/.github/workflows/constellation-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     
     - name: Setup Node.js
-      uses: actions/setup-node@1d0ff469b13e2e8e5e78b7b0cf6e63745e38d00b  # v4.2.0
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
       with:
         node-version: '20'
         cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
         repository: AUo959/aurora-cloudbank-symbolic
         
     - name: Setup Node.js
-      uses: actions/setup-node@1d0ff469b13e2e8e5e78b7b0cf6e63745e38d00b  # v4.2.0
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
       with:
         node-version: '20'
         
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     
     - name: Setup Node.js
-      uses: actions/setup-node@1d0ff469b13e2e8e5e78b7b0cf6e63745e38d00b  # v4.2.0
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
       with:
         node-version: '20'
         
@@ -82,7 +82,7 @@ jobs:
       run: npm audit --json > audit-results.json || true
       
     - name: Upload audit results
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: security-audit
         path: audit-results.json

--- a/.github/workflows/constellation-event-publisher.yml
+++ b/.github/workflows/constellation-event-publisher.yml
@@ -68,7 +68,7 @@ jobs:
           echo "correlation_id=$CORRELATION_ID" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch to hub
-        uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f2  # v3.0.0
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0
         with:
           token: ${{ secrets.CONSTELLATION_TOKEN }}
           repository: AUo959/aurora-cloudbank-symbolic

--- a/.github/workflows/constellation-event-router.yml
+++ b/.github/workflows/constellation-event-router.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: Route event
         if: needs.validate-event.outputs.event_type == matrix.event
-        uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f2  # v3.0.0
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0
         with:
           token: ${{ secrets.CONSTELLATION_TOKEN }}
           repository: ${{ matrix.owner }}/${{ matrix.subscriber }}

--- a/.github/workflows/cross-repo-capsule-exchange.yml
+++ b/.github/workflows/cross-repo-capsule-exchange.yml
@@ -65,7 +65,7 @@ jobs:
           echo "✅ Capsule exported to: $OUTPUT_FILE"
       
       - name: Upload capsule artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: capsule-export
           path: ${{ steps.export.outputs.capsule_file }}

--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     
     - name: Cache pip dependencies
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e4571d9c  # v4.2.3
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements*.txt') }}
@@ -85,7 +85,7 @@ jobs:
     
     - name: Upload dependency report
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: dependency-report-python-${{ matrix.python-version }}
         path: |
@@ -104,7 +104,7 @@ jobs:
         
     - name: Upload security report
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: security-report-python-${{ matrix.python-version }}
         path: safety-report.json

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -140,7 +140,7 @@ jobs:
       
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d  # v5.0.0
+        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d  # v6.12.0
         with:
           context: .
           file: ./k8s/Dockerfile
@@ -156,7 +156,7 @@ jobs:
       
       - name: Generate SBOM
         if: github.event_name != 'pull_request'
-        uses: anchore/sbom-action@61119d458adab75f756bc0b1e945f9dded6a6109  # v0.17.2
+        uses: anchore/sbom-action@61119d458adab75f756bc0b9e4bde25725f86a7a  # v0.17.2
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
           format: spdx-json
@@ -164,7 +164,7 @@ jobs:
       
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: sbom
           path: sbom.spdx.json
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1381784a5834  # v3.2.0
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8  # v3.2
         with:
           version: ${{ env.KUBECTL_VERSION }}
 
@@ -275,7 +275,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1381784a5834  # v3.2.0
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8  # v3.2
         with:
           version: ${{ env.KUBECTL_VERSION }}
       
@@ -360,7 +360,7 @@ jobs:
           cat deployment-manifest.json
       
       - name: Upload deployment manifest
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: deployment-manifest
           path: deployment-manifest.json

--- a/.github/workflows/pr-selective-integration.yml
+++ b/.github/workflows/pr-selective-integration.yml
@@ -108,7 +108,7 @@ jobs:
     
     - name: Prepare Integration Analysis Comment
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           const fs = require('fs');
@@ -252,7 +252,7 @@ jobs:
     
     - name: Add Strategy Label
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           const strategy = '${{ steps.integration.outputs.integration_strategy }}';
@@ -280,7 +280,7 @@ jobs:
     
     - name: Add Score Label
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           const score = parseFloat('${{ steps.evaluate.outputs.evaluation_score }}');
@@ -304,7 +304,7 @@ jobs:
     
     - name: Check for Auto-Merge Eligibility
       if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.integration_strategy == 'direct_merge' && steps.evaluate.outputs.evaluation_score >= 0.9
-      uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           // Prepare auto-merge candidate comment
@@ -327,7 +327,7 @@ jobs:
     
     - name: Add Ready-to-Merge Label
       if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.integration_strategy == 'direct_merge' && steps.evaluate.outputs.evaluation_score >= 0.9
-      uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           try {

--- a/.github/workflows/pr-selective-integration.yml
+++ b/.github/workflows/pr-selective-integration.yml
@@ -98,7 +98,7 @@ jobs:
     
     - name: Upload evaluation artifacts
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: pr-evaluation-artifacts
         path: |

--- a/.github/workflows/pr_evaluation.yml
+++ b/.github/workflows/pr_evaluation.yml
@@ -52,7 +52,7 @@ jobs:
     
     - name: Upload evaluation results
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: pr-evaluation-results
         path: pr_results.json

--- a/.github/workflows/pr_evaluation.yml
+++ b/.github/workflows/pr_evaluation.yml
@@ -59,7 +59,7 @@ jobs:
     
     - name: Comment on PR
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/pr_evaluation.yml.backup
+++ b/.github/workflows/pr_evaluation.yml.backup
@@ -52,7 +52,7 @@ jobs:
     
     - name: Upload evaluation results
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
         name: pr-evaluation-results
         path: pr_results.json

--- a/.github/workflows/pr_evaluation.yml.backup
+++ b/.github/workflows/pr_evaluation.yml.backup
@@ -65,7 +65,7 @@ jobs:
     
     - name: Comment on PR
       if: steps.detect.outputs.should_run == 'true'
-      uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/project-board-ci-sync.yml
+++ b/.github/workflows/project-board-ci-sync.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Get PR/Issue from Check Suite
         id: get-item
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             let pr_number = null;
@@ -44,7 +44,7 @@ jobs:
       - name: Determine CI Status
         id: ci-status
         if: steps.get-item.outputs.has_item == 'true'
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const conclusion = context.payload.check_suite?.conclusion || 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Update Project Board - Move to In Progress (CI Failed)
         if: steps.ci-status.outputs.ci_failed == 'true'
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -105,7 +105,7 @@ jobs:
 
       - name: Update Project Board - Move to In Review (CI Passed)
         if: steps.ci-status.outputs.ci_passed == 'true'
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -149,7 +149,7 @@ jobs:
 
       - name: Add Status Comment
         if: steps.get-item.outputs.has_item == 'true'
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const pr_number = parseInt('${{ steps.get-item.outputs.pr_number }}');

--- a/.github/workflows/stale-and-blocked-report.yml
+++ b/.github/workflows/stale-and-blocked-report.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Generate Weekly Blocked Items Report
-        uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/synergy_dashboard.yml
+++ b/.github/workflows/synergy_dashboard.yml
@@ -235,7 +235,7 @@ jobs:
       
       - name: Upload dashboard artifact (for PRs)
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a96e1c98e851de01adfe1f14  # v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: synergy-dashboard
           path: .github/dashboards/synergy_dashboard.md


### PR DESCRIPTION
## Summary
Every push to `main` fails `project-board-ci-sync.yml` and `ci-status-project-automation.yml` (and other workflows) with:

> Unable to resolve action `actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea`, unable to find version

The SHA-pinning pass from #832 introduced corrupted commit SHAs — each keeps the real SHA's prefix but has a fabricated tail, so the commits don't exist upstream. `actions/github-script` was a one-character typo of the real v7.0.1 commit (`c` → `f` at position 11); PR CI on the first commit here then surfaced nine more pins with the same defect.

## Changes
**Commit 1** — replace all 22 occurrences of the bad `actions/github-script` pin with the real v7.0.1 commit `60a0d83039c74a4aee543508d2ffcb1c3799cdea` (verified against `refs/tags/v7.0.1`).

**Commit 2** — repair the remaining corrupted pins, each verified against its commented release tag via the GitHub API:

| Action | Tag | New pin |
|---|---|---|
| actions/cache | v4.2.3 | `5a3ec84e…e93e2684` |
| actions/labeler | v3.0.0 | `9794b149…c98be95` |
| actions/setup-node | v4.2.0 | `1d0ff469…4821de2a` |
| actions/upload-artifact | v4.4.3 | `b4b15b8c…75cf882` |
| anchore/sbom-action | v0.17.2 | `61119d45…25f86a7a` |
| azure/setup-kubectl | v3.2 (no v3.2.0 tag exists) | `901a10e8…e7de06d8` |
| codacy/codacy-analysis-cli-action | v4.4.0 | `33d45594…cc83754b` |
| kentaro-m/auto-assign-action | v2.0.0 | `f4648c0a…ce17bb7e` |
| peter-evans/repository-dispatch | v3.0.0 | `ff45666b…9ff4d7c0` |

Comment-only fix: `docker/build-push-action@67a2d409…` is a valid commit but is **v6.12.0**, not v5.0.0 as commented — label corrected, pin unchanged.

No workflow logic changed — pin/comment replacement only.

## Verification
- All 18 unique SHA pins across `.github/workflows` confirmed to exist upstream via `gh api repos/<owner>/<repo>/git/commits/<sha>`
- Tag → SHA mappings resolved from `refs/tags/<tag>` with annotated-tag dereferencing
- The two project-automation workflows named in the failure report already pass on this PR's first commit

Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)