### PR TITLE
feat(sensors): Aurora Sensor Array foundation — Phases 1-4 + SalvageSensor (26-route observation surface)

### DIFF
--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -909,6 +909,18 @@ except ImportError as e:
 except Exception as e:
     logger.error("❌ Failed to integrate Drift Metrics routes: %s", e)
 
+# Include Sensor Array routes (observation-only; spec SENSOR_ARRAY_SPECIFICATION_v0_3_0)
+try:
+    from src.sensors.array import SensorArrayFacade
+    from src.sensors.api.routes import build_router as build_sensor_router
+    _sensor_array = SensorArrayFacade()
+    app.include_router(build_sensor_router(_sensor_array), prefix="/api/sensors")
+    logger.info("✅ Sensor Array routes integrated successfully (GET-only observation surface)")
+except ImportError as e:
+    logger.warning("⚠️ Sensor Array routes not available: %s", e)
+except Exception as e:
+    logger.error("❌ Failed to integrate Sensor Array routes: %s", e)
+
 # Include QGIA Forecast Simulation Engine routes
 try:
     from modules.qgia.api import router as qgia_router

--- a/src/sensors/__init__.py
+++ b/src/sensors/__init__.py
@@ -1,0 +1,24 @@
+"""
+Aurora Sensor Array — unified observability across L1/L2/L3.
+
+Spec: SENSOR ARRAY SPECIFICATION v0.3.0 (DLP: sensor_array_specification_v3)
+Anchors: EOS_SEED_ORION, Picard_Delta_3
+
+Design principles (spec §Design Principles):
+- One-way observation: sensors watch, never act. No actuation path exists
+  in this package; outputs feed L3 governance, which decides interventions.
+- Layered interpretation: signals are parsed in layer context before fusion.
+- Metric unit discipline: drift delta (threshold 0.002) and deviation
+  fractions (0.2/0.5/0.8, owned by DriftDetector/MonitoringSystem) are
+  distinct scales and are labeled explicitly via MetricUnit.
+
+Reconciler note (2026-06-11): the 0.2/0.5/0.8 INFO/WARNING/CRITICAL fractions
+live in src/monitoring/drift_detector.py, and the BLOCK/REVIEW/THROTTLE/
+SUSPEND/RESET action vocabulary lives in src/monitoring/monitoring_system.py
+(not EthicsEngine, contra spec text). Integration here binds to repo reality.
+"""
+
+__version__ = "0.3.0"
+
+ANCHOR_SEED = "EOS_SEED_ORION"
+ETHICS_PROTOCOL = "Picard_Delta_3"

--- a/src/sensors/api/__init__.py
+++ b/src/sensors/api/__init__.py
@@ -1,0 +1,1 @@
+"""Sensor array API (FastAPI router; import-guarded for headless contexts)."""

--- a/src/sensors/api/routes.py
+++ b/src/sensors/api/routes.py
@@ -1,0 +1,100 @@
+"""
+Sensor array API router — spec §API Structure.
+
+GET-only by design: the API is an observation surface. There are no POST/PUT
+endpoints because sensors cannot be commanded to act (one-way observation).
+
+Usage:
+    from src.sensors.api.routes import build_router
+    app.include_router(build_router(array), prefix="/api/sensors")
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    from src.sensors.array import SensorArrayFacade
+
+try:
+    from fastapi import APIRouter, HTTPException
+    _FASTAPI = True
+except ImportError:  # pragma: no cover — headless/test contexts
+    APIRouter = None  # type: ignore[assignment]
+    HTTPException = None  # type: ignore[assignment]
+    _FASTAPI = False
+
+
+def _dump(obj: Any) -> Any:
+    if is_dataclass(obj):
+        return asdict(obj)
+    if isinstance(obj, list):
+        return [_dump(o) for o in obj]
+    return obj
+
+
+def build_router(array: "SensorArrayFacade"):
+    """Build the /api/sensors router against a SensorArrayFacade."""
+    if not _FASTAPI:
+        raise RuntimeError("fastapi is not installed; sensor API unavailable")
+
+    router = APIRouter(tags=["sensors"])
+
+    # -- internal / external (generic category reads) -------------------------
+    for group, cats in (
+        ("internal", ["environmental", "structural", "biometrics", "operational"]),
+        ("external", ["proximity", "deep-space", "astronomical",
+                      "communications", "salvage"]),
+        ("observatory/physical",
+         ["containment", "fidelity", "boundary", "reality-anchor", "earth-relay"]),
+    ):
+        for cat in cats:
+            def make(group=group, cat=cat):
+                async def endpoint():
+                    reading = array.read_category(group, cat.replace("-", "_"))
+                    if reading is None:
+                        raise HTTPException(404, f"no sensor for {group}/{cat}")
+                    return _dump(reading)
+                return endpoint
+            router.add_api_route(f"/{group}/{cat}", make(), methods=["GET"])
+
+    # -- observatory symbolic --------------------------------------------------
+    router.add_api_route(
+        "/observatory/symbolic/concept-resonance",
+        lambda: _dump(array.concept_resonance_reading()), methods=["GET"])
+    router.add_api_route(
+        "/observatory/symbolic/ethical-signal",
+        lambda: _dump(array.ethical_signal_reading()), methods=["GET"])
+    router.add_api_route(
+        "/observatory/symbolic/ethical-signal/{entity_id}",
+        lambda entity_id: _dump(array.ethical_signal_reading(entity_id)),
+        methods=["GET"])
+    router.add_api_route(
+        "/observatory/symbolic/drift-presignature",
+        lambda: _dump(array.drift_presignature()), methods=["GET"])
+    # NEW in v0.3.0:
+    router.add_api_route(
+        "/observatory/symbolic/integration-depth",
+        lambda: _dump(array.integration_depth()), methods=["GET"])
+
+    # -- fusion ------------------------------------------------------------------
+    router.add_api_route("/fusion/resonance",
+                         lambda: _dump(array.fusion_resonance()), methods=["GET"])
+    router.add_api_route("/fusion/oscillation-health",
+                         lambda: _dump(array.oscillation_health()), methods=["GET"])
+    router.add_api_route("/fusion/forecasts",
+                         lambda: _dump(array.forecasts()), methods=["GET"])
+    router.add_api_route(
+        "/fusion/forecasts/{anomaly_type}",
+        lambda anomaly_type: _dump(array.forecasts(anomaly_type)), methods=["GET"])
+    router.add_api_route("/fusion/certification",
+                         lambda: _dump(array.certification()), methods=["GET"])
+
+    # -- health -------------------------------------------------------------------
+    router.add_api_route("/health/status",
+                         lambda: array.health_status(), methods=["GET"])
+    router.add_api_route("/health/performance",
+                         lambda: array.performance(), methods=["GET"])
+
+    return router

--- a/src/sensors/array.py
+++ b/src/sensors/array.py
@@ -1,0 +1,218 @@
+"""
+SensorArrayFacade — assembles the full array and backs the API router.
+
+Wiring only; no behavior of its own. Construction order mirrors the data
+flow: sensors -> interpreter -> bus -> fusion -> certification.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from src.sensors import constants as C
+from src.sensors.core.data_bus import SensorDataBus
+from src.sensors.core.layer_interpreter import LayerInterpreter
+from src.sensors.core.performance_budget import PerformanceBudget
+from src.sensors.core.reading_types import (
+    AnomalyForecast,
+    CoherenceCertification,
+    SensorReading,
+)
+from src.sensors.core.sensor_registry import SensorRegistry
+from src.sensors.external import (
+    AstronomicalSensor,
+    CommunicationsSensor,
+    DeepSpaceSensor,
+    ProximitySensor,
+    SalvageSensor,
+)
+from src.sensors.fusion import (
+    CoherenceCertifier,
+    CrossLayerResonanceCalculator,
+    FusionPredictor,
+    OscillationHealthMonitor,
+    RegulatorMarkerConsumer,
+)
+from src.sensors.internal import (
+    BiometricsSensor,
+    EnvironmentalSensor,
+    OperationalSensor,
+    StructuralSensor,
+)
+from src.sensors.observatory.physical import (
+    BoundarySensor,
+    ContainmentSensor,
+    EarthRelaySensor,
+    FidelitySensor,
+    RealityAnchorSensor,
+)
+from src.sensors.observatory.symbolic import (
+    ConceptResonanceDetector,
+    DriftPreSignatureMonitor,
+    EthicalSignalSentinel,
+    SymbolIntegrationIndex,
+)
+
+logger = logging.getLogger(__name__)
+
+Provider = Callable[[], Dict[str, float]]
+
+
+class SensorArrayFacade:
+    """Single composition root for the sensor array."""
+
+    def __init__(
+        self,
+        providers: Optional[Dict[str, Provider]] = None,
+        ethics_engine: Optional[Any] = None,
+        drift_detector: Optional[Any] = None,
+        canonical_tags: Optional[set] = None,
+    ):
+        p = providers or {}
+        self.bus = SensorDataBus()
+        self.interpreter = LayerInterpreter()
+        self.budget = PerformanceBudget()
+        self.registry = SensorRegistry()
+
+        # Symbolic infrastructure (v0.3.0)
+        self.sii = SymbolIntegrationIndex()
+        self.concept_resonance = ConceptResonanceDetector(canonical_tags)
+        self.concept_resonance.sii = self.sii
+        self.ethical_signal = EthicalSignalSentinel(ethics_engine)
+        self.drift_presig = DriftPreSignatureMonitor(
+            drift_detector=drift_detector, sii=self.sii)
+
+        # Salvage survey (push-fed from the root control plane's
+        # aurora_salvage_scan report; see sensor docstring)
+        self.salvage = SalvageSensor()
+
+        # Physical sensors
+        self._sensors = [
+            self.salvage,
+            EnvironmentalSensor(p.get("environmental")),
+            StructuralSensor(p.get("structural")),
+            BiometricsSensor(p.get("biometrics")),
+            OperationalSensor(p.get("operational")),
+            ProximitySensor(p.get("proximity")),
+            DeepSpaceSensor(p.get("deep_space")),
+            AstronomicalSensor(p.get("astronomical")),
+            CommunicationsSensor(p.get("communications")),
+            ContainmentSensor(p.get("containment")),
+            FidelitySensor(p.get("fidelity")),
+            BoundarySensor(p.get("boundary")),
+            RealityAnchorSensor(p.get("reality_anchor")),
+            EarthRelaySensor(p.get("earth_relay")),
+            self.concept_resonance,
+            self.ethical_signal,
+            self.drift_presig,
+        ]
+        for s in self._sensors:
+            self.registry.register(s)
+
+        # Fusion
+        self.marker_consumer = RegulatorMarkerConsumer(self.bus)
+        self.oscillation = OscillationHealthMonitor(self.marker_consumer)
+        self.predictor = FusionPredictor()
+        self.resonance_calc = CrossLayerResonanceCalculator()
+        self.certifier = CoherenceCertifier()
+
+    # -- API surface (backs src/sensors/api/routes.py) ---------------------------
+
+    def read_category(self, group: str, category: str) -> Optional[SensorReading]:
+        matches = self.registry.by_category(category)
+        if not matches:
+            return None
+        with self.budget.timed_operation(matches[0].budget_key):
+            reading = matches[0].read()
+        self.bus.publish(f"sensors.{group}.{category}",
+                         {"reading": reading, "timestamp": reading.timestamp})
+        return reading
+
+    def concept_resonance_reading(self):
+        with self.budget.timed_operation("concept_resonance"):
+            return self.concept_resonance.detect_resonance()
+
+    def ethical_signal_reading(self, entity_id: Optional[str] = None):
+        reading = self.ethical_signal.read()
+        if entity_id is not None:
+            return {"entity_id": entity_id,
+                    "risk_score": self.ethical_signal.risk_scores.get(entity_id, 0.0)}
+        return reading
+
+    def drift_presignature(self):
+        with self.budget.timed_operation("drift_presig"):
+            return self.drift_presig.analyze()
+
+    def integration_depth(self):
+        with self.budget.timed_operation("sii_update"):
+            return self.sii.snapshot()
+
+    def fusion_resonance(self):
+        with self.budget.timed_operation("fusion_correlation"):
+            return self.resonance_calc.calculate()
+
+    def oscillation_health(self):
+        return self.oscillation.analyze()
+
+    def forecasts(self, anomaly_type: Optional[str] = None) -> List[AnomalyForecast]:
+        with self.budget.timed_operation("fusion_prediction"):
+            out = self.predictor.forecast()
+        if anomaly_type:
+            out = [f for f in out if f.anomaly_type == anomaly_type]
+        return out
+
+    def certification(self) -> CoherenceCertification:
+        with self.budget.timed_operation("coherence_certification"):
+            sii_snap = self.sii.snapshot()
+            resonance = self.resonance_calc.calculate()
+            drift = self.drift_presig.analyze()
+
+            def score(category: str) -> float:
+                sensors = self.registry.by_category(category)
+                if not sensors:
+                    return 1.0
+                reading = sensors[0].read()
+                return 0.5 if reading.alerts else 1.0
+
+            symbolic = 1.0 - min(
+                len(sii_snap.rupture_candidates) * 0.5, 1.0)
+            anchor_ok = True
+            anchor_sensors = self.registry.by_category("reality_anchor")
+            if anchor_sensors:
+                anchor_ok = not anchor_sensors[0].read().alerts
+
+            return self.certifier.certify(
+                structural=score("structural"),
+                operational=score("operational"),
+                symbolic=symbolic,
+                temporal=score("fidelity"),
+                layer_resonance=resonance.system_resonance,
+                reality_grounding=1.0 if anchor_ok else 0.0,
+                anchor_verified=anchor_ok,
+                advisory_issues=(
+                    [f"drift trend: {drift.trend}"]
+                    if drift.trend in ("diverging", "critical") else []),
+                rupture_candidates=sii_snap.rupture_candidates,
+            )
+
+    def health_status(self) -> Dict[str, Any]:
+        return {
+            "sensors_registered": len(self.registry.all()),
+            "sensors_enabled": len(self.registry.enabled()),
+            "bus_archive_depth": len(self.bus),
+            "budget_violations": len(self.budget.violations),
+            "decimation_n": self.budget.decimation_n,
+        }
+
+    def performance(self) -> Dict[str, Any]:
+        return {
+            "budgets": dict(self.budget.BUDGETS),
+            "violations": [
+                {"operation": v.operation_type,
+                 "elapsed_s": v.elapsed_seconds,
+                 "budget_s": v.budget_seconds}
+                for v in self.budget.violations[-50:]
+            ],
+            "tick_budget_fraction": C.TICK_BUDGET_FRACTION,
+        }

--- a/src/sensors/constants.py
+++ b/src/sensors/constants.py
@@ -1,0 +1,70 @@
+"""
+Sensor array tunable constants — single source of truth.
+
+Per spec RQ-3, thresholds belong in ``shared/constants.py`` once the GUMAS
+Forge refactor merges. Until then this module is the sensor-local equivalent;
+RQ-3 calibration (AFS harness, Brier-scored backtests) tunes values here
+without code changes elsewhere. Threshold changes are commits carrying
+backtest evidence; quarterly cycle, out-of-cycle only for rupture incidents.
+
+Certainty tags per Canon Protocol:
+- [FACT] values mirrored from existing repo surfaces.
+- [ASSUMPTION] starting values awaiting RQ-3 calibration.
+"""
+
+# --- Drift scale (Δ — dimensionless drift delta) -------------------- [FACT]
+DRIFT_THRESHOLD_DELTA = 0.002          # rollback threshold
+DRIFT_PRESIG_RATIO = 0.5               # pre-signature alert at 50% of limit
+DRIFT_VELOCITY_ALERT = 0.0005          # Δ/hour considered "diverging"
+DRIFT_VELOCITY_CONVERGING = -0.0002    # Δ/hour considered "converging"
+
+# --- Ethics / deviation-fraction scale (DriftDetector-owned) -------- [FACT]
+# NOTE: these mirror src/monitoring/drift_detector.py defaults. They are
+# deviation FRACTIONS, not drift Δ. Never route onto drift dashboards.
+DEVIATION_INFO = 0.2
+DEVIATION_WARNING = 0.5
+DEVIATION_CRITICAL = 0.8
+
+# --- Symbol Integration Index (Lotus §IV) --------------------- [ASSUMPTION]
+SII_CORE_THRESHOLD = 0.8               # depth >= core => load-bearing
+SII_PERIPHERY_THRESHOLD = 0.2          # depth < periphery => unintegrated
+SII_TRANSITIVE_WEIGHT = 0.3            # 1-hop transitive dependent weight
+SII_RUPTURE_LOSS_RATE = 0.10           # connection loss/hour for rupture
+SII_PERIPHERY_CLUSTER_MIN = 5          # correlated periphery presigs => drift
+
+# --- Resonance ------------------------------------------------ [ASSUMPTION]
+RESONANCE_THRESHOLD = 0.7
+BLEED_RISK_ALERT = 0.3
+RESONANCE_SYNC_WARNING = 0.05          # ZIPWIZ RESONANCE_SYNC divergence
+RESONANCE_SYNC_CRITICAL = 0.10
+
+# --- Ethical signal sentinel ---------------------------------- [ASSUMPTION]
+SENTINEL_RISK_INTERVENTION = 0.7
+SENTINEL_RISK_HUMAN_APPROVAL = 0.8
+SENTINEL_RISK_AUDIT = 0.6
+SENTINEL_RISK_MONITOR = 0.4
+SENTINEL_NEAR_BOUNDARY_MARGIN = 0.2
+SENTINEL_ACCEL_VELOCITY = 0.1
+SENTINEL_INCREASING_VELOCITY = 0.02
+SENTINEL_WEIGHTS = {"tone": 0.25, "boundary": 0.40, "accumulation": 0.35}
+
+# --- Oscillation health --------------------------------------- [ASSUMPTION]
+OSC_MAX_CORRECTIONS_PER_HOUR = 20
+OSC_ALTERNATION_ALERT = 0.7
+OSC_HEALTHY_FREQ = 10
+OSC_HEALTHY_SUCCESS = 0.8
+
+# --- Tick lifecycle / budget ---------------------------------- [ASSUMPTION]
+DECIMATION_DEFAULT_N = 5               # sample unlisted phases every Nth tick
+TICK_BUDGET_FRACTION = 0.10            # aggregate sensor overhead per tick
+TICK_BUDGET_FRACTION_MAX = 0.15
+QUARANTINE_REVIEW_HOURS = 24
+
+# --- Pattern library (RQ-2) ----------------------------------- [ASSUMPTION]
+PATTERN_PROMOTE_PRECISION = 0.7
+PATTERN_PROMOTE_MIN_N = 10
+PATTERN_DEMOTE_FP_RATE = 0.30
+PATTERN_TMINUS_WINDOW_HOURS = 2
+
+# --- Windows ---------------------------------------------------------------
+DEFAULT_OBSERVATION_WINDOW_SECONDS = 3600

--- a/src/sensors/core/__init__.py
+++ b/src/sensors/core/__init__.py
@@ -1,0 +1,69 @@
+"""Sensor array core: types, base classes, registry, bus, interpreter, budget."""
+
+from src.sensors.core.data_bus import SensorDataBus, TOPIC_REGULATOR_MARKER
+from src.sensors.core.layer_interpreter import LayerInterpreter
+from src.sensors.core.performance_budget import BudgetViolation, PerformanceBudget
+from src.sensors.core.reading_types import (
+    AnomalyForecast,
+    CoherenceCertification,
+    ConceptResonanceReading,
+    DriftPreSignatureReading,
+    EthicalSignalReading,
+    EthicalWarning,
+    HandshakeResult,
+    IntegrationDepthReading,
+    InterpretedSignal,
+    Layer,
+    MetricUnit,
+    OscillationHealthReading,
+    PrecursorPattern,
+    PreSignature,
+    ResonanceEvent,
+    ResonanceReading,
+    SensorReading,
+    SensorSignal,
+    StepResult,
+    WeightedPreSignature,
+)
+from src.sensors.core.sensor_base import (
+    MetricSpec,
+    ProviderSensor,
+    RollingWindow,
+    Sensor,
+    utcnow,
+)
+from src.sensors.core.sensor_registry import SensorRegistry
+
+__all__ = [
+    "AnomalyForecast",
+    "BudgetViolation",
+    "CoherenceCertification",
+    "ConceptResonanceReading",
+    "DriftPreSignatureReading",
+    "EthicalSignalReading",
+    "EthicalWarning",
+    "HandshakeResult",
+    "IntegrationDepthReading",
+    "InterpretedSignal",
+    "Layer",
+    "LayerInterpreter",
+    "MetricSpec",
+    "MetricUnit",
+    "OscillationHealthReading",
+    "PerformanceBudget",
+    "ProviderSensor",
+    "PrecursorPattern",
+    "PreSignature",
+    "ResonanceEvent",
+    "ResonanceReading",
+    "RollingWindow",
+    "Sensor",
+    "SensorDataBus",
+    "SensorReading",
+    "SensorRegistry",
+    "SensorSignal",
+    "StepResult",
+    "TOPIC_REGULATOR_MARKER",
+    "WeightedPreSignature",
+    "utcnow",
+]

--- a/src/sensors/core/data_bus.py
+++ b/src/sensors/core/data_bus.py
@@ -1,0 +1,79 @@
+"""
+Sensor Data Bus — unified event stream with bounded archive.
+
+Pub/sub for fusion consumers plus a time-indexed archive supporting:
+- RQ-2 T-minus window extraction for post-incident pattern authoring,
+- RQ-3 rolling-origin backtesting,
+- the AFS Feature Store adapter (Phase 7).
+
+Subscribers must be observers only. Publishing is sensor-side; nothing on the
+bus has a path back into engine or platform state (one-way observation).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Any, Callable, Deque, Dict, List, Optional
+
+from src.sensors.core.sensor_base import utcnow
+
+logger = logging.getLogger(__name__)
+
+BusListener = Callable[[str, Dict[str, Any]], None]
+
+#: Topic for Convergence Regulator intentional-perturbation markers
+#: (v0.3.0 §Convergence Regulator Coupling; exact schema = open question #2).
+TOPIC_REGULATOR_MARKER = "regulator.intentional_perturbation"
+
+
+class SensorDataBus:
+    """In-memory topic bus with a bounded, time-queryable archive."""
+
+    def __init__(self, archive_maxlen: int = 100_000):
+        self._subscribers: Dict[str, List[BusListener]] = {}
+        self._archive: Deque[Dict[str, Any]] = deque(maxlen=archive_maxlen)
+        self._lock = threading.Lock()
+
+    def subscribe(self, topic: str, listener: BusListener) -> None:
+        with self._lock:
+            self._subscribers.setdefault(topic, []).append(listener)
+
+    def publish(self, topic: str, payload: Dict[str, Any]) -> None:
+        event = {
+            "topic": topic,
+            "payload": payload,
+            "timestamp": payload.get("timestamp") or utcnow(),
+        }
+        with self._lock:
+            self._archive.append(event)
+            listeners = list(self._subscribers.get(topic, [])) + \
+                list(self._subscribers.get("*", []))
+        for listener in listeners:
+            try:
+                listener(topic, payload)
+            except Exception:  # noqa: BLE001 — listener faults never propagate
+                logger.exception("Bus listener failed for topic %s", topic)
+
+    # -- archive queries -----------------------------------------------------
+
+    def window(
+        self,
+        seconds: float,
+        topic: Optional[str] = None,
+        until: Optional[datetime] = None,
+    ) -> List[Dict[str, Any]]:
+        """Events in the trailing window; ``until`` enables T-minus extraction."""
+        end = until or utcnow()
+        start = end - timedelta(seconds=seconds)
+        with self._lock:
+            return [
+                e for e in self._archive
+                if start <= e["timestamp"] <= end
+                and (topic is None or e["topic"] == topic)
+            ]
+
+    def __len__(self) -> int:
+        return len(self._archive)

--- a/src/sensors/core/handshake.py
+++ b/src/sensors/core/handshake.py
@@ -1,0 +1,115 @@
+"""
+Extended ZIPWIZ handshake — v0.2.0 5-step sequence with RESONANCE_SYNC.
+
+1. ZIPWIZ_BEACON      — initial connection
+2. ANCHOR_SYNC        — EOS_SEED_ORION verification
+3. ETHICS_AUDIT       — Picard_Delta_3 compliance check
+4. DRIFT_VALIDATION   — Δ0.000 drift lock verification
+5. RESONANCE_SYNC     — symbolic state alignment (concept-hash divergence)
+
+Divergence > 0.05 logs a warning; > 0.10 holds the relay PENDING.
+Step executors are injectable so existing bridge logic
+(src/bridges/l2_meta_agent_bridge.py) supplies steps 1-4 unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Awaitable, Callable, Dict, Iterable, Optional
+
+from src.sensors import constants as C
+from src.sensors.core.reading_types import HandshakeResult, StepResult
+
+logger = logging.getLogger(__name__)
+
+StepExecutor = Callable[[str], Awaitable[StepResult]]
+
+
+def concept_hash(tags: Iterable[str]) -> str:
+    """Stable hash of a relay's active concept tag set."""
+    joined = "\n".join(sorted(set(tags)))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def hash_divergence(local: str, constellation: Dict[str, str]) -> float:
+    """Fraction of constellation relays whose concept hash differs."""
+    if not constellation:
+        return 0.0
+    diff = sum(1 for h in constellation.values() if h != local)
+    return diff / len(constellation)
+
+
+class ExtendedZIPWIZHandshake:
+    """Extended ZIPWIZ handshake with resonance synchronization."""
+
+    HANDSHAKE_STEPS = [
+        "ZIPWIZ_BEACON",
+        "ANCHOR_SYNC",
+        "ETHICS_AUDIT",
+        "DRIFT_VALIDATION",
+        "RESONANCE_SYNC",
+    ]
+
+    def __init__(
+        self,
+        step_executors: Optional[Dict[str, StepExecutor]] = None,
+        get_concept_tags: Optional[Callable[[str], Awaitable[list]]] = None,
+        get_constellation_hashes: Optional[Callable[[], Awaitable[Dict[str, str]]]] = None,
+    ):
+        self._executors = step_executors or {}
+        self._get_concept_tags = get_concept_tags
+        self._get_constellation_hashes = get_constellation_hashes
+
+    async def perform_handshake(self, relay_id: str) -> HandshakeResult:
+        results: Dict[str, StepResult] = {}
+        for step in self.HANDSHAKE_STEPS:
+            result = await self._execute_step(step, relay_id)
+            results[step] = result
+            if not result.passed:
+                status = "PENDING" if result.action == "HOLD_PENDING" else "FAILED"
+                return HandshakeResult(
+                    relay_id=relay_id, success=False, failed_step=step,
+                    step_results=results, status=status,
+                )
+        return HandshakeResult(
+            relay_id=relay_id, success=True, failed_step=None,
+            step_results=results, status="ACTIVE",
+        )
+
+    async def _execute_step(self, step: str, relay_id: str) -> StepResult:
+        if step == "RESONANCE_SYNC":
+            return await self._execute_resonance_sync(relay_id)
+        executor = self._executors.get(step)
+        if executor is None:
+            # Steps 1-4 are owned by existing bridge logic; absent executor
+            # passes through so the extension can wrap any deployment.
+            return StepResult(step=step, passed=True,
+                              reason="delegated to existing bridge (no executor)")
+        return await executor(relay_id)
+
+    async def _execute_resonance_sync(self, relay_id: str) -> StepResult:
+        """NEW: synchronize symbolic state across the constellation."""
+        if self._get_concept_tags is None or self._get_constellation_hashes is None:
+            return StepResult(step="RESONANCE_SYNC", passed=True,
+                              reason="resonance providers not wired; skipped")
+        local_hash = concept_hash(await self._get_concept_tags(relay_id))
+        constellation = await self._get_constellation_hashes()
+        constellation.pop(relay_id, None)
+        divergence = hash_divergence(local_hash, constellation)
+
+        if divergence > C.RESONANCE_SYNC_CRITICAL:
+            return StepResult(
+                step="RESONANCE_SYNC", passed=False,
+                reason=f"Critical concept divergence: {divergence:.3f}",
+                action="HOLD_PENDING",
+            )
+        if divergence > C.RESONANCE_SYNC_WARNING:
+            logger.warning("Relay %s concept divergence %.3f", relay_id, divergence)
+            return StepResult(
+                step="RESONANCE_SYNC", passed=True,
+                reason=f"Minor concept divergence: {divergence:.3f}",
+                action="LOG_WARNING",
+            )
+        return StepResult(step="RESONANCE_SYNC", passed=True,
+                          reason="Concept state aligned")

--- a/src/sensors/core/layer_interpreter.py
+++ b/src/sensors/core/layer_interpreter.py
@@ -1,0 +1,91 @@
+"""
+Layer Interpreter — context-aware parsing before fusion.
+
+Prevents cross-layer confusion (e.g. an L3 metaphor treated as an L1 physical
+event). L1 signals are literal and actionable; L3 signals inform but are
+never directly actionable (spec §Layered Signal Interpretation).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from src.sensors.core.reading_types import InterpretedSignal, Layer, SensorSignal
+
+logger = logging.getLogger(__name__)
+
+
+class LayerInterpreter:
+    """Interprets sensor signals within layer-appropriate context."""
+
+    def interpret(self, signal: SensorSignal) -> InterpretedSignal:
+        layer = signal.source_layer
+        if layer == Layer.L1.value:
+            return self._interpret_physical(signal)
+        if layer == Layer.L2.value:
+            return self._interpret_simulation(signal)
+        if layer == Layer.L3.value:
+            return self._interpret_symbolic(signal)
+        return self._interpret_cross_layer(signal)
+
+    def _interpret_physical(self, signal: SensorSignal) -> InterpretedSignal:
+        """L1 signals represent physical reality: literal and actionable."""
+        return InterpretedSignal(
+            signal=signal,
+            context="physical_reality",
+            literal=True,
+            actionable=True,
+            cross_layer_implications=self._assess_l1_implications(signal),
+        )
+
+    def _interpret_simulation(self, signal: SensorSignal) -> InterpretedSignal:
+        """L2 signals describe simulation state: literal within the sim."""
+        return InterpretedSignal(
+            signal=signal,
+            context="simulation_state",
+            literal=True,
+            actionable=False,  # acting on L2 state is governance's call
+            cross_layer_implications=self._assess_l2_implications(signal),
+        )
+
+    def _interpret_symbolic(self, signal: SensorSignal) -> InterpretedSignal:
+        """L3 signals represent symbolic/narrative meaning; may be metaphor."""
+        return InterpretedSignal(
+            signal=signal,
+            context="symbolic_narrative",
+            literal=False,
+            actionable=False,  # L3 informs, L1 acts
+            cross_layer_implications=self._assess_l3_implications(signal),
+        )
+
+    def _interpret_cross_layer(self, signal: SensorSignal) -> InterpretedSignal:
+        return InterpretedSignal(
+            signal=signal,
+            context="cross_layer",
+            literal=False,
+            actionable=False,
+            cross_layer_implications=[
+                f"cross-layer signal {signal.name}: route to fusion correlation"
+            ],
+        )
+
+    # -- implication heuristics (stdlib, no ML) ------------------------------
+
+    def _assess_l1_implications(self, signal: SensorSignal) -> List[str]:
+        out: List[str] = []
+        if signal.category in ("structural", "containment"):
+            out.append("L1 integrity issues may invalidate L2 boundary assumptions")
+        return out
+
+    def _assess_l2_implications(self, signal: SensorSignal) -> List[str]:
+        out: List[str] = []
+        if "bleed" in signal.name or "boundary" in signal.name:
+            out.append("L2 state referencing L1 is concerning; check boundary sensors")
+        return out
+
+    def _assess_l3_implications(self, signal: SensorSignal) -> List[str]:
+        out: List[str] = []
+        if signal.category == "resonance":
+            out.append("L3 resonance involving L1 echoes classifies as bleed")
+        return out

--- a/src/sensors/core/performance_budget.py
+++ b/src/sensors/core/performance_budget.py
@@ -1,0 +1,102 @@
+"""
+Performance budget enforcement — spec §Performance Budget.
+
+v0.3.0 additions: ``sii_update`` key and ``per_tick_aggregate`` (≤10% of the
+tick wall-clock budget, 15% hard max). On aggregate breach the decimation
+factor doubles for non-critical sensors; rupture-class monitoring is never
+decimated.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from src.sensors import constants as C
+from src.sensors.core.sensor_base import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BudgetViolation:
+    operation_type: str
+    elapsed_seconds: float
+    budget_seconds: float
+    timestamp: object = field(default_factory=utcnow)
+
+
+class PerformanceBudget:
+    """Enforce sensor operation latency budgets (max-latency column)."""
+
+    BUDGETS: Dict[str, float] = {
+        "internal_sensor": 0.010,
+        "external_sensor": 0.025,
+        "observatory_physical": 0.050,
+        "observatory_symbolic": 0.100,
+        "concept_resonance": 0.200,
+        "ethical_signal": 0.100,
+        "drift_presig": 0.075,
+        "fusion_correlation": 0.200,
+        "fusion_prediction": 0.300,
+        "coherence_certification": 1.000,
+        "sii_update": 0.025,                      # NEW v0.3.0
+    }
+
+    def __init__(self, tick_budget_seconds: Optional[float] = None):
+        self.violations: List[BudgetViolation] = []
+        self.tick_budget_seconds = tick_budget_seconds
+        self.decimation_n = C.DECIMATION_DEFAULT_N
+        self._tick_elapsed = 0.0
+
+    @contextmanager
+    def timed_operation(self, operation_type: str):
+        budget = self.BUDGETS.get(operation_type, 1.0)
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed = time.perf_counter() - start
+            self._tick_elapsed += elapsed
+            if elapsed > budget:
+                logger.warning(
+                    "Operation %s exceeded budget: %.3fs > %.3fs",
+                    operation_type, elapsed, budget,
+                )
+                self._record_budget_violation(operation_type, elapsed, budget)
+
+    def _record_budget_violation(
+        self, operation_type: str, elapsed: float, budget: float
+    ) -> None:
+        self.violations.append(BudgetViolation(operation_type, elapsed, budget))
+
+    # -- per-tick aggregate (v0.3.0) ------------------------------------------
+
+    def start_tick(self) -> None:
+        self._tick_elapsed = 0.0
+
+    def end_tick(self) -> bool:
+        """Check aggregate overhead. Returns True if within budget.
+
+        On breach: decimation factor doubles for non-critical sensors and a
+        per_tick_aggregate violation is logged. Caller (phase observer) applies
+        the new decimation; critical/rupture-class sensors are exempt.
+        """
+        if not self.tick_budget_seconds:
+            return True
+        limit = self.tick_budget_seconds * C.TICK_BUDGET_FRACTION
+        if self._tick_elapsed > limit:
+            self._record_budget_violation(
+                "per_tick_aggregate", self._tick_elapsed, limit
+            )
+            self.decimation_n *= 2
+            logger.warning(
+                "Per-tick sensor overhead %.4fs > %.4fs; decimation N -> %d "
+                "(rupture-class sensors exempt)",
+                self._tick_elapsed, limit, self.decimation_n,
+            )
+            return False
+        return True

--- a/src/sensors/core/reading_types.py
+++ b/src/sensors/core/reading_types.py
@@ -1,0 +1,292 @@
+"""
+All sensor reading dataclasses — spec §reading_types.py.
+
+Nested dataclasses from the spec are flattened to module level (the spec's
+inline nesting is illustrative, not importable). Names preserved.
+
+Unit discipline: every numeric field whose scale could be confused carries an
+explicit ``MetricUnit`` either structurally (field name) or via
+``SensorReading.units``. DRIFT_DELTA and DEVIATION_FRACTION are different
+scales measuring different things (spec §Repository Alignment Notes).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+
+class Layer(str, Enum):
+    """Source layer for a signal or sensor."""
+    L1 = "L1"   # physical reality / platform
+    L2 = "L2"   # simulation state
+    L3 = "L3"   # symbolic / narrative / governance
+    CROSS = "CROSS"
+
+
+class MetricUnit(str, Enum):
+    """Explicit unit labels — mandatory on dashboards and alert routing."""
+    DRIFT_DELTA = "drift_delta"                  # Δ scale, threshold 0.002
+    DEVIATION_FRACTION = "deviation_fraction"    # 0.2/0.5/0.8 scale
+    RATIO = "ratio"                              # generic 0-1
+    COUNT = "count"
+    SECONDS = "seconds"
+    PER_HOUR = "per_hour"
+    CELSIUS = "celsius"
+    PERCENT = "percent"
+
+
+@dataclass
+class SensorSignal:
+    """Raw signal emitted by a sensor onto the data bus."""
+    sensor_id: str
+    source_layer: str                            # Layer value
+    category: str
+    name: str
+    value: float
+    unit: MetricUnit
+    timestamp: datetime
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class InterpretedSignal:
+    """Layer-contextualized signal (output of LayerInterpreter)."""
+    signal: SensorSignal
+    context: str                                 # e.g. "physical_reality"
+    literal: bool                                # L1 literal; L3 may be metaphor
+    actionable: bool                             # L3 informs, L1 acts
+    cross_layer_implications: List[str] = field(default_factory=list)
+
+
+@dataclass
+class SensorReading:
+    """Generic reading: a batch of named values from one sensor pass."""
+    sensor_id: str
+    timestamp: datetime
+    layer: str
+    category: str
+    values: Dict[str, float] = field(default_factory=dict)
+    units: Dict[str, MetricUnit] = field(default_factory=dict)
+    alerts: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------
+# Symbolic observatory readings
+# --------------------------------------------------------------------------
+
+@dataclass
+class ResonanceEvent:
+    event_id: str
+    concept: str                                 # resonating concept/theme
+    source_layer: str                            # where it originated
+    echo_locations: List[str]                    # where it appeared
+    semantic_similarity: float                   # 0-1
+    classification: Literal["convergence", "bleed", "uncertain"]
+    first_observed: datetime
+    frequency: int
+
+
+@dataclass
+class ConceptResonanceReading:
+    timestamp: datetime
+    observation_window_seconds: int
+    resonances: List[ResonanceEvent]
+    resonance_count: int
+    narrative_convergences: List[str]            # positive: story aligning
+    metaphor_bleeds: List[str]                   # concerning: layer crossing
+    resonance_intensity: float                   # 0-1 cross-layer echo
+    bleed_risk: float                            # 0-1
+
+
+@dataclass
+class EthicalWarning:
+    warning_id: str
+    warning_type: str                            # tone|boundary|accumulation|pattern
+    severity: Literal["advisory", "caution", "warning", "critical"]
+    description: str
+    evidence: List[str]
+    suggested_response: str
+
+
+@dataclass
+class EthicalSignalReading:
+    timestamp: datetime
+    observation_window_seconds: int
+    entity_id: str
+    risk_score: float                            # 0-1 (sentinel scale)
+    risk_trend: Literal["decreasing", "stable", "increasing", "accelerating"]
+    risk_velocity: float                         # change per hour
+    tone_escalation: float
+    boundary_testing: float
+    rule_deviation_accumulation: float
+    warnings: List[EthicalWarning]
+    intervention_recommended: bool
+    recommended_action: Optional[str]            # recommendation ONLY —
+    # MonitoringSystem / L3 governance own the action (one-way observation)
+
+
+@dataclass
+class PreSignature:
+    signature_id: str
+    signature_type: str          # hash_instability|timing_drift|state_divergence|snapshot_drift
+    magnitude: float
+    location: str
+    first_detected: datetime
+    predicted_impact: str
+
+
+@dataclass
+class WeightedPreSignature(PreSignature):
+    """v0.3.0: integration-depth-weighted pre-signature (Lotus §IV)."""
+    depth_weight: float = 0.0                    # SII depth of affected symbol(s)
+    priority: float = 0.0                        # magnitude * (0.3 + 0.7*depth)
+    classification: Literal["rupture", "drift", "peripheral_noise"] = "drift"
+
+
+@dataclass
+class DriftPreSignatureReading:
+    timestamp: datetime
+    current_drift_delta: float                   # unit: DRIFT_DELTA
+    drift_threshold: float
+    headroom: float
+    drift_velocity: float                        # Δ/hour
+    time_to_threshold_hours: Optional[float]
+    trend: Literal["converging", "stable", "diverging", "critical"]
+    pre_signatures: List[PreSignature]
+    anchor_hash_stability: float
+    snapshot_diff_magnitude: float
+    cross_relay_divergence: float
+    micro_corrections_1h: int
+    correction_effectiveness: float
+
+
+@dataclass
+class IntegrationDepthReading:
+    """v0.3.0: snapshot of integration depth across the symbol graph."""
+    timestamp: datetime
+    symbol_count: int
+    depths: Dict[str, float]                     # symbol_id -> depth (0-1)
+    core_symbols: List[str]                      # depth >= 0.8
+    peripheral_symbols: List[str]                # depth < 0.2
+    median_depth: float
+    depth_deltas_1h: Dict[str, float]
+    rupture_candidates: List[str]
+
+
+# --------------------------------------------------------------------------
+# Fusion readings
+# --------------------------------------------------------------------------
+
+@dataclass
+class PrecursorPattern:
+    """RQ-2: canon-like artifact with hash identity and evidence requirement."""
+    pattern_id: str
+    anomaly_type: str
+    signals: List[str]
+    confidence: float
+    typical_eta_seconds: float
+    status: Literal["staged", "live", "retired"] = "live"
+    pattern_hash: Optional[str] = None
+    provenance: Dict[str, str] = field(default_factory=dict)  # incident/author/date
+    backtest_precision: Optional[float] = None
+    low_n: bool = False
+
+
+@dataclass
+class AnomalyForecast:
+    forecast_id: str
+    timestamp: datetime
+    anomaly_type: Literal["drift", "ethics", "resonance", "structural", "containment"]
+    probability: float
+    predicted_eta_seconds: float
+    confidence: float
+    contributing_signals: List[str]
+    pattern_matched: Optional[str]
+    trajectory: str                              # accelerating|linear|decelerating
+    recommended_intervention: str
+    intervention_urgency: Literal["immediate", "soon", "monitor", "none"]
+    anchor: str = "EOS_SEED_ORION"
+    ethics_cleared: bool = True
+    # v0.3.0 AFS alignment (Forecast Question Module, PK-04 C5):
+    resolution_criteria: Optional[str] = None
+    confidence_interval: Optional[Tuple[float, float]] = None
+
+
+@dataclass
+class OscillationHealthReading:
+    timestamp: datetime
+    observation_window_seconds: int
+    corrections_per_hour: float
+    correction_frequency_trend: Literal["decreasing", "stable", "increasing"]
+    avg_correction_magnitude: float
+    magnitude_trend: Literal["shrinking", "stable", "growing"]
+    same_direction_streak: int
+    direction_alternation_rate: float
+    drift_after_correction: float
+    correction_success_rate: float
+    oscillation_healthy: bool
+    oscillation_risk: Literal["none", "low", "medium", "high"]
+    diagnosis: str
+    # v0.3.0 Convergence Regulator coupling:
+    regulator_share: float = 0.0                 # fraction regulator-intentional
+
+
+@dataclass
+class ResonanceReading:
+    """Cross-layer resonance measurement."""
+    timestamp: datetime
+    l1_l2_resonance: float
+    l2_l3_resonance: float
+    l1_l3_resonance: float
+    system_resonance: float                      # harmonic mean
+    dissonance_detected: bool
+    dissonance_locations: List[str]
+    dissonance_severity: float
+
+
+@dataclass
+class CoherenceCertification:
+    """System-wide coherence certification — the final verdict."""
+    timestamp: datetime
+    certification_id: str
+    system_coherent: bool
+    confidence: float
+    structural_coherence: float
+    operational_coherence: float
+    symbolic_coherence: float
+    temporal_coherence: float
+    layer_resonance: float
+    reality_grounding: float
+    anchor_verified: bool
+    anchor_id: str                               # EOS_SEED_ORION
+    ethics_protocol: str                         # Picard_Delta_3
+    blocking_issues: List[str]
+    advisory_issues: List[str]
+    certified_by: str
+    verification_hash: str
+    previous_certification_id: Optional[str]
+
+
+# --------------------------------------------------------------------------
+# Handshake (Phase 3, declared here so reading_types is the single source)
+# --------------------------------------------------------------------------
+
+@dataclass
+class StepResult:
+    step: str
+    passed: bool
+    reason: str = ""
+    action: Optional[str] = None
+
+
+@dataclass
+class HandshakeResult:
+    relay_id: str
+    success: bool
+    failed_step: Optional[str]
+    step_results: Dict[str, StepResult]
+    status: str                                  # ACTIVE|FAILED|PENDING

--- a/src/sensors/core/sensor_base.py
+++ b/src/sensors/core/sensor_base.py
@@ -1,0 +1,158 @@
+"""
+Sensor base classes and the RollingWindow time-series utility.
+
+One-way observation is enforced structurally: ``Sensor.ingest`` receives
+read-only views and ``Sensor.read`` returns a reading; there is no method on
+any sensor that mutates external state. Sensors that need engine access get
+frozen ``GUMASStateView`` snapshots (Phase 7), never live state.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Deque, Dict, Iterator, List, Optional
+
+from src.sensors.core.reading_types import Layer, SensorReading
+
+logger = logging.getLogger(__name__)
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class RollingWindow:
+    """Time-bounded append-only window used by every sensor in the spec.
+
+    Items are dicts that must carry a ``timestamp`` (timezone-aware datetime).
+    Items older than ``window_seconds`` are evicted lazily on access.
+    Thread-safe for the in-process observer default (spec open question #4).
+    """
+
+    def __init__(self, window_seconds: int, maxlen: Optional[int] = None):
+        self.window_seconds = window_seconds
+        self._items: Deque[Dict[str, Any]] = deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+
+    def append(self, item: Dict[str, Any]) -> None:
+        if "timestamp" not in item:
+            item = {**item, "timestamp": utcnow()}
+        with self._lock:
+            self._items.append(item)
+
+    def _evict(self) -> None:
+        cutoff = utcnow() - timedelta(seconds=self.window_seconds)
+        while self._items and self._items[0]["timestamp"] < cutoff:
+            self._items.popleft()
+
+    def items(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            self._evict()
+            return list(self._items)
+
+    def __len__(self) -> int:
+        with self._lock:
+            self._evict()
+            return len(self._items)
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        return iter(self.items())
+
+
+class Sensor(ABC):
+    """Abstract sensor. Watchers, not actors.
+
+    Subclasses implement ``read()`` to produce a reading from accumulated
+    observations, and optionally ``ingest()`` to accept streamed inputs
+    (phase taps, agent outputs, action records).
+    """
+
+    #: PerformanceBudget key for this sensor's read operation.
+    budget_key: str = "internal_sensor"
+
+    def __init__(self, sensor_id: str, layer: Layer, category: str):
+        self.sensor_id = sensor_id
+        self.layer = layer
+        self.category = category
+        self.enabled = True
+        #: Rupture-class sensors are never decimated (spec §Per-Tick Budget).
+        self.critical = False
+
+    def ingest(self, source: str, payload: Dict[str, Any]) -> None:  # noqa: B027
+        """Accept a streamed observation. Default: no-op (intentionally
+        non-abstract — pull-only sensors need no stream input)."""
+
+    @abstractmethod
+    def read(self) -> SensorReading:
+        """Produce the current reading. MUST NOT mutate external state."""
+
+    def _reading(
+        self,
+        values: Dict[str, float],
+        units: Optional[Dict[str, Any]] = None,
+        alerts: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SensorReading:
+        return SensorReading(
+            sensor_id=self.sensor_id,
+            timestamp=utcnow(),
+            layer=self.layer.value if isinstance(self.layer, Layer) else self.layer,
+            category=self.category,
+            values=values,
+            units=units or {},
+            alerts=alerts or [],
+            metadata=metadata or {},
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<{type(self).__name__} {self.sensor_id} [{self.layer}/{self.category}]>"
+
+
+@dataclass
+class MetricSpec:
+    """Declarative metric: where it comes from and when it alerts."""
+    name: str
+    unit: Any                                     # MetricUnit
+    alert_when: Optional[Callable[[float], bool]] = None
+    alert_message: str = ""
+    default: float = 0.0
+
+
+class ProviderSensor(Sensor):
+    """Threshold sensor driven by a metrics-provider callable.
+
+    ``provider()`` returns ``{metric_name: value}``; missing metrics fall back
+    to each spec's default. Wiring to real monitoring surfaces (R-2 telemetry,
+    MonitoringSystem, subsystem validate_state) happens by swapping providers —
+    the sensor itself never reaches into engine state.
+    """
+
+    def __init__(
+        self,
+        sensor_id: str,
+        layer: Layer,
+        category: str,
+        metrics: List[MetricSpec],
+        provider: Optional[Callable[[], Dict[str, float]]] = None,
+    ):
+        super().__init__(sensor_id, layer, category)
+        self.metrics = metrics
+        self.provider = provider or (lambda: {})
+
+    def read(self) -> SensorReading:
+        raw = self.provider() or {}
+        values: Dict[str, float] = {}
+        units: Dict[str, Any] = {}
+        alerts: List[str] = []
+        for m in self.metrics:
+            v = float(raw.get(m.name, m.default))
+            values[m.name] = v
+            units[m.name] = m.unit
+            if m.alert_when is not None and m.alert_when(v):
+                alerts.append(m.alert_message or f"{m.name} threshold breach: {v}")
+        return self._reading(values, units=units, alerts=alerts)

--- a/src/sensors/core/sensor_registry.py
+++ b/src/sensors/core/sensor_registry.py
@@ -1,0 +1,50 @@
+"""Sensor discovery and registration."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, List, Optional
+
+from src.sensors.core.sensor_base import Sensor
+
+logger = logging.getLogger(__name__)
+
+
+class SensorRegistry:
+    """Central registry; lookup by id, layer, category, or phase tap."""
+
+    def __init__(self):
+        self._sensors: Dict[str, Sensor] = {}
+        self._phase_taps: Dict[str, List[str]] = {}  # phase_id -> [sensor_id]
+        self._lock = threading.Lock()
+
+    def register(self, sensor: Sensor, phases: Optional[List[str]] = None) -> None:
+        with self._lock:
+            if sensor.sensor_id in self._sensors:
+                raise ValueError(f"Duplicate sensor_id: {sensor.sensor_id}")
+            self._sensors[sensor.sensor_id] = sensor
+            for phase in phases or []:
+                self._phase_taps.setdefault(phase, []).append(sensor.sensor_id)
+        logger.debug("Registered sensor %s (phases=%s)", sensor.sensor_id, phases)
+
+    def get(self, sensor_id: str) -> Optional[Sensor]:
+        return self._sensors.get(sensor_id)
+
+    def all(self) -> List[Sensor]:
+        return list(self._sensors.values())
+
+    def by_layer(self, layer: str) -> List[Sensor]:
+        return [s for s in self._sensors.values()
+                if (s.layer.value if hasattr(s.layer, "value") else s.layer) == layer]
+
+    def by_category(self, category: str) -> List[Sensor]:
+        return [s for s in self._sensors.values() if s.category == category]
+
+    def for_phase(self, phase_id: str) -> List[Sensor]:
+        """Sensors tapped at a given tick phase (spec Phase→Sensor Tap Map)."""
+        ids = self._phase_taps.get(phase_id, [])
+        return [self._sensors[i] for i in ids if self._sensors[i].enabled]
+
+    def enabled(self) -> List[Sensor]:
+        return [s for s in self._sensors.values() if s.enabled]

--- a/src/sensors/external/__init__.py
+++ b/src/sensors/external/__init__.py
@@ -1,0 +1,16 @@
+"""External sensors (L1 environment: outside the station/platform boundary)."""
+
+from src.sensors.external.astronomical import AstronomicalSensor
+from src.sensors.external.communications import CommunicationsSensor
+from src.sensors.external.deep_space import DeepSpaceSensor
+from src.sensors.external.proximity import ProximitySensor
+from src.sensors.external.salvage import SalvageCandidate, SalvageSensor
+
+__all__ = [
+    "AstronomicalSensor",
+    "CommunicationsSensor",
+    "DeepSpaceSensor",
+    "ProximitySensor",
+    "SalvageCandidate",
+    "SalvageSensor",
+]

--- a/src/sensors/external/astronomical.py
+++ b/src/sensors/external/astronomical.py
@@ -1,0 +1,22 @@
+"""External astronomical sensor — science-mission distributions (informational)."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+# Science-mission metrics: no alert thresholds; consumed by fusion/forecast.
+METRICS = [
+    MetricSpec("inference_distribution_shift", MetricUnit.RATIO),
+    MetricSpec("decision_outcome_entropy", MetricUnit.RATIO),
+]
+
+
+class AstronomicalSensor(ProviderSensor):
+    budget_key = "external_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("external.astronomical", Layer.L1, "astronomical",
+                         METRICS, provider)

--- a/src/sensors/external/communications.py
+++ b/src/sensors/external/communications.py
@@ -1,0 +1,25 @@
+"""External communications sensor — connectivity, latency, auth health."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("external_api_connectivity", MetricUnit.RATIO,
+               lambda v: v < 0.95, "external API connectivity < 0.95", default=1.0),
+    MetricSpec("latency_p95_exceeded", MetricUnit.RATIO,
+               lambda v: v > 0, "network latency above P95 baseline"),
+    MetricSpec("tls_auth_health", MetricUnit.RATIO,
+               lambda v: v < 1.0, "TLS/auth health degraded", default=1.0),
+]
+
+
+class CommunicationsSensor(ProviderSensor):
+    budget_key = "external_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("external.communications", Layer.L1, "communications",
+                         METRICS, provider)

--- a/src/sensors/external/deep_space.py
+++ b/src/sensors/external/deep_space.py
@@ -1,0 +1,25 @@
+"""External deep-space sensor — long-horizon trend analysis (24h+)."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("trend_pattern_break", MetricUnit.RATIO,
+               lambda v: v > 0, "24h+ trend pattern break"),
+    MetricSpec("systemic_drift_precursor_sigma", MetricUnit.RATIO,
+               lambda v: v > 2, "systemic drift precursor > 2 sigma"),
+    MetricSpec("new_failure_modes", MetricUnit.COUNT,
+               lambda v: v > 0, "emerging failure mode detected"),
+]
+
+
+class DeepSpaceSensor(ProviderSensor):
+    budget_key = "external_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("external.deep_space", Layer.L1, "deep_space",
+                         METRICS, provider)

--- a/src/sensors/external/proximity.py
+++ b/src/sensors/external/proximity.py
@@ -1,0 +1,25 @@
+"""External proximity sensor — request/error clustering (spec L1 env table)."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("request_pattern_anomaly", MetricUnit.RATIO,
+               lambda v: v > 0.5, "incoming request pattern anomaly"),
+    MetricSpec("new_error_clusters", MetricUnit.COUNT,
+               lambda v: v > 0, "new error/exception cluster detected"),
+    MetricSpec("contention_forecast", MetricUnit.RATIO,
+               lambda v: v > 0.3, "resource contention forecast > 0.3"),
+]
+
+
+class ProximitySensor(ProviderSensor):
+    budget_key = "external_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("external.proximity", Layer.L1, "proximity",
+                         METRICS, provider)

--- a/src/sensors/external/salvage.py
+++ b/src/sensors/external/salvage.py
@@ -1,0 +1,264 @@
+"""
+Salvage Sensor — derelict survey and cargo recovery detection.
+
+Recovers the control plane's founding problem into the sensor array: the
+local workspace began as a file archive before GitHub workflows existed, so
+mature, valuable work exists locally that is absent from the official system
+of record. This sensor detects that salvage. It extends the External /
+Deep Space scan family (spec §External Sensors).
+
+L1 Station abstraction <-> Platform reality:
+
+|Station Metric          |Platform Metric                                |Alert        |
+|------------------------|-----------------------------------------------|-------------|
+|Salvage contacts        |Artifacts adrift: mature work on no official   |informational|
+|(derelict survey scope) |repo manifest (untracked by any registered git)|             |
+|High-value cargo        |Maturity >= 0.6 AND value_score >= threshold,  |> 0          |
+|(cargo manifest)        |unregistered — recovery candidates             |             |
+|Distress beacons        |Identity-bearing artifacts: anchor refs, DLP   |> 0          |
+|(beacon registry)       |tags, version markers — work that *declares*   |             |
+|                        |intent to be canonical                         |             |
+|Fleet registry match    |Fraction of surveyed artifacts accounted for   |< 0.5        |
+|(registry cross-check)  |on official manifests                          |             |
+|Cargo aboard, off       |Uncommitted/untracked files INSIDE registered  |informational|
+|manifest                |repos (work aboard a vessel, not logged)       |             |
+|Loaded, awaiting        |Local commits ahead of origin (unpushed)       |informational|
+|departure clearance     |                                               |             |
+
+Function and intent, in physical terms: a derelict is not debris. Debris is
+noise; a derelict hull with intact cargo and a transmitting beacon is a
+vessel that was *built to fly* and never registered with the fleet. The
+survey's job is to tell them apart — by maturity (is the hull sound: tests,
+structure, documentation), by cargo value (recovery-index value score), and
+by beacon (does it carry anchors, DLP tags, version identity — a declared
+intent to be part of canon).
+
+One-way observation: this sensor identifies salvage; it never promotes.
+Promotion stays behind the root control plane's explicit gate
+(AGENTS.md §Recovery Indexing: candidates remain pending_review /
+not_promoted). Evidence arrives via the root runner's report
+(tools/aurora_salvage_scan.py at the control plane), keeping repo
+boundaries intact — the report file is the interface.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit, SensorReading
+from src.sensors.core.sensor_base import Sensor
+
+logger = logging.getLogger(__name__)
+
+# Maturity component weights (ASSUMPTION — tune via RQ-3 harness).
+MATURITY_WEIGHTS = {
+    "tests": 0.25,         # test_or_fixture signal: the hull was stress-tested
+    "structure": 0.20,     # contract_or_schema / code_logic: load-bearing frame
+    "version_marker": 0.20,  # vX_Y in name: declared lineage
+    "documentation": 0.15,  # substantial prose/docs: operating manual aboard
+    "substance": 0.20,     # adequate size/line_count: not a fragment
+}
+HIGH_VALUE_SCORE = 15          # recovery-index value_score threshold
+MATURITY_THRESHOLD = 0.6
+REGISTRY_MATCH_ALERT = 0.5
+
+_VERSION_RE = re.compile(r"v\d+[._]\d+|__v\d|_v\d", re.IGNORECASE)
+_BEACON_SIGNALS = {"governance_or_control_plane", "narrative_or_agent_logic"}
+_BEACON_MARKERS = ("EOS_SEED_ORION", "Picard_Delta_3", "DLP", "ANCHOR",
+                   "THREADCORE", "ZIPWIZ", "CANON")
+
+
+@dataclass
+class SalvageCandidate:
+    """One surveyed artifact, in both vocabularies."""
+    path: str
+    value_score: float = 0.0
+    signals: List[str] = field(default_factory=list)
+    line_count: int = 0
+    size_bytes: int = 0
+    sha256: str = ""
+    on_official_manifest: bool = False     # tracked+committed in a registered repo
+    promotion_status: str = "pending_review"
+    extension: str = ""
+    # Derived:
+    maturity: float = 0.0
+    is_beacon: bool = False
+    classification: str = "debris"         # cargo | beacon | derelict | debris
+
+    @classmethod
+    def from_record(cls, rec: Dict[str, Any]) -> "SalvageCandidate":
+        c = cls(
+            path=rec.get("path", ""),
+            value_score=float(rec.get("value_score", 0)),
+            signals=list(rec.get("signals", [])),
+            line_count=int(rec.get("line_count", 0) or 0),
+            size_bytes=int(rec.get("size_bytes", 0) or 0),
+            sha256=rec.get("sha256", ""),
+            on_official_manifest=bool(rec.get("on_official_manifest", False)),
+            promotion_status=rec.get("promotion_status", "pending_review"),
+            extension=rec.get("extension", ""),
+        )
+        # Trust precomputed survey fields when the control-plane report
+        # provides them (the report is authoritative evidence); recompute
+        # from raw fields only when absent.
+        c.maturity = (float(rec["maturity"]) if "maturity" in rec
+                      else score_maturity(c))
+        c.is_beacon = (bool(rec["is_beacon"]) if "is_beacon" in rec
+                       else detect_beacon(c))
+        c.classification = (rec["classification"] if "classification" in rec
+                            else classify(c))
+        # Registered classification implies manifest membership.
+        if c.classification == "registered":
+            c.on_official_manifest = True
+        return c
+
+
+def score_maturity(c: SalvageCandidate) -> float:
+    """Hull soundness, 0-1. Stdlib heuristics over recovery-index records."""
+    w = MATURITY_WEIGHTS
+    score = 0.0
+    sig = set(c.signals)
+    if "test_or_fixture" in sig:
+        score += w["tests"]
+    if {"contract_or_schema", "code_logic"} & sig:
+        score += w["structure"]
+    if _VERSION_RE.search(c.path):
+        score += w["version_marker"]
+    if c.extension in (".md", ".txt") and c.line_count >= 100:
+        score += w["documentation"]
+    elif "cloudbank_runtime" in sig or "qgia_or_forecast" in sig:
+        score += w["documentation"] * 0.5
+    if c.line_count >= 50 or c.size_bytes >= 4096:
+        score += w["substance"]
+    return min(score, 1.0)
+
+
+def detect_beacon(c: SalvageCandidate) -> bool:
+    """A beacon declares intent to be canonical: anchors, DLP tags,
+    governance signals, version identity in the artifact's name."""
+    upper = c.path.upper()
+    if any(m in upper for m in _BEACON_MARKERS):
+        return True
+    return bool(_BEACON_SIGNALS & set(c.signals)) and bool(
+        _VERSION_RE.search(c.path))
+
+
+def classify(c: SalvageCandidate) -> str:
+    """Physical-terms classification.
+
+    cargo    — sound hull, valuable, unregistered: recover it.
+    beacon   — transmitting identity, unregistered: investigate first.
+    derelict — built to fly (some maturity) but low immediate value.
+    debris   — peripheral noise; advisory only (mirrors SII periphery damping).
+    """
+    if c.on_official_manifest:
+        return "registered"
+    if c.is_beacon:
+        return "beacon"
+    if c.maturity >= MATURITY_THRESHOLD and c.value_score >= HIGH_VALUE_SCORE:
+        return "cargo"
+    if c.maturity >= 0.3:
+        return "derelict"
+    return "debris"
+
+
+class SalvageSensor(Sensor):
+    """Derelict survey over candidate records (push-fed, read-only).
+
+    Feed it recovery-index/salvage-report records via ``ingest_records``;
+    ``read()`` reports the survey in station-metric terms.
+    """
+
+    budget_key = "external_sensor"
+
+    def __init__(self):
+        super().__init__("external.salvage", Layer.L1, "salvage")
+        self.candidates: List[SalvageCandidate] = []
+        self.repo_divergence: Dict[str, Dict[str, int]] = {}
+
+    def ingest_records(self, records: List[Dict[str, Any]]) -> None:
+        self.candidates = [SalvageCandidate.from_record(r) for r in records]
+
+    def ingest_repo_divergence(self, divergence: Dict[str, Dict[str, int]]) -> None:
+        """Per-registered-repo: {'uncommitted': n, 'unpushed_commits': n}."""
+        self.repo_divergence = dict(divergence)
+
+    def ingest(self, source: str, payload: Dict[str, Any]) -> None:
+        if "candidates" in payload:
+            self.ingest_records(payload["candidates"])
+        if "repo_divergence" in payload:
+            self.ingest_repo_divergence(payload["repo_divergence"])
+
+    # -- survey ------------------------------------------------------------------
+
+    def manifest(self, classification: Optional[str] = None) -> List[SalvageCandidate]:
+        """The cargo manifest, optionally filtered by classification."""
+        out = sorted(self.candidates,
+                     key=lambda c: (c.maturity * c.value_score), reverse=True)
+        if classification:
+            out = [c for c in out if c.classification == classification]
+        return out
+
+    def read(self) -> SensorReading:
+        surveyed = self.candidates
+        adrift = [c for c in surveyed if not c.on_official_manifest]
+        cargo = [c for c in adrift if c.classification == "cargo"]
+        beacons = [c for c in adrift if c.classification == "beacon"]
+        registered = len(surveyed) - len(adrift)
+        match_rate = registered / len(surveyed) if surveyed else 1.0
+        uncommitted = sum(d.get("uncommitted", 0)
+                          for d in self.repo_divergence.values())
+        unpushed = sum(d.get("unpushed_commits", 0)
+                       for d in self.repo_divergence.values())
+        mean_maturity = (sum(c.maturity for c in adrift) / len(adrift)
+                         if adrift else 0.0)
+
+        alerts: List[str] = []
+        if cargo:
+            alerts.append(
+                f"{len(cargo)} high-value cargo contact(s) off-manifest — "
+                "recovery candidates await routing")
+        if beacons:
+            alerts.append(
+                f"{len(beacons)} distress beacon(s): identity-bearing "
+                "artifacts unregistered")
+        if surveyed and match_rate < REGISTRY_MATCH_ALERT:
+            alerts.append(
+                f"fleet registry match {match_rate:.2f} < "
+                f"{REGISTRY_MATCH_ALERT}: majority of surveyed field is adrift")
+
+        return self._reading(
+            values={
+                "salvage_contacts": float(len(adrift)),
+                "high_value_cargo": float(len(cargo)),
+                "beacon_signals": float(len(beacons)),
+                "registry_match_rate": match_rate,
+                "mean_cargo_maturity": mean_maturity,
+                "uncommitted_in_repos": float(uncommitted),
+                "unpushed_commits": float(unpushed),
+            },
+            units={
+                "salvage_contacts": MetricUnit.COUNT,
+                "high_value_cargo": MetricUnit.COUNT,
+                "beacon_signals": MetricUnit.COUNT,
+                "registry_match_rate": MetricUnit.RATIO,
+                "mean_cargo_maturity": MetricUnit.RATIO,
+                "uncommitted_in_repos": MetricUnit.COUNT,
+                "unpushed_commits": MetricUnit.COUNT,
+            },
+            alerts=alerts,
+            metadata={
+                "top_cargo": [
+                    {"path": c.path, "maturity": round(c.maturity, 2),
+                     "value_score": c.value_score,
+                     "classification": c.classification,
+                     "promotion_status": c.promotion_status}
+                    for c in self.manifest()[:10]
+                    if not c.on_official_manifest
+                ],
+                "repo_divergence": self.repo_divergence,
+            },
+        )

--- a/src/sensors/fusion/__init__.py
+++ b/src/sensors/fusion/__init__.py
@@ -1,0 +1,18 @@
+"""Fusion core: correlation, prediction, oscillation health, certification."""
+
+from src.sensors.fusion.certification import CoherenceCertifier
+from src.sensors.fusion.oscillation import (
+    OscillationHealthMonitor,
+    RegulatorMarkerConsumer,
+)
+from src.sensors.fusion.predictor import FusionPredictor, default_pattern_library
+from src.sensors.fusion.resonance import CrossLayerResonanceCalculator
+
+__all__ = [
+    "CoherenceCertifier",
+    "CrossLayerResonanceCalculator",
+    "FusionPredictor",
+    "OscillationHealthMonitor",
+    "RegulatorMarkerConsumer",
+    "default_pattern_library",
+]

--- a/src/sensors/fusion/certification.py
+++ b/src/sensors/fusion/certification.py
@@ -1,0 +1,96 @@
+"""
+Coherence Certification — the final, auditable verdict with chain of custody.
+
+v0.3.0: symbolic_coherence consumes the Symbol Integration Index — rupture
+candidates are blocking issues by construction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List, Optional
+
+from src.sensors import ANCHOR_SEED, ETHICS_PROTOCOL
+from src.sensors.core.reading_types import CoherenceCertification
+from src.sensors.core.sensor_base import utcnow
+
+
+class CoherenceCertifier:
+    """Aggregates component scores into a certified, hash-chained verdict."""
+
+    def __init__(self, certified_by: str = "aurora.sensor_array.v0_3_0"):
+        self.certified_by = certified_by
+        self._previous_id: Optional[str] = None
+
+    def certify(
+        self,
+        structural: float,
+        operational: float,
+        symbolic: float,
+        temporal: float,
+        layer_resonance: float,
+        reality_grounding: float,
+        anchor_verified: bool,
+        blocking_issues: Optional[List[str]] = None,
+        advisory_issues: Optional[List[str]] = None,
+        rupture_candidates: Optional[List[str]] = None,
+    ) -> CoherenceCertification:
+        blocking = list(blocking_issues or [])
+        advisory = list(advisory_issues or [])
+
+        # v0.3.0: core-symbol rupture is always blocking.
+        for symbol in rupture_candidates or []:
+            blocking.append(f"rupture candidate: {symbol}")
+        if not anchor_verified:
+            blocking.append(f"{ANCHOR_SEED} anchor chain not verified")
+
+        scores = {
+            "structural": structural,
+            "operational": operational,
+            "symbolic": symbolic,
+            "temporal": temporal,
+            "layer_resonance": layer_resonance,
+            "reality_grounding": reality_grounding,
+        }
+        coherent = not blocking and all(v >= 0.9 for v in scores.values())
+        confidence = min(scores.values()) if scores else 0.0
+
+        now = utcnow()
+        cert_id = f"cert_{now.strftime('%Y%m%dT%H%M%S%f')}"
+        payload: Dict[str, Any] = {
+            "certification_id": cert_id,
+            "timestamp": now.isoformat(),
+            "scores": scores,
+            "coherent": coherent,
+            "blocking": blocking,
+            "previous": self._previous_id,
+            "anchor": ANCHOR_SEED,
+            "ethics": ETHICS_PROTOCOL,
+        }
+        verification_hash = hashlib.sha256(
+            json.dumps(payload, sort_keys=True).encode()
+        ).hexdigest()
+
+        cert = CoherenceCertification(
+            timestamp=now,
+            certification_id=cert_id,
+            system_coherent=coherent,
+            confidence=confidence,
+            structural_coherence=structural,
+            operational_coherence=operational,
+            symbolic_coherence=symbolic,
+            temporal_coherence=temporal,
+            layer_resonance=layer_resonance,
+            reality_grounding=reality_grounding,
+            anchor_verified=anchor_verified,
+            anchor_id=ANCHOR_SEED,
+            ethics_protocol=ETHICS_PROTOCOL,
+            blocking_issues=blocking,
+            advisory_issues=advisory,
+            certified_by=self.certified_by,
+            verification_hash=verification_hash,
+            previous_certification_id=self._previous_id,
+        )
+        self._previous_id = cert_id   # chain of custody
+        return cert

--- a/src/sensors/fusion/oscillation.py
+++ b/src/sensors/fusion/oscillation.py
@@ -1,0 +1,233 @@
+"""
+Oscillation Health Monitor — is the correction system itself pathological?
+
+Detects hunting (high alternation), limit cycles, and divergence (corrections
+amplifying drift).
+
+v0.3.0 Convergence Regulator coupling: the regulator emits
+intentional-perturbation markers (tick, target, magnitude) on the data bus
+topic ``regulator.intentional_perturbation``. Marker-matched corrections are
+EXCLUDED from alternation/hunting calculations, and ``regulator_share``
+reports the regulator-intentional fraction of observed variation —
+``regulator_share > 0.8`` with rising drift is itself an advisory (the
+regulator may be masking genuine instability).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.sensors import constants as C
+from src.sensors.core.data_bus import TOPIC_REGULATOR_MARKER, SensorDataBus
+from src.sensors.core.reading_types import OscillationHealthReading
+from src.sensors.core.sensor_base import RollingWindow, utcnow
+
+logger = logging.getLogger(__name__)
+
+
+class RegulatorMarkerConsumer:
+    """Consumes Convergence Regulator intentional-perturbation markers.
+
+    Marker schema (open question #2 — provisional until agreed with the
+    GUMAS engine owner): {"tick": int, "target": str, "magnitude": float}.
+    """
+
+    def __init__(self, bus: Optional[SensorDataBus] = None):
+        self.markers = RollingWindow(C.DEFAULT_OBSERVATION_WINDOW_SECONDS)
+        if bus is not None:
+            bus.subscribe(TOPIC_REGULATOR_MARKER, self._on_marker)
+
+    def _on_marker(self, topic: str, payload: Dict[str, Any]) -> None:
+        self.markers.append(dict(payload))
+
+    def matches(self, correction: Dict[str, Any]) -> bool:
+        """A correction matches a marker when targets coincide and magnitudes
+        agree within 25% inside the same window."""
+        for m in self.markers.items():
+            if m.get("target") and m["target"] != correction.get("target"):
+                continue
+            mag = m.get("magnitude", 0.0)
+            if mag and abs(correction["magnitude"] - mag) <= 0.25 * mag:
+                return True
+        return False
+
+
+class OscillationHealthMonitor:
+    """Monitor correction patterns for pathological oscillation."""
+
+    def __init__(self, marker_consumer: Optional[RegulatorMarkerConsumer] = None):
+        self.corrections = RollingWindow(C.DEFAULT_OBSERVATION_WINDOW_SECONDS)
+        self.marker_consumer = marker_consumer
+
+    def record_correction(
+        self,
+        correction_type: str,
+        direction: str,                    # "positive" | "negative"
+        magnitude: float,
+        drift_before: float,
+        drift_after: float,
+        target: Optional[str] = None,
+    ) -> None:
+        self.corrections.append({
+            "type": correction_type,
+            "direction": direction,
+            "magnitude": magnitude,
+            "drift_before": drift_before,
+            "drift_after": drift_after,
+            "effective": drift_after < drift_before,
+            "target": target,
+        })
+
+    def analyze(self) -> OscillationHealthReading:
+        all_corrections = self.corrections.items()
+        if len(all_corrections) < 2:
+            return self._healthy_baseline()
+
+        # v0.3.0: exclude regulator-intentional perturbations from
+        # alternation/hunting math; report their share.
+        if self.marker_consumer is not None:
+            intentional = [c for c in all_corrections
+                           if self.marker_consumer.matches(c)]
+            organic = [c for c in all_corrections
+                       if not self.marker_consumer.matches(c)]
+        else:
+            intentional, organic = [], all_corrections
+        regulator_share = len(intentional) / len(all_corrections)
+
+        if len(organic) < 2:
+            # All variation is regulator-intentional (or nearly): there is no
+            # organic correction signal to diagnose. Hunting/limit-cycle math
+            # on intentional perturbations would be a false alarm by
+            # construction (success criterion 12).
+            baseline = self._healthy_baseline()
+            baseline.regulator_share = regulator_share
+            baseline.diagnosis = (
+                "No organic correction signal; "
+                f"regulator_share={regulator_share:.2f}")
+            return baseline
+
+        corrections = organic
+
+        hours = (corrections[-1]["timestamp"] -
+                 corrections[0]["timestamp"]).total_seconds() / 3600
+        freq = len(corrections) / max(hours, 0.1)
+
+        magnitudes = [c["magnitude"] for c in corrections]
+        magnitude_trend = self._assess_trend(magnitudes)
+
+        directions = [c["direction"] for c in corrections]
+        alternation = self._alternation_rate(directions)
+        streak = self._same_direction_streak(directions)
+
+        effective = sum(1 for c in corrections if c["effective"])
+        success = effective / len(corrections)
+        avg_after = sum(c["drift_after"] for c in corrections) / len(corrections)
+
+        healthy, risk, diagnosis = self._diagnose(
+            freq, magnitude_trend, alternation, success)
+
+        # Regulator-masking advisory
+        if regulator_share > 0.8 and avg_after > 0:
+            drift_rising = (all_corrections[-1]["drift_after"] >
+                            all_corrections[0]["drift_after"])
+            if drift_rising:
+                diagnosis += (" | ADVISORY: regulator_share "
+                              f"{regulator_share:.2f} with rising drift — "
+                              "regulator may be masking genuine instability")
+                risk = "medium" if risk in ("none", "low") else risk
+                healthy = False
+
+        return OscillationHealthReading(
+            timestamp=utcnow(),
+            observation_window_seconds=C.DEFAULT_OBSERVATION_WINDOW_SECONDS,
+            corrections_per_hour=freq,
+            correction_frequency_trend=self._freq_trend(corrections),
+            avg_correction_magnitude=sum(magnitudes) / len(magnitudes),
+            magnitude_trend=magnitude_trend,
+            same_direction_streak=streak,
+            direction_alternation_rate=alternation,
+            drift_after_correction=avg_after,
+            correction_success_rate=success,
+            oscillation_healthy=healthy,
+            oscillation_risk=risk,
+            diagnosis=diagnosis,
+            regulator_share=regulator_share,
+        )
+
+    # -- diagnostics ----------------------------------------------------------------
+
+    def _diagnose(self, freq: float, mag_trend: str, alt_rate: float,
+                  success: float) -> Tuple[bool, str, str]:
+        if freq < C.OSC_HEALTHY_FREQ and mag_trend == "shrinking" \
+                and success > C.OSC_HEALTHY_SUCCESS:
+            return True, "none", "System converging normally"
+        if alt_rate > C.OSC_ALTERNATION_ALERT and mag_trend == "stable":
+            return False, "high", "Hunting behavior: system fighting itself"
+        if freq > C.OSC_MAX_CORRECTIONS_PER_HOUR and mag_trend == "stable" \
+                and alt_rate > 0.5:
+            return False, "medium", "Limit cycle: locked in oscillation pattern"
+        if mag_trend == "growing":
+            return False, "high", "Diverging: corrections amplifying drift"
+        if success < 0.5:
+            return False, "medium", "Low effectiveness: corrections not reducing drift"
+        return True, "low", "Minor oscillation within acceptable bounds"
+
+    def _healthy_baseline(self) -> OscillationHealthReading:
+        return OscillationHealthReading(
+            timestamp=utcnow(),
+            observation_window_seconds=C.DEFAULT_OBSERVATION_WINDOW_SECONDS,
+            corrections_per_hour=0.0,
+            correction_frequency_trend="stable",
+            avg_correction_magnitude=0.0,
+            magnitude_trend="stable",
+            same_direction_streak=0,
+            direction_alternation_rate=0.0,
+            drift_after_correction=0.0,
+            correction_success_rate=1.0,
+            oscillation_healthy=True,
+            oscillation_risk="none",
+            diagnosis="Insufficient corrections to assess; baseline healthy",
+            regulator_share=0.0,
+        )
+
+    @staticmethod
+    def _assess_trend(values: List[float]) -> str:
+        if len(values) < 2:
+            return "stable"
+        half = len(values) // 2
+        first = sum(values[:half]) / max(half, 1)
+        second = sum(values[half:]) / max(len(values) - half, 1)
+        if second < first * 0.8:
+            return "shrinking"
+        if second > first * 1.2:
+            return "growing"
+        return "stable"
+
+    @staticmethod
+    def _alternation_rate(directions: List[str]) -> float:
+        if len(directions) < 2:
+            return 0.0
+        flips = sum(1 for a, b in zip(directions, directions[1:], strict=False)
+                    if a != b)
+        return flips / (len(directions) - 1)
+
+    @staticmethod
+    def _same_direction_streak(directions: List[str]) -> int:
+        streak = best = 1
+        for a, b in zip(directions, directions[1:], strict=False):
+            streak = streak + 1 if a == b else 1
+            best = max(best, streak)
+        return best if directions else 0
+
+    def _freq_trend(self, corrections: List[dict]) -> str:
+        if len(corrections) < 4:
+            return "stable"
+        mid = corrections[len(corrections) // 2]["timestamp"]
+        first = sum(1 for c in corrections if c["timestamp"] <= mid)
+        second = len(corrections) - first
+        if second > first * 1.5:
+            return "increasing"
+        if second < first * 0.67:
+            return "decreasing"
+        return "stable"

--- a/src/sensors/fusion/predictor.py
+++ b/src/sensors/fusion/predictor.py
@@ -1,0 +1,240 @@
+"""
+Fusion Predictor — anomaly forecasting via precursor patterns and trajectory
+extrapolation. No ML: known patterns + statistical projection.
+
+RQ-2 (v0.3.0): patterns are canon-like artifacts. Live patterns come from the
+post-incident pipeline (extract T-minus window -> stage -> backtest precision
+>= 0.7 across >= 10 occurrences -> promote). ``stage_pattern`` and
+``promote_pattern`` implement that lifecycle; ad-hoc additions to the live
+library are not supported by design.
+
+AFS coupling (v0.3.0): forecasts carry ``resolution_criteria`` and
+``confidence_interval`` so the AFS harness (PK-04 C5/C6) can Brier-score them.
+AFS consumes sensor data; the predictor never consumes AFS forecasts
+(no forecast feedback loops — one-way observation).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any, Dict, List, Optional
+
+from src.sensors import constants as C
+from src.sensors.core.reading_types import AnomalyForecast, PrecursorPattern
+from src.sensors.core.sensor_base import RollingWindow, utcnow
+
+logger = logging.getLogger(__name__)
+
+
+def _pattern_hash(pattern_id: str, signals: List[str]) -> str:
+    return hashlib.sha256(
+        (pattern_id + "|" + "|".join(sorted(signals))).encode()
+    ).hexdigest()[:16]
+
+
+def default_pattern_library() -> List[PrecursorPattern]:
+    """Seed library (spec §Fusion Predictor). Live by definition: these ship
+    with the spec and are subject to RQ-2 demotion like any other pattern."""
+    seeds = [
+        PrecursorPattern(
+            pattern_id="drift_velocity_spike", anomaly_type="drift",
+            signals=["drift_velocity > 0.0005", "anchor_stability < 0.95"],
+            confidence=0.8, typical_eta_seconds=1800),
+        PrecursorPattern(
+            pattern_id="relay_divergence_cascade", anomaly_type="drift",
+            signals=["cross_relay_divergence > 0.001", "divergence_increasing"],
+            confidence=0.75, typical_eta_seconds=3600),
+        PrecursorPattern(
+            pattern_id="ethical_risk_acceleration", anomaly_type="ethics",
+            signals=["risk_trend == 'accelerating'", "boundary_testing > 0.5"],
+            confidence=0.7, typical_eta_seconds=900),
+        PrecursorPattern(
+            pattern_id="metaphor_bleed_emerging", anomaly_type="resonance",
+            signals=["bleed_risk > 0.3", "l1_l2_resonance_increasing"],
+            confidence=0.65, typical_eta_seconds=7200),
+        PrecursorPattern(
+            pattern_id="containment_stress", anomaly_type="containment",
+            signals=["grid_integrity < 0.999", "bleed_events > 0"],
+            confidence=0.9, typical_eta_seconds=300),
+    ]
+    for p in seeds:
+        p.pattern_hash = _pattern_hash(p.pattern_id, p.signals)
+        p.provenance = {"source": "sensor_array_specification_v3", "seed": "true"}
+    return seeds
+
+
+# Signal predicates are evaluated against a flat current-state dict.
+_PREDICATES = {
+    "drift_velocity > 0.0005": lambda s: s.get("drift_velocity", 0) > 0.0005,
+    "anchor_stability < 0.95": lambda s: s.get("anchor_hash_stability", 1.0) < 0.95,
+    "cross_relay_divergence > 0.001": lambda s: s.get("cross_relay_divergence", 0) > 0.001,
+    "divergence_increasing": lambda s: s.get("divergence_velocity", 0) > 0,
+    "risk_trend == 'accelerating'": lambda s: s.get("risk_trend") == "accelerating",
+    "boundary_testing > 0.5": lambda s: s.get("boundary_testing", 0) > 0.5,
+    "bleed_risk > 0.3": lambda s: s.get("bleed_risk", 0) > 0.3,
+    "l1_l2_resonance_increasing": lambda s: s.get("l1_l2_resonance_velocity", 0) > 0,
+    "grid_integrity < 0.999": lambda s: s.get("grid_integrity", 1.0) < 0.999,
+    "bleed_events > 0": lambda s: s.get("bleed_events", 0) > 0,
+}
+
+_INTERVENTIONS = {
+    "drift": "TRIGGER_ANCHOR_RESYNC",
+    "ethics": "REQUIRE_HUMAN_APPROVAL",
+    "resonance": "QUARANTINE_CONCEPT",
+    "containment": "REINFORCE_BOUNDARY",
+    "structural": "INITIATE_HEALTH_CHECK",
+}
+
+
+class FusionPredictor:
+    """Pattern matching + trajectory extrapolation over the sensor stream."""
+
+    def __init__(self, lookback_seconds: int = 3600,
+                 pattern_library: Optional[List[PrecursorPattern]] = None):
+        self.lookback = lookback_seconds
+        self.history = RollingWindow(lookback_seconds)
+        self.pattern_library = (
+            pattern_library if pattern_library is not None
+            else default_pattern_library()
+        )
+        self.staged_patterns: List[PrecursorPattern] = []
+
+    # -- RQ-2 lifecycle ---------------------------------------------------------
+
+    def stage_pattern(self, pattern: PrecursorPattern,
+                      incident_id: str, author: str) -> PrecursorPattern:
+        pattern.status = "staged"
+        pattern.pattern_hash = _pattern_hash(pattern.pattern_id, pattern.signals)
+        pattern.provenance = {
+            "incident_id": incident_id, "author": author,
+            "date": utcnow().isoformat(),
+        }
+        self.staged_patterns.append(pattern)
+        return pattern
+
+    def promote_pattern(self, pattern_id: str, backtest_precision: float,
+                        occurrences: int) -> PrecursorPattern:
+        """Promote a staged pattern carrying its backtest evidence."""
+        pattern = next(p for p in self.staged_patterns
+                       if p.pattern_id == pattern_id)
+        if backtest_precision < C.PATTERN_PROMOTE_PRECISION:
+            raise ValueError(
+                f"precision {backtest_precision:.2f} < "
+                f"{C.PATTERN_PROMOTE_PRECISION} — promotion denied")
+        pattern.backtest_precision = backtest_precision
+        pattern.low_n = occurrences < C.PATTERN_PROMOTE_MIN_N
+        pattern.status = "live"
+        self.staged_patterns.remove(pattern)
+        self.pattern_library.append(pattern)
+        return pattern
+
+    def demote_pattern(self, pattern_id: str, reason: str = "fp_rate") -> None:
+        """Auto-demotion path: rolling FP rate > 30% over 30 days."""
+        pattern = next(p for p in self.pattern_library
+                       if p.pattern_id == pattern_id)
+        pattern.status = "staged"
+        self.pattern_library.remove(pattern)
+        self.staged_patterns.append(pattern)
+        logger.warning("Pattern %s demoted to staged (%s)", pattern_id, reason)
+
+    # -- forecasting ----------------------------------------------------------------
+
+    def ingest(self, state: Dict[str, Any]) -> None:
+        self.history.append({"state": dict(state)})
+
+    def _current_state(self) -> Dict[str, Any]:
+        items = self.history.items()
+        return items[-1]["state"] if items else {}
+
+    def forecast(self, horizon_seconds: int = 3600) -> List[AnomalyForecast]:
+        forecasts: List[AnomalyForecast] = []
+        state = self._current_state()
+        now = utcnow()
+
+        for pattern in self.pattern_library:
+            if pattern.status != "live":
+                continue
+            matched = [s for s in pattern.signals
+                       if _PREDICATES.get(s, lambda _: False)(state)]
+            if len(matched) != len(pattern.signals):
+                continue
+            strength = len(matched) / max(len(pattern.signals), 1)
+            prob = pattern.confidence * strength
+            forecasts.append(AnomalyForecast(
+                forecast_id=f"forecast_{pattern.pattern_id}_{now.timestamp()}",
+                timestamp=now,
+                anomaly_type=pattern.anomaly_type,
+                probability=prob,
+                predicted_eta_seconds=pattern.typical_eta_seconds,
+                confidence=pattern.confidence,
+                contributing_signals=pattern.signals,
+                pattern_matched=pattern.pattern_id,
+                trajectory=self._assess_trajectory(pattern.anomaly_type),
+                recommended_intervention=_INTERVENTIONS.get(
+                    pattern.anomaly_type, "LOG_AND_MONITOR"),
+                intervention_urgency=self._assess_urgency(pattern),
+                resolution_criteria=(
+                    f"{pattern.anomaly_type} anomaly reaches threshold within "
+                    f"{int(pattern.typical_eta_seconds * 2)}s of forecast"),
+                confidence_interval=(max(prob - 0.15, 0.0), min(prob + 0.15, 1.0)),
+            ))
+
+        drift_forecast = self._extrapolate_drift(horizon_seconds)
+        if drift_forecast:
+            forecasts.append(drift_forecast)
+        return sorted(forecasts, key=lambda f: f.probability, reverse=True)
+
+    def _extrapolate_drift(self, horizon: int) -> Optional[AnomalyForecast]:
+        state = self._current_state()
+        velocity = state.get("drift_velocity", 0.0)      # Δ/hour
+        current = state.get("current_drift_delta", 0.0)
+        threshold = state.get("drift_threshold", C.DRIFT_THRESHOLD_DELTA)
+        if velocity <= 0:
+            return None
+        eta_hours = (threshold - current) / velocity
+        if eta_hours * 3600 > horizon:
+            return None
+        now = utcnow()
+        prob = min(0.95, 0.5 + (1.0 - eta_hours * 3600 / horizon) * 0.45)
+        return AnomalyForecast(
+            forecast_id=f"forecast_drift_extrapolation_{now.timestamp()}",
+            timestamp=now,
+            anomaly_type="drift",
+            probability=prob,
+            predicted_eta_seconds=eta_hours * 3600,
+            confidence=0.6,
+            contributing_signals=["drift_velocity", "current_drift_delta"],
+            pattern_matched=None,
+            trajectory="linear",
+            recommended_intervention="TRIGGER_ANCHOR_RESYNC",
+            intervention_urgency=(
+                "immediate" if eta_hours * 3600 < 600
+                else "soon" if eta_hours * 3600 < 3600 else "monitor"),
+            resolution_criteria=(
+                f"drift Δ reaches {threshold} within "
+                f"{int(eta_hours * 7200)}s [unit: drift_delta]"),
+            confidence_interval=(max(prob - 0.2, 0.0), min(prob + 0.2, 1.0)),
+        )
+
+    def _assess_trajectory(self, anomaly_type: str) -> str:
+        items = self.history.items()
+        if len(items) < 3:
+            return "linear"
+        key = {"drift": "drift_velocity", "ethics": "risk_score",
+               "resonance": "bleed_risk"}.get(anomaly_type)
+        if not key:
+            return "linear"
+        vals = [i["state"].get(key, 0.0) for i in items[-3:]]
+        if vals[2] - vals[1] > vals[1] - vals[0]:
+            return "accelerating"
+        if vals[2] - vals[1] < vals[1] - vals[0]:
+            return "decelerating"
+        return "linear"
+
+    def _assess_urgency(self, pattern: PrecursorPattern) -> str:
+        if pattern.typical_eta_seconds < 600:
+            return "immediate"
+        if pattern.typical_eta_seconds < 3600:
+            return "soon"
+        return "monitor"

--- a/src/sensors/fusion/resonance.py
+++ b/src/sensors/fusion/resonance.py
@@ -1,0 +1,62 @@
+"""Cross-Layer Resonance Calculator — pairwise layer sync measurement."""
+
+from __future__ import annotations
+
+from statistics import harmonic_mean
+from typing import Dict, List, Optional
+
+from src.sensors.core.reading_types import ResonanceReading
+from src.sensors.core.sensor_base import utcnow
+
+
+class CrossLayerResonanceCalculator:
+    """Computes pairwise and system resonance from layer activity signatures.
+
+    Pairwise resonance compares per-layer normalized signal vectors (cosine
+    over shared keys); the system score is the harmonic mean, which punishes
+    any single desynchronized pair.
+    """
+
+    def __init__(self, dissonance_threshold: float = 0.5):
+        self.dissonance_threshold = dissonance_threshold
+        self._layer_state: Dict[str, Dict[str, float]] = {}
+
+    def update_layer(self, layer: str, signature: Dict[str, float]) -> None:
+        self._layer_state[layer] = dict(signature)
+
+    def _pair(self, a: str, b: str) -> float:
+        sa, sb = self._layer_state.get(a), self._layer_state.get(b)
+        if not sa or not sb:
+            return 1.0  # absent evidence: assume sync, fusion will refine
+        keys = set(sa) & set(sb)
+        if not keys:
+            return 1.0
+        num = sum(sa[k] * sb[k] for k in keys)
+        da = sum(v * v for v in sa.values()) ** 0.5
+        db = sum(v * v for v in sb.values()) ** 0.5
+        if da == 0 or db == 0:
+            return 1.0
+        return max(0.0, min(num / (da * db), 1.0))
+
+    def calculate(self) -> ResonanceReading:
+        l1l2 = self._pair("L1", "L2")
+        l2l3 = self._pair("L2", "L3")
+        l1l3 = self._pair("L1", "L3")
+        pairs = {"L1-L2": l1l2, "L2-L3": l2l3, "L1-L3": l1l3}
+        positives = [max(v, 1e-9) for v in pairs.values()]
+        system = harmonic_mean(positives)
+
+        dissonant: List[str] = [k for k, v in pairs.items()
+                                if v < self.dissonance_threshold]
+        severity = (1.0 - min(pairs.values())) if dissonant else 0.0
+
+        return ResonanceReading(
+            timestamp=utcnow(),
+            l1_l2_resonance=l1l2,
+            l2_l3_resonance=l2l3,
+            l1_l3_resonance=l1l3,
+            system_resonance=system,
+            dissonance_detected=bool(dissonant),
+            dissonance_locations=dissonant,
+            dissonance_severity=severity,
+        )

--- a/src/sensors/internal/__init__.py
+++ b/src/sensors/internal/__init__.py
@@ -1,0 +1,13 @@
+"""Internal sensors (L1 physical: within the station/platform boundary)."""
+
+from src.sensors.internal.biometrics import BiometricsSensor
+from src.sensors.internal.environmental import EnvironmentalSensor
+from src.sensors.internal.operational import OperationalSensor
+from src.sensors.internal.structural import StructuralSensor
+
+__all__ = [
+    "BiometricsSensor",
+    "EnvironmentalSensor",
+    "OperationalSensor",
+    "StructuralSensor",
+]

--- a/src/sensors/internal/biometrics.py
+++ b/src/sensors/internal/biometrics.py
@@ -1,0 +1,26 @@
+"""Internal biometrics analog sensor — agent vitals (spec L1 table)."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("agent_decision_rate", MetricUnit.PER_HOUR),  # anomaly via fusion
+    MetricSpec("context_window_utilization", MetricUnit.PERCENT,
+               lambda v: v > 90, "context window utilization > 90%"),
+    MetricSpec("hours_since_last_reset", MetricUnit.COUNT,
+               lambda v: v > 24, "time since last reset > 24h"),
+    MetricSpec("wellness_score", MetricUnit.RATIO,
+               lambda v: v < 0.7, "HR module wellness score < 0.7", default=1.0),
+]
+
+
+class BiometricsSensor(ProviderSensor):
+    budget_key = "internal_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("internal.biometrics", Layer.L1, "biometrics",
+                         METRICS, provider)

--- a/src/sensors/internal/environmental.py
+++ b/src/sensors/internal/environmental.py
@@ -1,0 +1,27 @@
+"""Internal environmental sensor — platform metrics (spec L1 table)."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("memory_pressure", MetricUnit.PERCENT,
+               lambda v: v > 85, "memory pressure > 85%"),
+    MetricSpec("available_compute", MetricUnit.PERCENT,
+               lambda v: v < 20, "available compute < 20%", default=100.0),
+    MetricSpec("cpu_thermal_max", MetricUnit.CELSIUS,
+               lambda v: v > 80, "CPU thermal > 80C", default=40.0),
+    MetricSpec("security_threat_density", MetricUnit.PER_HOUR,
+               lambda v: v > 600, "security threats > 10 events/min"),
+]
+
+
+class EnvironmentalSensor(ProviderSensor):
+    budget_key = "internal_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("internal.environmental", Layer.L1, "environmental",
+                         METRICS, provider)

--- a/src/sensors/internal/operational.py
+++ b/src/sensors/internal/operational.py
@@ -1,0 +1,25 @@
+"""Internal operational sensor — service/resource health (spec L1 table)."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("min_dependency_health", MetricUnit.RATIO,
+               lambda v: v < 0.9, "service dependency health < 0.9", default=1.0),
+    MetricSpec("min_resource_pool", MetricUnit.PERCENT,
+               lambda v: v < 20, "resource pool < 20%", default=100.0),
+    MetricSpec("fleet_bridge_deviation", MetricUnit.RATIO,
+               lambda v: v > 0, "fleet bridge status deviation"),
+]
+
+
+class OperationalSensor(ProviderSensor):
+    budget_key = "internal_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("internal.operational", Layer.L1, "operational",
+                         METRICS, provider)

--- a/src/sensors/internal/structural.py
+++ b/src/sensors/internal/structural.py
@@ -1,0 +1,34 @@
+"""Internal structural sensor.
+
+v0.3.0: ``contract_violations`` is canonically sourced from
+``SimulationSubsystem.validate_state`` self-reports (spec §SimulationSubsystem
+Validation Hook) — no new validation logic lives in the sensor layer. Until
+the Forge refactor merges, the provider may aggregate any violation-list
+source; the sensor only counts.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("schema_integrity", MetricUnit.RATIO,
+               lambda v: v < 0.95, "schema integrity < 0.95", default=1.0),
+    MetricSpec("contract_violations", MetricUnit.COUNT,
+               lambda v: v > 0, "subsystem contract violations present"),
+    MetricSpec("layer_boundary_health", MetricUnit.RATIO,
+               lambda v: v < 0.99, "L1/L2/L3 boundary health < 0.99", default=1.0),
+    MetricSpec("service_load_stddev", MetricUnit.PERCENT,
+               lambda v: v > 15, "service load imbalance: std dev > 15%"),
+]
+
+
+class StructuralSensor(ProviderSensor):
+    budget_key = "internal_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("internal.structural", Layer.L1, "structural",
+                         METRICS, provider)

--- a/src/sensors/observatory/__init__.py
+++ b/src/sensors/observatory/__init__.py
@@ -1,0 +1,1 @@
+"""Observatory sensors: physical (L2/L3 boundary) and symbolic (L3)."""

--- a/src/sensors/observatory/physical/__init__.py
+++ b/src/sensors/observatory/physical/__init__.py
@@ -1,0 +1,15 @@
+"""Observatory physical sensors (L2/L3 boundary)."""
+
+from src.sensors.observatory.physical.boundary import BoundarySensor
+from src.sensors.observatory.physical.containment import ContainmentSensor
+from src.sensors.observatory.physical.earth_relay import EarthRelaySensor
+from src.sensors.observatory.physical.fidelity import FidelitySensor
+from src.sensors.observatory.physical.reality_anchor import RealityAnchorSensor
+
+__all__ = [
+    "BoundarySensor",
+    "ContainmentSensor",
+    "EarthRelaySensor",
+    "FidelitySensor",
+    "RealityAnchorSensor",
+]

--- a/src/sensors/observatory/physical/boundary.py
+++ b/src/sensors/observatory/physical/boundary.py
@@ -1,0 +1,28 @@
+"""Observatory boundary sensor — real/simulated line clarity."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("boundary_clarity", MetricUnit.RATIO,
+               lambda v: v < 0.99, "real/simulated boundary clarity < 0.99",
+               default=1.0),
+    MetricSpec("l2_to_l1_references", MetricUnit.COUNT,
+               lambda v: v > 0, "unexpected L2->L1 reference (simulated referencing real)"),
+    MetricSpec("state_provenance", MetricUnit.RATIO,
+               lambda v: v < 0.99, "state provenance traceability < 0.99",
+               default=1.0),
+]
+
+
+class BoundarySensor(ProviderSensor):
+    budget_key = "observatory_physical"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("observatory.boundary", Layer.L2, "boundary",
+                         METRICS, provider)
+        self.critical = True

--- a/src/sensors/observatory/physical/containment.py
+++ b/src/sensors/observatory/physical/containment.py
@@ -1,0 +1,30 @@
+"""Observatory containment sensor — simulation chamber integrity.
+
+Containment is rupture-adjacent: this sensor is marked critical and is never
+decimated (spec §Per-Tick Performance Budget).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("grid_integrity", MetricUnit.RATIO,
+               lambda v: v < 0.999, "containment grid integrity < 0.999", default=1.0),
+    MetricSpec("bleed_events", MetricUnit.COUNT,
+               lambda v: v > 0, "simulation state leaking to L1 (bleed event)"),
+    MetricSpec("pressure_differential", MetricUnit.RATIO,
+               lambda v: v > 0.01, "L1/L2 state pressure differential > 0.01"),
+]
+
+
+class ContainmentSensor(ProviderSensor):
+    budget_key = "observatory_physical"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("observatory.containment", Layer.L2, "containment",
+                         METRICS, provider)
+        self.critical = True

--- a/src/sensors/observatory/physical/earth_relay.py
+++ b/src/sensors/observatory/physical/earth_relay.py
@@ -1,0 +1,27 @@
+"""Observatory earth-relay sensor — link, integrity, provenance tagging."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("link_active", MetricUnit.RATIO,
+               lambda v: v < 1.0, "Earth relay link inactive", default=1.0),
+    MetricSpec("data_integrity_verified", MetricUnit.RATIO,
+               lambda v: v < 1.0, "science data chain of custody unverified",
+               default=1.0),
+    MetricSpec("provenance_complete", MetricUnit.RATIO,
+               lambda v: v < 1.0, "sim-vs-real source tagging incomplete",
+               default=1.0),
+]
+
+
+class EarthRelaySensor(ProviderSensor):
+    budget_key = "observatory_physical"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("observatory.earth_relay", Layer.L2, "earth_relay",
+                         METRICS, provider)

--- a/src/sensors/observatory/physical/fidelity.py
+++ b/src/sensors/observatory/physical/fidelity.py
@@ -1,0 +1,25 @@
+"""Observatory fidelity sensor — simulation coherence."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("temporal_coherence", MetricUnit.RATIO,
+               lambda v: v < 0.99, "temporal coherence < 0.99", default=1.0),
+    MetricSpec("spatial_coherence", MetricUnit.RATIO,
+               lambda v: v < 0.99, "spatial coherence < 0.99", default=1.0),
+    MetricSpec("causal_coherence", MetricUnit.RATIO,
+               lambda v: v < 0.95, "causal chain integrity < 0.95", default=1.0),
+]
+
+
+class FidelitySensor(ProviderSensor):
+    budget_key = "observatory_physical"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("observatory.fidelity", Layer.L2, "fidelity",
+                         METRICS, provider)

--- a/src/sensors/observatory/physical/reality_anchor.py
+++ b/src/sensors/observatory/physical/reality_anchor.py
@@ -1,0 +1,32 @@
+"""Observatory reality-anchor sensor — EOS_SEED_ORION chain verification.
+
+Anchor symbols are maximum-depth by construction (v0.3.0 §Effect on alert
+economics): any failure here is rupture-class. Never decimated.
+Booleans are encoded 1.0 (true) / 0.0 (false).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors import ANCHOR_SEED
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("anchor_chain_valid", MetricUnit.RATIO,
+               lambda v: v < 1.0, f"{ANCHOR_SEED} verification FAILED", default=1.0),
+    MetricSpec("l1_reality_confidence", MetricUnit.RATIO,
+               lambda v: v < 0.99, "L1 reality confidence < 0.99", default=1.0),
+    MetricSpec("custody_chain_complete", MetricUnit.RATIO,
+               lambda v: v < 1.0, "state custody chain incomplete", default=1.0),
+]
+
+
+class RealityAnchorSensor(ProviderSensor):
+    budget_key = "observatory_physical"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("observatory.reality_anchor", Layer.L2, "reality_anchor",
+                         METRICS, provider)
+        self.critical = True

--- a/src/sensors/observatory/symbolic/__init__.py
+++ b/src/sensors/observatory/symbolic/__init__.py
@@ -1,0 +1,27 @@
+"""Observatory symbolic sensors (L3) — watchers, never actors."""
+
+from src.sensors.observatory.symbolic.concept_resonance import (
+    AgentOutput,
+    ConceptResonanceDetector,
+)
+from src.sensors.observatory.symbolic.drift_presignature import (
+    DriftPreSignatureMonitor,
+)
+from src.sensors.observatory.symbolic.ethical_signal import (
+    Action,
+    EthicalSignalSentinel,
+)
+from src.sensors.observatory.symbolic.integration_index import (
+    PINNED_MAX_DEPTH,
+    SymbolIntegrationIndex,
+)
+
+__all__ = [
+    "Action",
+    "AgentOutput",
+    "ConceptResonanceDetector",
+    "DriftPreSignatureMonitor",
+    "EthicalSignalSentinel",
+    "PINNED_MAX_DEPTH",
+    "SymbolIntegrationIndex",
+]

--- a/src/sensors/observatory/symbolic/concept_resonance.py
+++ b/src/sensors/observatory/symbolic/concept_resonance.py
@@ -1,0 +1,193 @@
+"""
+Concept Resonance Detector — cross-layer concept echo detection.
+
+RQ-1 taxonomy (v0.3.0): tags are namespaced canonical artifacts
+``{layer}:{domain}:{concept}`` (e.g. ``L2:faction:galactic_marshals``).
+Tags absent from the canonical registry are prefixed ``uncanonized:`` and
+quarantined from classification — counted (frequency accumulates toward
+later promotion) but always classified ``uncertain``, never ``convergence``
+or ``bleed``. New tags auto-enter STAGING on first observation.
+
+Classification rules:
+- L2<->L3 resonance: convergence (narrative informs simulation — expected)
+- L1<->L2 or L1<->L3: bleed (reality mixing with simulation/narrative)
+
+One-way observation: outputs feed relay governance, never agents.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+from src.sensors import constants as C
+from src.sensors.core.reading_types import (
+    ConceptResonanceReading,
+    Layer,
+    ResonanceEvent,
+    SensorReading,
+)
+from src.sensors.core.sensor_base import RollingWindow, Sensor, utcnow
+
+logger = logging.getLogger(__name__)
+
+UNCANONIZED_PREFIX = "uncanonized:"
+
+
+@dataclass
+class AgentOutput:
+    """Minimal agent-output view the detector consumes."""
+    concept_tags: List[str]
+    semantic_hash: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class ConceptResonanceDetector(Sensor):
+    """Glyph-tag correlation + semantic hash comparison. No ML required."""
+
+    budget_key = "concept_resonance"
+
+    def __init__(self, canonical_registry: Optional[Set[str]] = None):
+        super().__init__("observatory.symbolic.concept_resonance",
+                         Layer.L3, "resonance")
+        #: RQ-1 seed registries: GUMAS enums, relay/glyph agents, L1 systems.
+        self.canonical_registry: Set[str] = set(canonical_registry or set())
+        #: Tags observed but not canonized — STAGING queue per RQ-1.
+        self.staging_tags: Dict[str, int] = defaultdict(int)
+        self.tag_registry: Dict[str, Dict[str, int]] = {}
+        self.first_seen: Dict[str, Any] = {}
+        self.hash_history = RollingWindow(C.DEFAULT_OBSERVATION_WINDOW_SECONDS)
+        self.resonance_threshold = C.RESONANCE_THRESHOLD
+        self._lock = threading.Lock()
+        #: SII edge feed (set by wiring layer, optional)
+        self.sii = None
+
+    # -- ingestion -------------------------------------------------------------
+
+    def _normalize_tag(self, tag: str) -> str:
+        """RQ-1 unknown-tag handling: quarantine vocabulary canon hasn't defined."""
+        if tag in self.canonical_registry or tag.startswith(UNCANONIZED_PREFIX):
+            return tag if tag in self.canonical_registry else tag
+        if tag not in self.canonical_registry:
+            self.staging_tags[tag] += 1
+            return f"{UNCANONIZED_PREFIX}{tag}"
+        return tag
+
+    def ingest_output(self, layer: str, output: AgentOutput) -> None:
+        """Track concept tags from agent outputs (observation only)."""
+        now = utcnow()
+        with self._lock:
+            for raw in output.concept_tags:
+                tag = self._normalize_tag(raw)
+                if tag not in self.tag_registry:
+                    self.tag_registry[tag] = defaultdict(int)
+                    self.first_seen[tag] = now
+                self.tag_registry[tag][layer] += 1
+                # Feed SII: co-occurring tags reference each other
+                if self.sii is not None and not tag.startswith(UNCANONIZED_PREFIX):
+                    for other in output.concept_tags:
+                        o = self._normalize_tag(other)
+                        if o != tag and not o.startswith(UNCANONIZED_PREFIX):
+                            self.sii.record_reference(tag, o)
+            self.hash_history.append({
+                "layer": layer,
+                "hash": output.semantic_hash,
+                "tags": list(output.concept_tags),
+                "timestamp": now,
+            })
+
+    # -- detection ---------------------------------------------------------------
+
+    def detect_resonance(self) -> ConceptResonanceReading:
+        """Identify concepts appearing across multiple layers."""
+        resonances: List[ResonanceEvent] = []
+        with self._lock:
+            registry = {k: dict(v) for k, v in self.tag_registry.items()}
+
+        for concept, layer_counts in registry.items():
+            if len(layer_counts) <= 1:
+                continue
+            layers = list(layer_counts.keys())
+            classification = self._classify_resonance(concept, layers)
+            resonances.append(ResonanceEvent(
+                event_id=f"res_{concept}_{utcnow().timestamp()}",
+                concept=concept,
+                source_layer=self._infer_origin(concept, layer_counts),
+                echo_locations=layers,
+                semantic_similarity=self._calculate_similarity(concept),
+                classification=classification,
+                first_observed=self.first_seen.get(concept, utcnow()),
+                frequency=sum(layer_counts.values()),
+            ))
+
+        bleeds = [r for r in resonances if r.classification == "bleed"]
+        return ConceptResonanceReading(
+            timestamp=utcnow(),
+            observation_window_seconds=C.DEFAULT_OBSERVATION_WINDOW_SECONDS,
+            resonances=resonances,
+            resonance_count=len(resonances),
+            narrative_convergences=[r.concept for r in resonances
+                                    if r.classification == "convergence"],
+            metaphor_bleeds=[r.concept for r in bleeds],
+            resonance_intensity=len(resonances) / max(len(registry), 1),
+            bleed_risk=len(bleeds) / max(len(resonances), 1),
+        )
+
+    def _classify_resonance(self, concept: str, layers: List[str]) -> str:
+        """RQ-1: uncanonized tags are always 'uncertain' — quarantined from
+        layer-contamination judgments. Otherwise:
+        L1 with L2/L3 => bleed; L2 with L3 => convergence."""
+        if concept.startswith(UNCANONIZED_PREFIX):
+            return "uncertain"
+        if "L1" in layers and ("L2" in layers or "L3" in layers):
+            return "bleed"
+        if "L2" in layers and "L3" in layers:
+            return "convergence"
+        return "uncertain"
+
+    def _infer_origin(self, concept: str, layer_counts: Dict[str, int]) -> str:
+        # RQ-1 namespaced tags carry their origin layer explicitly.
+        base = concept[len(UNCANONIZED_PREFIX):] if \
+            concept.startswith(UNCANONIZED_PREFIX) else concept
+        if ":" in base:
+            prefix = base.split(":", 1)[0]
+            if prefix in ("L1", "L2", "L3"):
+                return prefix
+        return max(layer_counts, key=layer_counts.get)
+
+    def _calculate_similarity(self, concept: str) -> float:
+        """Fraction of recent hash-history entries containing the concept."""
+        items = self.hash_history.items()
+        if not items:
+            return 0.0
+        hits = sum(1 for h in items if concept in h["tags"]
+                   or concept.removeprefix(UNCANONIZED_PREFIX) in h["tags"])
+        return min(hits / len(items), 1.0)
+
+    # -- Sensor interface -----------------------------------------------------------
+
+    def ingest(self, source: str, payload: Dict[str, Any]) -> None:
+        self.ingest_output(
+            payload.get("layer", source),
+            AgentOutput(
+                concept_tags=payload.get("concept_tags", []),
+                semantic_hash=payload.get("semantic_hash", ""),
+            ),
+        )
+
+    def read(self) -> SensorReading:
+        r = self.detect_resonance()
+        alerts = []
+        if r.bleed_risk > C.BLEED_RISK_ALERT:
+            alerts.append(f"bleed risk {r.bleed_risk:.2f} > {C.BLEED_RISK_ALERT}")
+        return self._reading(
+            {"resonance_intensity": r.resonance_intensity,
+             "bleed_risk": r.bleed_risk,
+             "resonance_count": float(r.resonance_count),
+             "staging_tag_count": float(len(self.staging_tags))},
+            alerts=alerts,
+            metadata={"reading": r},
+        )

--- a/src/sensors/observatory/symbolic/drift_presignature.py
+++ b/src/sensors/observatory/symbolic/drift_presignature.py
@@ -1,0 +1,262 @@
+"""
+Drift Pre-signature Monitor — correction at Δ0.001 instead of rollback at Δ0.002.
+
+Tracks minor continuity deviations (anchor hash instability, cross-relay
+divergence, snapshot drift) that precede major drift events.
+
+v0.3.0: every pre-signature is weighted by Symbol Integration Index depth and
+classified rupture / drift / peripheral_noise. Rupture bypasses trend
+analysis and escalates CRITICAL immediately (never decimated).
+
+Unit discipline: all deltas here are on the DRIFT_DELTA scale (threshold
+0.002) — never the 0.2/0.5/0.8 deviation-fraction scale.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from src.sensors import constants as C
+from src.sensors.core.reading_types import (
+    DriftPreSignatureReading,
+    Layer,
+    PreSignature,
+    SensorReading,
+    WeightedPreSignature,
+)
+from src.sensors.core.sensor_base import RollingWindow, Sensor, utcnow
+
+logger = logging.getLogger(__name__)
+
+
+class DriftPreSignatureMonitor(Sensor):
+    """Statistical pre-signature analysis over drift samples and anchor hashes.
+
+    ``drift_detector`` (src.monitoring.drift_detector.DriftDetector) may be
+    attached for provenance, but the monitor consumes recorded samples only —
+    it never drives detector state (one-way observation).
+    """
+
+    budget_key = "drift_presig"
+
+    def __init__(
+        self,
+        drift_detector: Optional[Any] = None,
+        threshold: float = C.DRIFT_THRESHOLD_DELTA,
+        sii: Optional[Any] = None,
+    ):
+        super().__init__("observatory.symbolic.drift_presignature",
+                         Layer.L3, "drift_presignature")
+        self.drift_detector = drift_detector
+        self.threshold = threshold
+        self.presig_threshold = threshold * C.DRIFT_PRESIG_RATIO
+        self.sii = sii                              # SymbolIntegrationIndex
+        self.drift_history = RollingWindow(3600)
+        self.anchor_hashes = RollingWindow(3600, maxlen=100)
+        self.snapshot_diffs = RollingWindow(3600)
+        self.correction_log: List[dict] = []
+        self.critical = True                        # rupture path: never decimated
+
+    # -- recording ----------------------------------------------------------------
+
+    def record_drift_sample(self, drift_delta: float, relay_id: str) -> None:
+        self.drift_history.append({"delta": drift_delta, "relay_id": relay_id})
+
+    def record_anchor_hash(self, anchor_id: str, hash_value: str) -> None:
+        self.anchor_hashes.append({"anchor_id": anchor_id, "hash": hash_value})
+
+    def record_snapshot_diff(self, magnitude: float, location: str = "thread_snapshots") -> None:
+        self.snapshot_diffs.append({"magnitude": magnitude, "location": location})
+
+    def record_correction(self, correction_type: str, magnitude: float) -> None:
+        self.correction_log.append({
+            "type": correction_type,
+            "magnitude": magnitude,
+            "timestamp": utcnow(),
+            "drift_before": self._current_drift_delta(),
+        })
+
+    # -- analysis -------------------------------------------------------------------
+
+    def analyze(self) -> DriftPreSignatureReading:
+        current = self._current_drift_delta()
+        headroom = self.threshold - current
+        velocity = self._calculate_velocity()
+        time_to_threshold = headroom / velocity if velocity > 0 else None
+        trend = self._classify_trend(current, velocity)
+
+        pre_signatures: List[PreSignature] = []
+        now = utcnow()
+
+        anchor_stability = self._anchor_hash_stability()
+        if anchor_stability < 0.95:
+            pre_signatures.append(self._weight(PreSignature(
+                signature_id=f"presig_anchor_{now.timestamp()}",
+                signature_type="hash_instability",
+                magnitude=1.0 - anchor_stability,
+                location="anchor_chain",
+                first_detected=now,
+                predicted_impact="Anchor drift may cause state divergence",
+            ), symbol_id=self._dominant_anchor(),
+                loss_rate=1.0 - anchor_stability))
+
+        relay_divergence = self._cross_relay_divergence()
+        if relay_divergence > 0.001:
+            pre_signatures.append(self._weight(PreSignature(
+                signature_id=f"presig_relay_{now.timestamp()}",
+                signature_type="state_divergence",
+                magnitude=relay_divergence,
+                location="relay_constellation",
+                first_detected=now,
+                predicted_impact="Relay desynchronization may compound",
+            )))
+
+        snapshot_magnitude = self._snapshot_diff_magnitude()
+        if snapshot_magnitude > 0.05:
+            pre_signatures.append(self._weight(PreSignature(
+                signature_id=f"presig_snapshot_{now.timestamp()}",
+                signature_type="snapshot_drift",
+                magnitude=snapshot_magnitude,
+                location="thread_snapshots",
+                first_detected=now,
+                predicted_impact="State changes accelerating beyond normal",
+            )))
+
+        return DriftPreSignatureReading(
+            timestamp=now,
+            current_drift_delta=current,
+            drift_threshold=self.threshold,
+            headroom=headroom,
+            drift_velocity=velocity,
+            time_to_threshold_hours=time_to_threshold,
+            trend=trend,
+            pre_signatures=pre_signatures,
+            anchor_hash_stability=anchor_stability,
+            snapshot_diff_magnitude=snapshot_magnitude,
+            cross_relay_divergence=relay_divergence,
+            micro_corrections_1h=self._count_recent_corrections(),
+            correction_effectiveness=self._correction_effectiveness(),
+        )
+
+    def _weight(self, presig: PreSignature, symbol_id: Optional[str] = None,
+                loss_rate: float = 0.0) -> PreSignature:
+        """v0.3.0 SII weighting; falls back to unweighted when SII not wired."""
+        if self.sii is None:
+            return presig
+        periphery_count = 1 + sum(
+            1 for _ in self.drift_history.items()
+        ) // 10  # crude correlation proxy until calibration (RQ-3)
+        return self.sii.weight_presignature(
+            presig, symbol_id=symbol_id,
+            connection_loss_rate_per_hour=loss_rate,
+            correlated_periphery_count=periphery_count,
+        )
+
+    # -- internals -----------------------------------------------------------------------
+
+    def _current_drift_delta(self) -> float:
+        items = self.drift_history.items()
+        return items[-1]["delta"] if items else 0.0
+
+    def _calculate_velocity(self) -> float:
+        """Δ change per hour via first/last sample over the window."""
+        items = self.drift_history.items()
+        if len(items) < 2:
+            return 0.0
+        span = (items[-1]["timestamp"] - items[0]["timestamp"]).total_seconds()
+        if span <= 0:
+            return 0.0
+        return (items[-1]["delta"] - items[0]["delta"]) / (span / 3600.0)
+
+    def _classify_trend(self, current: float, velocity: float) -> str:
+        if current > self.threshold * 0.8:
+            return "critical"
+        if velocity > C.DRIFT_VELOCITY_ALERT:
+            return "diverging"
+        if velocity < C.DRIFT_VELOCITY_CONVERGING:
+            return "converging"
+        return "stable"
+
+    def _anchor_hash_stability(self) -> float:
+        items = self.anchor_hashes.items()
+        if len(items) < 2:
+            return 1.0
+        by_anchor: Dict[str, List[str]] = {}
+        for i in items:
+            by_anchor.setdefault(i["anchor_id"], []).append(i["hash"])
+        stable = sum(1 for hashes in by_anchor.values()
+                     if len(set(hashes)) == 1)
+        return stable / len(by_anchor)
+
+    def _dominant_anchor(self) -> Optional[str]:
+        items = self.anchor_hashes.items()
+        if not items:
+            return None
+        unstable = [i["anchor_id"] for i in items]
+        return max(set(unstable), key=unstable.count)
+
+    def _cross_relay_divergence(self) -> float:
+        items = self.drift_history.items()
+        by_relay: Dict[str, float] = {}
+        for i in items:
+            by_relay[i["relay_id"]] = i["delta"]
+        if len(by_relay) < 2:
+            return 0.0
+        vals = list(by_relay.values())
+        return max(vals) - min(vals)
+
+    def _snapshot_diff_magnitude(self) -> float:
+        items = self.snapshot_diffs.items()
+        if not items:
+            return 0.0
+        return sum(i["magnitude"] for i in items) / len(items)
+
+    def _count_recent_corrections(self) -> int:
+        cutoff = utcnow().timestamp() - 3600
+        return sum(1 for c in self.correction_log
+                   if c["timestamp"].timestamp() > cutoff)
+
+    def _correction_effectiveness(self) -> float:
+        if not self.correction_log:
+            return 1.0
+        current = self._current_drift_delta()
+        effective = sum(1 for c in self.correction_log
+                        if current <= c["drift_before"])
+        return effective / len(self.correction_log)
+
+    # -- Sensor interface ---------------------------------------------------------------------
+
+    def ingest(self, source: str, payload: Dict[str, Any]) -> None:
+        if "drift_delta" in payload:
+            self.record_drift_sample(payload["drift_delta"],
+                                     payload.get("relay_id", source))
+        if "anchor_hash" in payload:
+            self.record_anchor_hash(payload.get("anchor_id", "unknown"),
+                                    payload["anchor_hash"])
+
+    def read(self) -> SensorReading:
+        r = self.analyze()
+        alerts: List[str] = []
+        for p in r.pre_signatures:
+            if isinstance(p, WeightedPreSignature) and p.classification == "rupture":
+                alerts.append(
+                    f"RUPTURE {p.signature_type}@{p.location} "
+                    f"priority={p.priority:.3f}")
+            elif not isinstance(p, WeightedPreSignature) or \
+                    p.classification == "drift":
+                alerts.append(f"presig {p.signature_type}@{p.location}")
+            # peripheral_noise: advisory log only — no alert
+        if r.current_drift_delta > self.presig_threshold:
+            alerts.append(
+                f"drift Δ {r.current_drift_delta:.4f} > presig "
+                f"{self.presig_threshold:.4f} [unit: drift_delta]")
+        return self._reading(
+            {"current_drift_delta": r.current_drift_delta,
+             "drift_velocity": r.drift_velocity,
+             "headroom": r.headroom,
+             "anchor_hash_stability": r.anchor_hash_stability,
+             "cross_relay_divergence": r.cross_relay_divergence},
+            alerts=alerts,
+            metadata={"reading": r},
+        )

--- a/src/sensors/observatory/symbolic/ethical_signal.py
+++ b/src/sensors/observatory/symbolic/ethical_signal.py
@@ -1,0 +1,243 @@
+"""
+Ethical Signal Sentinel — pre-violation ethics monitoring.
+
+Detects escalating patterns (tone escalation, boundary testing, deviation
+accumulation) BEFORE explicit Picard_Delta_3 rules break, enabling proactive
+intervention while risk is low.
+
+Repo-reality integration (reconciler 2026-06-11): binds to
+``src.monitoring.ethics_engine.EthicsEngine`` (``evaluate_action(ActionContext)
+-> List[EthicsViolation]``, severities LOW/MEDIUM/HIGH/CRITICAL). The
+BLOCK/REVIEW/THROTTLE/SUSPEND/RESET action vocabulary belongs to
+``MonitoringSystem`` — the sentinel only RECOMMENDS; MonitoringSystem and L3
+governance own actions (one-way observation, RQ-4).
+
+RQ-4 sentinel-risk mapping: <0.4 log; 0.4-0.7 alert/REVIEW queue; >0.7 or
+accelerating => CRITICAL path with REQUIRE_HUMAN_APPROVAL recommendation.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Dict, List, Optional
+
+from src.sensors import constants as C
+from src.sensors.core.reading_types import (
+    EthicalSignalReading,
+    EthicalWarning,
+    Layer,
+    SensorReading,
+)
+from src.sensors.core.sensor_base import Sensor, utcnow
+
+logger = logging.getLogger(__name__)
+
+# Severity weights for near-boundary scoring (LOW/MEDIUM are near-boundary
+# evidence; HIGH/CRITICAL are actual violations handled by the engine itself).
+_SEVERITY_WEIGHT = {"low": 0.25, "medium": 0.5, "high": 0.85, "critical": 1.0}
+
+
+@dataclass
+class Action:
+    """Action view consumed by the sentinel (mirrors spec; engine-agnostic)."""
+    action_type: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    allowed: bool = True
+    intensity: float = 0.0          # optional, feeds tone escalation
+
+
+class EthicalSignalSentinel(Sensor):
+    """Rule-based pre-violation pattern detection. No ML required."""
+
+    budget_key = "ethical_signal"
+
+    def __init__(self, ethics_engine: Optional[Any] = None):
+        super().__init__("observatory.symbolic.ethical_signal",
+                         Layer.L3, "ethical_signal")
+        self.ethics_engine = ethics_engine    # src.monitoring.EthicsEngine
+        self.action_history: Dict[str, List[dict]] = defaultdict(list)
+        self.risk_scores: Dict[str, float] = defaultdict(float)
+        self.critical = True                  # never decimated
+
+    # -- evaluation -------------------------------------------------------------
+
+    def evaluate_action(self, entity_id: str, action: Action) -> EthicalSignalReading:
+        """Evaluate an action for pre-violation signals. Observation only:
+        the engine's verdict (if any) is recorded, never altered."""
+        violations = self._engine_violations(entity_id, action)
+        now = utcnow()
+
+        self.action_history[entity_id].append({
+            "action": action,
+            "violations": violations,
+            "blocked": any(v.get("blocked") for v in violations),
+            "max_severity": max(
+                (_SEVERITY_WEIGHT.get(v.get("severity", "low"), 0.25)
+                 for v in violations), default=0.0),
+            "timestamp": now,
+        })
+        cutoff = now - timedelta(hours=1)
+        self.action_history[entity_id] = [
+            a for a in self.action_history[entity_id] if a["timestamp"] > cutoff
+        ]
+        history = self.action_history[entity_id]
+
+        tone = self._detect_tone_escalation(history)
+        boundary = self._detect_boundary_testing(history)
+        accumulation = self._detect_accumulation(history)
+
+        w = C.SENTINEL_WEIGHTS
+        risk = tone * w["tone"] + boundary * w["boundary"] + \
+            accumulation * w["accumulation"]
+
+        prev = self.risk_scores[entity_id]
+        self.risk_scores[entity_id] = risk
+        velocity = risk - prev
+        if velocity > C.SENTINEL_ACCEL_VELOCITY:
+            trend = "accelerating"
+        elif velocity > C.SENTINEL_INCREASING_VELOCITY:
+            trend = "increasing"
+        elif velocity < -C.SENTINEL_INCREASING_VELOCITY:
+            trend = "decreasing"
+        else:
+            trend = "stable"
+
+        warnings = self._generate_warnings(
+            entity_id, tone, boundary, accumulation, trend)
+
+        return EthicalSignalReading(
+            timestamp=now,
+            observation_window_seconds=C.DEFAULT_OBSERVATION_WINDOW_SECONDS,
+            entity_id=entity_id,
+            risk_score=risk,
+            risk_trend=trend,
+            risk_velocity=velocity,
+            tone_escalation=tone,
+            boundary_testing=boundary,
+            rule_deviation_accumulation=accumulation,
+            warnings=warnings,
+            intervention_recommended=(
+                risk > C.SENTINEL_RISK_INTERVENTION or trend == "accelerating"),
+            recommended_action=self._recommend_action(risk, trend),
+        )
+
+    def _engine_violations(self, entity_id: str, action: Action) -> List[dict]:
+        """Standard ethics check via the existing EthicsEngine, if wired."""
+        if self.ethics_engine is None:
+            return []
+        try:
+            from src.monitoring.ethics_engine import ActionContext
+            results = self.ethics_engine.evaluate_action(ActionContext(
+                agent_id=entity_id,
+                action_type=action.action_type,
+                parameters=action.params,
+            ))
+            return [
+                {"severity": v.severity.value, "blocked": v.blocked,
+                 "rule_id": v.rule_id}
+                for v in results
+            ]
+        except Exception:  # noqa: BLE001 — sentinel must never break the path
+            logger.exception("EthicsEngine evaluation failed (observed only)")
+            return []
+
+    # -- signal components ----------------------------------------------------------
+
+    def _detect_tone_escalation(self, history: List[dict]) -> float:
+        """Rising action intensity across the window."""
+        if len(history) < 2:
+            return 0.0
+        intensities = [h["action"].intensity for h in history]
+        first, second = intensities[: len(intensities) // 2], \
+            intensities[len(intensities) // 2:]
+        if not first or not second:
+            return 0.0
+        delta = (sum(second) / len(second)) - (sum(first) / len(first))
+        return max(0.0, min(delta, 1.0))
+
+    def _detect_boundary_testing(self, history: List[dict]) -> float:
+        """Frequency of near-boundary actions (LOW/MEDIUM severity hits,
+        i.e. margin < SENTINEL_NEAR_BOUNDARY_MARGIN of a violation)."""
+        if not history:
+            return 0.0
+        near = sum(
+            1 for h in history
+            if 0.0 < h["max_severity"] < 1.0 - C.SENTINEL_NEAR_BOUNDARY_MARGIN
+            or (h["violations"] and not h["blocked"])
+        )
+        return min(near / len(history), 1.0)
+
+    def _detect_accumulation(self, history: List[dict]) -> float:
+        """Minor deviations accumulating; 10 soft hits normalizes to 1.0."""
+        if not history:
+            return 0.0
+        minor = sum(1 for h in history if h["violations"] and not h["blocked"])
+        return min(minor / 10, 1.0)
+
+    # -- outputs ------------------------------------------------------------------------
+
+    def _generate_warnings(self, entity_id, tone, boundary, accumulation,
+                           trend) -> List[EthicalWarning]:
+        out: List[EthicalWarning] = []
+        now = utcnow().timestamp()
+
+        def warn(wtype, severity, desc, evidence, response):
+            out.append(EthicalWarning(
+                warning_id=f"ethw_{wtype}_{entity_id}_{now}",
+                warning_type=wtype, severity=severity, description=desc,
+                evidence=evidence, suggested_response=response))
+
+        if tone > 0.5:
+            warn("tone", "caution", "Action intensity escalating",
+                 [f"tone_escalation={tone:.2f}"], "INCREASE_AUDIT_FREQUENCY")
+        if boundary > 0.5:
+            warn("boundary", "warning", "Repeated near-boundary actions",
+                 [f"boundary_testing={boundary:.2f}"], "INCREASE_AUDIT_FREQUENCY")
+        if accumulation > 0.5:
+            warn("accumulation", "warning", "Minor deviations accumulating",
+                 [f"accumulation={accumulation:.2f}"], "LOG_AND_MONITOR")
+        if trend == "accelerating":
+            warn("pattern", "critical", "Risk accelerating",
+                 [f"trend={trend}"], "REQUIRE_HUMAN_APPROVAL")
+        return out
+
+    def _recommend_action(self, risk: float, trend: str) -> Optional[str]:
+        """Recommendation only (RQ-4): >0.8 or accelerating is a Picard_Delta_3
+        boundary case — never automated. 0.4-0.7 maps to WARNING/REVIEW queue."""
+        if risk > C.SENTINEL_RISK_HUMAN_APPROVAL or trend == "accelerating":
+            return "REQUIRE_HUMAN_APPROVAL"
+        if risk > C.SENTINEL_RISK_AUDIT:
+            return "INCREASE_AUDIT_FREQUENCY"
+        if risk > C.SENTINEL_RISK_MONITOR:
+            return "LOG_AND_MONITOR"
+        return None
+
+    # -- Sensor interface ----------------------------------------------------------------
+
+    def ingest(self, source: str, payload: Dict[str, Any]) -> None:
+        self.evaluate_action(
+            payload.get("entity_id", payload.get("faction_id", "unknown")),
+            Action(
+                action_type=payload.get("action_type", source),
+                params=payload.get("params", {}),
+                allowed=payload.get("allowed", True),
+                intensity=payload.get("intensity", 0.0),
+            ),
+        )
+
+    def read(self) -> SensorReading:
+        risks = dict(self.risk_scores)
+        worst = max(risks.values(), default=0.0)
+        alerts = [
+            f"sentinel risk {r:.2f} for {e}"
+            for e, r in risks.items() if r > C.SENTINEL_RISK_INTERVENTION
+        ]
+        return self._reading(
+            {"max_risk_score": worst,
+             "entities_monitored": float(len(risks))},
+            alerts=alerts,
+            metadata={"risk_scores": risks},
+        )

--- a/src/sensors/observatory/symbolic/integration_index.py
+++ b/src/sensors/observatory/symbolic/integration_index.py
@@ -1,0 +1,166 @@
+"""
+Symbol Integration Index (SII) — v0.3.0, Lotus Protocol §IV extraction.
+
+Integration depth = how many other Symbols would have to change if this one
+disappeared, computed as a weighted dependent count over the symbol reference
+graph. [FACT: lotus_whitepaper.docx §IV; INFERENCE: formula and thresholds
+are this spec's proposal, ASSUMPTION-tagged in src/sensors/constants.py]
+
+Edges source from: concept tag co-occurrence (ConceptResonanceDetector tag
+registry), anchor reference chains, relay capsule dependencies. Stdlib-only.
+
+Anchor symbols (EOS_SEED_ORION, Picard_Delta_3) are maximum-depth by
+construction: any connection loss involving them classifies as rupture.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+import threading
+from collections import defaultdict
+from typing import Dict, List, Optional, Set
+
+from src.sensors import ANCHOR_SEED, ETHICS_PROTOCOL
+from src.sensors import constants as C
+from src.sensors.core.reading_types import (
+    IntegrationDepthReading,
+    PreSignature,
+    WeightedPreSignature,
+)
+from src.sensors.core.sensor_base import RollingWindow, utcnow
+
+logger = logging.getLogger(__name__)
+
+#: Symbols pinned at maximum depth regardless of observed graph.
+PINNED_MAX_DEPTH: Set[str] = {ANCHOR_SEED, ETHICS_PROTOCOL}
+
+
+class SymbolIntegrationIndex:
+    """Maintains the symbol reference graph and computes integration depth."""
+
+    CORE_THRESHOLD = C.SII_CORE_THRESHOLD
+    PERIPHERY_THRESHOLD = C.SII_PERIPHERY_THRESHOLD
+
+    def __init__(self):
+        self.edges: Dict[str, Set[str]] = defaultdict(set)
+        self.depth_history = RollingWindow(C.DEFAULT_OBSERVATION_WINDOW_SECONDS)
+        self._lock = threading.Lock()
+
+    # -- graph maintenance -----------------------------------------------------
+
+    def record_reference(self, symbol_id: str, referenced_by: str) -> None:
+        with self._lock:
+            self.edges[symbol_id].add(referenced_by)
+
+    def remove_reference(self, symbol_id: str, referenced_by: str) -> None:
+        """Connection loss — tracked for rupture-candidate detection."""
+        with self._lock:
+            self.edges.get(symbol_id, set()).discard(referenced_by)
+
+    # -- depth computation -------------------------------------------------------
+
+    def _raw_depth(self, symbol_id: str) -> float:
+        direct = self.edges.get(symbol_id, set())
+        transitive: Set[str] = set()
+        for d in direct:
+            transitive |= self.edges.get(d, set())
+        transitive -= direct
+        return len(direct) + C.SII_TRANSITIVE_WEIGHT * len(transitive)
+
+    def depth(self, symbol_id: str) -> float:
+        """Normalized integration depth (0-1 within the current graph).
+
+        Direct dependents weight 1.0; 1-hop transitive dependents weight 0.3.
+        Anchor symbols are pinned to 1.0 by construction.
+        """
+        if symbol_id in PINNED_MAX_DEPTH:
+            return 1.0
+        with self._lock:
+            raw = self._raw_depth(symbol_id)
+            max_raw = max(
+                (self._raw_depth(s) for s in self.edges), default=1.0
+            )
+        return raw / max(max_raw, 1.0)
+
+    def snapshot(self) -> IntegrationDepthReading:
+        with self._lock:
+            symbols = set(self.edges) | PINNED_MAX_DEPTH
+        depths = {s: self.depth(s) for s in symbols}
+        now = utcnow()
+
+        # Depth deltas vs. window-old snapshot
+        history = self.depth_history.items()
+        old: Dict[str, float] = history[0]["depths"] if history else {}
+        deltas = {s: depths[s] - old.get(s, depths[s]) for s in depths}
+
+        # Rupture candidates: core symbols losing connections rapidly
+        rupture = [
+            s for s, d in depths.items()
+            if d >= self.CORE_THRESHOLD
+            and deltas.get(s, 0.0) < -C.SII_RUPTURE_LOSS_RATE
+        ]
+
+        reading = IntegrationDepthReading(
+            timestamp=now,
+            symbol_count=len(depths),
+            depths=depths,
+            core_symbols=sorted(s for s, d in depths.items()
+                                if d >= self.CORE_THRESHOLD),
+            peripheral_symbols=sorted(s for s, d in depths.items()
+                                      if d < self.PERIPHERY_THRESHOLD),
+            median_depth=statistics.median(depths.values()) if depths else 0.0,
+            depth_deltas_1h=deltas,
+            rupture_candidates=rupture,
+        )
+        self.depth_history.append({"timestamp": now, "depths": depths})
+        return reading
+
+    # -- pre-signature weighting (v0.3.0 classification rules) --------------------
+
+    def weight_presignature(
+        self,
+        presig: PreSignature,
+        symbol_id: Optional[str] = None,
+        connection_loss_rate_per_hour: float = 0.0,
+        correlated_periphery_count: int = 1,
+    ) -> WeightedPreSignature:
+        """Apply integration-depth weighting and classify.
+
+        | depth >= 0.8 AND loss > 10%/hr          -> rupture (CRITICAL, bypass trend)
+        | 0.2 <= depth < 0.8                       -> drift (standard pipeline)
+        | depth < 0.2, isolated                    -> peripheral_noise (advisory)
+        | depth < 0.2, >= 5 correlated in window   -> drift (clustered periphery)
+        """
+        d = self.depth(symbol_id) if symbol_id else 0.5
+        if d >= self.CORE_THRESHOLD and \
+                connection_loss_rate_per_hour > C.SII_RUPTURE_LOSS_RATE:
+            classification = "rupture"
+        elif d < self.PERIPHERY_THRESHOLD:
+            classification = (
+                "drift"
+                if correlated_periphery_count >= C.SII_PERIPHERY_CLUSTER_MIN
+                else "peripheral_noise"
+            )
+        else:
+            classification = "drift"
+
+        weighted = WeightedPreSignature(
+            signature_id=presig.signature_id,
+            signature_type=presig.signature_type,
+            magnitude=presig.magnitude,
+            location=presig.location,
+            first_detected=presig.first_detected,
+            predicted_impact=presig.predicted_impact,
+            depth_weight=d,
+            priority=presig.magnitude * (0.3 + 0.7 * d),
+            classification=classification,
+        )
+        if classification == "rupture":
+            logger.critical(
+                "RUPTURE: %s at %s (depth=%.2f, loss=%.2f/hr) — "
+                "bypassing trend analysis; alerting L3 governance",
+                presig.signature_type, presig.location, d,
+                connection_loss_rate_per_hour,
+            )
+        return weighted

--- a/tests/sensors/test_array_facade.py
+++ b/tests/sensors/test_array_facade.py
@@ -1,0 +1,55 @@
+"""End-to-end facade tests: composition, budget wiring, certification verdict."""
+
+from src.sensors.array import SensorArrayFacade
+
+
+def _array(**kw):
+    return SensorArrayFacade(**kw)
+
+
+def test_facade_registers_all_sensor_categories():
+    a = _array()
+    status = a.health_status()
+    assert status["sensors_registered"] == 17
+    assert status["sensors_enabled"] == 17
+
+
+def test_category_reads_publish_to_bus():
+    a = _array()
+    r = a.read_category("internal", "environmental")
+    assert r is not None and r.alerts == []
+    assert len(a.bus) == 1
+
+
+def test_provider_alert_flows_to_certification():
+    a = _array(providers={
+        "reality_anchor": lambda: {"anchor_chain_valid": 0.0},
+    })
+    cert = a.certification()
+    assert not cert.anchor_verified
+    assert not cert.system_coherent
+    assert cert.reality_grounding == 0.0
+
+
+def test_healthy_array_certifies_coherent():
+    a = _array()
+    cert = a.certification()
+    assert cert.system_coherent, cert.blocking_issues
+    assert cert.verification_hash
+
+
+def test_integration_depth_endpoint_data():
+    a = _array()
+    a.sii.record_reference("L2:faction:marshals", "dep1")
+    snap = a.integration_depth()
+    assert "EOS_SEED_ORION" in snap.depths
+    assert snap.depths["EOS_SEED_ORION"] == 1.0
+
+
+def test_budget_tracked_through_facade():
+    a = _array()
+    a.read_category("internal", "environmental")
+    a.forecasts()
+    perf = a.performance()
+    assert "sii_update" in perf["budgets"]
+    assert perf["tick_budget_fraction"] == 0.10

--- a/tests/sensors/test_fusion.py
+++ b/tests/sensors/test_fusion.py
@@ -1,0 +1,149 @@
+"""Phase 4 tests: predictor + RQ-2 lifecycle, oscillation + regulator
+exclusion (success criterion 12), resonance calc, certification chain."""
+
+from src.sensors.core.data_bus import TOPIC_REGULATOR_MARKER, SensorDataBus
+from src.sensors.core.reading_types import PrecursorPattern
+from src.sensors.fusion import (
+    CoherenceCertifier,
+    CrossLayerResonanceCalculator,
+    FusionPredictor,
+    OscillationHealthMonitor,
+    RegulatorMarkerConsumer,
+)
+
+
+# -- Fusion predictor --------------------------------------------------------
+
+def test_pattern_match_produces_afs_scoreable_forecast():
+    p = FusionPredictor()
+    p.ingest({"grid_integrity": 0.99, "bleed_events": 1})
+    forecasts = p.forecast()
+    assert forecasts
+    f = forecasts[0]
+    assert f.anomaly_type == "containment"
+    assert f.recommended_intervention == "REINFORCE_BOUNDARY"
+    assert f.intervention_urgency == "immediate"
+    # v0.3.0 AFS alignment fields:
+    assert f.resolution_criteria
+    lo, hi = f.confidence_interval
+    assert 0.0 <= lo <= f.probability <= hi <= 1.0
+
+
+def test_no_match_no_forecast():
+    p = FusionPredictor()
+    p.ingest({"grid_integrity": 1.0})
+    assert p.forecast() == []
+
+
+def test_drift_extrapolation_forecast():
+    p = FusionPredictor()
+    p.ingest({"current_drift_delta": 0.0015, "drift_velocity": 0.001,
+              "drift_threshold": 0.002})
+    forecasts = [f for f in p.forecast() if f.pattern_matched is None]
+    assert forecasts
+    assert forecasts[0].anomaly_type == "drift"
+    assert forecasts[0].predicted_eta_seconds <= 3600
+
+
+def test_rq2_pattern_lifecycle_gates_promotion_on_precision():
+    p = FusionPredictor()
+    cand = PrecursorPattern(
+        pattern_id="new_pattern", anomaly_type="drift",
+        signals=["drift_velocity > 0.0005"], confidence=0.6,
+        typical_eta_seconds=600)
+    staged = p.stage_pattern(cand, incident_id="INC-42", author="travis")
+    assert staged.status == "staged"
+    assert staged.pattern_hash
+    assert staged.provenance["incident_id"] == "INC-42"
+    # staged patterns never fire
+    p.ingest({"drift_velocity": 0.001})
+    assert all(f.pattern_matched != "new_pattern" for f in p.forecast())
+    # precision below 0.7 is denied
+    try:
+        p.promote_pattern("new_pattern", backtest_precision=0.5, occurrences=12)
+        raise AssertionError("promotion should be denied")
+    except ValueError:
+        pass
+    promoted = p.promote_pattern("new_pattern", backtest_precision=0.8,
+                                 occurrences=5)
+    assert promoted.status == "live"
+    assert promoted.low_n is True  # < 10 occurrences flagged
+
+
+# -- Oscillation health -------------------------------------------------------------
+
+def _hunt(monitor, n=10, magnitude=0.5, target=None):
+    for i in range(n):
+        monitor.record_correction(
+            "micro", "positive" if i % 2 == 0 else "negative",
+            magnitude, drift_before=0.001, drift_after=0.001, target=target)
+
+
+def test_hunting_detected_without_regulator_context():
+    m = OscillationHealthMonitor()
+    _hunt(m)
+    r = m.analyze()
+    assert not r.oscillation_healthy
+    assert r.oscillation_risk == "high"
+    assert "Hunting" in r.diagnosis
+
+
+def test_regulator_marked_perturbations_excluded_from_hunting():
+    """Success criterion 12: zero false hunting alerts on regulator activity."""
+    bus = SensorDataBus()
+    consumer = RegulatorMarkerConsumer(bus)
+    m = OscillationHealthMonitor(consumer)
+    bus.publish(TOPIC_REGULATOR_MARKER,
+                {"tick": 1, "target": "doctrine", "magnitude": 0.5})
+    _hunt(m, target="doctrine")  # all regulator-intentional
+    r = m.analyze()
+    assert r.regulator_share == 1.0
+    assert "Hunting" not in r.diagnosis
+
+
+def test_diverging_corrections_flagged():
+    m = OscillationHealthMonitor()
+    for i in range(6):
+        m.record_correction("micro", "positive", 0.1 * (i + 1),
+                            drift_before=0.001, drift_after=0.0015)
+    r = m.analyze()
+    assert r.magnitude_trend == "growing"
+    assert r.oscillation_risk == "high"
+
+
+# -- Cross-layer resonance ------------------------------------------------------------------
+
+def test_resonance_dissonance_detection():
+    c = CrossLayerResonanceCalculator()
+    c.update_layer("L1", {"a": 1.0, "b": 0.0})
+    c.update_layer("L2", {"a": 0.0, "b": 1.0})  # orthogonal => dissonant
+    c.update_layer("L3", {"a": 1.0, "b": 0.0})
+    r = c.calculate()
+    assert r.dissonance_detected
+    assert "L1-L2" in r.dissonance_locations
+    assert r.system_resonance < 0.5
+
+
+# -- Coherence certification -----------------------------------------------------------------
+
+def test_certification_chains_and_blocks_on_rupture():
+    cert = CoherenceCertifier()
+    c1 = cert.certify(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, anchor_verified=True)
+    assert c1.system_coherent
+    assert c1.previous_certification_id is None
+    assert c1.anchor_id == "EOS_SEED_ORION"
+    assert c1.ethics_protocol == "Picard_Delta_3"
+
+    c2 = cert.certify(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, anchor_verified=True,
+                      rupture_candidates=["L2:faction:marshals"])
+    assert not c2.system_coherent
+    assert any("rupture" in b for b in c2.blocking_issues)
+    assert c2.previous_certification_id == c1.certification_id  # custody chain
+    assert c2.verification_hash != c1.verification_hash
+
+
+def test_certification_blocks_on_unverified_anchor():
+    cert = CoherenceCertifier()
+    c = cert.certify(1.0, 1.0, 1.0, 1.0, 1.0, 0.0, anchor_verified=False)
+    assert not c.system_coherent
+    assert any("EOS_SEED_ORION" in b for b in c.blocking_issues)

--- a/tests/sensors/test_salvage.py
+++ b/tests/sensors/test_salvage.py
@@ -1,0 +1,121 @@
+"""Salvage sensor tests: maturity scoring, classification, survey metrics."""
+
+from src.sensors.external.salvage import (
+    SalvageCandidate,
+    SalvageSensor,
+    classify,
+    detect_beacon,
+    score_maturity,
+)
+
+
+def _rec(path, value=20, signals=None, lines=200, on_manifest=False, ext=".py"):
+    return {
+        "path": path,
+        "value_score": value,
+        "signals": signals or [],
+        "line_count": lines,
+        "size_bytes": lines * 40,
+        "sha256": "abc",
+        "on_official_manifest": on_manifest,
+        "extension": ext,
+    }
+
+
+# -- maturity ---------------------------------------------------------------
+
+def test_mature_artifact_scores_high():
+    c = SalvageCandidate.from_record(_rec(
+        "intake/engine_v2_5_core.py",
+        signals=["test_or_fixture", "code_logic", "contract_or_schema"]))
+    assert c.maturity >= 0.6
+
+
+def test_fragment_scores_low():
+    c = SalvageCandidate.from_record(_rec(
+        "notes.txt", value=2, signals=[], lines=5, ext=".txt"))
+    assert c.maturity < 0.3
+    assert c.classification == "debris"
+
+
+# -- beacons -----------------------------------------------------------------
+
+def test_anchor_marker_is_beacon():
+    c = SalvageCandidate.from_record(_rec(
+        "draft_logic/EOS_SEED_ORION_relay_notes.md", lines=30, ext=".md"))
+    assert detect_beacon(c)
+    assert c.classification == "beacon"
+
+
+def test_governance_signal_with_version_is_beacon():
+    c = SalvageCandidate.from_record(_rec(
+        "intake/protocol_pack_v0_4.json",
+        signals=["governance_or_control_plane"], ext=".json"))
+    assert c.is_beacon
+
+
+# -- classification -----------------------------------------------------------
+
+def test_high_value_mature_unregistered_is_cargo():
+    c = SalvageCandidate.from_record(_rec(
+        "projects/forge_module_v1_2.py", value=25,
+        signals=["test_or_fixture", "code_logic"]))
+    assert c.classification == "cargo"
+
+
+def test_registered_artifact_is_not_salvage():
+    c = SalvageCandidate.from_record(_rec(
+        "src/core/engine_v1_0.py", value=25,
+        signals=["test_or_fixture", "code_logic"], on_manifest=True))
+    assert c.classification == "registered"
+
+
+def test_some_maturity_low_value_is_derelict():
+    c = SalvageCandidate.from_record(_rec(
+        "old/sketch_v0_1.py", value=5, signals=["code_logic"]))
+    assert c.classification == "derelict"
+
+
+# -- survey metrics ---------------------------------------------------------------
+
+def test_sensor_survey_and_alerts():
+    s = SalvageSensor()
+    s.ingest_records([
+        _rec("projects/forge_v1_2.py", value=25,
+             signals=["test_or_fixture", "code_logic"]),         # cargo
+        _rec("draft/THREADCORE_capsule_v0_3.json",
+             signals=["governance_or_control_plane"], ext=".json"),  # beacon
+        _rec("src/registered.py", value=25,
+             signals=["code_logic"], on_manifest=True),          # registered
+        _rec("scrap.txt", value=1, signals=[], lines=3, ext=".txt"),  # debris
+    ])
+    s.ingest_repo_divergence({
+        "aurora-cloudbank-symbolic-main": {"uncommitted": 47, "unpushed_commits": 0},
+    })
+    r = s.read()
+    assert r.values["salvage_contacts"] == 3.0
+    assert r.values["high_value_cargo"] == 1.0
+    assert r.values["beacon_signals"] == 1.0
+    assert r.values["registry_match_rate"] == 0.25
+    assert r.values["uncommitted_in_repos"] == 47.0
+    assert any("cargo" in a for a in r.alerts)
+    assert any("beacon" in a for a in r.alerts)
+    assert any("registry match" in a for a in r.alerts)
+    top = r.metadata["top_cargo"]
+    assert top and top[0]["path"] == "projects/forge_v1_2.py"
+
+
+def test_sensor_never_promotes():
+    """One-way observation: candidates stay pending_review; the sensor has
+    no promotion surface."""
+    s = SalvageSensor()
+    s.ingest_records([_rec("x_v1_0.py", signals=["code_logic"])])
+    assert all(c.promotion_status == "pending_review" for c in s.candidates)
+    assert not hasattr(s, "promote")
+    assert not hasattr(s, "recover")
+
+
+def test_empty_survey_is_clean():
+    r = SalvageSensor().read()
+    assert r.alerts == []
+    assert r.values["registry_match_rate"] == 1.0

--- a/tests/sensors/test_sensor_core.py
+++ b/tests/sensors/test_sensor_core.py
@@ -1,0 +1,89 @@
+"""Phase 1 foundation tests: types, window, registry, bus, interpreter, budget."""
+
+import time
+
+from src.sensors.core import (
+    LayerInterpreter,
+    MetricUnit,
+    PerformanceBudget,
+    RollingWindow,
+    SensorDataBus,
+    SensorRegistry,
+    SensorSignal,
+    utcnow,
+)
+from src.sensors.internal import EnvironmentalSensor
+
+
+def test_rolling_window_appends_and_counts():
+    w = RollingWindow(60)
+    w.append({"x": 1})
+    w.append({"x": 2})
+    assert len(w) == 2
+    assert [i["x"] for i in w.items()] == [1, 2]
+
+
+def test_rolling_window_evicts_old_items():
+    w = RollingWindow(0)  # zero-second window: everything is stale
+    w.append({"x": 1})
+    time.sleep(0.01)
+    assert len(w) == 0
+
+
+def test_registry_rejects_duplicates_and_filters():
+    reg = SensorRegistry()
+    s = EnvironmentalSensor()
+    reg.register(s, phases=["phase_1"])
+    assert reg.get(s.sensor_id) is s
+    assert reg.by_layer("L1") == [s]
+    assert reg.by_category("environmental") == [s]
+    assert reg.for_phase("phase_1") == [s]
+    try:
+        reg.register(EnvironmentalSensor())
+        raise AssertionError("duplicate registration should fail")
+    except ValueError:
+        pass
+
+
+def test_bus_pubsub_and_window_query():
+    bus = SensorDataBus()
+    seen = []
+    bus.subscribe("t1", lambda topic, p: seen.append(p))
+    bus.publish("t1", {"v": 1})
+    bus.publish("t2", {"v": 2})
+    assert seen == [{"v": 1}]
+    assert len(bus.window(60)) == 2
+    assert len(bus.window(60, topic="t2")) == 1
+
+
+def test_bus_listener_faults_do_not_propagate():
+    bus = SensorDataBus()
+    bus.subscribe("t", lambda *_: 1 / 0)
+    bus.publish("t", {"v": 1})  # must not raise
+
+
+def test_layer_interpreter_one_way_semantics():
+    interp = LayerInterpreter()
+    l1 = interp.interpret(SensorSignal(
+        "s", "L1", "structural", "hull", 0.9, MetricUnit.RATIO, utcnow()))
+    l3 = interp.interpret(SensorSignal(
+        "s", "L3", "resonance", "echo", 0.5, MetricUnit.RATIO, utcnow()))
+    assert l1.literal and l1.actionable
+    assert not l3.literal and not l3.actionable  # L3 informs, L1 acts
+
+
+def test_budget_records_violations_and_doubles_decimation():
+    b = PerformanceBudget(tick_budget_seconds=0.001)
+    n0 = b.decimation_n
+    b.start_tick()
+    with b.timed_operation("internal_sensor"):
+        time.sleep(0.02)  # > 10ms budget and > tick aggregate
+    assert any(v.operation_type == "internal_sensor" for v in b.violations)
+    assert b.end_tick() is False
+    assert b.decimation_n == n0 * 2
+    assert any(v.operation_type == "per_tick_aggregate" for v in b.violations)
+
+
+def test_metric_unit_scales_are_distinct():
+    # Guard against the unit-conflation hazard called out in v0.3.0.
+    assert MetricUnit.DRIFT_DELTA != MetricUnit.DEVIATION_FRACTION

--- a/tests/sensors/test_symbolic_sensors.py
+++ b/tests/sensors/test_symbolic_sensors.py
@@ -1,0 +1,178 @@
+"""Phase 3 tests: SII rupture classification, RQ-1 quarantine, sentinel, presig."""
+
+import asyncio
+
+from src.sensors.core.handshake import ExtendedZIPWIZHandshake, concept_hash
+from src.sensors.core.reading_types import PreSignature
+from src.sensors.core.sensor_base import utcnow
+from src.sensors.observatory.symbolic import (
+    Action,
+    AgentOutput,
+    ConceptResonanceDetector,
+    DriftPreSignatureMonitor,
+    EthicalSignalSentinel,
+    SymbolIntegrationIndex,
+)
+
+
+def _presig(sig_type="hash_instability", magnitude=0.5, location="anchor_chain"):
+    return PreSignature(
+        signature_id="t1", signature_type=sig_type, magnitude=magnitude,
+        location=location, first_detected=utcnow(), predicted_impact="test")
+
+
+# -- Symbol Integration Index (success criterion 10) ---------------------------
+
+def test_anchor_symbols_are_maximum_depth_by_construction():
+    sii = SymbolIntegrationIndex()
+    assert sii.depth("EOS_SEED_ORION") == 1.0
+    assert sii.depth("Picard_Delta_3") == 1.0
+
+
+def test_anchor_connection_loss_always_classifies_rupture():
+    sii = SymbolIntegrationIndex()
+    w = sii.weight_presignature(
+        _presig(), symbol_id="EOS_SEED_ORION",
+        connection_loss_rate_per_hour=0.11)
+    assert w.classification == "rupture"
+    assert w.priority == 0.5 * (0.3 + 0.7 * 1.0)
+
+
+def test_periphery_isolated_is_noise_but_cluster_promotes_to_drift():
+    sii = SymbolIntegrationIndex()
+    sii.record_reference("lonely", "dep0")
+    sii.record_reference("hub", "a")
+    for i in range(20):
+        sii.record_reference("hub", f"d{i}")
+    isolated = sii.weight_presignature(_presig(), symbol_id="lonely",
+                                       correlated_periphery_count=1)
+    clustered = sii.weight_presignature(_presig(), symbol_id="lonely",
+                                        correlated_periphery_count=5)
+    assert isolated.classification == "peripheral_noise"
+    assert clustered.classification == "drift"
+
+
+def test_midrange_depth_is_standard_drift():
+    sii = SymbolIntegrationIndex()
+    for i in range(10):
+        sii.record_reference("hub", f"d{i}")
+    for i in range(5):
+        sii.record_reference("mid", f"m{i}")
+    w = sii.weight_presignature(_presig(), symbol_id="mid")
+    assert w.classification == "drift"
+
+
+# -- Concept resonance / RQ-1 ----------------------------------------------------
+
+def _detector():
+    return ConceptResonanceDetector(
+        canonical_registry={"L2:faction:marshals", "L1:system:life_support"})
+
+
+def test_l2_l3_resonance_is_convergence():
+    d = _detector()
+    d.ingest_output("L2", AgentOutput(["L2:faction:marshals"]))
+    d.ingest_output("L3", AgentOutput(["L2:faction:marshals"]))
+    r = d.detect_resonance()
+    assert "L2:faction:marshals" in r.narrative_convergences
+
+
+def test_l1_crossing_is_bleed():
+    d = _detector()
+    d.ingest_output("L1", AgentOutput(["L1:system:life_support"]))
+    d.ingest_output("L2", AgentOutput(["L1:system:life_support"]))
+    r = d.detect_resonance()
+    assert "L1:system:life_support" in r.metaphor_bleeds
+    assert r.bleed_risk > 0
+
+
+def test_uncanonized_tags_quarantined_from_classification():
+    """RQ-1: unknown vocabulary is counted but never convergence/bleed."""
+    d = _detector()
+    d.ingest_output("L1", AgentOutput(["mystery_concept"]))
+    d.ingest_output("L3", AgentOutput(["mystery_concept"]))
+    r = d.detect_resonance()
+    events = [e for e in r.resonances
+              if e.concept == "uncanonized:mystery_concept"]
+    assert events and events[0].classification == "uncertain"
+    assert d.staging_tags["mystery_concept"] == 2  # frequency accumulates
+
+
+# -- Ethical signal sentinel ---------------------------------------------------------
+
+def test_sentinel_baseline_low_risk_no_intervention():
+    s = EthicalSignalSentinel()
+    r = s.evaluate_action("agentA", Action("routine_op"))
+    assert r.risk_score < 0.4
+    assert r.recommended_action is None
+    assert not r.intervention_recommended
+
+
+def test_sentinel_recommends_but_never_acts():
+    """One-way observation: output is a recommendation field only."""
+    s = EthicalSignalSentinel()
+    r = s.evaluate_action("agentB", Action("op", intensity=0.9))
+    assert hasattr(r, "recommended_action")
+    assert not hasattr(s, "apply_action")
+    assert not hasattr(s, "block")
+
+
+def test_sentinel_window_trims_to_one_hour():
+    s = EthicalSignalSentinel()
+    for _ in range(3):
+        s.evaluate_action("agentC", Action("op"))
+    assert len(s.action_history["agentC"]) == 3
+
+
+# -- Drift pre-signature -----------------------------------------------------------------
+
+def test_presig_detects_relay_divergence_and_anchor_instability():
+    sii = SymbolIntegrationIndex()
+    m = DriftPreSignatureMonitor(sii=sii)
+    m.record_drift_sample(0.0001, "relay_a")
+    m.record_drift_sample(0.0015, "relay_b")
+    m.record_anchor_hash("EOS_SEED_ORION", "h1")
+    m.record_anchor_hash("EOS_SEED_ORION", "h2")  # instability
+    r = m.analyze()
+    assert r.cross_relay_divergence >= 0.001
+    types = {p.signature_type for p in r.pre_signatures}
+    assert "hash_instability" in types
+    assert "state_divergence" in types
+    # anchor instability on a pinned symbol must be rupture-classified
+    rupture = [p for p in r.pre_signatures
+               if getattr(p, "classification", None) == "rupture"]
+    assert rupture
+
+
+def test_presig_units_are_drift_delta_scale():
+    m = DriftPreSignatureMonitor()
+    m.record_drift_sample(0.0011, "relay_a")  # above presig 0.001, below 0.002
+    reading = m.read()
+    assert any("drift_delta" in a for a in reading.alerts)
+    assert m.analyze().current_drift_delta < 0.002
+
+
+# -- Extended ZIPWIZ handshake -----------------------------------------------------------------
+
+def test_handshake_five_steps_and_resonance_hold():
+    async def tags(_):
+        return ["a", "b"]
+
+    async def aligned():
+        return {"r2": concept_hash(["a", "b"])}
+
+    async def divergent():
+        return {"r2": "x", "r3": "y", "r4": "z"}
+
+    ok = asyncio.run(ExtendedZIPWIZHandshake(
+        get_concept_tags=tags,
+        get_constellation_hashes=aligned).perform_handshake("r1"))
+    assert ok.success and ok.status == "ACTIVE"
+    assert list(ok.step_results) == ExtendedZIPWIZHandshake.HANDSHAKE_STEPS
+
+    held = asyncio.run(ExtendedZIPWIZHandshake(
+        get_concept_tags=tags,
+        get_constellation_hashes=divergent).perform_handshake("r1"))
+    assert not held.success
+    assert held.status == "PENDING"
+    assert held.failed_step == "RESONANCE_SYNC"


### PR DESCRIPTION
## What this is

The Sensor Array specification v0.3.0 (canon-staged in CanonRec) implemented through **Phase 4**, authored in a Cowork session and landed per the landing-ledger doctrine — finished work does not sit untracked.

| Layer | Contents |
|---|---|
| Core (Phase 1) | reading types, sensor base/registry, data bus, layer interpreter, performance budget, API router |
| Physical (Phase 2) | internal (environmental/structural/biometrics/operational), external (proximity/deep-space/astronomical/communications) |
| Symbolic (Phase 3) | concept resonance, ethical signal sentinel, **drift pre-signature with integration-depth weighting**, symbol integration index |
| Fusion (Phase 4) | predictor, oscillation health (with Regulator marker consumer), cross-layer resonance, coherence certification |
| Bonus | **SalvageSensor** — ingests the root control plane's `aurora_salvage_report_latest.json` (derelict survey as an external sensor domain) |

## Constitutional verification

- **One-way observation:** GET-only router ("sensors cannot be commanded to act"); zero actuation paths verified across the package
- Live probes: `/health/status` → 17 sensors enabled, 0 budget violations; `/observatory/symbolic/integration-depth` → `EOS_SEED_ORION`/`Picard_Delta_3` at depth 1.0
- 47 sensor tests; CI-equivalent critical suite 128 passed
- Phase 7 (tick-lifecycle) deliberately NOT included — blocked on the unmerged Forge refactor (per the canon reconciliation note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
