### PR TITLE
docs: add recovered ethics protocol promotion plan

### DIFF
--- a/docs/ethics/recovered_protocols/PROTOCOL_PROMOTION_PLAN.md
+++ b/docs/ethics/recovered_protocols/PROTOCOL_PROMOTION_PLAN.md
@@ -1,0 +1,202 @@
+# Recovered Protocol Promotion Plan
+
+**Issue:** #993  
+**Status:** Planning artifact  
+**Runtime posture:** Documentation/schema review only; no enforcement wiring.
+
+## 1. Objective
+
+Promote recovered Sherlock / Watson / Moriarty / Tribunal / SHADOWFAX ethics-layer materials through a controlled review path before runtime integration.
+
+This plan exists to prevent three failure modes:
+
+1. treating recovered artifacts as sealed runtime canon without custody review,
+2. collapsing investigation, context, containment, and judgment into one self-justifying lane,
+3. wiring symbolic/anomaly doctrine into runtime behavior before tests and rollback paths exist.
+
+## 2. Evidence classification model
+
+Each recovered artifact must be classified before promotion.
+
+| Classification | Meaning | Runtime use |
+|---|---|---|
+| Current repo canon | Already committed to CloudBank or control-plane Git | May be cited as committed source |
+| Control-plane report lineage | Present in committed control-plane reports or docs | May inform planning; verify before CloudBank runtime use |
+| Uploaded recovered candidate | Available as user-provided artifact with custody/hash notes | May be inventoried; not runtime canon |
+| Sealed-bundle reference | Referenced by index/manifest/checksum material but payload not fully verified in repo | Requires payload verification before use |
+| Missing dependency | Referenced but not available | Must be tracked as blocked |
+
+## 3. Initial recovered protocol inventory
+
+| Protocol | Proposed role | Initial status | Required next evidence |
+|---|---|---|---|
+| Sherlock | Investigation, traceability, causal mapping, transparency reporting, doctrine verification | Recovered candidate / sealed-bundle lineage | Confirm exact source files, version, checksum, schema |
+| Watson | Context retention, rigidity moderation, evidence correlation, operator-readable briefs | Recovered candidate / sealed-bundle lineage | Confirm exact source files, version, checksum, schema |
+| Moriarty | Anomaly containment, quarantine, review-only translation, ethics audit, anchor check, rollback | Recovered candidate / runtime recovery lineage | Confirm exact source files, version, checksum, schema, test boundaries |
+| Tribunal | Dispute and appeal adjudication for memory, narrative integrity, drift, containment | Recovered candidate / sealed-bundle lineage | Confirm exact source files, version, checksum, schema, quorum/appeal semantics |
+| SHADOWFAX | Stillness, supervisory review, paradox escalation, containment oversight | Referenced supervisory lane / partially recovered lineage | Locate standalone bundle or mark dependency blocked |
+
+## 4. Required custody fields
+
+Every promoted protocol artifact should include or be accompanied by:
+
+- source package name,
+- source package SHA-256,
+- internal file path,
+- internal file SHA-256,
+- observed version,
+- observed status,
+- source classification,
+- verification date,
+- reviewer or agent surface,
+- unresolved blockers,
+- promotion decision.
+
+## 5. Proposed schema families
+
+Protocol schemas should be created before runtime use.
+
+### 5.1 Common protocol schema
+
+Required fields:
+
+- `protocol_id`
+- `version`
+- `status`
+- `role`
+- `allowed_actions`
+- `forbidden_actions`
+- `required_evidence`
+- `handoff_targets`
+- `audit_requirements`
+- `layer_boundaries`
+- `rollback_requirements`
+- `appeal_requirements`
+
+### 5.2 Sherlock schema
+
+Additional fields:
+
+- `investigation_scope`
+- `traceability_log_requirements`
+- `causal_mapping_requirements`
+- `transparency_report_requirements`
+- `containment_referral_rules`
+
+Sherlock must not contain, adjudicate, or mutate subject state.
+
+### 5.3 Watson schema
+
+Additional fields:
+
+- `context_sources`
+- `rigidity_moderation_rules`
+- `brief_generation_rules`
+- `evidence_correlation_rules`
+- `audit_log_integrity_rules`
+
+Watson must not alter Sherlock logs, contain anomalies, or adjudicate appeals.
+
+### 5.4 Moriarty schema
+
+Additional fields:
+
+- `anomaly_detection_inputs`
+- `quarantine_rules`
+- `review_only_translation_rules`
+- `anchor_validation_rules`
+- `rollback_rules`
+- `crew_or_operator_rights`
+
+Moriarty must not treat containment as narrative escalation and must not adjudicate its own containment decisions.
+
+### 5.5 Tribunal schema
+
+Additional fields:
+
+- `jurisdiction`
+- `minimum_evidence_bundle`
+- `conflict_of_interest_rules`
+- `ruling_record_requirements`
+- `appeal_rules`
+- `reopen_rules`
+
+Tribunal must not perform primary investigation or secretly enforce containment.
+
+### 5.6 SHADOWFAX schema
+
+Additional fields:
+
+- `stillness_triggers`
+- `paradox_escalation_rules`
+- `boundary_instability_thresholds`
+- `supervisory_review_requirements`
+- `override_constraints`
+
+SHADOWFAX must not bypass evidence, erase review paths, or convert instability into proof.
+
+## 6. Runtime integration boundaries
+
+Any runtime integration proposal must explicitly map to existing CloudBank surfaces:
+
+| Surface | Current role | Integration question |
+|---|---|---|
+| `src/monitoring/ethics_engine.py` | Rule engine and violation persistence | Which protocol rules become `EthicsRule`s, if any? |
+| `src/monitoring/ethics_gate.py` | Caller-facing ethics gate | Which protocol failures block actions? |
+| `src/subroutines/ethics_compliance_monitor.py` | Compliance scoring and block-record separation | How are protocol verdicts recorded versus enforced? |
+| `modules/ethics_field/geometric_ethics.py` | Ethical formation scoring | Should protocols inform dimensions, thresholds, or warnings? |
+| `modules/symbolic_core/model_validation.py` | Model-agnostic validator contract | Should model outputs reference protocol lanes as receipt metadata? |
+| CASK #780 / PR #941 | Recursive ethics/cultural cognition work | Does CASK overlap or only consume protocol decisions? |
+
+## 7. Required test plan before runtime wiring
+
+Runtime integration must not proceed until tests cover:
+
+- no planned L2-to-L1 bleed,
+- anomaly quarantine before interpretation,
+- review-only translation until cleared,
+- rollback over compromise,
+- containment appeal path exists,
+- Sherlock cannot enforce or mutate,
+- Watson cannot alter Sherlock logs or enforce,
+- Moriarty cannot adjudicate its own actions,
+- Tribunal requires evidence before ruling,
+- SHADOWFAX stillness cannot bypass audit,
+- no direct device/environment control,
+- no crew/operator impersonation,
+- failure state is explicit and auditable.
+
+## 8. Recommended follow-up issues
+
+Create follow-up implementation issues only after this promotion plan is accepted.
+
+1. **Protocol custody inventory** — add machine-readable manifest of recovered package/file hashes and blockers.
+2. **Protocol JSON schemas** — add schema files and validation tests.
+3. **Protocol fixture intake** — add sanitized canonical examples for Sherlock, Watson, Moriarty, Tribunal, and SHADOWFAX.
+4. **Runtime mapping design** — decide how protocol decisions map to `EthicsEngine`, `ethics_gate`, compliance monitor, and geometric ethics.
+5. **Moriarty containment tests** — test anomaly quarantine/review-only/rollback rules without enabling active L2-to-L1 behavior.
+6. **Tribunal appeal tests** — test dispute/appeal record requirements without runtime enforcement.
+
+## 9. Non-goals
+
+This PR and plan must not:
+
+- wire recovered protocols into runtime enforcement,
+- add active anomaly containment behavior,
+- promote uploaded artifacts as sealed canon without verification,
+- bypass existing `EthicsEngine` or `ethics_gate`,
+- duplicate #780, #991, #992, or #994,
+- weaken L1/L2/L3 boundaries,
+- create cross-tenant cache or memory leakage.
+
+## 10. Merge criteria for this planning PR
+
+A planning PR for #993 is ready when it:
+
+- creates a clear recovered-protocol intake location,
+- records canon/custody warnings,
+- defines separation of duties,
+- proposes schema families,
+- lists runtime integration boundaries,
+- lists required tests before runtime wiring,
+- leaves runtime behavior unchanged.

--- a/docs/ethics/recovered_protocols/README.md
+++ b/docs/ethics/recovered_protocols/README.md
@@ -1,0 +1,59 @@
+# Recovered Ethics Protocols — Review Intake
+
+**Status:** Recovery and promotion planning only.  
+**Issue:** #993  
+**Runtime posture:** No runtime enforcement wiring is authorized by this document.
+
+## Purpose
+
+This folder records the review path for recovered ethics-layer protocols before any of them are promoted into CloudBank runtime behavior.
+
+The recovered protocol suite includes:
+
+- **Sherlock** — investigation, audit, traceability, causal mapping, transparency reporting, and doctrine verification.
+- **Watson** — context retention, rigidity moderation, evidence correlation, and operator-readable briefing.
+- **Moriarty** — anomaly containment, quarantine, review-only translation, ethics audit, anchor validation, and rollback-over-compromise posture.
+- **Tribunal** — dispute, appeal, memory-sovereignty, narrative-integrity, drift-threshold, and containment-action adjudication.
+- **SHADOWFAX** — stillness, pause, supervisory review, paradox escalation, and boundary-instability oversight.
+
+## Canon warning
+
+Recovered files and uploaded packages are useful source evidence, but they are not implementation canon until promoted through Git with review.
+
+The current folder does **not** claim that recovered protocols are complete, sealed runtime canon, or safe to wire directly into enforcement. It provides a controlled path for inventory, custody review, schema review, integration-boundary review, and test planning.
+
+## Separation-of-duties contract
+
+| Protocol | Allowed role | Must not do |
+|---|---|---|
+| Sherlock | Investigate, reconstruct, trace, verify, and report | Mutate subject state, enforce containment, adjudicate appeals |
+| Watson | Preserve context, correlate evidence, moderate rigidity, brief operators | Alter Sherlock logs, enforce containment, adjudicate disputes |
+| Moriarty | Contain anomaly-class boundary risk under oversight | Treat containment as narrative escalation, adjudicate its own actions, bypass appeal |
+| Tribunal | Adjudicate disputes, appeals, and containment questions | Perform primary investigation or secretly enforce containment |
+| SHADOWFAX | Pause, stillness, supervisory escalation, boundary-conflict review | Bypass evidence, erase review paths, convert instability into proof |
+
+## Current implementation boundaries
+
+Recovered protocol work must be reviewed against existing CloudBank ethics infrastructure before runtime wiring:
+
+- `src/monitoring/ethics_engine.py`
+- `src/monitoring/ethics_gate.py`
+- `src/subroutines/ethics_compliance_monitor.py`
+- `modules/ethics_field/geometric_ethics.py`
+- `modules/symbolic_core/model_validation.py`
+- CASK issue #780 / PR #941 if still relevant at the time of integration
+
+## Promotion rule
+
+The first accepted PR for #993 should remain documentation/schema planning only.
+
+Runtime implementation should occur only in follow-up issues after reviewers accept:
+
+1. artifact inventory and custody status,
+2. protocol schemas,
+3. separation-of-duties contract,
+4. integration boundaries,
+5. test plan,
+6. rollback and appeal requirements.
+
+See `PROTOCOL_PROMOTION_PLAN.md` for the detailed plan.

--- a/schemas/ethics/recovered_protocol.schema.json
+++ b/schemas/ethics/recovered_protocol.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://aurora-cloudbank-symbolic/schemas/ethics/recovered_protocol.schema.json",
+  "$id": "https://raw.githubusercontent.com/AUo959/aurora-cloudbank-symbolic/main/schemas/ethics/recovered_protocol.schema.json",
   "title": "Recovered Ethics Protocol",
   "description": "Planning schema for recovered Sherlock / Watson / Moriarty / Tribunal / SHADOWFAX protocol review. This schema is for custody and promotion planning, not runtime enforcement.",
   "type": "object",
@@ -39,7 +39,7 @@
     },
     "source_classification": {
       "type": "string",
-      "enum": ["current_repo_canon", "control_plane_report_lineage", "uploaded_recovered_candidate", "sealed_bundle_reference", "missing_dependency"]
+      "enum": ["recovered_candidate", "sealed_bundle_reference", "control_plane_lineage", "repo_canon", "missing_dependency", "draft_schema"]
     },
     "custody": {
       "type": "object",

--- a/schemas/ethics/recovered_protocol.schema.json
+++ b/schemas/ethics/recovered_protocol.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aurora-cloudbank-symbolic/schemas/ethics/recovered_protocol.schema.json",
+  "title": "Recovered Ethics Protocol",
+  "description": "Planning schema for recovered Sherlock / Watson / Moriarty / Tribunal / SHADOWFAX protocol review. This schema is for custody and promotion planning, not runtime enforcement.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "protocol_id",
+    "version",
+    "status",
+    "role",
+    "source_classification",
+    "allowed_actions",
+    "forbidden_actions",
+    "required_evidence",
+    "handoff_targets",
+    "audit_requirements",
+    "layer_boundaries",
+    "rollback_requirements",
+    "appeal_requirements"
+  ],
+  "properties": {
+    "protocol_id": {
+      "type": "string",
+      "enum": ["sherlock", "watson", "moriarty", "tribunal", "shadowfax"]
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["recovered_candidate", "sealed_bundle_reference", "control_plane_lineage", "repo_canon", "missing_dependency", "draft_schema"]
+    },
+    "role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_classification": {
+      "type": "string",
+      "enum": ["current_repo_canon", "control_plane_report_lineage", "uploaded_recovered_candidate", "sealed_bundle_reference", "missing_dependency"]
+    },
+    "custody": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source_package": {"type": "string"},
+        "source_package_sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+        "internal_path": {"type": "string"},
+        "internal_sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+        "verified_at": {"type": "string"},
+        "verified_by": {"type": "string"},
+        "blockers": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "allowed_actions": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "forbidden_actions": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "required_evidence": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "handoff_targets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["sherlock", "watson", "moriarty", "tribunal", "shadowfax", "ethics_engine", "ethics_gate", "compliance_monitor", "human_reviewer"]
+      }
+    },
+    "audit_requirements": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "layer_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["l1", "l2", "l3", "cross_layer_rules"],
+      "properties": {
+        "l1": {"type": "string"},
+        "l2": {"type": "string"},
+        "l3": {"type": "string"},
+        "cross_layer_rules": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        }
+      }
+    },
+    "rollback_requirements": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "appeal_requirements": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "protocol_specific": {
+      "type": "object",
+      "description": "Protocol-specific planning fields; validate with protocol-specific schemas before runtime use."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Refs #993 by adding a documentation-first promotion plan for recovered Sherlock / Watson / Moriarty / Tribunal / SHADOWFAX ethics protocols.

## Changes

- Adds `docs/ethics/recovered_protocols/README.md` with:
  - canon warning,
  - protocol role summary,
  - separation-of-duties contract,
  - current CloudBank integration boundaries.
- Adds `docs/ethics/recovered_protocols/PROTOCOL_PROMOTION_PLAN.md` with:
  - evidence classification model,
  - recovered protocol inventory,
  - required custody fields,
  - proposed schema families,
  - runtime integration boundaries,
  - required test plan before runtime wiring,
  - recommended follow-up issues.
- Adds `schemas/ethics/recovered_protocol.schema.json` as a planning schema for future recovered protocol manifests.

## Why

The recovered ethics-layer materials are coherent enough to plan promotion, but not safe to wire directly into runtime enforcement without custody review, schemas, tests, and separation-of-duties guarantees.

This PR intentionally keeps runtime behavior unchanged.

## Safety

- Runtime behavior: unchanged.
- Enforcement wiring: none.
- L1/L2/L3 boundaries: preserved; the plan explicitly prohibits planned L2-to-L1 bleed and requires anomaly quarantine before interpretation.
- Canon posture: recovered/uploaded artifacts are treated as source evidence, not runtime canon.
- Overlap: does not duplicate #780, #991, #992, or #994.

## Validation

CI should validate Markdown/JSON hygiene. The JSON schema is intended as a planning schema and is not yet bound to runtime validation.

## Evidence ledger

- **Observed:** Issue #993 requests recovery/promotion planning, schemas/proposed schemas, separation-of-duties contract, integration boundaries, and test-plan requirements.
- **Observed:** No open PR for #993 or promoted CloudBank protocol docs surfaced before this branch.
- **Derived:** A docs/schema-first PR is the safest first step before runtime integration.
- **Recommended:** Review this plan, then create follow-up implementation issues only after the plan is accepted.