### PR TITLE
fix(threadcore): capsule identity + role on the payload registry (governance orchestration finding)

### DIFF
--- a/threadcore_registry.json
+++ b/threadcore_registry.json
@@ -1,5 +1,7 @@
 {
   "registry_version": "1.0.0",
+  "capsule_id": "threadcore_registry",
+  "role": "ThreadCore payload registry \u2014 canonical payload index and authority map",
   "canonical_version": "v3.5.1",
   "anchor_seed": "EOS_SEED_ORION",
   "ethics_protocol": "Picard_Delta_3",


### PR DESCRIPTION
The full-system governance orchestration (2026-06-11 integration pass) flagged `threadcore_registry.json` with `B_MISSING_IDENTITY` and `B_PAYLOAD_REQUIRED_FIELD` — the capsule contract requires `capsule_id`/`role` on capsule-family artifacts. The registry already carried `anchor_seed` and `ethics_protocol`; this adds the two missing fields. Two-line change, semantically true to the artifact's function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)