### PR TITLE
docs: wire in the central development roadmap (recovered from never-PR'd branches)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,9 +19,9 @@
 
 <!-- Describe what you changed and why -->
 
-- 
-- 
-- 
+-
+-
+-
 
 ## 🧪 Testing
 
@@ -36,7 +36,7 @@
 ### Test Results
 <!-- Paste relevant test output or describe test scenarios -->
 
-```
+```text
 # Test output here
 ```
 
@@ -50,6 +50,24 @@
 - [ ] README or docs updated (if needed)
 - [ ] API documentation updated (if applicable)
 - [ ] Examples added/updated (if applicable)
+
+## 🧭 Roadmap / Review Intake / Governance
+
+<!-- Required for feature work, architecture changes, outside-review follow-ups, API/runtime changes, and issue-triage PRs -->
+
+- [ ] This PR does **not** affect roadmap sequencing, review-note status, API/runtime authority, or path-drift status
+- [ ] `docs/ROADMAP.md` updated because this PR changes active priority, sequencing, or feature maturity
+- [ ] `docs/review-notes/` updated because this PR picks up, issues, resolves, or supersedes an intake note
+- [ ] Runtime governance docs updated because this PR changes API surface, service authority, startup paths, or route ownership
+- [ ] Linked GitHub issue(s) include acceptance criteria and reflect the final implementation scope
+
+Relevant references:
+
+- [`docs/ROADMAP.md`](../docs/ROADMAP.md)
+- [`docs/review-notes/README.md`](../docs/review-notes/README.md)
+- [`docs/api/API_CATALOG_GOVERNANCE.md`](../docs/api/API_CATALOG_GOVERNANCE.md)
+- [`docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md`](../docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md)
+- [`docs/architecture/RUNTIME_PATH_DRIFT_LEDGER.md`](../docs/architecture/RUNTIME_PATH_DRIFT_LEDGER.md)
 
 ## 🔗 Related Issues/PRs
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,13 @@
 # Aurora CloudBank Roadmap
 
-This root file exists so the active development roadmap is easy to find from the repository landing page and file tree.
+The active development roadmap lives at [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
-- **Current development roadmap:** [`docs/ROADMAP.md`](docs/ROADMAP.md)
-- **Outside/session review intake queue:** [`docs/review-notes/`](docs/review-notes/)
-- **Actionable execution queue:** [GitHub Issues](https://github.com/AUo959/aurora-cloudbank-symbolic/issues)
+Related planning surfaces:
 
-Use the roadmap to understand priority and sequencing. Use review notes to preserve observations before they become work. Use GitHub Issues for committed, actionable tasks.
+- [`docs/review-notes/`](docs/review-notes/) — intake queue for outside reviews and session observations
+- GitHub Issues — execution queue for actionable work
+
+Use the roadmap for priority and sequencing. Use review notes to preserve observations before they become issues.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,13 @@
+# Aurora CloudBank Roadmap
+
+This root file exists so the active development roadmap is easy to find from the repository landing page and file tree.
+
+- **Current development roadmap:** [`docs/ROADMAP.md`](docs/ROADMAP.md)
+- **Outside/session review intake queue:** [`docs/review-notes/`](docs/review-notes/)
+- **Actionable execution queue:** [GitHub Issues](https://github.com/AUo959/aurora-cloudbank-symbolic/issues)
+
+Use the roadmap to understand priority and sequencing. Use review notes to preserve observations before they become work. Use GitHub Issues for committed, actionable tasks.
+
+---
+
+*Built for consistency, clarity, and care.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,82 +2,94 @@
 
 ## 📚 **Comprehensive Documentation Suite**
 
-Welcome to the Aurora CloudBank documentation! This quantum-symbolic platform features comprehensive documentation covering all aspects from basic usage to advanced quantum computing operations.
+Welcome to the Aurora CloudBank documentation. This quantum-symbolic platform includes documentation for setup, runtime governance, development planning, security, observability, and advanced symbolic/quantum modules.
 
-### 🛡️ **Rebuild Protection System** (NEW! - September 2025)
-- **[Rebuild Failure Prevention](../REBUILD_FAILURE_PREVENTION.md)** - Complete guide to our bulletproof rebuild protection system
+## 🧭 **Current Development Control Plane**
+
+Start here when deciding what to build, review, or triage next:
+
+- **[Current Development Roadmap](ROADMAP.md)** — central priority and sequencing document
+- **[Review Notes Intake Queue](review-notes/README.md)** — persistent destination for outside reviews, session observations, risks, and architectural tensions
+- **[Runtime API Governance](api/API_CATALOG_GOVERNANCE.md)** — source-of-truth rules for active API surfaces
+- **[Runtime Topology and L3 Authority](architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md)** — current runtime authority map
+- **[Runtime Path Drift Ledger](architecture/RUNTIME_PATH_DRIFT_LEDGER.md)** — stale/conflicting path and route claims to resolve
+
+## 🛡️ **Rebuild Protection System**
+
+- **[Rebuild Failure Prevention](../REBUILD_FAILURE_PREVENTION.md)** - Complete guide to the rebuild protection system
 - **[Rebuild Protection Status](../REBUILD_PROTECTION_ACTIVATED.md)** - Current system status and emergency commands
-- **Emergency Commands**: 
+- **Emergency Commands**:
   - `bash scripts/emergency_rebuild_recovery.sh` - Complete disaster recovery
   - `python3 scripts/prevent_rebuild_failures.py` - System validation
   - `bash scripts/activate_rebuild_protection.sh` - Protection status
 
-### 🏆 **System Health & Optimization**
-- **[Health Optimization Complete](../AURORA_HEALTH_OPTIMIZATION_COMPLETE.md)** - Outstanding 95.8/100 achievement
-- **[Security Guidelines](SECURITY_GUIDELINES.md)** - Enterprise-grade security framework
-- **[Dependency Management](DEPENDENCY_MANAGEMENT.md)** - Bulletproof dependency handling
+## 🏆 **System Health & Optimization**
 
-### 🚀 **Quick Start & Setup**
+- **[Health Optimization Complete](../AURORA_HEALTH_OPTIMIZATION_COMPLETE.md)** - Historical 95.8/100 achievement report
+- **[Security Guidelines](SECURITY_GUIDELINES.md)** - Enterprise-grade security framework
+- **[Dependency Management](DEPENDENCY_MANAGEMENT.md)** - Dependency handling guidance
+
+## 🚀 **Quick Start & Setup**
+
 - **[Main README](../README.md)** - Complete project overview and quick start
 - **[Phase 0 Completion Report](PHASE0_COMPLETION_REPORT.md)** - Security baseline implementation
 - **[Playground Quickstart](PLAYGROUND_QUICKSTART.md)** - Gallery-driven starter scenarios with PII masking defaults
 
-### 🔧 **Technical Documentation**
+## 🔧 **Technical Documentation**
+
 - **[Architecture Overview](architecture.md)** - Quantum-symbolic system design
 - **[API Schema Documentation](symbolicvector_api_schema.md)** - VSA-based symbolic data structures
+- **[API Surface Inventory](api/api_surface_inventory.json)** - Machine-readable API surface registry
 
-### 🌟 **Advanced Features**
+## 🌟 **Advanced Features**
+
 - **VSA-Based Symbolic Data** - Vector Symbolic Architecture implementation (see `modules/symbolic_core/vsa.py`)
 - **Opal2 Graphics Module** - Quantum symbolic vector graphics processing (see `modules/opal2/`)
 - **Quantum Computing Integration** - Hybrid quantum-classical processing capabilities
 
-## 🎯 **Current System Status** (September 27, 2025)
+## 📋 **Recent Planning Updates**
 
-### ✅ **Operational Excellence**
-- **Health Score**: 95.8/100 (Outstanding - Industry Leading)
-- **Rebuild Protection**: BULLETPROOF (Multi-layer failsafe system)
-- **Dependencies**: FastAPI 0.117.1, HTTPX 0.28.1, HTTPCore 1.0.9, H11 0.16.0
-- **API Endpoints**: 27 total (16 core + 11 AuMemManager)
-- **Security Score**: 25/25 (Perfect)
-- **Emergency Recovery**: Ready and validated
+### [2026-05-28] Central roadmap and review intake wiring
 
-### 🛡️ **Protection Features**
-- **Zero Rebuild Failures**: Multi-strategy dependency installation
-- **Automatic Backups**: Timestamped state preservation
-- **Emergency Recovery**: Complete disaster recovery protocols
-- **Continuous Monitoring**: Health checks and status tracking
-
-## 📋 **Recent Updates**
+- Added `docs/ROADMAP.md` as the active development roadmap.
+- Promoted `docs/review-notes/` as the persistent intake queue for outside/session reviews.
+- Linked runtime governance, topology, and path-drift docs from this index.
 
 ### [2025-09-27] Bulletproof Rebuild Protection System
-- **Multi-layer failsafe system** prevents DevContainer rebuild failures
-- **Emergency recovery scripts** for disaster scenarios
-- **Automatic backup creation** with timestamped state preservation
-- **Comprehensive logging** and audit trails
+
+- Multi-layer failsafe system prevents DevContainer rebuild failures.
+- Emergency recovery scripts support disaster scenarios.
+- Automatic backup creation includes timestamped state preservation.
+- Comprehensive logging and audit trails are documented.
 
 ### [2025-06-30] Opal2 Graphics Card Module
-- Introduces `modules/opal2` with the first Opal2 component
-- `GlyphGenerator` combines geometric algebra with quantum symbolic vectors
-- Designed to function as a lightweight graphics card for hybrid symbolic processing
-- Configuration lives in `config/opal2_graphics.yaml`
+
+- Introduces `modules/opal2` with the first Opal2 component.
+- `GlyphGenerator` combines geometric algebra with quantum symbolic vectors.
+- Designed to function as a lightweight graphics card for hybrid symbolic processing.
+- Configuration lives in `config/opal2_graphics.yaml`.
 
 ### [2025-06-25] VSA-Based Symbolic Data & API Schema Update
-- Symbolic data structures are now VSA-based (see `modules/symbolic_core/vsa.py`)
-- All symbolic REST/WebSocket endpoints use the `SymbolicVector` JSON schema
-- Extension points for quantum/geometric plugins
+
+- Symbolic data structures are now VSA-based (see `modules/symbolic_core/vsa.py`).
+- All symbolic REST/WebSocket endpoints use the `SymbolicVector` JSON schema.
+- Extension points support quantum/geometric plugins.
 
 ## 🚀 **Getting Started**
 
 1. **Clone Repository**: `git clone https://github.com/AUo959/aurora-cloudbank-symbolic.git`
-2. **Quick Setup**: `make install && make run`
-3. **Validate System**: `python3 scripts/prevent_rebuild_failures.py`
-4. **Access Demo**: Visit http://localhost:8000
+2. **Quick Setup**: `make setup`
+3. **Validate System**: `make check`
+4. **Review Current Work**: read [`ROADMAP.md`](ROADMAP.md)
 
 ## 🆘 **Emergency Support**
 
-If you encounter any issues:
+If you encounter setup or runtime issues:
+
 1. **System Health**: `python3 scripts/prevent_rebuild_failures.py`
 2. **Emergency Recovery**: `bash scripts/emergency_rebuild_recovery.sh`
 3. **Protection Status**: `bash scripts/activate_rebuild_protection.sh`
 
-**The system is designed to be bulletproof - protection systems will activate automatically!** 🛡️✨
+---
+
+*Built for consistency, clarity, and care.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,167 @@
+# Aurora CloudBank Development Roadmap
+
+**Status:** Active control-plane document  
+**Last updated:** 2026-05-28  
+**Owner surface:** repository maintainers, Codex agents, Aurora review sessions  
+**Related intake queue:** [`docs/review-notes/`](review-notes/)  
+**Execution queue:** [GitHub Issues](https://github.com/AUo959/aurora-cloudbank-symbolic/issues)
+
+This is the central, discoverable roadmap for current and upcoming Aurora CloudBank feature work. It is intentionally short enough to stay readable and explicit enough to steer agents, contributors, and outside reviews toward the same priorities.
+
+Older roadmap and status documents remain useful as historical references, but this file is the current coordination surface.
+
+---
+
+## 1. Purpose
+
+Aurora CloudBank is building toward a governed AI control plane: a modular runtime where memory, simulation, ethics, drift monitoring, audit logs, mesh communication, and developer tools can operate through clear API surfaces with traceable authority boundaries.
+
+Roadmap work should therefore prioritize:
+
+1. **Trustworthy operation** — tests, startup paths, secrets, and docs must fail closed or state uncertainty clearly.
+2. **Usable vertical workflows** — existing modules should compose into coherent operator journeys.
+3. **Governed extensibility** — new features must enter through documented intake, issue, and PR paths.
+
+---
+
+## 2. Canonical planning surfaces
+
+| Surface | Path | Purpose | Update rule |
+|---|---|---|---|
+| Current roadmap | `docs/ROADMAP.md` | Central priority and sequencing document | Update when priorities, lanes, or issue status materially change |
+| Review-note intake | `docs/review-notes/` | Persistent queue for outside reviews, session observations, architectural tensions, and risks | Add an entry before work becomes actionable, then triage to issue or direct fix |
+| GitHub Issues | Repository issues | Execution queue for actionable work | Open only evidence-backed tasks with acceptance criteria |
+| Runtime governance | `docs/api/API_CATALOG_GOVERNANCE.md`, `docs/api/api_surface_inventory.json`, `docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md` | API/runtime authority map | Update with API or service-surface changes |
+| Path-drift ledger | `docs/architecture/RUNTIME_PATH_DRIFT_LEDGER.md` | Known stale/conflicting runtime claims | Update when a stale path is fixed, retired, or newly discovered |
+
+---
+
+## 3. Intake-to-roadmap workflow
+
+Use this path for outside reviews, AI audits, architecture reviews, and session discoveries:
+
+```text
+outside/session review
+  → docs/review-notes/entries/YYYYMMDD-short-slug.md
+  → triage status: open | picked_up | issued | resolved | wont_fix
+  → GitHub issue when actionable
+  → roadmap lane when priority affects sequencing
+  → implementation PR
+  → update issue + review note + roadmap
+```
+
+Rules:
+
+- Do not delete review notes. They are permanent audit records.
+- Do not convert every observation directly into an issue. Preserve uncertain observations as review notes first.
+- Open GitHub issues only when the evidence, risk, and acceptance criteria are clear.
+- When a review note becomes an issue, update its frontmatter to `status: issued` and add `issue_url`.
+- When a PR closes or materially changes a roadmap item, update this file in the same PR or a follow-up docs PR.
+
+---
+
+## 4. Current active lanes
+
+### Lane A — Verification and trust hardening
+
+**Goal:** make the repository's stated health match enforced checks.
+
+| Issue | Title | Priority | Outcome sought |
+|---|---|---:|---|
+| [#758](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/758) | Harden CI gates so critical tests and quality checks fail closed | Critical | Mandatory tests fail workflows when critical runtime behavior regresses |
+| [#760](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/760) | Reconcile README production and coverage claims with enforced verification | High | README assurance language matches real, reproducible verification |
+| [#766](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/766) | Fail closed if Vercel build-phase placeholder secrets reach runtime | Critical | Placeholder secrets cannot silently reach runtime |
+
+**Next feature impact:** no major expansion should rely on unverified production claims until this lane is complete or explicitly scoped.
+
+---
+
+### Lane B — Runtime entrypoint and API authority cleanup
+
+**Goal:** make startup commands, API docs, and runtime authority consistent.
+
+| Issue | Title | Priority | Outcome sought |
+|---|---|---:|---|
+| [#759](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/759) | Align startup and deployment commands with canonical FastAPI entrypoint | Critical | Operators launch the canonical runtime surface, not stale root scripts |
+| [#763](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/763) | Regenerate or retire stale generated API catalog snapshots | High | Generated API docs are current or clearly historical |
+| [#764](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/764) | Resolve Mesh Runtime V1 contract drift for `/api/mesh/agents` routes | High | Mesh contract is either implemented and tested or marked future/planned |
+
+**Next feature impact:** new API surfaces should not be added until the inventory, generated docs, and drift ledger update process is followed.
+
+---
+
+### Lane C — Feature completion and capability honesty
+
+**Goal:** convert partial or mock-backed surfaces into honest, testable capabilities.
+
+| Issue | Title | Priority | Outcome sought |
+|---|---|---:|---|
+| [#761](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/761) | Replace or explicitly gate HR mock fallbacks and implement `OrganizationalIntelligence` | High | HR routes either use real implementations or return explicit degraded/mock status |
+| [#762](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/762) | Implement or explicitly scope quantum simulator mixed-state operations | Medium | Mixed-state behavior is implemented or rejected through documented capability errors |
+| [#765](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/765) | Fix Opal2 API decorators and add Opal2 syntax coverage | High | Opal2 route registration and syntax/import health are covered by tests |
+
+**Next feature impact:** feature work should prefer finishing and testing these surfaces before starting large new modules.
+
+---
+
+### Lane D — Review-note intake and architecture references
+
+**Goal:** keep outside/session review findings persistent, triageable, and discoverable.
+
+| Review note | Status | Priority | Next step |
+|---|---|---:|---|
+| [`20260526-drift-threshold-stratification`](review-notes/entries/20260526-drift-threshold-stratification.md) | open | Medium | Promote stable drift-threshold reference and decide whether to open an issue |
+
+**Next feature impact:** outside reviews should enter through `docs/review-notes/` before becoming issues unless the task is already fully actionable.
+
+---
+
+## 5. Feature-development direction
+
+### Near-term product goal
+
+Turn the existing module constellation into reliable operator workflows:
+
+1. **Operator console / mission control** — health, drift, telemetry, audit, active agents, and warnings in one place.
+2. **Simulation run lifecycle** — create scenario, run, stream progress, record result, audit ethics/drift, export receipt.
+3. **Memory + ledger workflow** — store context, retrieve, inspect provenance, sign or record ledger entry.
+4. **Mesh agent workflow** — inspect/register agents, send messages, view channel history, enforce L3 boundaries.
+5. **Governance review workflow** — evaluate proposed action, allow/block/degrade, record rationale and lineage.
+
+### Development posture
+
+- Prefer vertical workflows over new isolated modules.
+- Prefer explicit degraded states over mock success.
+- Prefer small, issue-linked PRs over broad rewrites.
+- Update roadmap, review-note status, and runtime governance docs as part of the change when affected.
+
+---
+
+## 6. Roadmap update triggers
+
+Update this file when any of the following occurs:
+
+- A new outside/session review identifies a gap that affects sequencing.
+- A review note is promoted to a GitHub issue.
+- A GitHub issue in an active lane is opened, closed, or materially re-scoped.
+- A PR changes canonical startup paths, API surfaces, mesh contracts, security posture, or feature maturity.
+- A new feature family is proposed.
+- Historical roadmap claims are superseded by current repo evidence.
+
+---
+
+## 7. Historical roadmap references
+
+These documents remain useful, but they are not the primary current coordination surface:
+
+- [`docs/operational/reports/FEATURE_ROADMAP_STATUS.md`](operational/reports/FEATURE_ROADMAP_STATUS.md)
+- [`docs/FEATURE_IMPLEMENTATION_ROADMAP_7PHASE.md`](FEATURE_IMPLEMENTATION_ROADMAP_7PHASE.md)
+- [`docs/implementation/PHASED_IMPLEMENTATION_PLAN.md`](implementation/PHASED_IMPLEMENTATION_PLAN.md)
+- [`docs/reports/STRATEGIC_ANALYSIS.md`](reports/STRATEGIC_ANALYSIS.md)
+- [`docs/reports/STRATEGIC_VANTAGE_POINT.md`](reports/STRATEGIC_VANTAGE_POINT.md)
+
+When these documents conflict with current runtime evidence or open issue status, prefer this roadmap plus the runtime governance docs.
+
+---
+
+*Built for consistency, clarity, and care.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,21 +2,18 @@
 
 **Status:** Active control-plane document  
 **Last updated:** 2026-05-28  
-**Owner surface:** repository maintainers, Codex agents, Aurora review sessions  
 **Related intake queue:** [`docs/review-notes/`](review-notes/)  
 **Execution queue:** [GitHub Issues](https://github.com/AUo959/aurora-cloudbank-symbolic/issues)
 
-This is the central, discoverable roadmap for current and upcoming Aurora CloudBank feature work. It is intentionally short enough to stay readable and explicit enough to steer agents, contributors, and outside reviews toward the same priorities.
-
-Older roadmap and status documents remain useful as historical references, but this file is the current coordination surface.
+This is the central roadmap for current Aurora CloudBank feature work. Older roadmap and status documents remain useful as historical references, but this file is the current coordination surface.
 
 ---
 
-## 1. Purpose
+## Purpose
 
 Aurora CloudBank is building toward a governed AI control plane: a modular runtime where memory, simulation, ethics, drift monitoring, audit logs, mesh communication, and developer tools can operate through clear API surfaces with traceable authority boundaries.
 
-Roadmap work should therefore prioritize:
+Roadmap work should prioritize:
 
 1. **Trustworthy operation** — tests, startup paths, secrets, and docs must fail closed or state uncertainty clearly.
 2. **Usable vertical workflows** — existing modules should compose into coherent operator journeys.
@@ -24,7 +21,7 @@ Roadmap work should therefore prioritize:
 
 ---
 
-## 2. Canonical planning surfaces
+## Canonical planning surfaces
 
 | Surface | Path | Purpose | Update rule |
 |---|---|---|---|
@@ -36,18 +33,16 @@ Roadmap work should therefore prioritize:
 
 ---
 
-## 3. Intake-to-roadmap workflow
-
-Use this path for outside reviews, AI audits, architecture reviews, and session discoveries:
+## Intake-to-roadmap workflow
 
 ```text
 outside/session review
-  → docs/review-notes/entries/YYYYMMDD-short-slug.md
-  → triage status: open | picked_up | issued | resolved | wont_fix
-  → GitHub issue when actionable
-  → roadmap lane when priority affects sequencing
-  → implementation PR
-  → update issue + review note + roadmap
+  -> docs/review-notes/entries/YYYYMMDD-short-slug.md
+  -> triage status: open | picked_up | issued | resolved | wont_fix
+  -> GitHub issue when actionable
+  -> roadmap lane when priority affects sequencing
+  -> implementation PR
+  -> update issue + review note + roadmap
 ```
 
 Rules:
@@ -60,7 +55,7 @@ Rules:
 
 ---
 
-## 4. Current active lanes
+## Current active lanes
 
 ### Lane A — Verification and trust hardening
 
@@ -72,10 +67,6 @@ Rules:
 | [#760](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/760) | Reconcile README production and coverage claims with enforced verification | High | README assurance language matches real, reproducible verification |
 | [#766](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/766) | Fail closed if Vercel build-phase placeholder secrets reach runtime | Critical | Placeholder secrets cannot silently reach runtime |
 
-**Next feature impact:** no major expansion should rely on unverified production claims until this lane is complete or explicitly scoped.
-
----
-
 ### Lane B — Runtime entrypoint and API authority cleanup
 
 **Goal:** make startup commands, API docs, and runtime authority consistent.
@@ -84,11 +75,7 @@ Rules:
 |---|---|---:|---|
 | [#759](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/759) | Align startup and deployment commands with canonical FastAPI entrypoint | Critical | Operators launch the canonical runtime surface, not stale root scripts |
 | [#763](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/763) | Regenerate or retire stale generated API catalog snapshots | High | Generated API docs are current or clearly historical |
-| [#764](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/764) | Resolve Mesh Runtime V1 contract drift for `/api/mesh/agents` routes | High | Mesh contract is either implemented and tested or marked future/planned |
-
-**Next feature impact:** new API surfaces should not be added until the inventory, generated docs, and drift ledger update process is followed.
-
----
+| [#764](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/764) | Resolve Mesh Runtime V1 contract drift for `/api/mesh/agents` routes | High | Mesh contract is implemented and tested or marked future/planned |
 
 ### Lane C — Feature completion and capability honesty
 
@@ -100,27 +87,19 @@ Rules:
 | [#762](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/762) | Implement or explicitly scope quantum simulator mixed-state operations | Medium | Mixed-state behavior is implemented or rejected through documented capability errors |
 | [#765](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/765) | Fix Opal2 API decorators and add Opal2 syntax coverage | High | Opal2 route registration and syntax/import health are covered by tests |
 
-**Next feature impact:** feature work should prefer finishing and testing these surfaces before starting large new modules.
-
----
-
 ### Lane D — Review-note intake and architecture references
 
 **Goal:** keep outside/session review findings persistent, triageable, and discoverable.
 
 | Review note | Status | Priority | Next step |
 |---|---|---:|---|
-| [`20260526-drift-threshold-stratification`](review-notes/entries/20260526-drift-threshold-stratification.md) | open | Medium | Promote stable drift-threshold reference and decide whether to open an issue |
-
-**Next feature impact:** outside reviews should enter through `docs/review-notes/` before becoming issues unless the task is already fully actionable.
+| [`20260526-drift-threshold-stratification`](review-notes/entries/20260526-drift-threshold-stratification.md) | open | Medium | Maintain the stable drift-threshold reference and decide whether to open an implementation issue |
 
 ---
 
-## 5. Feature-development direction
+## Feature-development direction
 
-### Near-term product goal
-
-Turn the existing module constellation into reliable operator workflows:
+Near-term feature work should turn the existing module constellation into reliable operator workflows:
 
 1. **Operator console / mission control** — health, drift, telemetry, audit, active agents, and warnings in one place.
 2. **Simulation run lifecycle** — create scenario, run, stream progress, record result, audit ethics/drift, export receipt.
@@ -128,7 +107,7 @@ Turn the existing module constellation into reliable operator workflows:
 4. **Mesh agent workflow** — inspect/register agents, send messages, view channel history, enforce L3 boundaries.
 5. **Governance review workflow** — evaluate proposed action, allow/block/degrade, record rationale and lineage.
 
-### Development posture
+Development posture:
 
 - Prefer vertical workflows over new isolated modules.
 - Prefer explicit degraded states over mock success.
@@ -137,7 +116,7 @@ Turn the existing module constellation into reliable operator workflows:
 
 ---
 
-## 6. Roadmap update triggers
+## Roadmap update triggers
 
 Update this file when any of the following occurs:
 
@@ -150,7 +129,7 @@ Update this file when any of the following occurs:
 
 ---
 
-## 7. Historical roadmap references
+## Historical roadmap references
 
 These documents remain useful, but they are not the primary current coordination surface:
 

--- a/docs/dev-notes/drift-threshold-stratification.md
+++ b/docs/dev-notes/drift-threshold-stratification.md
@@ -1,65 +1,58 @@
-# Dev Note: Drift Threshold Stratification
+# Drift Threshold Stratification Reference
 
-**Status:** Needs formal architecture doc entry  
-**Priority:** Medium — debugging hazard for new contributors  
-**Filed:** 2026-05-26  
-**Relates to:** `capsule_linter.py`, `threadcore_registry.json`, QGIA operational layer  
+**Status:** Active architecture reference  
+**Origin:** [`docs/review-notes/entries/20260526-drift-threshold-stratification.md`](../review-notes/entries/20260526-drift-threshold-stratification.md)  
+**Last updated:** 2026-05-28  
+**Related roadmap lane:** [`docs/ROADMAP.md`](../ROADMAP.md#lane-d--review-note-intake-and-architecture-references)
 
----
+Aurora uses a three-layer symbolic drift threshold model. The thresholds are intentionally stratified so lower-level capsule and governance checks remain more sensitive than larger, noisier agent or macro-system checks.
 
-## Context
-
-Aurora uses **three distinct symbolic drift thresholds** across three different system layers. These values are currently implicit — they live in code constants, registry config, and the QGIA model layer, but are **not documented together anywhere**. Anyone debugging a drift-related issue without this map will have a hard time.
+This document is the stable contributor reference. Review-note entries capture intake history and unresolved observations; this file captures durable guidance that PRs, instructions, and code comments can link to.
 
 ---
 
-## The Three Thresholds
+## Threshold model
 
-| Layer | Threshold | Where Defined | What Triggers |
-|---|---|---|---|
-| **Capsule / ThreadCore** | `0.002` | `threadcore_registry.json` → `validation_rules.max_drift_threshold`; also hardcoded as `DEFAULT_MAX_DRIFT` in `capsule_linter.py` | `symbolic_drift_high` warning finding → `review_drift` correction action planned |
-| **QGIA Agent Network** | `0.02` | QGIA operational layer (agent-level drift monitoring) | Agent flagged for drift review by Velatrix; escalation to human if unresolved |
-| **System / Macro** | `0.1` | QGIA macro-level / NexusEnhancementHub `DriftAwareAgent` | Hard alert; constellation coherence at risk; potential LOOMFIELD breach |
+| Layer | Current threshold | Intended scope | Notes |
+|---|---:|---|---|
+| L1 Capsule / Governance | `0.002` | Per-capsule or tight governance drift | Tightest layer; small symbolic changes matter |
+| L2 Agent / QGIA | `0.02` | Per-agent or session-level drift | Mid-layer; tolerates more variation across active agents |
+| L3 Macro / Network | `0.1` | Cross-network or macro-system coherence | Loosest layer; evaluates broader, noisier system behavior |
 
----
-
-## Why Three Separate Thresholds?
-
-The stratification is intentional, not accidental:
-
-- **0.002 (capsule layer)** — the tightest because capsule payloads are structural governance artifacts. A ThreadCore payload with drift above 0.002 is potentially misaligned with the anchor seed, which is a *governance* problem, not just a performance one.
-- **0.02 (agent layer)** — agents naturally have more variability than static capsules. A single agent drifting up to 2% is within acceptable operating range for the SBM network; above that, Velatrix should be notified.
-- **0.1 (system layer)** — macro drift is measured across the full 551-agent QGIA network. Aggregate drift at 10% indicates systemic misalignment. Hard alert threshold — not a soft warning.
-
-**The 10x ratio between layers is deliberate**: each layer is an order of magnitude more tolerant than the layer below it because it operates over a larger, noisier population.
+The rough 10x step between layers is intentional. A value that is safe at one layer may be too loose or too strict at another.
 
 ---
 
-## Risk if Left Undocumented
+## Contributor rule
 
-- A contributor seeing `0.002` in `capsule_linter.py` may assume it applies universally and be confused when agent-level drift at `0.015` does not trigger a linter warning.
-- A contributor tuning the QGIA agent thresholds may not realize the capsule linter has a separate, independent threshold with different semantics.
-- Debugging a `symbolic_drift_high` warning at the capsule layer while also seeing Velatrix quiet at the agent layer (because `0.015 < 0.02`) will look inconsistent without this map.
+Before changing drift thresholds, anomaly logic, capsule validation, QGIA agent monitoring, or macro drift handling:
 
----
-
-## Action Items for Future Dev
-
-- [ ] Add a **Drift Threshold Reference** section to the main `ARCHITECTURE.md` (or create one if it doesn't exist) with this three-layer table
-- [ ] Add inline comments in `capsule_linter.py` and `threadcore_registry.json` cross-referencing the other two thresholds, so the values are not read in isolation
-- [ ] Consider a single `drift_thresholds.yaml` config file that all three layers import from, eliminating the risk of the values diverging silently over time
-- [ ] Confirm the `0.02` and `0.1` thresholds are hardcoded or configurable in the QGIA layer — if hardcoded, add them to the same config consolidation
+1. Identify which layer the change affects.
+2. Check whether the other two layers remain semantically consistent.
+3. Update this file if a threshold value or rationale changes.
+4. Update the originating review note or related issue if the change resolves a tracked observation.
+5. Add or update tests where threshold behavior is externally visible.
 
 ---
 
-## Related Files
+## Known references to keep aligned
 
-- `modules/reflective_autonomy/capsule_linter.py` — `DEFAULT_MAX_DRIFT = 0.002`
-- `threadcore_registry.json` — `validation_rules.max_drift_threshold`
-- `src/nexus_enhancement_hub.js` — `DriftAwareAgent` (system-level threshold)
-- QGIA operational model (agent-level threshold)
-- `modules/reflective_autonomy/autonomic_correction_engine.py` — `symbolic_drift_high` → `review_drift` action mapping
+- `modules/reflective_autonomy/capsule_linter.py`
+- `threadcore_registry.json`
+- `src/nexus_enhancement_hub.js`
+- `modules/reflective_autonomy/autonomic_correction_engine.py`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/instructions/drift-thresholds.instructions.md`
+- `connector/tools/get_drift.py`
+
+If any of these files encode a drift value directly, prefer moving toward shared configuration or an explicit local constant with a comment linking here.
 
 ---
 
-*Filed during architecture review session, 2026-05-26. The system remembers because we chose to align.*
+## Open follow-up
+
+The review intake note remains open until the implementation surface is fully reconciled. The key unresolved question is whether all drift thresholds should be sourced from a shared `drift_thresholds.yaml` or similar configuration file.
+
+---
+
+*Built for consistency, clarity, and care.*

--- a/docs/review-notes/README.md
+++ b/docs/review-notes/README.md
@@ -4,11 +4,30 @@ This directory is a **persistent intake queue** for architectural observations, 
 
 Agents should check this directory regularly. Notes in `status: open` are eligible to be picked up as tasks or opened as GitHub issues.
 
+**Central roadmap:** [`docs/ROADMAP.md`](../ROADMAP.md)  
+**Execution queue:** [GitHub Issues](https://github.com/AUo959/aurora-cloudbank-symbolic/issues)
+
+---
+
+## Where this fits
+
+```text
+outside/session review
+  → docs/review-notes/entries/YYYYMMDD-short-slug.md
+  → triage status: open | picked_up | issued | resolved | wont_fix
+  → GitHub issue when actionable
+  → docs/ROADMAP.md when priority affects sequencing
+  → implementation PR
+  → update issue + review note + roadmap
+```
+
+Use review notes for observations that should not disappear but are not yet fully scoped as implementation work. Use GitHub Issues once the evidence, impact, and acceptance criteria are clear.
+
 ---
 
 ## Directory Structure
 
-```
+```text
 docs/review-notes/
 ├── README.md              ← This file (schema + workflow)
 ├── _template.md           ← Copy this to create a new note
@@ -20,7 +39,7 @@ docs/review-notes/
 
 ## Lifecycle
 
-```
+```text
 open → picked_up → issued → resolved
          ↓
        wont_fix
@@ -56,6 +75,7 @@ tags: []                   # Optional free-form tags
 ```
 
 Followed by a freeform body with at minimum:
+
 - **Observation** — what was noticed
 - **Risk / Impact** — why it matters
 - **Suggested Actions** — concrete next steps (use `- [ ]` task checkboxes)
@@ -66,11 +86,12 @@ Followed by a freeform body with at minimum:
 
 When scanning this directory:
 
-1. List all entries in `entries/` where `status: open`
-2. Evaluate priority and category to decide whether to pick up or open an issue
-3. To open an issue: copy the note's **Observation** as the issue body, link back to the note file, then update `status: issued` and `issue_url` in the frontmatter
-4. To pick up directly: update `status: picked_up`, implement the suggested actions, then update to `resolved` when done
-5. Never delete note files — they are a permanent audit record. Only update their `status`.
+1. List all entries in `entries/` where `status: open`.
+2. Evaluate priority and category to decide whether to pick up or open an issue.
+3. To open an issue: copy the note's **Observation** as the issue body, link back to the note file, then update `status: issued` and `issue_url` in the frontmatter.
+4. If the issue changes project sequencing, update [`docs/ROADMAP.md`](../ROADMAP.md) in the same PR or a follow-up docs PR.
+5. To pick up directly: update `status: picked_up`, implement the suggested actions, then update to `resolved` when done.
+6. Never delete note files — they are a permanent audit record. Only update their `status`.
 
 ---
 


### PR DESCRIPTION
## What this is

The project's **central development roadmap** — written 2026-05-28 on `codex/central-dev-roadmap-review-intake` (+`-v2`), matured, and then never PR'd. Recovered in the remote-branch sweep targeting exactly this pattern: foundational work staying unwired.

Combines both variants: **v1**'s full wiring (review-note intake linked to the roadmap, docs index entries, PR-template roadmap maintenance checks, drift-threshold reference clarification) plus **v2**'s refined roadmap text.

## What it establishes

- `docs/ROADMAP.md` as the central priority/sequencing surface, with explicit update rules
- `docs/review-notes/` as the persistent intake queue feeding it
- The roadmap-maintenance checklist in the PR template, so the roadmap stays current as a side effect of normal work
- The three priority principles: trustworthy operation, usable vertical workflows, governed extensibility

Docs-only; no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
