### PR TITLE
fix: identify MCP connector requests in telemetry (issue #826)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -544,7 +544,10 @@ async def telemetry_middleware(request: Request, call_next):
         attributes={
             "http.method": request.method,
             "http.url": str(request.url.path),
-            "http.client": request.client.host if request.client else "unknown"
+            "http.client": request.client.host if request.client else "unknown",
+            "http.user_agent": request.headers.get("user-agent", "unknown"),
+            "aurora.source_client": request.headers.get("x-source-client", "unknown"),
+            "aurora.connector_version": request.headers.get("x-connector-version", "unknown"),
         }
     ):
         try:

--- a/src/middleware/dlp_auto_tracker.py
+++ b/src/middleware/dlp_auto_tracker.py
@@ -186,6 +186,8 @@ class DLPAutoTrackingMiddleware(BaseHTTPMiddleware):
             "query_params": dict(request.query_params) if request.query_params else {},
             "client_host": request.client.host if request.client else "unknown",
             "user_agent": request.headers.get("user-agent", "unknown"),
+            "source_client": request.headers.get("x-source-client", "unknown"),
+            "connector_version": request.headers.get("x-connector-version", "unknown"),
             "content_type": request.headers.get("content-type", "unknown")
         }
     

--- a/tests/test_dlp_auto_tracker.py
+++ b/tests/test_dlp_auto_tracker.py
@@ -309,6 +309,8 @@ class TestRequestDataExtraction:
             client = type('obj', (object,), {'host': 'localhost'})
             headers = {
                 "user-agent": "test-client",
+                "x-source-client": "aurora-mcp-connector",
+                "x-connector-version": "0.1.0",
                 "content-type": "application/json"
             }
         
@@ -320,6 +322,8 @@ class TestRequestDataExtraction:
         assert data["query_params"] == {"param": "value"}
         assert data["client_host"] == "localhost"
         assert data["user_agent"] == "test-client"
+        assert data["source_client"] == "aurora-mcp-connector"
+        assert data["connector_version"] == "0.1.0"
         assert data["content_type"] == "application/json"
 
 

--- a/tests/test_mcp_connector_bridge_headers.py
+++ b/tests/test_mcp_connector_bridge_headers.py
@@ -1,0 +1,26 @@
+from connector import __version__
+from connector.transport.bridge import CloudbankBridge
+
+
+def test_bridge_headers_include_connector_identity(monkeypatch) -> None:
+    monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", "test-token")
+
+    headers = CloudbankBridge()._headers
+
+    assert headers["User-Agent"] == f"aurora-mcp-connector/{__version__}"
+    assert headers["X-Source-Client"] == "aurora-mcp-connector"
+    assert headers["X-Connector-Version"] == __version__
+    assert headers["Authorization"] == "Bearer test-token"
+    assert headers["Content-Type"] == "application/json"
+    assert headers["Accept"] == "application/json"
+
+
+def test_curl_equivalent_does_not_match_connector_signature(monkeypatch) -> None:
+    monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", "test-token")
+
+    connector_headers = CloudbankBridge()._headers
+    curl_headers = {"User-Agent": "curl/8.0.0", "Accept": "*/*"}
+
+    assert curl_headers.get("User-Agent") != connector_headers["User-Agent"]
+    assert curl_headers.get("X-Source-Client") != connector_headers.get("X-Source-Client")
+    assert curl_headers.get("X-Connector-Version") != connector_headers.get("X-Connector-Version")


### PR DESCRIPTION
Stranded local commit from 2026-05-31 (30a673b5) that never got a branch push or PR — surfaced by the 2026-06-10 unlanded-work audit. Complements #828 (which wired the connector tools to live endpoints): this adds `x-source-client`/`x-connector-version` headers on the bridge and records them in API telemetry, so MCP traffic is attributable.

If it conflicts with post-#828 bridge changes, the conflict markers will show in the mergeability check — happy to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)