### PR TITLE
feat(mesh): Pilot is the user-interface role (canon ORION.ROLE.PILOT)

### DIFF
--- a/src/mesh/models.py
+++ b/src/mesh/models.py
@@ -90,8 +90,10 @@ class MeshMessageRequest:
     content: str
     to: Optional[str] = None
     channel: Optional[str] = None
-    sender_id: str = "captain"
-    sender_name: str = "Captain"
+    # Canon (ORION.ROLE.PILOT, owner-ruled 2026-06-11): the user-interface
+    # role is Pilot; "captain" is the accepted legacy alias from early sessions.
+    sender_id: str = "pilot"
+    sender_name: str = "Pilot"
     type: str = "direct"
 
     @classmethod
@@ -100,8 +102,8 @@ class MeshMessageRequest:
             content=str(payload["content"]),
             to=payload.get("to"),
             channel=payload.get("channel"),
-            sender_id=str(payload.get("sender_id", "captain")),
-            sender_name=str(payload.get("sender_name", "Captain")),
+            sender_id=str(payload.get("sender_id", "pilot")),
+            sender_name=str(payload.get("sender_name", "Pilot")),
             type=str(payload.get("type", "direct")),
         )
 

--- a/src/mesh/runtime.py
+++ b/src/mesh/runtime.py
@@ -494,7 +494,7 @@ class MeshRuntime:
     ) -> Dict[str, Any]:
         manifest = self._resolve_manifest(agent_id_or_alias)
         self.heartbeat(manifest.id)
-        channel_id = manifest.default_channel if target in {"Aurora", "Captain", "captain"} else target
+        channel_id = manifest.default_channel if target in {"Aurora", "Pilot", "pilot", "Captain", "captain"} else target
         message_id = uuid.uuid4().hex
         self.store.create_message(
             message_id=message_id,

--- a/tests/test_mesh_runtime_surface.py
+++ b/tests/test_mesh_runtime_surface.py
@@ -34,3 +34,17 @@ def test_mesh_runtime_initializes_from_agent_manifests(tmp_path: Path) -> None:
     assert status["total_agents"] == len(manifest_paths)
     assert runtime.get_agent("captain alex line")["agent_id"] == "alex_thorne"
     assert (tmp_path / "config" / "mesh" / "memory" / "alex_thorne.md").exists()
+
+
+def test_pilot_is_default_sender_and_captain_stays_legacy_alias(tmp_path):
+    """Canon ORION.ROLE.PILOT: defaults are Pilot; captain routes as legacy alias."""
+    from src.mesh.models import MeshMessageRequest
+
+    default = MeshMessageRequest.from_dict({"to": "alex_thorne", "content": "hi"})
+    assert default.sender_id == "pilot"
+    assert default.sender_name == "Pilot"
+
+    legacy = MeshMessageRequest.from_dict(
+        {"to": "alex_thorne", "content": "hi", "sender_id": "captain", "sender_name": "Captain"}
+    )
+    assert legacy.sender_name == "Captain"  # historical senders remain representable


### PR DESCRIPTION
## Canon ruling

Owner definitional ruling, 2026-06-11 (recorded in CanonRec `canon/L1/station/PILOT_ROLE_DEFINITION.md` + drift log): **the human user's role is Pilot** — specifically chosen for the user interface. **Commander Thorne commands Orion Station**; the user does not hold a command seat. "Captain" is the legacy alias from early conversations, preserved verbatim in the primary-source transcripts.

## Runtime alignment

- `MeshMessageRequest` defaults: `sender_id="pilot"`, `sender_name="Pilot"` (canon-comment inline)
- Routing special-case set now accepts `Pilot`/`pilot` alongside the legacy `Captain`/`captain`
- **Unchanged by design:** historical channel ids (`private:captain:alex`) — they are stable contracts and historical record; legacy senders remain fully representable (test included)

8 mesh + canon-gate tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
