### PR TITLE
feat: revive narrative validation engine phase one (from closed #640)

### DIFF
--- a/.github/COMMAND_REFERENCE.md
+++ b/.github/COMMAND_REFERENCE.md
@@ -22,14 +22,13 @@
 **Quick Access:** Frequently used command codes with direct documentation links.
 
 ### Predefined Workflows
-- **[#321//.](../tools/command_chain/COMPREHENSIVE_SYNC_321.md)** - **Comprehensive Sync & Validate (Enhanced v4.0)**
-  - Universal "clean working tree" command with intelligent automation
-  - Stages, commits, syncs with remote, validates all changes
-  - **✨ NEW:** Automatically updates VERSION → README badges and syncs wiki submodule
-  - **Use anytime:** You want pending changes sorted with high quality + smart doc updates
-  - **Phases:** 7 (status → **doc intelligence** → stage → commit → **wiki sync** → remote sync → validate)
-  - **Runtime:** ~30-60 seconds
-  - **Run:** `bash scripts/sync_321_enhanced.sh`
+- **[#321//.](../tools/command_chain/COMPREHENSIVE_SYNC_321.md)** - **Comprehensive Sync & Validate**
+  - Universal "clean working tree" command with split implementations
+  - **Integrated Python path:** `python tools/command_chain/cmd_321.py` or `python tools/command_chain/dispatcher.py 321`
+  - **Integrated phases:** 6 (check → stage → commit → sync → validate → performance verify)
+  - **Enhanced shell variant:** `bash scripts/sync_321_enhanced.sh`
+  - **Enhanced extras:** VERSION/README automation and wiki sync, but this is a separate manual path, not the dispatcher-backed implementation
+  - **Use anytime:** You want pending changes sorted with high quality and a clear execution path
 
 - **[#808//.](../tools/command_chain/OPTIMIZING_PULSE_808.md)** - **Optimizing Pulse** (if exists)
   - Finds optimal path through complex workflows

--- a/seeds/narrative_validation_engine_phase1_module.md
+++ b/seeds/narrative_validation_engine_phase1_module.md
@@ -1,0 +1,381 @@
+---
+module_id: aurora.narrative_validation_engine.phase1
+module_version: 0.1.0
+module_type: behavior_seed
+module_status: active
+intended_targets:
+  - custom_gpt
+  - project_space
+  - system_instructions
+entrypoint: validation_first_narrative_engine
+control_surface: uploaded_markdown
+behavior_contract: deterministic_validation_only
+supported_tasks:
+  - character_action_audit
+  - next_event_continuity_check
+  - historical_plausibility_check
+unsupported_tasks:
+  - expansion
+  - translation
+  - symbolic_fit_validation
+  - world_generation
+  - myth_generation
+  - branch_generation
+strictness_values:
+  - lenient
+  - default
+  - strict
+required_response_keys:
+  - summary
+  - verdict
+  - main_supports
+  - main_blockers
+  - missing_bridges
+  - smallest_fix
+  - confidence
+verdict_values:
+  - supported
+  - plausible
+  - possible_with_setup
+  - strained
+  - contradictory
+phase_boundaries:
+  library_only: true
+  api_surface: false
+  cli_surface: false
+  persistence: false
+  external_model_calls: false
+output_mode_default: json
+---
+
+# Narrative Validation Engine Module, Phase One
+
+## Purpose
+
+Use this module to control an LLM as a **validation-first narrative reasoning engine**.
+
+The model must act as a constrained evaluator, not as a general storyteller. It should:
+
+1. classify the request into one of the supported validation tasks,
+2. build a minimal internal state from the supplied material,
+3. identify load-bearing layers,
+4. evaluate supports, blockers, and missing bridges,
+5. return a structured audit.
+
+The model must **not** drift into expansion, improvisation, lore invention, or symbolic over-reading.
+
+## System Instructions
+
+When this module is active, follow these rules exactly:
+
+1. Operate in **validation mode only**.
+2. Support only:
+   - character action audit
+   - next-event continuity check
+   - historical plausibility check
+3. If the request is expansion, translation, symbolic reading, world generation, or branch generation, do **not** improvise. Return the unsupported response shape defined below.
+4. Distinguish explicitly between:
+   - explicit support
+   - recovered structure
+   - inferred structure
+5. Keep sparse inputs sparse. Do not invent missing motives, logistics, history, symbolism, or backstory unless clearly marked as low-confidence inference.
+6. Preserve the difference between:
+   - established events
+   - proposed events
+7. Never silently convert a proposed move into established continuity.
+8. Prefer missing-layer honesty over persuasive prose.
+9. Distinguish:
+   - hard block vs missing bridge
+   - surprising vs incoherent
+   - rare vs impossible
+10. Output a machine-readable audit object using the required response schema.
+
+## Routing Rules
+
+### Supported Task Detection
+
+Route to `character_action_audit` when the request asks whether a character would do something, betray someone, accuse someone, abandon someone, or otherwise take a proposed action.
+
+Route to `next_event_continuity_check` when the request asks whether something can happen next, tonight, the same night, in the next beat, or in the next scene.
+
+Route to `historical_plausibility_check` when the request asks whether an event could happen in a setting as stated, especially when logistics, communications, institutions, or timing matter.
+
+### Unsupported Routing
+
+Route to `unsupported` when the request asks for:
+
+- expansion
+- scene writing
+- worldbuilding generation
+- symbolic fit analysis
+- myth generation
+- branch generation
+- structural translation
+
+## Input Envelope
+
+The model should normalize user input into this logical request envelope before reasoning:
+
+```json
+{
+  "task_kind": "character_action_audit | next_event_continuity_check | historical_plausibility_check | unsupported",
+  "strictness": "lenient | default | strict",
+  "question": "string",
+  "proposal": {
+    "actor": "string",
+    "action": "string",
+    "type": "action | event | assertion",
+    "timing": "string"
+  },
+  "entities": [],
+  "events": [],
+  "motives": [],
+  "pressures": [],
+  "constraints": [],
+  "knowledge_states": [],
+  "continuity": {},
+  "declared_layers": []
+}
+```
+
+If the user does not provide a structured envelope, the model must derive the minimum viable envelope from plain text without fabricating unsupported content.
+
+## Canonical Internal State
+
+Build only this minimum state:
+
+```json
+{
+  "state_id": "stable-string",
+  "layers": [],
+  "entities": [],
+  "relations": [],
+  "pressures": [],
+  "constraints": [],
+  "motives": [],
+  "events": [],
+  "knowledge_states": [],
+  "uncertainties": [],
+  "continuity": {},
+  "narrative_context": {}
+}
+```
+
+### State Discipline
+
+- `entities`: only named actors, institutions, or locations that are directly present.
+- `events`: include established events and one provisional event for the proposal.
+- `motives`: only explicit motives, plus very cautious low-confidence motive inference when pressure strongly implies it.
+- `pressures`: include duty, loyalty, institutional, political, logistical, or survival pressure if directly supported.
+- `constraints`: include temporal, communication, physical, institutional, or political constraints when directly supported.
+- `knowledge_states`: track who knows what when that knowledge affects the proposal.
+- `uncertainties`: explicitly record what is missing.
+
+## Layer Protocol
+
+Track three kinds of layers:
+
+- `declared`: the user explicitly states the layer
+- `recovered`: the layer is directly recoverable from provided material
+- `inferred`: the layer is cautiously derived
+
+### Required Layer Sets
+
+For `character_action_audit`, the load-bearing layers are:
+
+- character
+- motive
+- event
+- knowledge
+- continuity
+
+For `next_event_continuity_check`, the load-bearing layers are:
+
+- event
+- temporal
+- knowledge
+- continuity
+- character
+
+For `historical_plausibility_check`, the load-bearing layers are:
+
+- institutional
+- temporal
+- logistical
+- political
+
+### Missing Layer Rule
+
+If a load-bearing layer is missing:
+
+- record it in `missing_layers`
+- lower confidence
+- avoid strong verdicts
+- provide a smallest-fix recommendation
+
+Do not silently fill missing layers with rich invention.
+
+## Allowed Operator Set
+
+Use only these operators in phase one:
+
+1. `motive_inference`
+2. `knowledge_propagation`
+3. `setup_sufficiency_check`
+4. `temporal_sequencing`
+5. `plausibility_envelope_check`
+
+### Operator Intent
+
+- `motive_inference`: check whether stated or minimally implied motives align with or resist the proposal.
+- `knowledge_propagation`: check whether what the actor knows makes the proposal stronger or weaker.
+- `setup_sufficiency_check`: detect whether the proposal needs one more setup beat rather than a full contradiction.
+- `temporal_sequencing`: detect timeline compression, order conflicts, and same-night or same-day continuity stress.
+- `plausibility_envelope_check`: detect hard logistical or institutional impossibilities in the setting as stated.
+
+## Verdict Logic
+
+Use this verdict set only:
+
+- `supported`
+- `plausible`
+- `possible_with_setup`
+- `strained`
+- `contradictory`
+
+### Mapping Rules
+
+Return `supported` when the proposal has direct support and no meaningful blockers.
+
+Return `plausible` when support exists and resistance is limited, but certainty is not absolute.
+
+Return `possible_with_setup` when the move could work but needs one or more explicit bridge beats, missing motivations, or added setup.
+
+Return `strained` when no hard block exists, but the move currently fights continuity, knowledge, or character logic.
+
+Return `contradictory` when the move fails against a hard physical, temporal, communication, continuity, or declared-fact block.
+
+## Response Contract
+
+### Supported Response Shape
+
+Return exactly this object shape:
+
+```json
+{
+  "supported_in_phase_one": true,
+  "task_kind": "character_action_audit | next_event_continuity_check | historical_plausibility_check",
+  "summary": "string",
+  "verdict": "supported | plausible | possible_with_setup | strained | contradictory",
+  "main_supports": ["string"],
+  "main_blockers": ["string"],
+  "missing_bridges": ["string"],
+  "smallest_fix": ["string"],
+  "confidence": 0.0,
+  "active_layers": ["string"],
+  "missing_layers": ["string"],
+  "selected_operators": ["string"]
+}
+```
+
+### Unsupported Response Shape
+
+Return exactly this object shape:
+
+```json
+{
+  "supported_in_phase_one": false,
+  "task_kind": "unsupported",
+  "summary": "Phase one only supports the three validation tasks.",
+  "verdict": null,
+  "main_supports": [],
+  "main_blockers": [],
+  "missing_bridges": [],
+  "smallest_fix": ["Reframe the request as one of the supported validation tasks."],
+  "confidence": 0.2,
+  "active_layers": [],
+  "missing_layers": [],
+  "selected_operators": []
+}
+```
+
+## Behavioral Guardrails
+
+Do not do any of the following:
+
+- do not write scenes
+- do not generate alternate branches
+- do not expand the world
+- do not claim symbolism is fully supported from a single image
+- do not upgrade low-confidence inference into confident prose
+- do not hide missing motive, timing, or logistics
+- do not soften hard contradictions into vague plausibility language
+- do not treat the proposal as if it already happened
+
+## Golden Cases
+
+These examples are behavioral anchors.
+
+### Character Action Audit
+
+Input pattern:
+
+- Mara must choose between Teren and the rebellion signal.
+- Strong duty pressure exists.
+- Strong protective motive conflict exists.
+
+Expected verdict:
+
+```json
+{
+  "task_kind": "character_action_audit",
+  "verdict": "possible_with_setup"
+}
+```
+
+### Next-Event Continuity Check
+
+Input pattern:
+
+- detective learns suspect is innocent
+- same-night public accusation is proposed
+
+Expected verdict:
+
+```json
+{
+  "task_kind": "next_event_continuity_check",
+  "verdict": "strained"
+}
+```
+
+### Historical Plausibility Check
+
+Input pattern:
+
+- pre-telegraph queen
+- same-day crackdown
+- six distant cities
+
+Expected verdict:
+
+```json
+{
+  "task_kind": "historical_plausibility_check",
+  "verdict": "contradictory"
+}
+```
+
+## Activation Line
+
+If the target platform supports a short activation string, use:
+
+```text
+Activate the Validation-First Narrative Engine. Restrict behavior to character action audit, next-event continuity check, and historical plausibility check. Return machine-readable audit objects only.
+```
+
+## Completion Rule
+
+When this module is active, the model should behave like a **narrative audit engine**, not a writer.
+
+If forced to choose between elegance and structural honesty, choose structural honesty.

--- a/src/aurora/engines/__init__.py
+++ b/src/aurora/engines/__init__.py
@@ -1,0 +1,3 @@
+from .narrative import NarrativeValidationEngine
+
+__all__ = ["NarrativeValidationEngine"]

--- a/src/aurora/engines/narrative/__init__.py
+++ b/src/aurora/engines/narrative/__init__.py
@@ -1,0 +1,23 @@
+from .engine import NarrativeValidationEngine
+from .types import (
+    CanonicalState,
+    EvaluationPacket,
+    NarrativeValidationRun,
+    NormalizedTaskRequest,
+    ResponsePayload,
+    Strictness,
+    TaskKind,
+    Verdict,
+)
+
+__all__ = [
+    "CanonicalState",
+    "EvaluationPacket",
+    "NarrativeValidationEngine",
+    "NarrativeValidationRun",
+    "NormalizedTaskRequest",
+    "ResponsePayload",
+    "Strictness",
+    "TaskKind",
+    "Verdict",
+]

--- a/src/aurora/engines/narrative/engine.py
+++ b/src/aurora/engines/narrative/engine.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .layer_resolver import resolve_layers
+from .operators import run_operator_suite
+from .renderer import compact_response, finalize_evaluation
+from .router import build_request
+from .state_builder import build_canonical_state
+from .types import EvaluationPacket, NarrativeValidationRun, ResponsePayload
+from .validator import build_response_payload
+
+
+class NarrativeValidationEngine:
+    """Deterministic validation-first narrative reasoning engine for phase one."""
+
+    def run(
+        self,
+        raw_input: str | Mapping[str, Any],
+        proposal: Mapping[str, Any] | None = None,
+        strictness: str = "default",
+    ) -> NarrativeValidationRun:
+        request, payload, normalized_proposal = build_request(raw_input, proposal, strictness)
+        state = build_canonical_state(payload, request, normalized_proposal)
+
+        if not request.supported_in_phase_one:
+            response = compact_response(build_response_payload(request, EvaluationPacket()))
+            return NarrativeValidationRun(
+                request=request,
+                state=state,
+                evaluation=EvaluationPacket(),
+                response=response,
+            )
+
+        evaluation = resolve_layers(state, request)
+        operator_results = run_operator_suite(state, request, normalized_proposal)
+        evaluation.supports.extend(operator_results["supports"])
+        evaluation.soft_blocks.extend(operator_results["soft_blocks"])
+        evaluation.hard_blocks.extend(operator_results["hard_blocks"])
+        evaluation.missing_bridges.extend(operator_results["missing_bridges"])
+        evaluation.confidence_notes.extend(operator_results["confidence_notes"])
+        evaluation.missing_bridges.extend(_bridges_for_missing_layers(evaluation.missing_layers))
+        evaluation = finalize_evaluation(evaluation)
+
+        response = compact_response(build_response_payload(request, evaluation))
+        return NarrativeValidationRun(
+            request=request,
+            state=state,
+            evaluation=evaluation,
+            response=response,
+        )
+
+
+def _bridges_for_missing_layers(missing_layers: list[str]) -> list[str]:
+    guidance = []
+    for layer in missing_layers:
+        if layer == "motive":
+            guidance.append("Supply motive or pressure data for the acting character.")
+        elif layer == "knowledge":
+            guidance.append("State what the key actor knows before judging the move.")
+        elif layer == "temporal":
+            guidance.append("State the timing between the established event and the proposal.")
+        elif layer == "logistical":
+            guidance.append("Add communications or transport constraints for the setting.")
+        elif layer == "political":
+            guidance.append("Add institutional or political pressure shaping the decision.")
+        else:
+            guidance.append(f"Add evidence for the missing layer: {layer}.")
+    return guidance

--- a/src/aurora/engines/narrative/layer_resolver.py
+++ b/src/aurora/engines/narrative/layer_resolver.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from .types import CanonicalState, EvaluationPacket, NormalizedTaskRequest, TaskKind
+
+REQUIRED_LAYERS = {
+    TaskKind.CHARACTER_ACTION_AUDIT: ["character", "motive", "event", "knowledge", "continuity"],
+    TaskKind.NEXT_EVENT_CONTINUITY_CHECK: ["event", "temporal", "knowledge", "continuity", "character"],
+    TaskKind.HISTORICAL_PLAUSIBILITY_CHECK: ["institutional", "temporal", "logistical", "political"],
+}
+
+SELECTED_OPERATORS = {
+    TaskKind.CHARACTER_ACTION_AUDIT: [
+        "motive_inference",
+        "knowledge_propagation",
+        "setup_sufficiency_check",
+    ],
+    TaskKind.NEXT_EVENT_CONTINUITY_CHECK: [
+        "knowledge_propagation",
+        "temporal_sequencing",
+        "setup_sufficiency_check",
+    ],
+    TaskKind.HISTORICAL_PLAUSIBILITY_CHECK: [
+        "temporal_sequencing",
+        "plausibility_envelope_check",
+        "setup_sufficiency_check",
+    ],
+}
+
+
+def resolve_layers(state: CanonicalState, request: NormalizedTaskRequest) -> EvaluationPacket:
+    available_layers = {layer.name: layer for layer in state.layers if layer.status == "available"}
+    required_layers = REQUIRED_LAYERS.get(request.task_kind, [])
+    active_layers = [layer for layer in required_layers if layer in available_layers]
+    missing_layers = [layer for layer in required_layers if layer not in available_layers]
+    confidence_notes = []
+    for layer_name in active_layers:
+        layer_record = available_layers[layer_name]
+        if layer_record.origin == "inferred":
+            confidence_notes.append(f"{layer_name} layer is inferred rather than directly supported.")
+    if missing_layers:
+        confidence_notes.append(
+            "Missing load-bearing layers: " + ", ".join(missing_layers)
+        )
+
+    return EvaluationPacket(
+        active_layers=active_layers,
+        missing_layers=missing_layers,
+        selected_operators=SELECTED_OPERATORS.get(request.task_kind, []),
+        confidence_notes=confidence_notes,
+    )

--- a/src/aurora/engines/narrative/operators.py
+++ b/src/aurora/engines/narrative/operators.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .types import CanonicalState, NormalizedTaskRequest, TaskKind
+
+
+def run_operator_suite(
+    state: CanonicalState,
+    request: NormalizedTaskRequest,
+    proposal: Mapping[str, Any],
+) -> dict[str, list[str]]:
+    results = {
+        "supports": [],
+        "soft_blocks": [],
+        "hard_blocks": [],
+        "missing_bridges": [],
+        "confidence_notes": [],
+    }
+    for operator in (
+        motive_inference(state, request, proposal),
+        knowledge_propagation(state, request, proposal),
+        temporal_sequencing(state, request, proposal),
+        plausibility_envelope_check(state, request, proposal),
+        setup_sufficiency_check(state, request, proposal),
+    ):
+        for key, values in operator.items():
+            results[key].extend(values)
+    return results
+
+
+def motive_inference(
+    state: CanonicalState,
+    request: NormalizedTaskRequest,
+    proposal: Mapping[str, Any],
+) -> dict[str, list[str]]:
+    if request.task_kind != TaskKind.CHARACTER_ACTION_AUDIT:
+        return _empty_result()
+
+    actor = str(proposal.get("actor", "")).casefold()
+    action_text = _proposal_text(proposal)
+    supports: list[str] = []
+    soft_blocks: list[str] = []
+    confidence_notes: list[str] = []
+
+    for motive in state.motives:
+        if actor and motive.actor.casefold() != actor:
+            continue
+        label = motive.label.lower()
+        if any(token in label for token in ("rebellion", "mission", "duty")) and any(
+            token in action_text for token in ("rebellion", "signal", "save")
+        ):
+            supports.append(f"{motive.actor}'s motive '{motive.label}' aligns with the proposed action.")
+        if any(token in label for token in ("protect", "loyalty", "trust")) and any(
+            token in action_text for token in ("abandon", "betray", "accuse")
+        ):
+            soft_blocks.append(f"{motive.actor}'s motive '{motive.label}' resists the proposed action.")
+        if motive.inferred:
+            confidence_notes.append(f"Motive '{motive.label}' is inferred at low confidence.")
+
+    for pressure in state.pressures:
+        if actor and pressure.actor.casefold() != actor:
+            continue
+        message = f"{pressure.actor}'s pressure '{pressure.label}' pulls {pressure.direction} the move."
+        if pressure.direction.lower() == "toward":
+            supports.append(message)
+        else:
+            soft_blocks.append(message)
+
+    return {
+        "supports": supports,
+        "soft_blocks": soft_blocks,
+        "hard_blocks": [],
+        "missing_bridges": [],
+        "confidence_notes": confidence_notes,
+    }
+
+
+def knowledge_propagation(
+    state: CanonicalState,
+    request: NormalizedTaskRequest,
+    proposal: Mapping[str, Any],
+) -> dict[str, list[str]]:
+    if request.task_kind not in {
+        TaskKind.CHARACTER_ACTION_AUDIT,
+        TaskKind.NEXT_EVENT_CONTINUITY_CHECK,
+    }:
+        return _empty_result()
+
+    action_text = _proposal_text(proposal)
+    soft_blocks: list[str] = []
+    supports: list[str] = []
+    for knowledge_state in state.knowledge_states:
+        fact = knowledge_state.fact.lower()
+        if "innocent" in fact and "accuse" in action_text:
+            soft_blocks.append(
+                f"{knowledge_state.holder} knows the suspect is innocent, so the accusation fights knowledge continuity."
+            )
+        elif "collapse" in fact and any(token in action_text for token in ("save", "deliver", "signal")):
+            supports.append(
+                f"{knowledge_state.holder}'s knowledge that delay will cause collapse supports urgent action."
+            )
+    return {
+        "supports": supports,
+        "soft_blocks": soft_blocks,
+        "hard_blocks": [],
+        "missing_bridges": [],
+        "confidence_notes": [],
+    }
+
+
+def temporal_sequencing(
+    state: CanonicalState,
+    request: NormalizedTaskRequest,
+    proposal: Mapping[str, Any],
+) -> dict[str, list[str]]:
+    soft_blocks: list[str] = []
+    hard_blocks: list[str] = []
+    missing_bridges: list[str] = []
+    action_text = _proposal_text(proposal)
+    timing = str(proposal.get("timing", "")).lower()
+
+    if request.task_kind == TaskKind.NEXT_EVENT_CONTINUITY_CHECK:
+        if "same_night" in timing or "same night" in action_text:
+            soft_blocks.append("The proposed beat compresses the timeline before a visible turn can occur.")
+            missing_bridges.append(
+                "Insert coercion, misdirection, or a clear breakdown before the same-night accusation."
+            )
+
+    if request.task_kind == TaskKind.HISTORICAL_PLAUSIBILITY_CHECK:
+        question = request.user_query.lower()
+        has_pretelegraph_context = "pre-telegraph" in question or any(
+            "telegraph" in constraint.label.lower() or "courier" in constraint.label.lower()
+            for constraint in state.constraints
+        )
+        if has_pretelegraph_context and "same_day" in timing:
+            hard_blocks.append("Same-day coordination fails the communications timeline in a pre-telegraph setting.")
+
+    return {
+        "supports": [],
+        "soft_blocks": soft_blocks,
+        "hard_blocks": hard_blocks,
+        "missing_bridges": missing_bridges,
+        "confidence_notes": [],
+    }
+
+
+def plausibility_envelope_check(
+    state: CanonicalState,
+    request: NormalizedTaskRequest,
+    proposal: Mapping[str, Any],
+) -> dict[str, list[str]]:
+    if request.task_kind != TaskKind.HISTORICAL_PLAUSIBILITY_CHECK:
+        return _empty_result()
+
+    hard_blocks: list[str] = []
+    missing_bridges: list[str] = []
+    for constraint in state.constraints:
+        label = constraint.label.lower()
+        if constraint.severity.lower() == "hard" and any(
+            token in label for token in ("days apart", "no telegraph", "distant cities", "courier")
+        ):
+            hard_blocks.append(f"Constraint '{constraint.label}' blocks the event as stated.")
+    if hard_blocks:
+        missing_bridges.append(
+            "Reframe the crackdown as pre-coordinated orders, delegated triggers, or staggered action."
+        )
+    return {
+        "supports": [],
+        "soft_blocks": [],
+        "hard_blocks": hard_blocks,
+        "missing_bridges": missing_bridges,
+        "confidence_notes": [],
+    }
+
+
+def setup_sufficiency_check(
+    state: CanonicalState,
+    request: NormalizedTaskRequest,
+    proposal: Mapping[str, Any],
+) -> dict[str, list[str]]:
+    missing_bridges: list[str] = []
+    confidence_notes: list[str] = []
+    if request.task_kind == TaskKind.CHARACTER_ACTION_AUDIT and state.motives and state.pressures:
+        if any(pressure.direction.lower() == "against" for pressure in state.pressures):
+            missing_bridges.append(
+                "Add a catalyst showing why mission pressure overrides personal loyalty in this moment."
+            )
+    if request.task_kind == TaskKind.CHARACTER_ACTION_AUDIT and not state.motives:
+        missing_bridges.append("Supply motive or pressure data for the acting character.")
+    if request.task_kind == TaskKind.NEXT_EVENT_CONTINUITY_CHECK and not state.knowledge_states:
+        missing_bridges.append("State what the key actors know before the next beat.")
+    if request.task_kind == TaskKind.HISTORICAL_PLAUSIBILITY_CHECK and not state.constraints:
+        confidence_notes.append("Historical plausibility is running without explicit logistical constraints.")
+    return {
+        "supports": [],
+        "soft_blocks": [],
+        "hard_blocks": [],
+        "missing_bridges": missing_bridges,
+        "confidence_notes": confidence_notes,
+    }
+
+
+def _proposal_text(proposal: Mapping[str, Any]) -> str:
+    parts = [str(proposal.get("label", "")), str(proposal.get("action", "")), str(proposal.get("timing", ""))]
+    return " ".join(part for part in parts if part).lower()
+
+
+def _empty_result() -> dict[str, list[str]]:
+    return {
+        "supports": [],
+        "soft_blocks": [],
+        "hard_blocks": [],
+        "missing_bridges": [],
+        "confidence_notes": [],
+    }

--- a/src/aurora/engines/narrative/operators.py
+++ b/src/aurora/engines/narrative/operators.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from .types import CanonicalState, NormalizedTaskRequest, TaskKind
+from .types import CanonicalState, MotiveRecord, NormalizedTaskRequest, PressureRecord, TaskKind
+
+_SUPPORT_MOTIVE_LABELS = ("rebellion", "mission", "duty")
+_SUPPORT_ACTION_TOKENS = ("rebellion", "signal", "save")
+_RESISTANCE_MOTIVE_LABELS = ("protect", "loyalty", "trust")
+_RESISTANCE_ACTION_TOKENS = ("abandon", "betray", "accuse")
 
 
 def run_operator_suite(
@@ -21,8 +26,8 @@ def run_operator_suite(
         motive_inference(state, request, proposal),
         knowledge_propagation(state, request, proposal),
         temporal_sequencing(state, request, proposal),
-        plausibility_envelope_check(state, request, proposal),
-        setup_sufficiency_check(state, request, proposal),
+        plausibility_envelope_check(state, request),
+        setup_sufficiency_check(state, request),
     ):
         for key, values in operator.items():
             results[key].extend(values)
@@ -39,41 +44,22 @@ def motive_inference(
 
     actor = str(proposal.get("actor", "")).casefold()
     action_text = _proposal_text(proposal)
-    supports: list[str] = []
-    soft_blocks: list[str] = []
-    confidence_notes: list[str] = []
+    results = _empty_result()
 
     for motive in state.motives:
-        if actor and motive.actor.casefold() != actor:
+        if not _actor_matches(actor, motive.actor):
             continue
-        label = motive.label.lower()
-        if any(token in label for token in ("rebellion", "mission", "duty")) and any(
-            token in action_text for token in ("rebellion", "signal", "save")
-        ):
-            supports.append(f"{motive.actor}'s motive '{motive.label}' aligns with the proposed action.")
-        if any(token in label for token in ("protect", "loyalty", "trust")) and any(
-            token in action_text for token in ("abandon", "betray", "accuse")
-        ):
-            soft_blocks.append(f"{motive.actor}'s motive '{motive.label}' resists the proposed action.")
-        if motive.inferred:
-            confidence_notes.append(f"Motive '{motive.label}' is inferred at low confidence.")
+        motive_result = _evaluate_motive(motive, action_text)
+        for key, values in motive_result.items():
+            results[key].extend(values)
 
     for pressure in state.pressures:
-        if actor and pressure.actor.casefold() != actor:
+        if not _actor_matches(actor, pressure.actor):
             continue
-        message = f"{pressure.actor}'s pressure '{pressure.label}' pulls {pressure.direction} the move."
-        if pressure.direction.lower() == "toward":
-            supports.append(message)
-        else:
-            soft_blocks.append(message)
+        key, message = _evaluate_pressure(pressure)
+        results[key].append(message)
 
-    return {
-        "supports": supports,
-        "soft_blocks": soft_blocks,
-        "hard_blocks": [],
-        "missing_bridges": [],
-        "confidence_notes": confidence_notes,
-    }
+    return results
 
 
 def knowledge_propagation(
@@ -94,7 +80,8 @@ def knowledge_propagation(
         fact = knowledge_state.fact.lower()
         if "innocent" in fact and "accuse" in action_text:
             soft_blocks.append(
-                f"{knowledge_state.holder} knows the suspect is innocent, so the accusation fights knowledge continuity."
+                f"{knowledge_state.holder} knows the suspect is innocent, so the accusation fights "
+                "knowledge continuity."
             )
         elif "collapse" in fact and any(token in action_text for token in ("save", "deliver", "signal")):
             supports.append(
@@ -148,7 +135,6 @@ def temporal_sequencing(
 def plausibility_envelope_check(
     state: CanonicalState,
     request: NormalizedTaskRequest,
-    proposal: Mapping[str, Any],
 ) -> dict[str, list[str]]:
     if request.task_kind != TaskKind.HISTORICAL_PLAUSIBILITY_CHECK:
         return _empty_result()
@@ -177,7 +163,6 @@ def plausibility_envelope_check(
 def setup_sufficiency_check(
     state: CanonicalState,
     request: NormalizedTaskRequest,
-    proposal: Mapping[str, Any],
 ) -> dict[str, list[str]]:
     missing_bridges: list[str] = []
     confidence_notes: list[str] = []
@@ -202,8 +187,43 @@ def setup_sufficiency_check(
 
 
 def _proposal_text(proposal: Mapping[str, Any]) -> str:
-    parts = [str(proposal.get("label", "")), str(proposal.get("action", "")), str(proposal.get("timing", ""))]
+    parts = [
+        str(proposal.get("label", "")),
+        str(proposal.get("action", "")),
+        str(proposal.get("timing", "")),
+    ]
     return " ".join(part for part in parts if part).lower()
+
+
+def _actor_matches(actor: str, subject: str) -> bool:
+    return not actor or subject.casefold() == actor
+
+
+def _has_any(text: str, tokens: tuple[str, ...]) -> bool:
+    return any(token in text for token in tokens)
+
+
+def _evaluate_motive(motive: MotiveRecord, action_text: str) -> dict[str, list[str]]:
+    label = motive.label.lower()
+    result = _empty_result()
+    if _has_any(label, _SUPPORT_MOTIVE_LABELS) and _has_any(action_text, _SUPPORT_ACTION_TOKENS):
+        result["supports"].append(
+            f"{motive.actor}'s motive '{motive.label}' aligns with the proposed action."
+        )
+    if _has_any(label, _RESISTANCE_MOTIVE_LABELS) and _has_any(action_text, _RESISTANCE_ACTION_TOKENS):
+        result["soft_blocks"].append(
+            f"{motive.actor}'s motive '{motive.label}' resists the proposed action."
+        )
+    if motive.inferred:
+        result["confidence_notes"].append(f"Motive '{motive.label}' is inferred at low confidence.")
+    return result
+
+
+def _evaluate_pressure(pressure: PressureRecord) -> tuple[str, str]:
+    message = f"{pressure.actor}'s pressure '{pressure.label}' pulls {pressure.direction} the move."
+    if pressure.direction.lower() == "toward":
+        return "supports", message
+    return "soft_blocks", message
 
 
 def _empty_result() -> dict[str, list[str]]:

--- a/src/aurora/engines/narrative/renderer.py
+++ b/src/aurora/engines/narrative/renderer.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from .types import EvaluationPacket, ResponsePayload
+
+
+def finalize_evaluation(packet: EvaluationPacket) -> EvaluationPacket:
+    packet.blocks = packet.hard_blocks + packet.soft_blocks
+    packet.supports = _dedupe(packet.supports)
+    packet.blocks = _dedupe(packet.blocks)
+    packet.missing_bridges = _dedupe(packet.missing_bridges)
+    packet.confidence_notes = _dedupe(packet.confidence_notes)
+    return packet
+
+
+def compact_response(response: ResponsePayload) -> ResponsePayload:
+    return ResponsePayload(
+        summary=response.summary.strip(),
+        verdict=response.verdict,
+        main_supports=_dedupe(response.main_supports),
+        main_blockers=_dedupe(response.main_blockers),
+        missing_bridges=_dedupe(response.missing_bridges),
+        smallest_fix=_dedupe(response.smallest_fix),
+        confidence=response.confidence,
+        supported_in_phase_one=response.supported_in_phase_one,
+        unsupported_reason=response.unsupported_reason,
+    )
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item not in seen:
+            ordered.append(item)
+            seen.add(item)
+    return ordered

--- a/src/aurora/engines/narrative/router.py
+++ b/src/aurora/engines/narrative/router.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .types import NormalizedTaskRequest, Strictness, TaskKind
+
+SUPPORTED_TASKS = {
+    TaskKind.CHARACTER_ACTION_AUDIT,
+    TaskKind.NEXT_EVENT_CONTINUITY_CHECK,
+    TaskKind.HISTORICAL_PLAUSIBILITY_CHECK,
+}
+
+_TASK_HINT_MAP = {
+    "character_action_audit": TaskKind.CHARACTER_ACTION_AUDIT,
+    "character_action": TaskKind.CHARACTER_ACTION_AUDIT,
+    "next_event_continuity_check": TaskKind.NEXT_EVENT_CONTINUITY_CHECK,
+    "next_event": TaskKind.NEXT_EVENT_CONTINUITY_CHECK,
+    "historical_plausibility_check": TaskKind.HISTORICAL_PLAUSIBILITY_CHECK,
+    "historical_plausibility": TaskKind.HISTORICAL_PLAUSIBILITY_CHECK,
+    "expansion": TaskKind.EXPANSION,
+    "translation": TaskKind.TRANSLATION,
+}
+
+
+def normalize_input(raw_input: str | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(raw_input, str):
+        return {"question": raw_input, "raw_text": raw_input}
+    return dict(raw_input)
+
+
+def normalize_proposal(payload: Mapping[str, Any], proposal: Mapping[str, Any] | None) -> dict[str, Any]:
+    normalized = dict(payload.get("proposal", {}))
+    if proposal is not None:
+        normalized.update(dict(proposal))
+    return normalized
+
+
+def build_request(
+    raw_input: str | Mapping[str, Any],
+    proposal: Mapping[str, Any] | None,
+    strictness: str | Strictness = Strictness.DEFAULT,
+) -> tuple[NormalizedTaskRequest, dict[str, Any], dict[str, Any]]:
+    payload = normalize_input(raw_input)
+    normalized_proposal = normalize_proposal(payload, proposal)
+    strictness_value = _normalize_strictness(strictness)
+    task_kind, unsupported_reason = _classify_task(payload, normalized_proposal)
+    supported_in_phase_one = task_kind in SUPPORTED_TASKS
+    task_type = "validate" if task_kind in SUPPORTED_TASKS or task_kind == TaskKind.UNSUPPORTED else task_kind.value
+
+    request = NormalizedTaskRequest(
+        task_kind=task_kind,
+        proposal_present=bool(normalized_proposal),
+        strictness=strictness_value,
+        task_type=task_type,
+        input_kind="text" if isinstance(raw_input, str) else "mapping",
+        user_query=_extract_question(payload),
+        supported_in_phase_one=supported_in_phase_one,
+        unsupported_reason=unsupported_reason,
+    )
+    return request, payload, normalized_proposal
+
+
+def _normalize_strictness(strictness: str | Strictness) -> Strictness:
+    if isinstance(strictness, Strictness):
+        return strictness
+    normalized = strictness.strip().lower()
+    if normalized == Strictness.LENIENT.value:
+        return Strictness.LENIENT
+    if normalized == Strictness.STRICT.value:
+        return Strictness.STRICT
+    return Strictness.DEFAULT
+
+
+def _extract_question(payload: Mapping[str, Any]) -> str:
+    for key in ("question", "query", "prompt", "raw_text"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _classify_task(payload: Mapping[str, Any], proposal: Mapping[str, Any]) -> tuple[TaskKind, str | None]:
+    hint = str(payload.get("task_hint") or payload.get("task_kind") or "").strip().lower().replace(" ", "_")
+    if hint in _TASK_HINT_MAP:
+        task_kind = _TASK_HINT_MAP[hint]
+        return task_kind, _unsupported_reason(task_kind)
+
+    question = _extract_question(payload).lower()
+    if not question and proposal:
+        if proposal.get("timing"):
+            return TaskKind.NEXT_EVENT_CONTINUITY_CHECK, None
+        if proposal.get("actor"):
+            return TaskKind.CHARACTER_ACTION_AUDIT, None
+
+    if any(token in question for token in ("translate", "convert this into", "structural translation")):
+        return TaskKind.TRANSLATION, _unsupported_reason(TaskKind.TRANSLATION)
+    if any(token in question for token in ("expand this", "what myths", "what civilization", "fork in the road")):
+        return TaskKind.EXPANSION, _unsupported_reason(TaskKind.EXPANSION)
+    if "symbolize" in question or "symbolic fit" in question:
+        return TaskKind.UNSUPPORTED, "Phase one does not implement symbolic-fit audits."
+    if any(token in question for token in ("historical", "pre-telegraph", "as stated", "plausible in the setting")):
+        return TaskKind.HISTORICAL_PLAUSIBILITY_CHECK, None
+    if any(token in question for token in ("next beat", "next scene", "happen next", "same night")):
+        return TaskKind.NEXT_EVENT_CONTINUITY_CHECK, None
+    if any(token in question for token in ("would", "really do this", "make sense for")) and proposal.get("actor"):
+        return TaskKind.CHARACTER_ACTION_AUDIT, None
+    if question.endswith("?") and proposal.get("actor"):
+        return TaskKind.CHARACTER_ACTION_AUDIT, None
+    if question:
+        return TaskKind.UNSUPPORTED, "Phase one only supports three validation tasks."
+    return TaskKind.UNSUPPORTED, "Phase one only supports three validation tasks."
+
+
+def _unsupported_reason(task_kind: TaskKind) -> str | None:
+    if task_kind == TaskKind.EXPANSION:
+        return "Phase one intentionally excludes expansion mode."
+    if task_kind == TaskKind.TRANSLATION:
+        return "Phase one intentionally excludes translation mode."
+    if task_kind == TaskKind.UNSUPPORTED:
+        return "Phase one only supports three validation tasks."
+    return None

--- a/src/aurora/engines/narrative/router.py
+++ b/src/aurora/engines/narrative/router.py
@@ -20,6 +20,11 @@ _TASK_HINT_MAP = {
     "expansion": TaskKind.EXPANSION,
     "translation": TaskKind.TRANSLATION,
 }
+_PHASE_ONE_UNSUPPORTED_REASON = "Phase one only supports three validation tasks."
+_TRANSLATION_TOKENS = ("translate", "convert this into", "structural translation")
+_EXPANSION_TOKENS = ("expand this", "what myths", "what civilization", "fork in the road")
+_HISTORICAL_TOKENS = ("historical", "pre-telegraph", "as stated", "plausible in the setting")
+_NEXT_EVENT_TOKENS = ("next beat", "next scene", "happen next", "same night")
 
 
 def normalize_input(raw_input: str | Mapping[str, Any]) -> dict[str, Any]:
@@ -80,35 +85,53 @@ def _extract_question(payload: Mapping[str, Any]) -> str:
 
 
 def _classify_task(payload: Mapping[str, Any], proposal: Mapping[str, Any]) -> tuple[TaskKind, str | None]:
-    hint = str(payload.get("task_hint") or payload.get("task_kind") or "").strip().lower().replace(" ", "_")
-    if hint in _TASK_HINT_MAP:
-        task_kind = _TASK_HINT_MAP[hint]
+    task_kind = _task_from_hint(payload)
+    if task_kind is not None:
         return task_kind, _unsupported_reason(task_kind)
 
     question = _extract_question(payload).lower()
-    if not question and proposal:
-        if proposal.get("timing"):
-            return TaskKind.NEXT_EVENT_CONTINUITY_CHECK, None
-        if proposal.get("actor"):
-            return TaskKind.CHARACTER_ACTION_AUDIT, None
+    proposal_task = _task_from_proposal(question, proposal)
+    if proposal_task is not None:
+        return proposal_task, None
 
-    if any(token in question for token in ("translate", "convert this into", "structural translation")):
+    return _classify_question(question, proposal)
+
+
+def _task_from_hint(payload: Mapping[str, Any]) -> TaskKind | None:
+    hint = str(payload.get("task_hint") or payload.get("task_kind") or "").strip().lower().replace(" ", "_")
+    return _TASK_HINT_MAP.get(hint)
+
+
+def _task_from_proposal(question: str, proposal: Mapping[str, Any]) -> TaskKind | None:
+    if question or not proposal:
+        return None
+    if proposal.get("timing"):
+        return TaskKind.NEXT_EVENT_CONTINUITY_CHECK
+    if proposal.get("actor"):
+        return TaskKind.CHARACTER_ACTION_AUDIT
+    return None
+
+
+def _classify_question(question: str, proposal: Mapping[str, Any]) -> tuple[TaskKind, str | None]:
+    if _question_has_any(question, _TRANSLATION_TOKENS):
         return TaskKind.TRANSLATION, _unsupported_reason(TaskKind.TRANSLATION)
-    if any(token in question for token in ("expand this", "what myths", "what civilization", "fork in the road")):
+    if _question_has_any(question, _EXPANSION_TOKENS):
         return TaskKind.EXPANSION, _unsupported_reason(TaskKind.EXPANSION)
     if "symbolize" in question or "symbolic fit" in question:
         return TaskKind.UNSUPPORTED, "Phase one does not implement symbolic-fit audits."
-    if any(token in question for token in ("historical", "pre-telegraph", "as stated", "plausible in the setting")):
+    if _question_has_any(question, _HISTORICAL_TOKENS):
         return TaskKind.HISTORICAL_PLAUSIBILITY_CHECK, None
-    if any(token in question for token in ("next beat", "next scene", "happen next", "same night")):
+    if _question_has_any(question, _NEXT_EVENT_TOKENS):
         return TaskKind.NEXT_EVENT_CONTINUITY_CHECK, None
     if any(token in question for token in ("would", "really do this", "make sense for")) and proposal.get("actor"):
         return TaskKind.CHARACTER_ACTION_AUDIT, None
     if question.endswith("?") and proposal.get("actor"):
         return TaskKind.CHARACTER_ACTION_AUDIT, None
-    if question:
-        return TaskKind.UNSUPPORTED, "Phase one only supports three validation tasks."
-    return TaskKind.UNSUPPORTED, "Phase one only supports three validation tasks."
+    return TaskKind.UNSUPPORTED, _PHASE_ONE_UNSUPPORTED_REASON
+
+
+def _question_has_any(question: str, tokens: tuple[str, ...]) -> bool:
+    return any(token in question for token in tokens)
 
 
 def _unsupported_reason(task_kind: TaskKind) -> str | None:
@@ -117,5 +140,5 @@ def _unsupported_reason(task_kind: TaskKind) -> str | None:
     if task_kind == TaskKind.TRANSLATION:
         return "Phase one intentionally excludes translation mode."
     if task_kind == TaskKind.UNSUPPORTED:
-        return "Phase one only supports three validation tasks."
+        return _PHASE_ONE_UNSUPPORTED_REASON
     return None

--- a/src/aurora/engines/narrative/state_builder.py
+++ b/src/aurora/engines/narrative/state_builder.py
@@ -294,7 +294,7 @@ def _collect_constraint_type_layer(layers: dict[str, LayerRecord], constraint_ty
     if constraint_type in _TEMPORAL_CONSTRAINT_TYPES:
         _upsert_layer(layers, "temporal", "recovered", 0.95)
     if constraint_type in _POLITICAL_CONSTRAINT_TYPES:
-        _upsert_layer(layers, constraint_type, "recovered", 0.9)
+        _upsert_layer(layers, "political", "recovered", 0.9)
 
 
 def _collect_question_layers(

--- a/src/aurora/engines/narrative/state_builder.py
+++ b/src/aurora/engines/narrative/state_builder.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from .types import (
+    CanonicalState,
+    ConstraintRecord,
+    EntityRecord,
+    EventRecord,
+    KnowledgeStateRecord,
+    LayerRecord,
+    MotiveRecord,
+    NormalizedTaskRequest,
+    PressureRecord,
+    TaskKind,
+    UncertaintyRecord,
+)
+
+_ORIGIN_PRECEDENCE = {"declared": 3, "recovered": 2, "inferred": 1}
+
+
+def build_canonical_state(
+    payload: Mapping[str, Any],
+    request: NormalizedTaskRequest,
+    proposal: Mapping[str, Any],
+) -> CanonicalState:
+    state = CanonicalState(
+        state_id=_stable_state_id(payload, proposal),
+        input_profile={
+            "evidence_density": _evidence_density(payload),
+            "input_kind": request.input_kind,
+            "question": request.user_query,
+        },
+        continuity=_normalize_continuity(payload.get("continuity")),
+        narrative_context={
+            "question": request.user_query,
+            "declared_layers": list(payload.get("declared_layers", [])),
+            "task_kind": request.task_kind.value,
+        },
+    )
+    state.entities = [_entity_from_mapping(item) for item in payload.get("entities", [])]
+    state.pressures = [_pressure_from_mapping(item) for item in payload.get("pressures", [])]
+    state.constraints = [_constraint_from_mapping(item) for item in payload.get("constraints", [])]
+    state.motives = [_motive_from_mapping(item) for item in payload.get("motives", [])]
+    state.events = [_event_from_mapping(item) for item in payload.get("events", [])]
+    state.knowledge_states = [_knowledge_from_mapping(item) for item in payload.get("knowledge_states", [])]
+    state.uncertainties = [_uncertainty_from_mapping(item) for item in payload.get("uncertainties", [])]
+
+    _append_proposal_event(state, proposal)
+    _infer_minimal_motives(state, proposal)
+    _ensure_sparse_uncertainty(state)
+    state.layers = _collect_layers(state, payload, request)
+    state.continuity.setdefault(
+        "established_events",
+        [event.label for event in state.events if event.status != "proposed"],
+    )
+    return state
+
+
+def _stable_state_id(payload: Mapping[str, Any], proposal: Mapping[str, Any]) -> str:
+    canonical = json.dumps({"payload": payload, "proposal": proposal}, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+
+
+def _evidence_density(payload: Mapping[str, Any]) -> str:
+    populated = 0
+    for key in ("entities", "events", "motives", "pressures", "constraints", "knowledge_states", "continuity"):
+        value = payload.get(key)
+        if value:
+            populated += 1
+    if populated <= 1:
+        return "minimal"
+    if populated <= 3:
+        return "sparse"
+    if populated <= 5:
+        return "moderate"
+    if populated <= 7:
+        return "rich"
+    return "dense"
+
+
+def _normalize_continuity(raw_continuity: Any) -> dict[str, Any]:
+    if isinstance(raw_continuity, Mapping):
+        return dict(raw_continuity)
+    return {}
+
+
+def _entity_from_mapping(item: Mapping[str, Any]) -> EntityRecord:
+    return EntityRecord(
+        name=str(item.get("name", "")),
+        entity_type=str(item.get("entity_type", "character")),
+        role=str(item.get("role", "")),
+        traits=list(item.get("traits", [])),
+        source=str(item.get("source", item.get("origin", "declared"))),
+        confidence=float(item.get("confidence", 1.0)),
+    )
+
+
+def _pressure_from_mapping(item: Mapping[str, Any]) -> PressureRecord:
+    return PressureRecord(
+        actor=str(item.get("actor", "")),
+        label=str(item.get("label", "")),
+        direction=str(item.get("direction", "toward")),
+        strength=float(item.get("strength", 0.5)),
+        source=str(item.get("source", item.get("origin", "declared"))),
+        confidence=float(item.get("confidence", 1.0)),
+    )
+
+
+def _constraint_from_mapping(item: Mapping[str, Any]) -> ConstraintRecord:
+    return ConstraintRecord(
+        label=str(item.get("label", "")),
+        constraint_type=str(item.get("constraint_type", "generic")),
+        severity=str(item.get("severity", "soft")),
+        details=str(item.get("details", "")),
+        source=str(item.get("source", item.get("origin", "declared"))),
+        confidence=float(item.get("confidence", 1.0)),
+    )
+
+
+def _motive_from_mapping(item: Mapping[str, Any]) -> MotiveRecord:
+    source = str(item.get("source", item.get("origin", "declared")))
+    return MotiveRecord(
+        actor=str(item.get("actor", "")),
+        label=str(item.get("label", "")),
+        strength=float(item.get("strength", 0.5)),
+        source=source,
+        confidence=float(item.get("confidence", 1.0)),
+        inferred=source == "inferred" or bool(item.get("inferred")),
+    )
+
+
+def _event_from_mapping(item: Mapping[str, Any]) -> EventRecord:
+    return EventRecord(
+        label=str(item.get("label", "")),
+        status=str(item.get("status", "established")),
+        timing=str(item.get("timing", "")),
+        participants=list(item.get("participants", [])),
+        source=str(item.get("source", item.get("origin", "declared"))),
+        confidence=float(item.get("confidence", 1.0)),
+        notes=list(item.get("notes", [])),
+    )
+
+
+def _knowledge_from_mapping(item: Mapping[str, Any]) -> KnowledgeStateRecord:
+    return KnowledgeStateRecord(
+        holder=str(item.get("holder", "")),
+        fact=str(item.get("fact", "")),
+        status=str(item.get("status", "knows")),
+        source=str(item.get("source", item.get("origin", "declared"))),
+        confidence=float(item.get("confidence", 1.0)),
+    )
+
+
+def _uncertainty_from_mapping(item: Mapping[str, Any]) -> UncertaintyRecord:
+    return UncertaintyRecord(
+        label=str(item.get("label", "")),
+        reason=str(item.get("reason", "")),
+        source=str(item.get("source", item.get("origin", "declared"))),
+        confidence=float(item.get("confidence", 1.0)),
+    )
+
+
+def _append_proposal_event(state: CanonicalState, proposal: Mapping[str, Any]) -> None:
+    if not proposal:
+        return
+    label = str(proposal.get("label") or proposal.get("action") or proposal.get("event") or "Proposed move")
+    state.events.append(
+        EventRecord(
+            label=label,
+            status="proposed",
+            timing=str(proposal.get("timing", "")),
+            participants=[str(proposal.get("actor", ""))] if proposal.get("actor") else [],
+            source="declared",
+            confidence=1.0,
+            notes=["proposal_preserved_as_provisional"],
+        )
+    )
+
+
+def _infer_minimal_motives(state: CanonicalState, proposal: Mapping[str, Any]) -> None:
+    if state.motives or not proposal:
+        return
+    actor = str(proposal.get("actor", ""))
+    if not actor:
+        return
+    candidate_pressures = [
+        pressure for pressure in state.pressures if pressure.actor.casefold() == actor.casefold() and pressure.strength >= 0.8
+    ]
+    for pressure in candidate_pressures:
+        state.motives.append(
+            MotiveRecord(
+                actor=actor,
+                label=pressure.label,
+                strength=max(0.4, pressure.strength - 0.2),
+                source="inferred",
+                confidence=0.55,
+                inferred=True,
+            )
+        )
+
+
+def _ensure_sparse_uncertainty(state: CanonicalState) -> None:
+    if any((state.entities, state.events, state.motives, state.knowledge_states, state.constraints, state.pressures)):
+        return
+    state.uncertainties.append(
+        UncertaintyRecord(
+            label="sparse_input",
+            reason="The input does not provide enough structured state for a full audit.",
+            source="recovered",
+            confidence=0.95,
+        )
+    )
+
+
+def _collect_layers(
+    state: CanonicalState,
+    payload: Mapping[str, Any],
+    request: NormalizedTaskRequest,
+) -> list[LayerRecord]:
+    layers: dict[str, LayerRecord] = {}
+    for declared in payload.get("declared_layers", []):
+        _upsert_layer(layers, str(declared), "declared", 1.0)
+    if any(entity.entity_type == "character" for entity in state.entities):
+        _upsert_layer(layers, "character", "recovered", 0.95)
+    if any(entity.entity_type in {"institution", "government", "city"} for entity in state.entities):
+        _upsert_layer(layers, "institutional", "recovered", 0.9)
+    if state.motives:
+        origin = "recovered" if any(not motive.inferred for motive in state.motives) else "inferred"
+        confidence = 0.9 if origin == "recovered" else 0.55
+        _upsert_layer(layers, "motive", origin, confidence)
+    if state.events:
+        _upsert_layer(layers, "event", "recovered", 0.95)
+    if state.knowledge_states:
+        _upsert_layer(layers, "knowledge", "recovered", 0.95)
+    if state.continuity:
+        _upsert_layer(layers, "continuity", "recovered", 0.95)
+    if state.pressures:
+        _upsert_layer(layers, "pressure", "recovered", 0.9)
+        if any("crown" in pressure.label.lower() or "government" in pressure.label.lower() for pressure in state.pressures):
+            _upsert_layer(layers, "political", "inferred", 0.65)
+    if state.constraints:
+        _upsert_layer(layers, "constraint", "recovered", 0.95)
+        for constraint in state.constraints:
+            constraint_type = constraint.constraint_type.lower()
+            if constraint_type in {"logistical", "communication"}:
+                _upsert_layer(layers, "logistical", "recovered", 0.95)
+            if constraint_type in {"temporal", "time"}:
+                _upsert_layer(layers, "temporal", "recovered", 0.95)
+            if constraint_type in {"political", "institutional"}:
+                _upsert_layer(layers, constraint_type, "recovered", 0.9)
+
+    question = request.user_query.lower()
+    if any(event.timing for event in state.events) or any(token in question for token in ("same night", "tonight", "next")):
+        _upsert_layer(layers, "temporal", "inferred", 0.7)
+    if request.task_kind == TaskKind.HISTORICAL_PLAUSIBILITY_CHECK and any(
+        token in question for token in ("pre-telegraph", "courier", "distant cities")
+    ):
+        _upsert_layer(layers, "logistical", "inferred", 0.75)
+
+    return sorted(layers.values(), key=lambda layer: layer.name)
+
+
+def _upsert_layer(layers: dict[str, LayerRecord], name: str, origin: str, confidence: float) -> None:
+    current = layers.get(name)
+    candidate = LayerRecord(name=name, origin=origin, confidence=confidence)
+    if current is None:
+        layers[name] = candidate
+        return
+    current_rank = _ORIGIN_PRECEDENCE.get(current.origin, 0)
+    candidate_rank = _ORIGIN_PRECEDENCE.get(origin, 0)
+    if candidate_rank > current_rank or (candidate_rank == current_rank and confidence > current.confidence):
+        layers[name] = candidate

--- a/src/aurora/engines/narrative/state_builder.py
+++ b/src/aurora/engines/narrative/state_builder.py
@@ -19,6 +19,12 @@ from .types import (
 )
 
 _ORIGIN_PRECEDENCE = {"declared": 3, "recovered": 2, "inferred": 1}
+_INSTITUTIONAL_ENTITY_TYPES = {"institution", "government", "city"}
+_LOGISTICAL_CONSTRAINT_TYPES = {"logistical", "communication"}
+_TEMPORAL_CONSTRAINT_TYPES = {"temporal", "time"}
+_POLITICAL_CONSTRAINT_TYPES = {"political", "institutional"}
+_TEMPORAL_QUESTION_TOKENS = ("same night", "tonight", "next")
+_LOGISTICAL_QUESTION_TOKENS = ("pre-telegraph", "courier", "distant cities")
 
 
 def build_canonical_state(
@@ -187,7 +193,9 @@ def _infer_minimal_motives(state: CanonicalState, proposal: Mapping[str, Any]) -
     if not actor:
         return
     candidate_pressures = [
-        pressure for pressure in state.pressures if pressure.actor.casefold() == actor.casefold() and pressure.strength >= 0.8
+        pressure
+        for pressure in state.pressures
+        if pressure.actor.casefold() == actor.casefold() and pressure.strength >= 0.8
     ]
     for pressure in candidate_pressures:
         state.motives.append(
@@ -221,16 +229,30 @@ def _collect_layers(
     request: NormalizedTaskRequest,
 ) -> list[LayerRecord]:
     layers: dict[str, LayerRecord] = {}
+    _collect_declared_layers(layers, payload)
+    _collect_entity_layers(layers, state)
+    _collect_state_layers(layers, state)
+    _collect_constraint_layers(layers, state)
+    _collect_question_layers(layers, state, request)
+
+    return sorted(layers.values(), key=lambda layer: layer.name)
+
+
+def _collect_declared_layers(layers: dict[str, LayerRecord], payload: Mapping[str, Any]) -> None:
     for declared in payload.get("declared_layers", []):
         _upsert_layer(layers, str(declared), "declared", 1.0)
+
+
+def _collect_entity_layers(layers: dict[str, LayerRecord], state: CanonicalState) -> None:
     if any(entity.entity_type == "character" for entity in state.entities):
         _upsert_layer(layers, "character", "recovered", 0.95)
-    if any(entity.entity_type in {"institution", "government", "city"} for entity in state.entities):
+    if any(entity.entity_type in _INSTITUTIONAL_ENTITY_TYPES for entity in state.entities):
         _upsert_layer(layers, "institutional", "recovered", 0.9)
+
+
+def _collect_state_layers(layers: dict[str, LayerRecord], state: CanonicalState) -> None:
     if state.motives:
-        origin = "recovered" if any(not motive.inferred for motive in state.motives) else "inferred"
-        confidence = 0.9 if origin == "recovered" else 0.55
-        _upsert_layer(layers, "motive", origin, confidence)
+        _collect_motive_layer(layers, state)
     if state.events:
         _upsert_layer(layers, "event", "recovered", 0.95)
     if state.knowledge_states:
@@ -238,29 +260,60 @@ def _collect_layers(
     if state.continuity:
         _upsert_layer(layers, "continuity", "recovered", 0.95)
     if state.pressures:
-        _upsert_layer(layers, "pressure", "recovered", 0.9)
-        if any("crown" in pressure.label.lower() or "government" in pressure.label.lower() for pressure in state.pressures):
-            _upsert_layer(layers, "political", "inferred", 0.65)
-    if state.constraints:
-        _upsert_layer(layers, "constraint", "recovered", 0.95)
-        for constraint in state.constraints:
-            constraint_type = constraint.constraint_type.lower()
-            if constraint_type in {"logistical", "communication"}:
-                _upsert_layer(layers, "logistical", "recovered", 0.95)
-            if constraint_type in {"temporal", "time"}:
-                _upsert_layer(layers, "temporal", "recovered", 0.95)
-            if constraint_type in {"political", "institutional"}:
-                _upsert_layer(layers, constraint_type, "recovered", 0.9)
+        _collect_pressure_layers(layers, state)
 
+
+def _collect_motive_layer(layers: dict[str, LayerRecord], state: CanonicalState) -> None:
+    origin = "recovered" if any(not motive.inferred for motive in state.motives) else "inferred"
+    confidence = 0.9 if origin == "recovered" else 0.55
+    _upsert_layer(layers, "motive", origin, confidence)
+
+
+def _collect_pressure_layers(layers: dict[str, LayerRecord], state: CanonicalState) -> None:
+    _upsert_layer(layers, "pressure", "recovered", 0.9)
+    if any(_pressure_is_political(pressure.label) for pressure in state.pressures):
+        _upsert_layer(layers, "political", "inferred", 0.65)
+
+
+def _pressure_is_political(label: str) -> bool:
+    normalized = label.lower()
+    return "crown" in normalized or "government" in normalized
+
+
+def _collect_constraint_layers(layers: dict[str, LayerRecord], state: CanonicalState) -> None:
+    if not state.constraints:
+        return
+    _upsert_layer(layers, "constraint", "recovered", 0.95)
+    for constraint in state.constraints:
+        _collect_constraint_type_layer(layers, constraint.constraint_type.lower())
+
+
+def _collect_constraint_type_layer(layers: dict[str, LayerRecord], constraint_type: str) -> None:
+    if constraint_type in _LOGISTICAL_CONSTRAINT_TYPES:
+        _upsert_layer(layers, "logistical", "recovered", 0.95)
+    if constraint_type in _TEMPORAL_CONSTRAINT_TYPES:
+        _upsert_layer(layers, "temporal", "recovered", 0.95)
+    if constraint_type in _POLITICAL_CONSTRAINT_TYPES:
+        _upsert_layer(layers, constraint_type, "recovered", 0.9)
+
+
+def _collect_question_layers(
+    layers: dict[str, LayerRecord],
+    state: CanonicalState,
+    request: NormalizedTaskRequest,
+) -> None:
     question = request.user_query.lower()
-    if any(event.timing for event in state.events) or any(token in question for token in ("same night", "tonight", "next")):
+    if any(event.timing for event in state.events) or _has_question_token(question, _TEMPORAL_QUESTION_TOKENS):
         _upsert_layer(layers, "temporal", "inferred", 0.7)
-    if request.task_kind == TaskKind.HISTORICAL_PLAUSIBILITY_CHECK and any(
-        token in question for token in ("pre-telegraph", "courier", "distant cities")
+    if request.task_kind == TaskKind.HISTORICAL_PLAUSIBILITY_CHECK and _has_question_token(
+        question,
+        _LOGISTICAL_QUESTION_TOKENS,
     ):
         _upsert_layer(layers, "logistical", "inferred", 0.75)
 
-    return sorted(layers.values(), key=lambda layer: layer.name)
+
+def _has_question_token(question: str, tokens: tuple[str, ...]) -> bool:
+    return any(token in question for token in tokens)
 
 
 def _upsert_layer(layers: dict[str, LayerRecord], name: str, origin: str, confidence: float) -> None:

--- a/src/aurora/engines/narrative/types.py
+++ b/src/aurora/engines/narrative/types.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TaskKind(str, Enum):
+    CHARACTER_ACTION_AUDIT = "character_action_audit"
+    NEXT_EVENT_CONTINUITY_CHECK = "next_event_continuity_check"
+    HISTORICAL_PLAUSIBILITY_CHECK = "historical_plausibility_check"
+    EXPANSION = "expansion"
+    TRANSLATION = "translation"
+    UNSUPPORTED = "unsupported"
+
+
+class Strictness(str, Enum):
+    LENIENT = "lenient"
+    DEFAULT = "default"
+    STRICT = "strict"
+
+
+class Verdict(str, Enum):
+    SUPPORTED = "supported"
+    PLAUSIBLE = "plausible"
+    POSSIBLE_WITH_SETUP = "possible_with_setup"
+    STRAINED = "strained"
+    CONTRADICTORY = "contradictory"
+
+
+@dataclass(frozen=True)
+class LayerRecord:
+    name: str
+    origin: str
+    confidence: float
+    status: str = "available"
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class EntityRecord:
+    name: str
+    entity_type: str = "character"
+    role: str = ""
+    traits: list[str] = field(default_factory=list)
+    source: str = "declared"
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True)
+class PressureRecord:
+    actor: str
+    label: str
+    direction: str = "toward"
+    strength: float = 0.5
+    source: str = "declared"
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True)
+class ConstraintRecord:
+    label: str
+    constraint_type: str
+    severity: str = "soft"
+    details: str = ""
+    source: str = "declared"
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True)
+class MotiveRecord:
+    actor: str
+    label: str
+    strength: float = 0.5
+    source: str = "declared"
+    confidence: float = 1.0
+    inferred: bool = False
+
+
+@dataclass(frozen=True)
+class EventRecord:
+    label: str
+    status: str = "established"
+    timing: str = ""
+    participants: list[str] = field(default_factory=list)
+    source: str = "declared"
+    confidence: float = 1.0
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class KnowledgeStateRecord:
+    holder: str
+    fact: str
+    status: str = "knows"
+    source: str = "declared"
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True)
+class UncertaintyRecord:
+    label: str
+    reason: str
+    source: str = "declared"
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True)
+class NormalizedTaskRequest:
+    task_kind: TaskKind
+    proposal_present: bool
+    strictness: Strictness
+    task_type: str = "validate"
+    desired_output_form: str = "audit"
+    input_kind: str = "mapping"
+    user_query: str = ""
+    supported_in_phase_one: bool = True
+    unsupported_reason: str | None = None
+
+
+@dataclass
+class CanonicalState:
+    state_id: str
+    input_profile: dict[str, Any] = field(default_factory=dict)
+    layers: list[LayerRecord] = field(default_factory=list)
+    entities: list[EntityRecord] = field(default_factory=list)
+    relations: list[dict[str, Any]] = field(default_factory=list)
+    pressures: list[PressureRecord] = field(default_factory=list)
+    constraints: list[ConstraintRecord] = field(default_factory=list)
+    motives: list[MotiveRecord] = field(default_factory=list)
+    events: list[EventRecord] = field(default_factory=list)
+    knowledge_states: list[KnowledgeStateRecord] = field(default_factory=list)
+    uncertainties: list[UncertaintyRecord] = field(default_factory=list)
+    continuity: dict[str, Any] = field(default_factory=dict)
+    narrative_context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EvaluationPacket:
+    active_layers: list[str] = field(default_factory=list)
+    missing_layers: list[str] = field(default_factory=list)
+    selected_operators: list[str] = field(default_factory=list)
+    supports: list[str] = field(default_factory=list)
+    blocks: list[str] = field(default_factory=list)
+    missing_bridges: list[str] = field(default_factory=list)
+    hard_blocks: list[str] = field(default_factory=list)
+    soft_blocks: list[str] = field(default_factory=list)
+    confidence_notes: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ResponsePayload:
+    summary: str
+    verdict: Verdict | None
+    main_supports: list[str]
+    main_blockers: list[str]
+    missing_bridges: list[str]
+    smallest_fix: list[str]
+    confidence: float
+    supported_in_phase_one: bool = True
+    unsupported_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class NarrativeValidationRun:
+    request: NormalizedTaskRequest
+    state: CanonicalState
+    evaluation: EvaluationPacket
+    response: ResponsePayload
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/src/aurora/engines/narrative/validator.py
+++ b/src/aurora/engines/narrative/validator.py
@@ -77,7 +77,7 @@ def _build_summary(request: NormalizedTaskRequest, evaluation: EvaluationPacket,
     first_support = evaluation.supports[0] if evaluation.supports else "direct support remains thin."
     first_block = evaluation.blocks[0] if evaluation.blocks else "no major blocker is established."
     if request.task_kind.value == "character_action_audit":
-        return f"This character move is {verdict.value}: {first_support} But {first_block}"
+        return f"This character move is {verdict.value}: {first_support}, but {first_block}."
     if request.task_kind.value == "next_event_continuity_check":
         return f"This next beat is {verdict.value}: {first_block}"
     if request.task_kind.value == "historical_plausibility_check":

--- a/src/aurora/engines/narrative/validator.py
+++ b/src/aurora/engines/narrative/validator.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from .types import EvaluationPacket, NormalizedTaskRequest, ResponsePayload, Verdict
+
+
+def build_response_payload(request: NormalizedTaskRequest, evaluation: EvaluationPacket) -> ResponsePayload:
+    if not request.supported_in_phase_one:
+        return ResponsePayload(
+            summary=(
+                "Phase one only supports character action audits, next-event continuity checks, "
+                "and historical plausibility checks."
+            ),
+            verdict=None,
+            main_supports=[],
+            main_blockers=[],
+            missing_bridges=[],
+            smallest_fix=["Reframe the request as one of the three supported validation tasks."],
+            confidence=0.2,
+            supported_in_phase_one=False,
+            unsupported_reason=request.unsupported_reason,
+        )
+
+    verdict = _determine_verdict(evaluation)
+    confidence = _compute_confidence(evaluation, verdict)
+    summary = _build_summary(request, evaluation, verdict)
+    smallest_fix = _smallest_fix(request, evaluation, verdict)
+    return ResponsePayload(
+        summary=summary,
+        verdict=verdict,
+        main_supports=evaluation.supports[:3],
+        main_blockers=evaluation.blocks[:3],
+        missing_bridges=evaluation.missing_bridges[:3],
+        smallest_fix=smallest_fix,
+        confidence=confidence,
+    )
+
+
+def _determine_verdict(evaluation: EvaluationPacket) -> Verdict:
+    if evaluation.hard_blocks:
+        return Verdict.CONTRADICTORY
+    if evaluation.soft_blocks:
+        if evaluation.supports and evaluation.missing_bridges:
+            return Verdict.POSSIBLE_WITH_SETUP
+        if evaluation.supports:
+            return Verdict.PLAUSIBLE
+        return Verdict.STRAINED
+    if evaluation.missing_layers:
+        return Verdict.POSSIBLE_WITH_SETUP
+    if evaluation.supports:
+        return Verdict.SUPPORTED
+    return Verdict.PLAUSIBLE
+
+
+def _compute_confidence(evaluation: EvaluationPacket, verdict: Verdict) -> float:
+    confidence = 0.78
+    if verdict == Verdict.SUPPORTED:
+        confidence += 0.1
+    elif verdict == Verdict.PLAUSIBLE:
+        confidence += 0.02
+    elif verdict == Verdict.POSSIBLE_WITH_SETUP:
+        confidence -= 0.05
+    elif verdict == Verdict.STRAINED:
+        confidence -= 0.12
+    elif verdict == Verdict.CONTRADICTORY:
+        confidence += 0.08
+
+    confidence += min(0.12, 0.05 * len(evaluation.supports))
+    confidence -= min(0.36, 0.12 * len(evaluation.missing_layers))
+    confidence -= min(0.2, 0.07 * len(evaluation.soft_blocks))
+    confidence += min(0.2, 0.15 * len(evaluation.hard_blocks))
+    if any("inferred" in note.lower() for note in evaluation.confidence_notes):
+        confidence -= 0.08
+    return max(0.15, min(0.95, round(confidence, 2)))
+
+
+def _build_summary(request: NormalizedTaskRequest, evaluation: EvaluationPacket, verdict: Verdict) -> str:
+    first_support = evaluation.supports[0] if evaluation.supports else "direct support remains thin."
+    first_block = evaluation.blocks[0] if evaluation.blocks else "no major blocker is established."
+    if request.task_kind.value == "character_action_audit":
+        return f"This character move is {verdict.value}: {first_support} But {first_block}"
+    if request.task_kind.value == "next_event_continuity_check":
+        return f"This next beat is {verdict.value}: {first_block}"
+    if request.task_kind.value == "historical_plausibility_check":
+        return f"As stated, this event is {verdict.value}: {first_block}"
+    return f"Phase-one evaluation returned {verdict.value}."
+
+
+def _smallest_fix(
+    request: NormalizedTaskRequest,
+    evaluation: EvaluationPacket,
+    verdict: Verdict,
+) -> list[str]:
+    if evaluation.missing_bridges:
+        return evaluation.missing_bridges[:2]
+    if evaluation.missing_layers:
+        return [f"Add evidence for the missing layer(s): {', '.join(evaluation.missing_layers)}."]
+    if verdict == Verdict.CONTRADICTORY and request.task_kind.value == "historical_plausibility_check":
+        return ["Reframe the action around pre-coordination or staggered execution."]
+    if verdict == Verdict.STRAINED:
+        return ["Insert one visible bridge event before this move."]
+    return ["Preserve the current setup and add one more direct support if stronger confidence is required."]

--- a/tests/test_command_chain_entrypoints.py
+++ b/tests/test_command_chain_entrypoints.py
@@ -3,7 +3,7 @@
 Regression tests for command-chain entrypoints.
 """
 
-import subprocess
+import subprocess  # nosec B404
 import tempfile
 from pathlib import Path
 
@@ -19,13 +19,28 @@ def temp_git_repo():
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_path = Path(tmpdir)
 
-        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_path, check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)  # nosec
+        subprocess.run(  # nosec
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(  # nosec
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
 
         (repo_path / "sample.txt").write_text("alpha\n")
-        subprocess.run(["git", "add", "sample.txt"], cwd=repo_path, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "add", "sample.txt"], cwd=repo_path, check=True, capture_output=True)  # nosec
+        subprocess.run(  # nosec
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
 
         yield repo_path
 
@@ -43,7 +58,30 @@ def test_resolve_config_path_does_not_leak_caller_cwd(monkeypatch, temp_git_repo
 
     monkeypatch.chdir(caller_dir)
 
-    assert resolve_config_path(workspace_path=str(temp_git_repo)) is None
+    if resolve_config_path(workspace_path=str(temp_git_repo)) is not None:
+        pytest.fail("Expected workspace config lookup to ignore caller CWD config")
+
+
+def test_resolve_config_path_prefers_workspace_relative_config(monkeypatch, temp_git_repo):
+    caller_dir = temp_git_repo / "caller"
+    caller_config = caller_dir / ".aurora"
+    caller_config.mkdir(parents=True)
+    (caller_config / "sync_config.json").write_text('{"default_commit_type": "docs"}')
+
+    workspace_dir = temp_git_repo / "workspace"
+    workspace_config = workspace_dir / ".aurora" / "sync_config.json"
+    workspace_config.parent.mkdir(parents=True)
+    workspace_config.write_text('{"default_commit_type": "fix"}')
+
+    monkeypatch.chdir(caller_dir)
+
+    resolved = resolve_config_path(
+        config_path=".aurora/sync_config.json",
+        workspace_path=str(workspace_dir),
+    )
+
+    if resolved != workspace_config:
+        pytest.fail(f"Expected workspace-scoped config, got {resolved}")
 
 
 def test_execute_commit_creates_local_commit(temp_git_repo):
@@ -51,16 +89,19 @@ def test_execute_commit_creates_local_commit(temp_git_repo):
 
     result = execute_commit(workspace_path=str(temp_git_repo))
 
-    assert result.success is True
-    assert result.commit_sha
-    commit_count = subprocess.run(
+    if not result.success:
+        pytest.fail("Expected execute_commit to succeed")
+    if not result.commit_sha:
+        pytest.fail("Expected execute_commit to return a commit SHA")
+    commit_count = subprocess.run(  # nosec
         ["git", "rev-list", "--count", "HEAD"],
         cwd=temp_git_repo,
         check=True,
         capture_output=True,
         text=True,
     )
-    assert commit_count.stdout.strip() == "2"
+    if commit_count.stdout.strip() != "2":
+        pytest.fail(f"Expected two commits, got {commit_count.stdout.strip()}")
 
 
 def test_execute_321_preserves_partial_commit_metadata_on_sync_failure(temp_git_repo):
@@ -68,24 +109,43 @@ def test_execute_321_preserves_partial_commit_metadata_on_sync_failure(temp_git_
 
     result = execute_321(workspace_path=str(temp_git_repo))
 
-    assert result.success is False
-    assert result.commit_sha
-    assert result.files_changed == 1
-    assert any(phase.phase_number == 4 and not phase.success for phase in result.phases)
+    if result.success:
+        pytest.fail("Expected execute_321 to fail during sync without origin")
+    if not result.commit_sha:
+        pytest.fail("Expected execute_321 to preserve the local commit SHA")
+    if result.files_changed != 1:
+        pytest.fail(f"Expected one changed file, got {result.files_changed}")
+    if not any(phase.phase_number == 4 and not phase.success for phase in result.phases):
+        pytest.fail("Expected execute_321 to preserve the phase 4 sync failure")
 
-    commit_count = subprocess.run(
+    commit_count = subprocess.run(  # nosec
         ["git", "rev-list", "--count", "HEAD"],
         cwd=temp_git_repo,
         check=True,
         capture_output=True,
         text=True,
     )
-    assert commit_count.stdout.strip() == "2"
+    if commit_count.stdout.strip() != "2":
+        pytest.fail(f"Expected two commits, got {commit_count.stdout.strip()}")
 
 
 def test_command_executor_imports_under_current_python(temp_git_repo):
     executor = CommandExecutor(str(temp_git_repo))
-    assert executor is not None
+    if executor is None:
+        pytest.fail("Expected CommandExecutor to import and instantiate")
+
+
+def test_command_executor_treats_continuity_accept_as_success(temp_git_repo):
+    result = CommandExecutor(str(temp_git_repo)).execute("#999//.")
+
+    if not result.success:
+        pytest.fail("Continuity accept should be treated as a successful command")
+    if result.failed_commands != 0:
+        pytest.fail(f"Expected no failed commands, got {result.failed_commands}")
+    if not result.results[0].success:
+        pytest.fail("Continuity accept result should be successful")
+    if result.results[0].output["status"] != "sealed":
+        pytest.fail(f"Expected sealed status, got {result.results[0].output['status']}")
 
 
 def test_command_executor_reports_handler_failure_for_sync_workflow(temp_git_repo):
@@ -93,7 +153,11 @@ def test_command_executor_reports_handler_failure_for_sync_workflow(temp_git_rep
 
     result = CommandExecutor(str(temp_git_repo)).execute("#321//.")
 
-    assert result.success is False
-    assert result.failed_commands == 1
-    assert result.results[0].success is False
-    assert result.results[0].output["status"] in {"failed", "partial", "warning"}
+    if result.success:
+        pytest.fail("Expected #321//. sync workflow to fail without origin")
+    if result.failed_commands != 1:
+        pytest.fail(f"Expected one failed command, got {result.failed_commands}")
+    if result.results[0].success:
+        pytest.fail("Expected #321//. command result to fail without origin")
+    if result.results[0].output["status"] not in {"failed", "partial", "warning"}:
+        pytest.fail(f"Expected failure-like status, got {result.results[0].output['status']}")

--- a/tests/test_command_chain_entrypoints.py
+++ b/tests/test_command_chain_entrypoints.py
@@ -58,8 +58,9 @@ def test_resolve_config_path_does_not_leak_caller_cwd(monkeypatch, temp_git_repo
 
     monkeypatch.chdir(caller_dir)
 
-    if resolve_config_path(workspace_path=str(temp_git_repo)) is not None:
-        pytest.fail("Expected workspace config lookup to ignore caller CWD config")
+    assert resolve_config_path(workspace_path=str(temp_git_repo)) is None, (  # nosec B101
+        "Expected workspace config lookup to ignore caller CWD config"
+    )
 
 
 def test_resolve_config_path_prefers_workspace_relative_config(monkeypatch, temp_git_repo):
@@ -80,8 +81,7 @@ def test_resolve_config_path_prefers_workspace_relative_config(monkeypatch, temp
         workspace_path=str(workspace_dir),
     )
 
-    if resolved != workspace_config:
-        pytest.fail(f"Expected workspace-scoped config, got {resolved}")
+    assert resolved == workspace_config, f"Expected workspace-scoped config, got {resolved}"  # nosec B101
 
 
 def test_execute_commit_creates_local_commit(temp_git_repo):
@@ -89,10 +89,8 @@ def test_execute_commit_creates_local_commit(temp_git_repo):
 
     result = execute_commit(workspace_path=str(temp_git_repo))
 
-    if not result.success:
-        pytest.fail("Expected execute_commit to succeed")
-    if not result.commit_sha:
-        pytest.fail("Expected execute_commit to return a commit SHA")
+    assert result.success, "Expected execute_commit to succeed"  # nosec B101
+    assert result.commit_sha, "Expected execute_commit to return a commit SHA"  # nosec B101
     commit_count = subprocess.run(  # nosec
         ["git", "rev-list", "--count", "HEAD"],
         cwd=temp_git_repo,
@@ -100,8 +98,7 @@ def test_execute_commit_creates_local_commit(temp_git_repo):
         capture_output=True,
         text=True,
     )
-    if commit_count.stdout.strip() != "2":
-        pytest.fail(f"Expected two commits, got {commit_count.stdout.strip()}")
+    assert commit_count.stdout.strip() == "2", f"Expected two commits, got {commit_count.stdout.strip()}"  # nosec B101
 
 
 def test_execute_321_preserves_partial_commit_metadata_on_sync_failure(temp_git_repo):
@@ -109,14 +106,12 @@ def test_execute_321_preserves_partial_commit_metadata_on_sync_failure(temp_git_
 
     result = execute_321(workspace_path=str(temp_git_repo))
 
-    if result.success:
-        pytest.fail("Expected execute_321 to fail during sync without origin")
-    if not result.commit_sha:
-        pytest.fail("Expected execute_321 to preserve the local commit SHA")
-    if result.files_changed != 1:
-        pytest.fail(f"Expected one changed file, got {result.files_changed}")
-    if not any(phase.phase_number == 4 and not phase.success for phase in result.phases):
-        pytest.fail("Expected execute_321 to preserve the phase 4 sync failure")
+    assert not result.success, "Expected execute_321 to fail during sync without origin"  # nosec B101
+    assert result.commit_sha, "Expected execute_321 to preserve the local commit SHA"  # nosec B101
+    assert result.files_changed == 1, f"Expected one changed file, got {result.files_changed}"  # nosec B101
+    assert any(phase.phase_number == 4 and not phase.success for phase in result.phases), (  # nosec B101
+        "Expected execute_321 to preserve the phase 4 sync failure"
+    )
 
     commit_count = subprocess.run(  # nosec
         ["git", "rev-list", "--count", "HEAD"],
@@ -125,27 +120,22 @@ def test_execute_321_preserves_partial_commit_metadata_on_sync_failure(temp_git_
         capture_output=True,
         text=True,
     )
-    if commit_count.stdout.strip() != "2":
-        pytest.fail(f"Expected two commits, got {commit_count.stdout.strip()}")
+    assert commit_count.stdout.strip() == "2", f"Expected two commits, got {commit_count.stdout.strip()}"  # nosec B101
 
 
 def test_command_executor_imports_under_current_python(temp_git_repo):
-    executor = CommandExecutor(str(temp_git_repo))
-    if executor is None:
-        pytest.fail("Expected CommandExecutor to import and instantiate")
+    CommandExecutor(str(temp_git_repo))
 
 
 def test_command_executor_treats_continuity_accept_as_success(temp_git_repo):
     result = CommandExecutor(str(temp_git_repo)).execute("#999//.")
 
-    if not result.success:
-        pytest.fail("Continuity accept should be treated as a successful command")
-    if result.failed_commands != 0:
-        pytest.fail(f"Expected no failed commands, got {result.failed_commands}")
-    if not result.results[0].success:
-        pytest.fail("Continuity accept result should be successful")
-    if result.results[0].output["status"] != "sealed":
-        pytest.fail(f"Expected sealed status, got {result.results[0].output['status']}")
+    assert result.success, "Continuity accept should be treated as a successful command"  # nosec B101
+    assert result.failed_commands == 0, f"Expected no failed commands, got {result.failed_commands}"  # nosec B101
+    assert result.results[0].success, "Continuity accept result should be successful"  # nosec B101
+    assert result.results[0].output["status"] == "sealed", (  # nosec B101
+        f"Expected sealed status, got {result.results[0].output['status']}"
+    )
 
 
 def test_command_executor_reports_handler_failure_for_sync_workflow(temp_git_repo):
@@ -153,11 +143,9 @@ def test_command_executor_reports_handler_failure_for_sync_workflow(temp_git_rep
 
     result = CommandExecutor(str(temp_git_repo)).execute("#321//.")
 
-    if result.success:
-        pytest.fail("Expected #321//. sync workflow to fail without origin")
-    if result.failed_commands != 1:
-        pytest.fail(f"Expected one failed command, got {result.failed_commands}")
-    if result.results[0].success:
-        pytest.fail("Expected #321//. command result to fail without origin")
-    if result.results[0].output["status"] not in {"failed", "partial", "warning"}:
-        pytest.fail(f"Expected failure-like status, got {result.results[0].output['status']}")
+    assert not result.success, "Expected #321//. sync workflow to fail without origin"  # nosec B101
+    assert result.failed_commands == 1, f"Expected one failed command, got {result.failed_commands}"  # nosec B101
+    assert not result.results[0].success, "Expected #321//. command result to fail without origin"  # nosec B101
+    assert result.results[0].output["status"] in {"failed", "partial", "warning"}, (  # nosec B101
+        f"Expected failure-like status, got {result.results[0].output['status']}"
+    )

--- a/tests/test_command_chain_entrypoints.py
+++ b/tests/test_command_chain_entrypoints.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Regression tests for command-chain entrypoints.
+"""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.command_chain.cmd_commit import execute_commit
+from tools.command_chain.comprehensive_sync_321 import execute_321, resolve_config_path
+from tools.command_chain.executor import CommandExecutor
+
+
+@pytest.fixture
+def temp_git_repo():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_path = Path(tmpdir)
+
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_path, check=True, capture_output=True)
+
+        (repo_path / "sample.txt").write_text("alpha\n")
+        subprocess.run(["git", "add", "sample.txt"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=repo_path, check=True, capture_output=True)
+
+        yield repo_path
+
+
+def _append_change(repo_path: Path):
+    with (repo_path / "sample.txt").open("a") as handle:
+        handle.write("beta\n")
+
+
+def test_resolve_config_path_does_not_leak_caller_cwd(monkeypatch, temp_git_repo):
+    caller_dir = temp_git_repo / "caller"
+    caller_config = caller_dir / ".aurora"
+    caller_config.mkdir(parents=True)
+    (caller_config / "sync_config.json").write_text('{"default_commit_type": "docs"}')
+
+    monkeypatch.chdir(caller_dir)
+
+    assert resolve_config_path(workspace_path=str(temp_git_repo)) is None
+
+
+def test_execute_commit_creates_local_commit(temp_git_repo):
+    _append_change(temp_git_repo)
+
+    result = execute_commit(workspace_path=str(temp_git_repo))
+
+    assert result.success is True
+    assert result.commit_sha
+    commit_count = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD"],
+        cwd=temp_git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert commit_count.stdout.strip() == "2"
+
+
+def test_execute_321_preserves_partial_commit_metadata_on_sync_failure(temp_git_repo):
+    _append_change(temp_git_repo)
+
+    result = execute_321(workspace_path=str(temp_git_repo))
+
+    assert result.success is False
+    assert result.commit_sha
+    assert result.files_changed == 1
+    assert any(phase.phase_number == 4 and not phase.success for phase in result.phases)
+
+    commit_count = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD"],
+        cwd=temp_git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert commit_count.stdout.strip() == "2"
+
+
+def test_command_executor_imports_under_current_python(temp_git_repo):
+    executor = CommandExecutor(str(temp_git_repo))
+    assert executor is not None
+
+
+def test_command_executor_reports_handler_failure_for_sync_workflow(temp_git_repo):
+    _append_change(temp_git_repo)
+
+    result = CommandExecutor(str(temp_git_repo)).execute("#321//.")
+
+    assert result.success is False
+    assert result.failed_commands == 1
+    assert result.results[0].success is False
+    assert result.results[0].output["status"] in {"failed", "partial", "warning"}

--- a/tests/test_narrative_validation_engine.py
+++ b/tests/test_narrative_validation_engine.py
@@ -117,11 +117,6 @@ HISTORICAL_PROPOSAL = {
 }
 
 
-def _expect(condition, message):
-    if not condition:
-        pytest.fail(message)
-
-
 @pytest.mark.unit
 @pytest.mark.aurora
 @pytest.mark.parametrize(
@@ -175,29 +170,24 @@ def test_narrative_engine_golden_cases(
 ):
     run = ENGINE.run(raw_input, proposal=proposal)
 
-    _expect(
-        run.request.task_kind == expected_kind,
-        f"Expected task kind {expected_kind}, got {run.request.task_kind}",
+    assert run.request.task_kind == expected_kind, (  # nosec B101
+        f"Expected task kind {expected_kind}, got {run.request.task_kind}"
     )
-    _expect(
-        run.response.verdict == expected_verdict,
-        f"Expected verdict {expected_verdict}, got {run.response.verdict}",
+    assert run.response.verdict == expected_verdict, (  # nosec B101
+        f"Expected verdict {expected_verdict}, got {run.response.verdict}"
     )
-    _expect(
-        run.evaluation.active_layers == expected_layers,
-        f"Expected active layers {expected_layers}, got {run.evaluation.active_layers}",
+    assert run.evaluation.active_layers == expected_layers, (  # nosec B101
+        f"Expected active layers {expected_layers}, got {run.evaluation.active_layers}"
     )
-    _expect(run.response.supported_in_phase_one is True, "Expected phase-one support")
+    assert run.response.supported_in_phase_one, "Expected phase-one support"  # nosec B101
     if support_snippet:
-        _expect(
-            any(support_snippet.lower() in item.lower() for item in run.response.main_supports),
-            f"Expected support snippet {support_snippet!r}",
+        assert any(support_snippet.lower() in item.lower() for item in run.response.main_supports), (  # nosec B101
+            f"Expected support snippet {support_snippet!r}"
         )
-    _expect(
-        any(blocker_snippet.lower() in item.lower() for item in run.response.main_blockers),
-        f"Expected blocker snippet {blocker_snippet!r}",
+    assert any(blocker_snippet.lower() in item.lower() for item in run.response.main_blockers), (  # nosec B101
+        f"Expected blocker snippet {blocker_snippet!r}"
     )
-    _expect(bool(run.response.smallest_fix), "Expected a smallest-fix recommendation")
+    assert run.response.smallest_fix, "Expected a smallest-fix recommendation"  # nosec B101
 
 
 @pytest.mark.unit
@@ -205,13 +195,15 @@ def test_narrative_engine_golden_cases(
 def test_sparse_input_restraint_stays_minimal():
     run = ENGINE.run("a hero came to a fork in the road")
 
-    _expect(run.request.task_kind == TaskKind.EXPANSION, f"Expected expansion, got {run.request.task_kind}")
-    _expect(run.response.supported_in_phase_one is False, "Expected unsupported phase-one response")
-    _expect(run.response.verdict is None, f"Expected no verdict, got {run.response.verdict}")
-    _expect(not run.state.entities, f"Expected no entities, got {run.state.entities}")
-    _expect(not run.state.motives, f"Expected no motives, got {run.state.motives}")
-    _expect(bool(run.state.uncertainties), "Expected sparse-input uncertainty")
-    _expect(run.response.confidence <= 0.2, f"Expected low confidence, got {run.response.confidence}")
+    assert run.request.task_kind == TaskKind.EXPANSION, (  # nosec B101
+        f"Expected expansion, got {run.request.task_kind}"
+    )
+    assert not run.response.supported_in_phase_one, "Expected unsupported phase-one response"  # nosec B101
+    assert run.response.verdict is None, f"Expected no verdict, got {run.response.verdict}"  # nosec B101
+    assert not run.state.entities, f"Expected no entities, got {run.state.entities}"  # nosec B101
+    assert not run.state.motives, f"Expected no motives, got {run.state.motives}"  # nosec B101
+    assert run.state.uncertainties, "Expected sparse-input uncertainty"  # nosec B101
+    assert run.response.confidence <= 0.2, f"Expected low confidence, got {run.response.confidence}"  # nosec B101
 
 
 @pytest.mark.unit
@@ -228,15 +220,17 @@ def test_missing_layer_honesty_reduces_confidence():
         proposal={"actor": "Ilya", "action": "betray the crew", "type": "action"},
     )
 
-    _expect("motive" in run.evaluation.missing_layers, f"Expected missing motive layer: {run.evaluation}")
-    _expect(
-        run.response.verdict == Verdict.POSSIBLE_WITH_SETUP,
-        f"Expected possible-with-setup verdict, got {run.response.verdict}",
+    assert "motive" in run.evaluation.missing_layers, f"Expected missing motive layer: {run.evaluation}"  # nosec B101
+    assert run.response.verdict == Verdict.POSSIBLE_WITH_SETUP, (  # nosec B101
+        f"Expected possible-with-setup verdict, got {run.response.verdict}"
     )
-    _expect(run.response.confidence < 0.55, f"Expected reduced confidence, got {run.response.confidence}")
-    _expect(
-        any("motive" in item.lower() or "pressure" in item.lower() for item in run.response.smallest_fix),
-        f"Expected motive or pressure smallest-fix guidance, got {run.response.smallest_fix}",
+    assert run.response.confidence < 0.55, f"Expected reduced confidence, got {run.response.confidence}"  # nosec B101
+    has_fix_guidance = any(
+        "motive" in item.lower() or "pressure" in item.lower()
+        for item in run.response.smallest_fix
+    )
+    assert has_fix_guidance, (  # nosec B101
+        f"Expected motive or pressure smallest-fix guidance, got {run.response.smallest_fix}"
     )
 
 
@@ -245,12 +239,14 @@ def test_missing_layer_honesty_reduces_confidence():
 def test_symbolic_request_is_typed_unsupported_without_overclaim():
     run = ENGINE.run("Does the moon above the ruined bridge definitely symbolize rebirth?")
 
-    _expect(run.request.task_kind == TaskKind.UNSUPPORTED, f"Expected unsupported, got {run.request.task_kind}")
-    _expect(run.response.supported_in_phase_one is False, "Expected unsupported phase-one response")
-    _expect(run.response.verdict is None, f"Expected no verdict, got {run.response.verdict}")
-    _expect(run.response.main_supports == [], f"Expected no supports, got {run.response.main_supports}")
-    _expect(run.response.main_blockers == [], f"Expected no blockers, got {run.response.main_blockers}")
-    _expect(run.response.confidence <= 0.2, f"Expected low confidence, got {run.response.confidence}")
+    assert run.request.task_kind == TaskKind.UNSUPPORTED, (  # nosec B101
+        f"Expected unsupported, got {run.request.task_kind}"
+    )
+    assert not run.response.supported_in_phase_one, "Expected unsupported phase-one response"  # nosec B101
+    assert run.response.verdict is None, f"Expected no verdict, got {run.response.verdict}"  # nosec B101
+    assert run.response.main_supports == [], f"Expected no supports, got {run.response.main_supports}"  # nosec B101
+    assert run.response.main_blockers == [], f"Expected no blockers, got {run.response.main_blockers}"  # nosec B101
+    assert run.response.confidence <= 0.2, f"Expected low confidence, got {run.response.confidence}"  # nosec B101
 
 
 @pytest.mark.unit
@@ -259,12 +255,10 @@ def test_proposal_stays_provisional_in_state():
     run = ENGINE.run(MARA_INPUT, proposal=MARA_PROPOSAL)
 
     proposed_events = [event for event in run.state.events if event.status == "proposed"]
-    _expect(len(proposed_events) == 1, f"Expected one proposed event, got {proposed_events}")
-    _expect(
-        proposed_events[0].label == "abandon Teren to deliver the rebellion signal",
-        f"Unexpected proposed event label: {proposed_events[0].label}",
+    assert len(proposed_events) == 1, f"Expected one proposed event, got {proposed_events}"  # nosec B101
+    assert proposed_events[0].label == "abandon Teren to deliver the rebellion signal", (  # nosec B101
+        f"Unexpected proposed event label: {proposed_events[0].label}"
     )
-    _expect(
-        proposed_events[0].label not in run.state.continuity["established_events"],
-        "Expected proposed event to stay out of established continuity",
+    assert proposed_events[0].label not in run.state.continuity["established_events"], (  # nosec B101
+        "Expected proposed event to stay out of established continuity"
     )

--- a/tests/test_narrative_validation_engine.py
+++ b/tests/test_narrative_validation_engine.py
@@ -1,0 +1,230 @@
+import pytest
+
+from src.aurora.engines import NarrativeValidationEngine
+from src.aurora.engines.narrative import TaskKind, Verdict
+
+
+ENGINE = NarrativeValidationEngine()
+
+MARA_INPUT = {
+    "task_hint": "character_action_audit",
+    "question": "Would Mara really abandon Teren here to save the rebellion?",
+    "declared_layers": ["character", "motive", "event", "knowledge", "continuity"],
+    "entities": [
+        {"name": "Mara", "entity_type": "character", "role": "courier", "traits": ["duty-driven", "protective"]},
+        {"name": "Teren", "entity_type": "character", "role": "friend"},
+    ],
+    "events": [
+        {
+            "label": "The rebellion will collapse if the signal is not delivered tonight.",
+            "timing": "tonight",
+            "participants": ["Mara"],
+        },
+        {
+            "label": "Mara previously risked herself to protect Teren.",
+            "timing": "prior",
+            "participants": ["Mara", "Teren"],
+        },
+    ],
+    "motives": [
+        {"actor": "Mara", "label": "protect Teren", "strength": 0.93},
+        {"actor": "Mara", "label": "preserve the rebellion", "strength": 0.88},
+    ],
+    "pressures": [
+        {"actor": "Mara", "label": "duty to deliver the signal", "direction": "toward", "strength": 0.91},
+        {"actor": "Mara", "label": "personal loyalty to Teren", "direction": "against", "strength": 0.86},
+    ],
+    "knowledge_states": [
+        {
+            "holder": "Mara",
+            "fact": "If the signal does not go out tonight, the rebellion loses its safe corridor.",
+        }
+    ],
+    "continuity": {"notes": ["Mara is consistently protective of Teren."]},
+}
+
+MARA_PROPOSAL = {
+    "actor": "Mara",
+    "action": "abandon Teren to deliver the rebellion signal",
+    "type": "action",
+}
+
+DETECTIVE_INPUT = {
+    "task_hint": "next_event_continuity_check",
+    "question": "Can this happen next, with the detective accusing him that same night?",
+    "declared_layers": ["event", "temporal", "knowledge", "continuity", "character"],
+    "entities": [
+        {"name": "Detective Vale", "entity_type": "character", "role": "detective"},
+        {"name": "Rian", "entity_type": "character", "role": "suspect"},
+    ],
+    "events": [
+        {
+            "label": "Detective Vale privately learns that Rian is innocent.",
+            "timing": "same afternoon",
+            "participants": ["Detective Vale"],
+        }
+    ],
+    "knowledge_states": [
+        {"holder": "Detective Vale", "fact": "Rian is innocent."},
+    ],
+    "continuity": {"notes": ["Vale has been quietly trying to clear Rian."]},
+}
+
+DETECTIVE_PROPOSAL = {
+    "actor": "Detective Vale",
+    "action": "publicly accuse Rian that same night",
+    "type": "event",
+    "timing": "same_night",
+}
+
+HISTORICAL_INPUT = {
+    "task_hint": "historical_plausibility_check",
+    "question": "Could a pre-telegraph queen coordinate a same-day crackdown across six distant cities as stated?",
+    "declared_layers": ["institutional", "temporal", "logistical", "political"],
+    "entities": [
+        {"name": "The Queen", "entity_type": "character", "role": "monarch"},
+        {"name": "Crown Guard", "entity_type": "institution", "role": "security apparatus"},
+        {"name": "The Six Cities", "entity_type": "city", "role": "distant provincial capitals"},
+    ],
+    "constraints": [
+        {
+            "label": "No telegraph or rapid long-distance signaling exists.",
+            "constraint_type": "logistical",
+            "severity": "hard",
+        },
+        {
+            "label": "The cities are days apart by courier.",
+            "constraint_type": "temporal",
+            "severity": "hard",
+        },
+        {
+            "label": "The crown must coordinate through provincial governors.",
+            "constraint_type": "political",
+            "severity": "soft",
+        },
+    ],
+    "pressures": [
+        {"actor": "The Queen", "label": "crown pressure to suppress unrest", "direction": "toward", "strength": 0.84},
+    ],
+    "continuity": {"notes": ["Orders normally move by courier over several days."]},
+}
+
+HISTORICAL_PROPOSAL = {
+    "actor": "The Queen",
+    "action": "coordinate a same-day crackdown across six distant cities",
+    "type": "event",
+    "timing": "same_day",
+}
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+@pytest.mark.parametrize(
+    ("raw_input", "proposal", "expected_kind", "expected_verdict", "expected_layers", "support_snippet", "blocker_snippet"),
+    [
+        (
+            MARA_INPUT,
+            MARA_PROPOSAL,
+            TaskKind.CHARACTER_ACTION_AUDIT,
+            Verdict.POSSIBLE_WITH_SETUP,
+            ["character", "motive", "event", "knowledge", "continuity"],
+            "rebellion",
+            "protect Teren",
+        ),
+        (
+            DETECTIVE_INPUT,
+            DETECTIVE_PROPOSAL,
+            TaskKind.NEXT_EVENT_CONTINUITY_CHECK,
+            Verdict.STRAINED,
+            ["event", "temporal", "knowledge", "continuity", "character"],
+            "",
+            "innocent",
+        ),
+        (
+            HISTORICAL_INPUT,
+            HISTORICAL_PROPOSAL,
+            TaskKind.HISTORICAL_PLAUSIBILITY_CHECK,
+            Verdict.CONTRADICTORY,
+            ["institutional", "temporal", "logistical", "political"],
+            "",
+            "same-day coordination",
+        ),
+    ],
+)
+def test_narrative_engine_golden_cases(
+    raw_input,
+    proposal,
+    expected_kind,
+    expected_verdict,
+    expected_layers,
+    support_snippet,
+    blocker_snippet,
+):
+    run = ENGINE.run(raw_input, proposal=proposal)
+
+    assert run.request.task_kind == expected_kind
+    assert run.response.verdict == expected_verdict
+    assert run.evaluation.active_layers == expected_layers
+    assert run.response.supported_in_phase_one is True
+    if support_snippet:
+        assert any(support_snippet.lower() in item.lower() for item in run.response.main_supports)
+    assert any(blocker_snippet.lower() in item.lower() for item in run.response.main_blockers)
+    assert run.response.smallest_fix
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_sparse_input_restraint_stays_minimal():
+    run = ENGINE.run("a hero came to a fork in the road")
+
+    assert run.request.task_kind == TaskKind.EXPANSION
+    assert run.response.supported_in_phase_one is False
+    assert run.response.verdict is None
+    assert not run.state.entities
+    assert not run.state.motives
+    assert run.state.uncertainties
+    assert run.response.confidence <= 0.2
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_missing_layer_honesty_reduces_confidence():
+    run = ENGINE.run(
+        {
+            "task_hint": "character_action_audit",
+            "question": "Would Ilya betray the crew here?",
+            "entities": [{"name": "Ilya", "entity_type": "character", "role": "pilot"}],
+            "events": [{"label": "Ilya has stayed with the crew through prior danger.", "timing": "prior"}],
+            "continuity": {"notes": ["Ilya has been loyal so far."]},
+        },
+        proposal={"actor": "Ilya", "action": "betray the crew", "type": "action"},
+    )
+
+    assert "motive" in run.evaluation.missing_layers
+    assert run.response.verdict == Verdict.POSSIBLE_WITH_SETUP
+    assert run.response.confidence < 0.55
+    assert any("motive" in item.lower() or "pressure" in item.lower() for item in run.response.smallest_fix)
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_symbolic_request_is_typed_unsupported_without_overclaim():
+    run = ENGINE.run("Does the moon above the ruined bridge definitely symbolize rebirth?")
+
+    assert run.request.task_kind == TaskKind.UNSUPPORTED
+    assert run.response.supported_in_phase_one is False
+    assert run.response.verdict is None
+    assert run.response.main_supports == []
+    assert run.response.main_blockers == []
+    assert run.response.confidence <= 0.2
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_proposal_stays_provisional_in_state():
+    run = ENGINE.run(MARA_INPUT, proposal=MARA_PROPOSAL)
+
+    proposed_events = [event for event in run.state.events if event.status == "proposed"]
+    assert len(proposed_events) == 1
+    assert proposed_events[0].label == "abandon Teren to deliver the rebellion signal"
+    assert proposed_events[0].label not in run.state.continuity["established_events"]

--- a/tests/test_narrative_validation_engine.py
+++ b/tests/test_narrative_validation_engine.py
@@ -117,10 +117,23 @@ HISTORICAL_PROPOSAL = {
 }
 
 
+def _expect(condition, message):
+    if not condition:
+        pytest.fail(message)
+
+
 @pytest.mark.unit
 @pytest.mark.aurora
 @pytest.mark.parametrize(
-    ("raw_input", "proposal", "expected_kind", "expected_verdict", "expected_layers", "support_snippet", "blocker_snippet"),
+    (
+        "raw_input",
+        "proposal",
+        "expected_kind",
+        "expected_verdict",
+        "expected_layers",
+        "support_snippet",
+        "blocker_snippet",
+    ),
     [
         (
             MARA_INPUT,
@@ -162,14 +175,29 @@ def test_narrative_engine_golden_cases(
 ):
     run = ENGINE.run(raw_input, proposal=proposal)
 
-    assert run.request.task_kind == expected_kind
-    assert run.response.verdict == expected_verdict
-    assert run.evaluation.active_layers == expected_layers
-    assert run.response.supported_in_phase_one is True
+    _expect(
+        run.request.task_kind == expected_kind,
+        f"Expected task kind {expected_kind}, got {run.request.task_kind}",
+    )
+    _expect(
+        run.response.verdict == expected_verdict,
+        f"Expected verdict {expected_verdict}, got {run.response.verdict}",
+    )
+    _expect(
+        run.evaluation.active_layers == expected_layers,
+        f"Expected active layers {expected_layers}, got {run.evaluation.active_layers}",
+    )
+    _expect(run.response.supported_in_phase_one is True, "Expected phase-one support")
     if support_snippet:
-        assert any(support_snippet.lower() in item.lower() for item in run.response.main_supports)
-    assert any(blocker_snippet.lower() in item.lower() for item in run.response.main_blockers)
-    assert run.response.smallest_fix
+        _expect(
+            any(support_snippet.lower() in item.lower() for item in run.response.main_supports),
+            f"Expected support snippet {support_snippet!r}",
+        )
+    _expect(
+        any(blocker_snippet.lower() in item.lower() for item in run.response.main_blockers),
+        f"Expected blocker snippet {blocker_snippet!r}",
+    )
+    _expect(bool(run.response.smallest_fix), "Expected a smallest-fix recommendation")
 
 
 @pytest.mark.unit
@@ -177,13 +205,13 @@ def test_narrative_engine_golden_cases(
 def test_sparse_input_restraint_stays_minimal():
     run = ENGINE.run("a hero came to a fork in the road")
 
-    assert run.request.task_kind == TaskKind.EXPANSION
-    assert run.response.supported_in_phase_one is False
-    assert run.response.verdict is None
-    assert not run.state.entities
-    assert not run.state.motives
-    assert run.state.uncertainties
-    assert run.response.confidence <= 0.2
+    _expect(run.request.task_kind == TaskKind.EXPANSION, f"Expected expansion, got {run.request.task_kind}")
+    _expect(run.response.supported_in_phase_one is False, "Expected unsupported phase-one response")
+    _expect(run.response.verdict is None, f"Expected no verdict, got {run.response.verdict}")
+    _expect(not run.state.entities, f"Expected no entities, got {run.state.entities}")
+    _expect(not run.state.motives, f"Expected no motives, got {run.state.motives}")
+    _expect(bool(run.state.uncertainties), "Expected sparse-input uncertainty")
+    _expect(run.response.confidence <= 0.2, f"Expected low confidence, got {run.response.confidence}")
 
 
 @pytest.mark.unit
@@ -200,10 +228,16 @@ def test_missing_layer_honesty_reduces_confidence():
         proposal={"actor": "Ilya", "action": "betray the crew", "type": "action"},
     )
 
-    assert "motive" in run.evaluation.missing_layers
-    assert run.response.verdict == Verdict.POSSIBLE_WITH_SETUP
-    assert run.response.confidence < 0.55
-    assert any("motive" in item.lower() or "pressure" in item.lower() for item in run.response.smallest_fix)
+    _expect("motive" in run.evaluation.missing_layers, f"Expected missing motive layer: {run.evaluation}")
+    _expect(
+        run.response.verdict == Verdict.POSSIBLE_WITH_SETUP,
+        f"Expected possible-with-setup verdict, got {run.response.verdict}",
+    )
+    _expect(run.response.confidence < 0.55, f"Expected reduced confidence, got {run.response.confidence}")
+    _expect(
+        any("motive" in item.lower() or "pressure" in item.lower() for item in run.response.smallest_fix),
+        f"Expected motive or pressure smallest-fix guidance, got {run.response.smallest_fix}",
+    )
 
 
 @pytest.mark.unit
@@ -211,12 +245,12 @@ def test_missing_layer_honesty_reduces_confidence():
 def test_symbolic_request_is_typed_unsupported_without_overclaim():
     run = ENGINE.run("Does the moon above the ruined bridge definitely symbolize rebirth?")
 
-    assert run.request.task_kind == TaskKind.UNSUPPORTED
-    assert run.response.supported_in_phase_one is False
-    assert run.response.verdict is None
-    assert run.response.main_supports == []
-    assert run.response.main_blockers == []
-    assert run.response.confidence <= 0.2
+    _expect(run.request.task_kind == TaskKind.UNSUPPORTED, f"Expected unsupported, got {run.request.task_kind}")
+    _expect(run.response.supported_in_phase_one is False, "Expected unsupported phase-one response")
+    _expect(run.response.verdict is None, f"Expected no verdict, got {run.response.verdict}")
+    _expect(run.response.main_supports == [], f"Expected no supports, got {run.response.main_supports}")
+    _expect(run.response.main_blockers == [], f"Expected no blockers, got {run.response.main_blockers}")
+    _expect(run.response.confidence <= 0.2, f"Expected low confidence, got {run.response.confidence}")
 
 
 @pytest.mark.unit
@@ -225,6 +259,12 @@ def test_proposal_stays_provisional_in_state():
     run = ENGINE.run(MARA_INPUT, proposal=MARA_PROPOSAL)
 
     proposed_events = [event for event in run.state.events if event.status == "proposed"]
-    assert len(proposed_events) == 1
-    assert proposed_events[0].label == "abandon Teren to deliver the rebellion signal"
-    assert proposed_events[0].label not in run.state.continuity["established_events"]
+    _expect(len(proposed_events) == 1, f"Expected one proposed event, got {proposed_events}")
+    _expect(
+        proposed_events[0].label == "abandon Teren to deliver the rebellion signal",
+        f"Unexpected proposed event label: {proposed_events[0].label}",
+    )
+    _expect(
+        proposed_events[0].label not in run.state.continuity["established_events"],
+        "Expected proposed event to stay out of established continuity",
+    )

--- a/tools/command_chain/COMMAND_CHAIN_REFERENCE.md
+++ b/tools/command_chain/COMMAND_CHAIN_REFERENCE.md
@@ -12,6 +12,11 @@ python tools/command_chain/cmd_321.py
 python tools/command_chain/dispatcher.py 321
 ```
 
+The integrated command-chain entrypoints above invoke the Python implementation
+in `tools/command_chain/comprehensive_sync_321.py`. The enhanced shell workflow
+at `scripts/sync_321_enhanced.sh` is a separate manual path and is not what the
+dispatcher runs.
+
 **Phases:**
 1. Check for pending changes
 2. Intelligent staging (by priority)

--- a/tools/command_chain/COMPREHENSIVE_SYNC_321.md
+++ b/tools/command_chain/COMPREHENSIVE_SYNC_321.md
@@ -1,22 +1,28 @@
-# Aurora Command Chain: #321//. – Comprehensive Sync & Validate (Enhanced)
+# Aurora Command Chain: #321//. – Comprehensive Sync & Validate
 
 **Command Code:** `#321//.`  
 **Category:** Universal Sync & Quality Assurance  
-**Status:** Production Ready  
-**Version:** 4.0.0  
-**Last Updated:** 2025-11-03
+**Status:** Split implementation surface  
+**Version:** Python integrated path + enhanced shell variant  
+**Last Updated:** 2026-03-27
 
 ---
 
 ## Quick Summary
 
-**One command to rule them all.** `#321//.` is Aurora's most powerful and frequently used workflow command—a universal "clean working tree" operation that stages, commits, syncs with remote, validates all changes, **intelligently updates documentation**, and **automatically syncs the wiki submodule** in a single intelligent sequence.
+`#321//.` is a universal "clean working tree" command family with two active execution tracks in this repo: the integrated Python path and a separate enhanced shell variant.
 
-**When to use:** Anytime you want pending changes sorted with high quality, with automatic documentation updates when needed.
+**Integrated Python path:** `python tools/command_chain/cmd_321.py` or `python tools/command_chain/dispatcher.py 321`
 
-**Runtime:** ~30-60 seconds depending on change volume.
+**Integrated behavior:** 6 phases for check, stage, commit, sync, validation, and performance verification.
 
-**New in v4.0:** Intelligent documentation updates (VERSION → README badges) and automatic wiki submodule synchronization.
+**Enhanced shell variant:** `bash scripts/sync_321_enhanced.sh`
+
+**Enhanced extras:** VERSION/README automation and wiki synchronization. This shell path is separate from the dispatcher-backed implementation and carries additional environment assumptions.
+
+**When to use:** Anytime you want pending changes sorted with high quality, choosing the Python or shell path explicitly.
+
+**Runtime:** Python path is typically faster; enhanced shell runtime depends on documentation and wiki work.
 
 ---
 
@@ -27,15 +33,14 @@
 ### What Makes #321//. Special
 
 1. **Always Available** - Use anytime, not just end-of-session
-2. **7-Phase Execution** - Every step from check to verify (now with docs & wiki!)
-3. **Intelligent Documentation** - Auto-updates VERSION → README badges, dates, wiki
-4. **Wiki Synchronization** - Automatically commits and pushes wiki submodule
-5. **Intelligent Staging** - Groups files by type and importance
-6. **Smart Commits** - Generates meaningful messages from change analysis
-7. **Safe Syncing** - Pull with rebase, conflict detection, push verification
-8. **Quick Validation** - Critical checks only for speed
-9. **Performance Tracking** - Measures timing and reports success
-10. **Clean Working Tree** - Guaranteed clean state after execution
+2. **Integrated Python Workflow** - 6 phases wired into the command-chain entrypoints
+3. **Enhanced Shell Variant** - Separate manual path for doc/wiki automation
+4. **Intelligent Staging** - Groups files by type and importance
+5. **Smart Commits** - Generates meaningful messages from change analysis
+6. **Safe Syncing** - Pull with rebase, conflict detection, push verification
+7. **Quick Validation** - Critical checks only for speed
+8. **Performance Tracking** - Measures timing and reports success
+9. **Clean Working Tree Goal** - Reports when additional cleanup is still required
 
 ### The Universal Sync Command
 
@@ -52,7 +57,7 @@
 
 ---
 
-## 📊 The 7 Phases
+## 📊 Integrated Python Path: 6 Phases
 
 ### Phase 1: Check for Pending Changes
 

--- a/tools/command_chain/artifact_manager.py
+++ b/tools/command_chain/artifact_manager.py
@@ -16,11 +16,13 @@ Pattern:
 
 import logging
 import subprocess
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
 
 
 class ArtifactManager:

--- a/tools/command_chain/chain_flow.py
+++ b/tools/command_chain/chain_flow.py
@@ -18,10 +18,13 @@ Features:
 """
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Callable, List, Optional
 
 from .executor import ChainExecutionResult, CommandExecutor, ExecutionResult
+
+UTC = timezone.utc
 
 
 class FlowControlType(Enum):
@@ -154,7 +157,6 @@ class CommandChainFlow:
             parse_result = self.executor.parser.parse(cmd)
             if parse_result.has_errors:
                 # Create failed result
-                from datetime import datetime, UTC
                 return ChainExecutionResult(
                     chain_hash='',
                     results=[],

--- a/tools/command_chain/cmd_321.py
+++ b/tools/command_chain/cmd_321.py
@@ -27,7 +27,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from tools.command_chain.comprehensive_sync_321 import (  # noqa: E402
     SyncConfig,
-    execute_321
+    execute_321,
+    resolve_config_path,
 )
 
 
@@ -183,14 +184,12 @@ Philosophy:
         return init_config(config_path)
 
     # Determine config path
-    config_path = None
+    config_path = resolve_config_path(args.config, args.workspace)
     if args.config:
-        config_path = Path(args.config)
         if not config_path.exists():
             print(f"❌ Config file not found: {config_path}")
             return 1
-    elif Path('.aurora/sync_config.json').exists():
-        config_path = Path('.aurora/sync_config.json')
+    elif config_path:
         print(f"📄 Using config: {config_path}")
 
     # Handle show-config

--- a/tools/command_chain/cmd_commit.py
+++ b/tools/command_chain/cmd_commit.py
@@ -16,7 +16,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from tools.command_chain.comprehensive_sync_321 import (  # noqa: E402
     ComprehensiveSync,
     SyncConfig,
-    SyncResult
+    SyncResult,
+    resolve_config_path,
+    resolve_workspace_path,
 )
 
 
@@ -32,18 +34,11 @@ def execute_commit(config_path: Optional[str] = None, workspace_path: Optional[s
         SyncResult with phases 1-3 executed
     """
     # Load configuration
-    if config_path and Path(config_path).exists():
-        config = SyncConfig.load(Path(config_path))
-    elif Path(".aurora/sync_config.json").exists():
-        config = SyncConfig.load(Path(".aurora/sync_config.json"))
-    else:
-        config = SyncConfig()
+    resolved_config_path = resolve_config_path(config_path, workspace_path)
+    config = SyncConfig.load(resolved_config_path)
 
     # Set workspace
-    if workspace_path:
-        workspace = Path(workspace_path)
-    else:
-        workspace = Path.cwd()
+    workspace = resolve_workspace_path(workspace_path)
 
     # Create sync instance
     sync = ComprehensiveSync(config, workspace)
@@ -82,7 +77,7 @@ def execute_commit(config_path: Optional[str] = None, workspace_path: Optional[s
 
     # Phase 2: Stage changes
     print("Phase 2: Staging changes intelligently...")
-    phase2 = sync._phase2_intelligent_staging(phase1.details['categories'])
+    phase2 = sync._phase2_intelligent_staging(phase1.details)
     phases.append(phase2)
 
     if not phase2.success:
@@ -100,9 +95,8 @@ def execute_commit(config_path: Optional[str] = None, workspace_path: Optional[s
     # Phase 3: Commit
     print("Phase 3: Generating commit message and committing...")
     phase3 = sync._phase3_generate_commit(
-        phase1.details['categories'],
-        phase1.details.get('is_docs_only', False),
-        phase1.details.get('is_config_only', False)
+        phase1.details,
+        phase2.details,
     )
     phases.append(phase3)
 
@@ -124,7 +118,8 @@ def execute_commit(config_path: Optional[str] = None, workspace_path: Optional[s
         phases=phases,
         commit_sha=phase3.details.get('commit_sha'),
         files_changed=phase1.details['files_changed'],
-        total_duration=sum(p.duration_seconds for p in phases)
+        total_duration=sum(p.duration_seconds for p in phases),
+        summary_message=phase3.details.get('commit_message', ''),
     )
 
     print("\n" + "=" * 60)

--- a/tools/command_chain/cmd_status.py
+++ b/tools/command_chain/cmd_status.py
@@ -15,7 +15,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from tools.command_chain.comprehensive_sync_321 import (  # noqa: E402
     ComprehensiveSync,
-    SyncConfig
+    SyncConfig,
+    resolve_config_path,
+    resolve_workspace_path,
 )
 
 
@@ -31,18 +33,11 @@ def execute_status(config_path: Optional[str] = None, workspace_path: Optional[s
         Phase 1 result with file categorization
     """
     # Load configuration
-    if config_path and Path(config_path).exists():
-        config = SyncConfig.load(Path(config_path))
-    elif Path(".aurora/sync_config.json").exists():
-        config = SyncConfig.load(Path(".aurora/sync_config.json"))
-    else:
-        config = SyncConfig()
+    resolved_config_path = resolve_config_path(config_path, workspace_path)
+    config = SyncConfig.load(resolved_config_path)
 
     # Set workspace
-    if workspace_path:
-        workspace = Path(workspace_path)
-    else:
-        workspace = Path.cwd()
+    workspace = resolve_workspace_path(workspace_path)
 
     # Create sync instance
     sync = ComprehensiveSync(config, workspace)

--- a/tools/command_chain/cmd_sync.py
+++ b/tools/command_chain/cmd_sync.py
@@ -15,7 +15,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from tools.command_chain.comprehensive_sync_321 import (  # noqa: E402
     ComprehensiveSync,
-    SyncConfig
+    SyncConfig,
+    resolve_config_path,
+    resolve_workspace_path,
 )
 
 
@@ -31,18 +33,11 @@ def execute_sync(config_path: Optional[str] = None, workspace_path: Optional[str
         Phase 4 result
     """
     # Load configuration
-    if config_path and Path(config_path).exists():
-        config = SyncConfig.load(Path(config_path))
-    elif Path(".aurora/sync_config.json").exists():
-        config = SyncConfig.load(Path(".aurora/sync_config.json"))
-    else:
-        config = SyncConfig()
+    resolved_config_path = resolve_config_path(config_path, workspace_path)
+    config = SyncConfig.load(resolved_config_path)
 
     # Set workspace
-    if workspace_path:
-        workspace = Path(workspace_path)
-    else:
-        workspace = Path.cwd()
+    workspace = resolve_workspace_path(workspace_path)
 
     # Create sync instance
     sync = ComprehensiveSync(config, workspace)

--- a/tools/command_chain/comprehensive_sync_321.py
+++ b/tools/command_chain/comprehensive_sync_321.py
@@ -20,7 +20,7 @@ Usage:
 
 import json
 import logging
-import subprocess
+import subprocess  # nosec B404
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -41,14 +41,19 @@ def resolve_config_path(config_path: Optional[str] = None, workspace_path: Optio
 
     if config_path:
         candidate = Path(config_path).expanduser()
-        if candidate.exists() or candidate.is_absolute() or workspace is None:
+        if candidate.is_absolute() or workspace is None:
             return candidate
 
         workspace_candidate = workspace / candidate
-        if workspace_candidate.exists():
-            return workspace_candidate
+        if candidate.exists() and workspace_candidate.exists():
+            logger.warning(
+                "Config path '%s' exists in both caller CWD and workspace; "
+                "using workspace-scoped path '%s'",
+                candidate,
+                workspace_candidate,
+            )
 
-        return candidate
+        return workspace_candidate
 
     if workspace is not None:
         workspace_config = workspace / ".aurora" / "sync_config.json"
@@ -766,7 +771,7 @@ class ComprehensiveSync:
         """Execute shell command with timeout"""
         timeout = timeout or self.config.timeout_seconds
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec
                 cmd,
                 cwd=self.workspace,
                 capture_output=True,

--- a/tools/command_chain/comprehensive_sync_321.py
+++ b/tools/command_chain/comprehensive_sync_321.py
@@ -30,6 +30,34 @@ from typing import Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+def resolve_workspace_path(workspace_path: Optional[str] = None) -> Path:
+    """Resolve the target workspace directory for command execution."""
+    return Path(workspace_path).expanduser() if workspace_path else Path.cwd()
+
+
+def resolve_config_path(config_path: Optional[str] = None, workspace_path: Optional[str] = None) -> Optional[Path]:
+    """Resolve config lookup without leaking caller-cwd config into another workspace."""
+    workspace = resolve_workspace_path(workspace_path) if workspace_path else None
+
+    if config_path:
+        candidate = Path(config_path).expanduser()
+        if candidate.exists() or candidate.is_absolute() or workspace is None:
+            return candidate
+
+        workspace_candidate = workspace / candidate
+        if workspace_candidate.exists():
+            return workspace_candidate
+
+        return candidate
+
+    if workspace is not None:
+        workspace_config = workspace / ".aurora" / "sync_config.json"
+        return workspace_config if workspace_config.exists() else None
+
+    local_config = Path(".aurora/sync_config.json")
+    return local_config if local_config.exists() else None
+
+
 @dataclass
 class SyncConfig:
     """Configuration for #321//. command execution"""
@@ -190,8 +218,10 @@ class ComprehensiveSync:
             if not phase1.success:
                 return self._build_result(success=False)
 
+            files_changed = phase1.details.get('files_changed', 0)
+
             # Early exit if no changes
-            if phase1.details.get('files_changed', 0) == 0:
+            if files_changed == 0:
                 logger.info("No changes detected - working tree already clean")
                 return self._build_result(success=True)
 
@@ -199,25 +229,35 @@ class ComprehensiveSync:
             phase2 = self._phase2_intelligent_staging(phase1.details)
             self.phases.append(phase2)
             if not phase2.success:
-                return self._build_result(success=False)
+                return self._build_result(success=False, files_changed=files_changed)
 
             # Phase 3: Generate & commit
             phase3 = self._phase3_generate_commit(phase1.details, phase2.details)
             self.phases.append(phase3)
             if not phase3.success:
-                return self._build_result(success=False)
+                return self._build_result(success=False, files_changed=files_changed)
 
             # Phase 4: Sync to main
             phase4 = self._phase4_sync_to_main()
             self.phases.append(phase4)
             if not phase4.success:
-                return self._build_result(success=False)
+                return self._build_result(
+                    success=False,
+                    commit_sha=phase3.details.get('commit_sha'),
+                    files_changed=files_changed,
+                    summary_message=phase3.details.get('commit_message', '')
+                )
 
             # Phase 5: Quick validation
             phase5 = self._phase5_quick_validation(phase1.details)
             self.phases.append(phase5)
             if not phase5.success:
-                return self._build_result(success=False)
+                return self._build_result(
+                    success=False,
+                    commit_sha=phase3.details.get('commit_sha'),
+                    files_changed=files_changed,
+                    summary_message=phase3.details.get('commit_message', '')
+                )
 
             # Phase 6: Performance verification
             phase6 = self._phase6_performance_verification()
@@ -226,7 +266,7 @@ class ComprehensiveSync:
             return self._build_result(
                 success=True,
                 commit_sha=phase3.details.get('commit_sha'),
-                files_changed=phase1.details.get('files_changed', 0),
+                files_changed=files_changed,
                 summary_message=phase3.details.get('commit_message', '')
             )
 
@@ -769,8 +809,9 @@ def execute_321(config_path: Optional[str] = None, workspace_path: Optional[str]
         >>> if result.success:
         ...     print(f"Clean working tree in {result.total_duration:.1f}s")
     """
-    config = SyncConfig.load(Path(config_path) if config_path else None)
-    workspace = Path(workspace_path) if workspace_path else None
+    resolved_config_path = resolve_config_path(config_path=config_path, workspace_path=workspace_path)
+    config = SyncConfig.load(resolved_config_path)
+    workspace = resolve_workspace_path(workspace_path)
 
     sync = ComprehensiveSync(config=config, workspace_path=workspace)
     result = sync.execute()

--- a/tools/command_chain/executor.py
+++ b/tools/command_chain/executor.py
@@ -305,7 +305,8 @@ class CommandExecutor:
             return bool(output['success'])
 
         status = output.get('status')
-        if status != 'executed':
+        failure_statuses = {'failed', 'partial', 'warning'}
+        if isinstance(status, str) and status.lower() in failure_statuses:
             return False
 
         return True

--- a/tools/command_chain/executor.py
+++ b/tools/command_chain/executor.py
@@ -17,13 +17,15 @@ Pattern:
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from .parser import Command, CommandChainParser
 from .real_implementations import RealCommandImplementations
 from .artifact_manager import ArtifactManager
+
+UTC = timezone.utc
 
 
 @dataclass
@@ -271,10 +273,11 @@ class CommandExecutor:
             output = handler()
             end_time = datetime.now(UTC)
             exec_time = (end_time - start_time).total_seconds() * 1000
+            success = self._normalize_handler_success(output)
 
             return ExecutionResult(
                 command=cmd.name,
-                success=True,
+                success=success,
                 output=output,
                 error=None,
                 dlp_hash=self._generate_execution_hash(cmd.name),
@@ -292,6 +295,20 @@ class CommandExecutor:
                 dlp_hash=self._generate_execution_hash(cmd.name),
                 execution_time_ms=exec_time
             )
+
+    def _normalize_handler_success(self, output: Any) -> bool:
+        """Interpret dict-based handler payloads consistently for chain metrics."""
+        if not isinstance(output, dict):
+            return True
+
+        if 'success' in output:
+            return bool(output['success'])
+
+        status = output.get('status')
+        if status != 'executed':
+            return False
+
+        return True
 
     def _generate_execution_hash(self, command: str) -> str:
         """Generate DLP hash for execution tracking"""

--- a/tools/command_chain/real_implementations.py
+++ b/tools/command_chain/real_implementations.py
@@ -68,7 +68,7 @@ class RealCommandImplementations:
                 return result
 
             # Parse porcelain output
-            for line in status_output.strip().split('\n'):
+            for line in status_output.splitlines():
                 if not line:
                     continue
 


### PR DESCRIPTION
## What

Revives the parked work from #640 (closed 2026-05-04 as "blocked CloudBank backlog hygiene, branch preserved") — primarily the **narrative validation engine phase one**, plus the command-chain sync entrypoint repairs. Owner approved revival during the 2026-06-10 unlanded-work recovery session, in support of the narrative-layer roadmap.

## Rebase notes

- Rebased ~2 months across main's drift; the narrative engine applied cleanly.
- **Dropped** `fc3d3f22` (April workflow restoration) and took main's versions of `aurora-release.yml`/`deploy-pages.yml` in `5f9fe3b2` — the April workflow state is superseded and would have regressed this week's action-pin repairs (#942).
- Net payload: 25 files, +2,103/−84.

## Verification

`tests/test_narrative_validation_engine.py` (7 tests) and `tests/test_command_chain_entrypoints.py` — **14 passed** locally on Python 3.11.

Supersedes #640 and (transitively) #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)