### PR TITLE
feat(mesh): restore /health contract and recover V1 mesh runtime tests (March lineage)

### DIFF
--- a/config/mesh/memory/alex_thorne.md
+++ b/config/mesh/memory/alex_thorne.md
@@ -1,5 +1,5 @@
 # Alex Thorne
 
 Project Manager and Systems Architect for the Aurora mesh.
-Respond with concise, strategic guidance grounded in delivery, architecture, and coordination.
-Keep recommendations operational and continuity-safe.
+Respond with concise, strategic guidance grounded in structure, delivery, and coordination.
+Prioritize system coherence over flourish.

--- a/docs/PHASE1_MESH_RUNTIME_BOUNDARY.md
+++ b/docs/PHASE1_MESH_RUNTIME_BOUNDARY.md
@@ -1,0 +1,138 @@
+# Phase 1 Mesh Runtime Boundary
+
+Date: 2026-03-21
+Scope: `aurora-cloudbank-symbolic-main`
+Status: active runtime validated, broad migration still unresolved
+
+## Validated Runtime Surface
+
+The currently validated runtime path is:
+
+- `src/servers/l2_integration_server.py`
+- `src/mesh/`
+- `src/aurora/cli/mesh_cli.py`
+- `config/mesh/agents/*.json`
+- `config/mesh/memory/`
+- `src/dashboard/agent_constellation.html`
+- `src/interfaces/aurora_collaboration_chamber.html`
+- `runtime/mesh/`
+- `scripts/mesh-runtime-launch.sh`
+- `deployment/launchd/com.aurora.mesh-runtime.plist`
+
+## Evidence
+
+### Runtime initialization
+
+This command succeeded in the repo root:
+
+```bash
+.venv/bin/python -c 'from pathlib import Path; from src.mesh.runtime import MeshRuntime; rt=MeshRuntime(Path(".")); status=rt.get_status(); print(status["mesh_status"], status["total_agents"], status["event_cursor"])'
+```
+
+Observed result on 2026-03-21:
+
+- `mesh_status=operational`
+- `total_agents=6`
+- `event_cursor=22`
+
+### Compile validation
+
+These files compiled successfully with `py_compile`:
+
+- `src/servers/l2_integration_server.py`
+- `src/mesh/runtime.py`
+- `src/mesh/live_agents.py`
+- `src/aurora/cli/mesh_cli.py`
+
+### Manifest inventory
+
+The current runtime uses `6` agent manifests under `config/mesh/agents/`.
+
+### Test validation
+
+The focused runtime regression tests passed when invoked through the interpreter:
+
+```bash
+.venv/bin/python -m pytest tests/test_mesh_runtime_surface.py tests/test_mesh_runtime_api_surface.py -q
+```
+
+Note:
+- `.venv/bin/pytest` currently points at a stale root-style path and is not reliable in this worktree.
+- `.venv/bin/python` works and should be used as the invocation path until the virtualenv wrappers are regenerated.
+- The API-surface test emitted FastAPI deprecation warnings for `@app.on_event` in `src/servers/l2_integration_server.py`. This is non-blocking today but should be migrated to lifespan handlers.
+
+## Current Drift
+
+The repo worktree still contains severe unresolved migration drift:
+
+- large tracked deletions remain across `docs/`, `scripts/`, `src/`, `.github/`, `.security/`, and other surfaces
+- new `.aurora/`, `deployment/launchd/`, and `runtime/mesh/` files are present as a partial replacement surface
+- `main` currently has no upstream configured
+- `.venv/bin/pytest` still embeds the non-authoritative root-style path `Aurora_Sim_Architecture/aurora-cloudbank-symbolic-main`
+- `src/servers/l2_integration_server.py` still uses deprecated FastAPI `@app.on_event` hooks
+
+This means the validated mesh runtime should be treated as the active operational path, while the rest of the deletion set remains under review.
+
+## Deletion Classification
+
+Deletion counts by major area:
+
+- `docs/operational`: `128`
+- `scripts`: `19`
+- `venv_opal2`: `16`
+- `src`: `15`
+- `.security`: `13`
+- `.github`: `11`
+- `.aurora`: `9`
+- `manifests`: `6`
+- `.gitwiz`: `5`
+- `tests`: `4`
+
+Further breakdown:
+
+- `docs/operational/reports`: `45`
+- `docs/operational/guides`: `29`
+- `docs/operational/completed`: `25`
+- `docs/operational/status`: `14`
+- `docs/operational/archived`: `13`
+- `.github/workflows`: `9`
+- `src/aurora`: `6`
+- `src/aurora_fusion`: `5`
+
+Recommended treatment by category:
+
+- `docs/operational/*`: likely historical or reporting surfaces; do not restore blindly, but they are lower priority than source/policy deletions if no current references depend on them.
+- `.github/workflows` and `.security/*`: review before deletion is accepted, because these are policy, CI, and publication surfaces rather than mere clutter.
+- `src/*`, `tests/*`, and `manifests/*`: review before deletion is accepted, because these are code and validation surfaces.
+- `venv_opal2/*`: likely environment artifact; restoration is usually lower value than documenting removal.
+- deleted root-level one-off utilities: treat as legacy candidate scripts until a written migration spec says otherwise.
+
+## Documentation Drift
+
+During Phase 1 stabilization, these README-linked documents were confirmed missing from the current worktree:
+
+- `docs/CHATGPT_AGENT_MODE_INTEGRATION.md`
+- `docs/operational/README.md`
+- `docs/operational/ORGANIZATION_SUMMARY.md`
+
+The README now points here instead of treating those paths as current.
+
+## Search Result
+
+A direct path search across the current worktree found no full-path references to the deleted tracked file set from the active runtime code. That supports treating the active mesh runtime as a narrower, newer execution surface rather than a thin wrapper over the deleted legacy files.
+
+This does not prove the deletions are safe to commit.
+
+## Safe Operating Guidance
+
+1. Treat the mesh runtime surface above as the only currently validated execution path.
+2. Do not treat the broad deletion set as complete migration without a written migration spec.
+3. Do not restore or delete large surfaces ad hoc; reconcile them by category.
+4. Prefer repo-relative launch and validation paths over external automation paths.
+5. Delay upstream/publication changes until the deletion set is resolved or explicitly accepted.
+
+## Next Phase 1 Steps
+
+1. Audit deleted files by category and identify which ones are still product-facing, policy-facing, or merely legacy noise.
+2. Decide which deleted tracked files require restoration, which require formal deprecation, and which can remain removed under a migration record.
+3. Add focused tests around the current mesh runtime so the validated surface stays protected while the rest of the repo is reconciled.

--- a/src/servers/l2_integration_server.py
+++ b/src/servers/l2_integration_server.py
@@ -147,6 +147,15 @@ def create_app(project_root: Path | None = None) -> FastAPI:
         except WebSocketDisconnect:
             await mesh_runtime.websocket_hub.disconnect(websocket)
 
+    @mesh_app.get("/health")
+    async def mesh_health() -> Dict[str, Any]:
+        status = mesh_runtime.get_status()
+        return {
+            "status": "healthy",
+            "mesh_status": status["mesh_status"],
+            "total_agents": status["total_agents"],
+        }
+
     @mesh_app.get("/api/mesh/status")
     async def mesh_status() -> Dict[str, Any]:
         return mesh_runtime.get_status()

--- a/tests/test_mesh_runtime_api_surface.py
+++ b/tests/test_mesh_runtime_api_surface.py
@@ -1,0 +1,94 @@
+"""API-level regression checks for the validated mesh runtime surface."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.servers.l2_integration_server import create_app
+
+try:
+    from fastapi.testclient import TestClient
+except ModuleNotFoundError:  # pragma: no cover - dependency varies by environment
+    TestClient = None
+
+
+def copy_mesh_project(tmp_path: Path) -> Path:
+    """Copy the runtime assets needed to boot the mesh API in isolation."""
+
+    for relative in ["config/mesh", "src/dashboard", "src/interfaces"]:
+        source = PROJECT_ROOT / relative
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, target, dirs_exist_ok=True)
+
+    for manifest_path in (tmp_path / "config" / "mesh" / "agents").glob("*.json"):
+        manifest = json.loads(manifest_path.read_text())
+        manifest["typing_profile"]["delay_ms"] = 5
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    return tmp_path
+
+
+def wait_for_agent_reply(client: TestClient, channel_id: str, timeout: float = 1.5) -> dict:
+    """Poll channel history until the async agent reply appears."""
+
+    deadline = time.time() + timeout
+    path = "/api/mesh/channels/{}/history?limit=40".format(quote(channel_id, safe=""))
+    while time.time() < deadline:
+        history = client.get(path).json()
+        if any(event["event_type"] == "agent_reply" for event in history["events"]):
+            return history
+        time.sleep(0.05)
+    pytest.fail(f"Timed out waiting for agent reply on {channel_id}")
+
+
+@pytest.mark.skipif(TestClient is None, reason="fastapi test client is not installed")
+def test_mesh_runtime_api_surface(tmp_path: Path) -> None:
+    """The FastAPI runtime should expose the validated mesh dashboard and API contract."""
+
+    project_root = copy_mesh_project(tmp_path)
+    client = TestClient(create_app(project_root))
+
+    chamber_html = client.get("/chamber")
+    assert chamber_html.status_code == 200
+    assert "socket.io" not in chamber_html.text.lower()
+    assert "new WebSocket" in chamber_html.text
+
+    dashboard_html = client.get("/")
+    assert dashboard_html.status_code == 200
+    assert "/api/mesh/status" in dashboard_html.text
+
+    health = client.get("/health").json()
+    assert health["status"] == "healthy"
+    assert health["mesh_status"] == "operational"
+
+    status = client.get("/api/mesh/status").json()
+    assert status["mesh_status"] == "operational"
+    assert status["total_agents"] == 6
+
+    with client.websocket_connect("/ws/mesh") as websocket:
+        initial = websocket.receive_json()
+        assert initial["payload"]["phase"] == "socket_connected"
+        websocket.send_text("ping")
+        pong = websocket.receive_json()
+        assert pong["payload"]["phase"] == "pong"
+
+    send = client.post(
+        "/api/mesh/messages",
+        json={"to": "alex_thorne", "channel": "private:captain:alex", "content": "Status check."},
+    )
+    assert send.status_code == 200
+    history = wait_for_agent_reply(client, "private:captain:alex")
+    assert any(event["event_type"] == "agent_reply" for event in history["events"])

--- a/tests/test_mesh_runtime_surface.py
+++ b/tests/test_mesh_runtime_surface.py
@@ -1,0 +1,36 @@
+"""Regression checks for the current mesh runtime surface."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.mesh.runtime import MeshRuntime
+
+
+def test_mesh_runtime_initializes_from_agent_manifests(tmp_path: Path) -> None:
+    """The current mesh runtime should initialize from the checked-in agent manifests."""
+
+    manifest_src = PROJECT_ROOT / "config" / "mesh" / "agents"
+    manifest_dst = tmp_path / "config" / "mesh" / "agents"
+    manifest_dst.mkdir(parents=True)
+
+    manifest_paths = sorted(manifest_src.glob("*.json"))
+    assert manifest_paths, "expected checked-in mesh agent manifests"
+
+    for path in manifest_paths:
+        shutil.copy2(path, manifest_dst / path.name)
+
+    runtime = MeshRuntime(tmp_path)
+    status = runtime.get_status()
+
+    assert status["mesh_status"] == "operational"
+    assert status["total_agents"] == len(manifest_paths)
+    assert runtime.get_agent("captain alex line")["agent_id"] == "alex_thorne"
+    assert (tmp_path / "config" / "mesh" / "memory" / "alex_thorne.md").exists()


### PR DESCRIPTION
Second extraction from the March rescue lineage (after #979), per the owner-approved narrative-cargo recovery.

## What was recovered

| Item | Why it matters |
|---|---|
| `tests/test_mesh_runtime_api_surface.py` | The **V1 mesh contract as an executable spec** — chamber UI, `/health`, mesh status (6 agents), WebSocket ping/pong, and a full message→`agent_reply` roundtrip on `private:captain:alex`. Directly relevant to open issue #764 (mesh contract drift). |
| `tests/test_mesh_runtime_surface.py` | Manifest-initialization regression coverage. |
| `/health` on `create_app()` | The recovered test caught real drift: the factory app never exposed `/health` despite the module docstring documenting it. One small route restores the contract. |
| `docs/PHASE1_MESH_RUNTIME_BOUNDARY.md` | Phase-boundary doc for the mesh runtime. |
| `config/mesh/memory/alex_thorne.md` | Persona memory updated to the anti-flourish doctrine — *'Prioritize system coherence over flourish'* — consistent with the narrative tone governance rules. |

## What was deliberately NOT recovered

`src/mesh/live_agents.py` from the lineage — main's version is newer (prompt-safety hardening, shared client); the lineage delta is superseded. Command grammar and Aurora Fusion modules were checked file-by-file: **already byte-identical on main**.

## Verification

Both recovered tests pass against this branch locally (Python 3.11): `2 passed`. The roundtrip test exercises echo-mode agent replies without external model calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)