### PR TITLE
fix: fail closed when ethics gate cannot evaluate high-impact actions

### DIFF
--- a/src/monitoring/ethics_gate.py
+++ b/src/monitoring/ethics_gate.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
+LOW_RISK_IMPACT_LEVELS = {"low", "informational", "read_only", "read-only"}
+
 
 class EthicsViolationError(Exception):
     """Raised when an ethics check fails."""
@@ -15,30 +17,61 @@ class EthicsViolationError(Exception):
         self.violations = violations
 
 
+def _gate_unavailable_violation(
+    action_type: str,
+    agent_id: str,
+    context_tag: str,
+    impact_level: str,
+    exc: Exception,
+) -> Dict[str, Any]:
+    return {
+        "rule_id": "ETHICS_GATE_UNAVAILABLE",
+        "rule_name": "Ethics Gate Availability",
+        "severity": "critical",
+        "blocked": True,
+        "description": "EthicsEngine could not evaluate the action.",
+        "action_type": action_type,
+        "agent_id": agent_id,
+        "context_tag": context_tag or None,
+        "impact_level": impact_level,
+        "error_type": type(exc).__name__,
+        "error": str(exc),
+    }
+
+
 def check_ethics(
     action_type: str,
     parameters: Dict[str, Any],
     *,
     agent_id: str = "api",
     context_tag: str = "",
+    impact_level: str = "high",
+    allow_degraded: bool = False,
 ) -> None:
     """Run the EthicsEngine check. Raises EthicsViolationError if not permitted.
 
     Uses EthicsEngine.evaluate_action(ActionContext) — the engine returns a list of
     EthicsViolation objects; if any have auto_block=True the gate raises.
 
-    No-op (passes silently) if EthicsEngine is unavailable.
+    The gate fails closed by default when EthicsEngine is unavailable or errors.
+    Low-risk callers may explicitly opt into degraded allow behavior by passing
+    ``impact_level="low"`` and ``allow_degraded=True``; this path emits a
+    warning so the degraded decision is visible in logs.
 
     Args:
         action_type: Type/name of the action being evaluated (e.g. "quantum_simulate").
         parameters: Free-form dict describing the action's parameters.
         agent_id: Identifier of the calling agent/service.
         context_tag: DLP context tag for audit trail.
+        impact_level: Risk/impact level for gate-unavailable fallback decisions.
+        allow_degraded: Allow explicit low-risk degraded operation if the engine
+            cannot evaluate the action.
 
     Raises:
-        EthicsViolationError: If the engine is available and determines the action
-            should be blocked.
+        EthicsViolationError: If the engine determines the action should be
+            blocked, or if the engine cannot evaluate a non-degraded operation.
     """
+    normalized_impact = str(impact_level or "high").strip().lower()
     try:
         from src.monitoring.ethics_engine import ActionContext, EthicsEngine
 
@@ -64,4 +97,28 @@ def check_ethics(
     except EthicsViolationError:
         raise
     except Exception as exc:
-        logger.debug("EthicsEngine unavailable, allowing action '%s': %s", action_type, exc)
+        violation = _gate_unavailable_violation(
+            action_type=action_type,
+            agent_id=agent_id,
+            context_tag=context_tag,
+            impact_level=normalized_impact,
+            exc=exc,
+        )
+        if allow_degraded and normalized_impact in LOW_RISK_IMPACT_LEVELS:
+            logger.warning(
+                "EthicsEngine unavailable; allowing low-risk degraded action '%s': %s",
+                action_type,
+                exc,
+            )
+            return
+
+        logger.error(
+            "EthicsEngine unavailable; blocking action '%s' at impact level '%s': %s",
+            action_type,
+            normalized_impact,
+            exc,
+        )
+        raise EthicsViolationError(
+            f"Ethics gate unavailable for {action_type}; failing closed",
+            violations=[violation],
+        )

--- a/tests/test_monitoring_ethics_gate.py
+++ b/tests/test_monitoring_ethics_gate.py
@@ -4,17 +4,19 @@ Tests for src.monitoring.ethics_gate — ethics-gated quantum simulation.
 Covers:
 - check_ethics passes when engine permits action
 - check_ethics raises EthicsViolationError when engine blocks action
-- check_ethics is a no-op when EthicsEngine is unavailable (ImportError)
+- check_ethics fails closed when EthicsEngine is unavailable for high-impact work
+- check_ethics fails closed when EthicsEngine raises an unexpected error
+- check_ethics can explicitly allow low-risk degraded operation with visible logging
 - EthicsViolationError carries the violations list
 - Quantum endpoint returns 422 when ethics check fails (mock)
 - Quantum endpoint proceeds when ethics check passes (mock)
-- check_ethics is a no-op when EthicsEngine raises an unexpected error
 - EthicsViolationError message includes the action type
 """
 
-import pytest
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from src.monitoring.ethics_gate import EthicsViolationError, check_ethics
 
@@ -67,9 +69,10 @@ def test_check_ethics_raises_when_blocked():
 
 
 @pytest.mark.unit
-def test_check_ethics_noop_when_import_fails():
-    """check_ethics silently passes when EthicsEngine cannot be imported."""
+def test_check_ethics_fails_closed_when_import_fails():
+    """High-impact checks fail closed when EthicsEngine cannot be imported."""
     import sys
+
     original_modules = {}
     modules_to_remove = ["src.monitoring.ethics_engine"]
 
@@ -79,25 +82,71 @@ def test_check_ethics_noop_when_import_fails():
 
     try:
         with patch.dict("sys.modules", {"src.monitoring.ethics_engine": None}):
-            # Should not raise — graceful degradation
-            check_ethics("quantum_simulate", {"scenario_type": "supply_chain"})
+            with pytest.raises(EthicsViolationError) as exc_info:
+                check_ethics("quantum_simulate", {"scenario_type": "supply_chain"})
     finally:
         # Restore original modules
         for mod, val in original_modules.items():
             sys.modules[mod] = val
 
+    assert exc_info.value.violations[0]["rule_id"] == "ETHICS_GATE_UNAVAILABLE"
+    assert exc_info.value.violations[0]["blocked"] is True
+    assert exc_info.value.violations[0]["impact_level"] == "high"
+
 
 @pytest.mark.unit
-def test_check_ethics_noop_on_unexpected_error():
-    """check_ethics silently passes when EthicsEngine raises an unexpected error."""
+def test_check_ethics_fails_closed_on_unexpected_error():
+    """High-impact checks fail closed when EthicsEngine raises an unexpected error."""
     mock_engine_instance = MagicMock()
     mock_engine_instance.evaluate_action.side_effect = RuntimeError("db connection lost")
     mock_engine_cls = MagicMock(return_value=mock_engine_instance)
 
     with patch("src.monitoring.ethics_engine.EthicsEngine", mock_engine_cls), \
          patch("src.monitoring.ethics_engine.ActionContext", MagicMock()):
-        # Should not raise — graceful degradation
-        check_ethics("quantum_simulate", {"scenario_type": "energy_grid"})
+        with pytest.raises(EthicsViolationError) as exc_info:
+            check_ethics("quantum_simulate", {"scenario_type": "energy_grid"})
+
+    assert "failing closed" in str(exc_info.value)
+    assert exc_info.value.violations[0]["rule_id"] == "ETHICS_GATE_UNAVAILABLE"
+    assert exc_info.value.violations[0]["error_type"] == "RuntimeError"
+
+
+@pytest.mark.unit
+def test_check_ethics_allows_explicit_low_risk_degraded_mode(caplog):
+    """Low-risk degraded operation is allowed only when explicitly requested."""
+    mock_engine_instance = MagicMock()
+    mock_engine_instance.evaluate_action.side_effect = RuntimeError("db connection lost")
+    mock_engine_cls = MagicMock(return_value=mock_engine_instance)
+
+    with patch("src.monitoring.ethics_engine.EthicsEngine", mock_engine_cls), \
+         patch("src.monitoring.ethics_engine.ActionContext", MagicMock()), \
+         caplog.at_level("WARNING"):
+        check_ethics(
+            "read_status",
+            {"resource": "health"},
+            impact_level="low",
+            allow_degraded=True,
+        )
+
+    assert "allowing low-risk degraded action 'read_status'" in caplog.text
+
+
+@pytest.mark.unit
+def test_check_ethics_degraded_mode_does_not_allow_high_impact():
+    """allow_degraded cannot silently permit high-impact operations."""
+    mock_engine_instance = MagicMock()
+    mock_engine_instance.evaluate_action.side_effect = RuntimeError("db connection lost")
+    mock_engine_cls = MagicMock(return_value=mock_engine_instance)
+
+    with patch("src.monitoring.ethics_engine.EthicsEngine", mock_engine_cls), \
+         patch("src.monitoring.ethics_engine.ActionContext", MagicMock()):
+        with pytest.raises(EthicsViolationError):
+            check_ethics(
+                "quantum_simulate",
+                {"scenario_type": "energy_grid"},
+                impact_level="high",
+                allow_degraded=True,
+            )
 
 
 @pytest.mark.unit
@@ -144,8 +193,9 @@ def test_check_ethics_error_message_includes_action_type():
 @pytest.mark.api
 def test_quantum_endpoint_returns_422_when_ethics_blocked():
     """POST /simulate/scenario returns 422 when ethics gate blocks the request."""
-    from fastapi.testclient import TestClient
     from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
     from modules.quantum_simulator.api import router
     from src.middleware.fastapi_security import require_csrf_token
 
@@ -190,10 +240,11 @@ def test_quantum_endpoint_returns_422_when_ethics_blocked():
 @pytest.mark.api
 def test_quantum_endpoint_proceeds_when_ethics_passes():
     """POST /simulate/scenario proceeds to simulation when ethics gate passes."""
-    from fastapi.testclient import TestClient
     from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
     from modules.quantum_simulator.api import router
-    from modules.quantum_simulator.schemas import SimulationResult, ScenarioType, QuantumBackend
+    from modules.quantum_simulator.schemas import QuantumBackend, ScenarioType, SimulationResult
     from src.middleware.fastapi_security import require_csrf_token
 
     app = FastAPI()


### PR DESCRIPTION
## Summary

Fixes #991 by hardening `src/monitoring/ethics_gate.py` so high-impact ethics checks fail closed when `EthicsEngine` cannot import or raises unexpectedly.

## Changes

- Adds explicit fail-closed behavior for unavailable/erroring ethics engine paths.
- Adds `impact_level` and `allow_degraded` parameters to permit only explicit low-risk degraded operation.
- Emits warning logs for allowed low-risk degraded operation.
- Emits error logs and raises `EthicsViolationError` for non-degraded/high-impact unavailable gate paths.
- Updates tests that previously encoded silent fail-open behavior.

## Why

The Moral Architecture Charter now says:

> Do not silently fail open on high-impact operations.

Current behavior allowed ethics dependency failures to become implicit permission. This PR makes that behavior explicit and conservative.

## Tests

Updated `tests/test_monitoring_ethics_gate.py` to cover:

- normal pass behavior,
- normal blocking violation behavior,
- import failure + high-impact action => fail closed,
- engine exception + high-impact action => fail closed,
- explicit low-risk degraded allow => warning + pass,
- `allow_degraded=True` cannot allow high-impact action,
- quantum endpoint still returns `422` when ethics blocks,
- quantum endpoint still proceeds when ethics passes.

## Non-goals

- Does not modify #780 / PR #941 CASK Recursive Ethics Validator work.
- Does not implement #992 model-agnostic validator contract.
- Does not promote Sherlock / Watson / Moriarty / Tribunal runtime protocols.

## Evidence ledger

- **Observed:** Existing tests documented silent fail-open behavior when `EthicsEngine` was unavailable or errored.
- **Observed:** `check_ethics()` was only found as a direct runtime call in the quantum simulator API during this patch pass.
- **Derived:** Default fail-closed behavior is safer for unknown/high-impact contexts.
- **Recommended:** Let CI validate the changed gate contract before merge.