### PR TITLE
fix: restore complete MIT license text (placeholder artifact truncated it)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,4 +5,17 @@ Copyright (c) 2025 Aurora
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-...existing code...
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The LICENSE file currently reads:

```
...including without limitation the rights
...existing code...
```

An AI edit committed a literal `...existing code...` placeholder over the body of the license, deleting the grant conditions and warranty disclaimer. Legally the file grants nothing, and GitHub now reports the repo license as **Other / NOASSERTION** (it was MIT at the May 27 outside review).

This restores the canonical MIT text, keeping the existing `Copyright (c) 2025 Aurora` line. Once merged, GitHub's license detection should re-classify the repo as MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)