### PR TITLE
fix: make Aurora PR automation traceable and quiet by default

### DIFF
--- a/.github/workflows/pr-selective-integration.yml
+++ b/.github/workflows/pr-selective-integration.yml
@@ -2,7 +2,7 @@ name: PR Selective Integration
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -12,14 +12,14 @@ permissions:
 jobs:
   evaluate-and-integrate:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout PR branch
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: 0  # Need full history for git operations
-    
+        fetch-depth: 0
+
     - name: Detect first-class directory changes (gate)
       id: detect
       run: |
@@ -34,68 +34,74 @@ jobs:
         if [ "$should_run" != "true" ]; then
           echo "No first-class directory changes detected; selective integration will be skipped."
         fi
-        
+
     - name: Checkout base branch for comparison
       if: steps.detect.outputs.should_run == 'true'
       run: |
         git fetch origin ${{ github.event.pull_request.base.ref }}
-        
+
     - name: Set up Python
       if: steps.detect.outputs.should_run == 'true'
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: '3.11'
         cache: 'pip'
-    
+
     - name: Install dependencies
       if: steps.detect.outputs.should_run == 'true'
       run: |
         python -m pip install --upgrade pip
         pip install pytest flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    
+
     - name: Run PR Evaluation
       if: steps.detect.outputs.should_run == 'true'
       id: evaluate
       env:
         PR_BRANCH: ${{ github.head_ref }}
+        GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        echo "🌟 Running Aurora PR Evaluation..."
+        echo "Running Aurora PR Evaluation..."
         python3 tools/pr_evaluator.py \
           --branch "$PR_BRANCH" \
           --output eval.json
-        
-        # Store exit code but continue
+
         EXIT_CODE=$?
         echo "evaluation_exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-        
-        # Extract score for later use
+
         SCORE=$(python3 -c "import json; data=json.load(open('eval.json')); print(data['overall_score'])")
         echo "evaluation_score=$SCORE" >> $GITHUB_OUTPUT
-        
-        exit 0  # Don't fail the job yet
+        PASSED=$(python3 -c "import json; data=json.load(open('eval.json')); print(str(data['passed']).lower())")
+        echo "evaluation_passed=$PASSED" >> $GITHUB_OUTPUT
+
+        exit 0
       continue-on-error: true
-    
+
     - name: Run Selective Integration Analysis
       if: steps.detect.outputs.should_run == 'true'
       id: integration
       env:
         PR_BRANCH: ${{ github.head_ref }}
       run: |
-        echo "🔧 Analyzing integration strategy..."
+        echo "Analyzing integration strategy..."
         python3 tools/selective_integrator.py \
           "$PR_BRANCH" \
           --evaluation eval.json \
           --output integration_plan.json
-        
-        # Extract strategy for later use
+
         STRATEGY=$(python3 -c "import json; data=json.load(open('integration_plan.json')); print(data['strategy'])")
         echo "integration_strategy=$STRATEGY" >> $GITHUB_OUTPUT
-        
+
         CONFIDENCE=$(python3 -c "import json; data=json.load(open('integration_plan.json')); print(data['confidence'])")
         echo "integration_confidence=$CONFIDENCE" >> $GITHUB_OUTPUT
+
+        COMMENT_REQUIRED=$(python3 -c "import json; data=json.load(open('integration_plan.json')); print(str(data.get('comment_required', False)).lower())")
+        echo "comment_required=$COMMENT_REQUIRED" >> $GITHUB_OUTPUT
+
+        COMMENT_REASON=$(python3 -c "import json; data=json.load(open('integration_plan.json')); print(data.get('comment_reason', ''))")
+        echo "comment_reason=$COMMENT_REASON" >> $GITHUB_OUTPUT
       continue-on-error: true
-    
+
     - name: Upload evaluation artifacts
       if: steps.detect.outputs.should_run == 'true'
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
@@ -105,15 +111,14 @@ jobs:
           eval.json
           integration_plan.json
         retention-days: 30
-    
+
     - name: Prepare Integration Analysis Comment
-      if: steps.detect.outputs.should_run == 'true'
+      if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.comment_required == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           const fs = require('fs');
-          
-          // Load evaluation results
+
           let evaluation, integrationPlan;
           try {
             evaluation = JSON.parse(fs.readFileSync('eval.json', 'utf8'));
@@ -122,134 +127,64 @@ jobs:
             console.error('Failed to load results:', error);
             return;
           }
-          
-          // Generate emoji for score
-          const score = evaluation.overall_score;
-          let scoreEmoji = '🔴';
-          if (score >= 0.9) scoreEmoji = '🟢';
-          else if (score >= 0.7) scoreEmoji = '🟡';
-          else if (score >= 0.5) scoreEmoji = '🟠';
-          
-          // Generate emoji for strategy
-          const strategyEmojis = {
-            'direct_merge': '✅',
-            'compatibility_layer': '🔄',
-            'value_extraction': '⚡',
-            'decline': '❌'
-          };
-          const strategyEmoji = strategyEmojis[integrationPlan.strategy] || '❓';
-          
-          // Build comment
-          let comment = `## 🌟 Aurora CloudBank - Selective Integration Analysis\n\n`;
-          
-          // Evaluation Summary
-          comment += `### ${scoreEmoji} Evaluation Score: ${score.toFixed(2)}/1.00\n\n`;
-          comment += `**Status:** ${evaluation.passed ? '✅ APPROVED' : '⚠️ NEEDS WORK'}\n\n`;
-          
-          // Integration Strategy
-          comment += `### ${strategyEmoji} Recommended Integration Strategy\n\n`;
-          comment += `**Strategy:** \`${integrationPlan.strategy.toUpperCase()}\`\n`;
-          comment += `**Confidence:** ${(integrationPlan.confidence * 100).toFixed(0)}%\n\n`;
-          
-          comment += `#### Reasoning\n${integrationPlan.reasoning}\n\n`;
-          
-          // Strategy Explanation
-          comment += `<details>\n<summary><b>What does "${integrationPlan.strategy}" mean?</b></summary>\n\n`;
-          
-          if (integrationPlan.strategy === 'direct_merge') {
-            comment += `This PR demonstrates excellent technical quality and conceptual alignment with Aurora's philosophy. It can be merged directly into the main codebase without modifications.\n\n`;
-            comment += `**Next Steps:** Review, approve, and merge when ready.\n`;
-          } else if (integrationPlan.strategy === 'compatibility_layer') {
-            comment += `This PR contains valuable technical contributions but approaches Aurora from a different philosophical perspective. We can integrate it through a compatibility layer that preserves Aurora's core identity while accepting the contribution.\n\n`;
-            comment += `**Next Steps:** Maintainers will create a wrapper module that adapts this code to Aurora's patterns.\n`;
-          } else if (integrationPlan.strategy === 'value_extraction') {
-            comment += `This PR contains some valuable elements (bug fixes, tests, documentation) but also includes changes that don't align with Aurora's conceptual foundation. We'll extract and integrate the valuable parts.\n\n`;
-            comment += `**Next Steps:** Maintainers will cherry-pick specific improvements and provide feedback on the rest.\n`;
-          } else {
-            comment += `This PR doesn't align with Aurora's core philosophy and identity. Rather than force-fit misaligned code, we recommend revisiting the conceptual foundation.\n\n`;
-            comment += `**Next Steps:** Review Aurora's documentation and consider a fresh approach aligned with the system's identity.\n`;
-          }
-          
-          comment += `</details>\n\n`;
-          
-          // Detailed Evaluation Results
-          comment += `### 📊 Detailed Evaluation\n\n`;
-          
-          for (const result of evaluation.results) {
-            const icon = result.passed ? '✅' : '⚠️';
-            const percentage = (result.score * 100).toFixed(0);
-            comment += `${icon} **${result.category}**: ${percentage}% (${result.score.toFixed(2)}/1.00)\n`;
-            
-            if (result.findings && result.findings.length > 0) {
-              comment += `\n<details>\n<summary>Findings</summary>\n\n`;
-              for (const finding of result.findings) {
-                comment += `- ${finding}\n`;
+
+          const score = Number(evaluation.overall_score || 0);
+          const confidence = Number(integrationPlan.confidence || 0);
+          const evidence = integrationPlan.evidence || [];
+          const maxEvidence = evidence.slice(0, 5);
+
+          let comment = `## Aurora PR Integration Check\n\n`;
+          comment += `**Score:** ${score.toFixed(2)}/1.00\n`;
+          comment += `**Strategy:** \`${integrationPlan.strategy}\`\n`;
+          comment += `**Confidence:** ${(confidence * 100).toFixed(0)}%\n`;
+          comment += `**Comment reason:** \`${integrationPlan.comment_reason}\`\n\n`;
+          comment += `${integrationPlan.reasoning}\n\n`;
+
+          if (maxEvidence.length > 0) {
+            comment += `### Actionable evidence\n\n`;
+            for (const item of maxEvidence) {
+              comment += `- **${item.category} / ${item.signal}**`;
+              comment += ` — delta ${Number(item.score_delta || 0).toFixed(2)}, weight ${Number(item.weight || 0).toFixed(2)}.\n`;
+              if (item.evidence) {
+                const trimmed = String(item.evidence).replace(/\s+/g, ' ').slice(0, 300);
+                comment += `  - Evidence: ${trimmed}\n`;
               }
-              comment += `</details>\n`;
-            }
-            
-            if (result.recommendations && result.recommendations.length > 0) {
-              comment += `\n<details>\n<summary>Recommendations</summary>\n\n`;
-              for (const rec of result.recommendations) {
-                comment += `- ${rec}\n`;
+              if (item.recommendation) {
+                comment += `  - Action: ${item.recommendation}\n`;
               }
-              comment += `</details>\n`;
             }
-            
             comment += `\n`;
           }
-          
-          // Integration Actions
+
           if (integrationPlan.actions && integrationPlan.actions.length > 0) {
-            comment += `### 🎯 Integration Actions\n\n`;
-            for (let i = 0; i < integrationPlan.actions.length; i++) {
-              comment += `${i + 1}. ${integrationPlan.actions[i]}\n`;
+            comment += `### Next actions\n\n`;
+            for (const action of integrationPlan.actions.slice(0, 5)) {
+              comment += `- ${action}\n`;
             }
             comment += `\n`;
           }
-          
-          // Safeguards
-          if (integrationPlan.safeguards && integrationPlan.safeguards.length > 0) {
-            comment += `<details>\n<summary><b>🛡️ Integration Safeguards</b></summary>\n\n`;
-            for (const safeguard of integrationPlan.safeguards) {
-              comment += `- ${safeguard}\n`;
-            }
-            comment += `</details>\n\n`;
-          }
-          
-          // Risks
-          if (integrationPlan.risks && integrationPlan.risks.length > 0) {
-            comment += `<details>\n<summary><b>⚠️ Integration Risks</b></summary>\n\n`;
-            for (const risk of integrationPlan.risks) {
-              comment += `- ${risk}\n`;
-            }
-            comment += `</details>\n\n`;
-          }
-          
-          // Resources
-          comment += `---\n\n`;
-          comment += `### 📚 Resources\n\n`;
-          comment += `- [PR Evaluation Guide](../blob/main/docs/PR_EVALUATION_GUIDE.md)\n`;
-          comment += `- [Selective Integration Documentation](../blob/main/docs/SELECTIVE_INTEGRATION.md)\n`;
-          comment += `- [Aurora Philosophy](../blob/main/seeds/aurora_seed_prompt.md)\n`;
-          comment += `- [Geometric Ethics Architecture](../blob/main/docs/GEOMETRIC_ETHICS_ARCHITECTURE.md)\n\n`;
-          
-          comment += `*This analysis combines technical evaluation with conceptual alignment assessment.*\n`;
-          comment += `*Aurora isn't just a codebase - it's a living system with specific philosophical commitments.*\n`;
-          
-          // Write comment to file
+
+          comment += `<details>\n<summary>Score model</summary>\n\n`;
+          comment += `\`\`\`json\n${JSON.stringify(evaluation.score_model || {}, null, 2)}\n\`\`\`\n`;
+          comment += `</details>\n\n`;
+          comment += `_Routine passing PRs stay quiet; this comment appears only when the evaluation has actionable evidence or non-routine integration posture._\n`;
+
           fs.writeFileSync('/tmp/integration_analysis.md', comment);
-          
-          console.log('✅ Integration analysis prepared');
-    
+          console.log('Integration analysis comment prepared');
+
     - name: Post Integration Analysis Comment
-      if: steps.detect.outputs.should_run == 'true'
+      if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.comment_required == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Use smart comment handler to update existing comment
         bash .github/scripts/smart-comment.sh ${{ github.event.pull_request.number }} "INTEGRATION_ANALYSIS" /tmp/integration_analysis.md
-    
+
+    - name: Note quiet integration decision
+      if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.comment_required != 'true'
+      run: |
+        echo "Integration analysis did not require a PR comment." >> $GITHUB_STEP_SUMMARY
+        echo "Reason: ${{ steps.integration.outputs.comment_reason }}" >> $GITHUB_STEP_SUMMARY
+
     - name: Add Strategy Label
       if: steps.detect.outputs.should_run == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
@@ -258,11 +193,10 @@ jobs:
           const strategy = '${{ steps.integration.outputs.integration_strategy }}';
           const labelMap = {
             'direct_merge': 'integration: direct-merge',
-            'compatibility_layer': 'integration: compatibility-layer',
-            'value_extraction': 'integration: value-extraction',
-            'decline': 'integration: decline'
+            'targeted_review': 'integration: targeted-review',
+            'hold': 'integration: hold'
           };
-          
+
           const label = labelMap[strategy];
           if (label) {
             try {
@@ -272,12 +206,12 @@ jobs:
                 repo: context.repo.repo,
                 labels: [label]
               });
-              console.log(`✅ Added label: ${label}`);
+              console.log(`Added label: ${label}`);
             } catch (error) {
-              console.log(`⚠️ Could not add label (may not exist): ${error.message}`);
+              console.log(`Could not add label (may not exist): ${error.message}`);
             }
           }
-    
+
     - name: Add Score Label
       if: steps.detect.outputs.should_run == 'true'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
@@ -285,11 +219,11 @@ jobs:
         script: |
           const score = parseFloat('${{ steps.evaluate.outputs.evaluation_score }}');
           let scoreLabel = 'score: needs-work';
-          
+
           if (score >= 0.9) scoreLabel = 'score: excellent';
-          else if (score >= 0.7) scoreLabel = 'score: good';
-          else if (score >= 0.5) scoreLabel = 'score: fair';
-          
+          else if (score >= 0.75) scoreLabel = 'score: good';
+          else if (score >= 0.6) scoreLabel = 'score: fair';
+
           try {
             await github.rest.issues.addLabels({
               issue_number: context.issue.number,
@@ -297,34 +231,16 @@ jobs:
               repo: context.repo.repo,
               labels: [scoreLabel]
             });
-            console.log(`✅ Added label: ${scoreLabel}`);
+            console.log(`Added label: ${scoreLabel}`);
           } catch (error) {
-            console.log(`⚠️ Could not add label (may not exist): ${error.message}`);
+            console.log(`Could not add label (may not exist): ${error.message}`);
           }
-    
+
     - name: Check for Auto-Merge Eligibility
       if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.integration_strategy == 'direct_merge' && steps.evaluate.outputs.evaluation_score >= 0.9
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-      with:
-        script: |
-          // Prepare auto-merge candidate comment
-          const comment = `🎉 **This PR is eligible for auto-merge!**\n\n` +
-            `With an excellent score of ${{ steps.evaluate.outputs.evaluation_score }} and direct merge strategy, ` +
-            `this contribution can be integrated immediately once approved by a maintainer.\n\n` +
-            `Maintainers: Review and approve to enable auto-merge.`;
-          
-          // Write to file
-          const fs = require('fs');
-          fs.writeFileSync('/tmp/auto_merge_eligible.md', comment);
-    
-    - name: Post Auto-Merge Eligibility Comment
-      if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.integration_strategy == 'direct_merge' && steps.evaluate.outputs.evaluation_score >= 0.9
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Use smart comment handler
-        bash .github/scripts/smart-comment.sh ${{ github.event.pull_request.number }} "AUTO_MERGE_ELIGIBLE" /tmp/auto_merge_eligible.md
-    
+        echo "Direct-merge eligible by automation score. Maintainer approval still required." >> $GITHUB_STEP_SUMMARY
+
     - name: Add Ready-to-Merge Label
       if: steps.detect.outputs.should_run == 'true' && steps.integration.outputs.integration_strategy == 'direct_merge' && steps.evaluate.outputs.evaluation_score >= 0.9
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
@@ -338,19 +254,20 @@ jobs:
               labels: ['ready-to-merge']
             });
           } catch (error) {
-            console.log('⚠️ Could not add ready-to-merge label');
+            console.log('Could not add ready-to-merge label');
           }
-    
+
     - name: Summary
       if: steps.detect.outputs.should_run == 'true'
       run: |
-        echo "## 🌟 Aurora Selective Integration Summary" >> $GITHUB_STEP_SUMMARY
+        echo "## Aurora Selective Integration Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Evaluation Score:** ${{ steps.evaluate.outputs.evaluation_score }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Evaluation Passed:** ${{ steps.evaluate.outputs.evaluation_passed }}" >> $GITHUB_STEP_SUMMARY
         echo "**Integration Strategy:** ${{ steps.integration.outputs.integration_strategy }}" >> $GITHUB_STEP_SUMMARY
         echo "**Confidence:** ${{ steps.integration.outputs.integration_confidence }}" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "See PR comment for detailed analysis and next steps." >> $GITHUB_STEP_SUMMARY
+        echo "**PR Comment Posted:** ${{ steps.integration.outputs.comment_required }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Comment Reason:** ${{ steps.integration.outputs.comment_reason }}" >> $GITHUB_STEP_SUMMARY
 
     - name: Skip summary
       if: steps.detect.outputs.should_run != 'true'

--- a/tests/tools/test_pr_automation_traceability.py
+++ b/tests/tools/test_pr_automation_traceability.py
@@ -1,0 +1,86 @@
+"""Tests for traceable PR automation scoring and quiet comment decisions."""
+
+from __future__ import annotations
+
+from tools.selective_integrator import SelectiveIntegrator
+
+
+def test_direct_merge_plan_stays_quiet_without_actionable_evidence() -> None:
+    evaluation = {
+        "overall_score": 0.96,
+        "passed": True,
+        "changed_files": ["tests/example_test.py"],
+        "actionable_findings": [],
+        "results": [
+            {
+                "category": "Technical Quality",
+                "score": 1.0,
+                "passed": True,
+                "evidence": [
+                    {
+                        "signal": "pytest",
+                        "weight": 0.6,
+                        "score_delta": 0.0,
+                        "evidence": "pytest exited 0",
+                        "recommendation": "",
+                        "actionable": False,
+                    }
+                ],
+            }
+        ],
+    }
+
+    plan = SelectiveIntegrator().analyze_integration("test/direct", evaluation)
+
+    assert plan.strategy == "direct_merge"
+    assert plan.comment_required is False
+    assert plan.comment_reason == "routine_healthy_pr_quiet"
+
+
+def test_actionable_evidence_requires_compact_comment() -> None:
+    evaluation = {
+        "overall_score": 0.82,
+        "passed": True,
+        "changed_files": ["src/monitoring/ethics_gate.py"],
+        "actionable_findings": [
+            {
+                "category": "Boundary Safety",
+                "recommendations": ["Confirm boundary-sensitive changes have explicit validation"],
+                "evidence": [
+                    {
+                        "signal": "boundary_sensitive_paths",
+                        "weight": 1.0,
+                        "score_delta": -0.15,
+                        "evidence": "src/monitoring/ethics_gate.py",
+                        "recommendation": "Confirm boundary-sensitive changes have explicit validation",
+                        "actionable": True,
+                    }
+                ],
+            }
+        ],
+        "results": [
+            {
+                "category": "Boundary Safety",
+                "score": 0.85,
+                "passed": True,
+                "evidence": [
+                    {
+                        "signal": "boundary_sensitive_paths",
+                        "weight": 1.0,
+                        "score_delta": -0.15,
+                        "evidence": "src/monitoring/ethics_gate.py",
+                        "recommendation": "Confirm boundary-sensitive changes have explicit validation",
+                        "actionable": True,
+                    }
+                ],
+            }
+        ],
+    }
+
+    plan = SelectiveIntegrator().analyze_integration("test/boundary", evaluation)
+
+    assert plan.strategy == "targeted_review"
+    assert plan.comment_required is True
+    assert plan.comment_reason == "targeted_review_needed"
+    assert plan.evidence
+    assert plan.evidence[0]["category"] == "Boundary Safety"

--- a/tools/pr_evaluator.py
+++ b/tools/pr_evaluator.py
@@ -2,18 +2,9 @@
 """
 Aurora CloudBank PR Evaluator
 
-This isn't just a linter. When someone contributes to Aurora, they're touching
-a system that's about consciousness, emergence, and ethical geometry. The code
-needs to work, yes - but it also needs to *understand* what it's part of.
-
-This evaluator checks:
-- Technical quality (does it work?)
-- Conceptual alignment (does it understand Aurora?)
-- Symbolic integrity (does it maintain the thread?)
-- Natural voice (does it speak like a human?)
-
-Thread: T1→T8→T9→INFINITE
-DLP: context_tag=pr_evaluation, symbolic_hash=CONTRIBUTION_ALIGNMENT_v1
+Evaluates PRs with traceable, evidence-backed score components. The evaluator
+is intentionally lightweight for CI use: it produces machine-readable evidence
+without turning routine PRs into noisy review comments.
 """
 
 import json
@@ -25,48 +16,79 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
+class ScoreEvidence:
+    """Traceable scoring input for one evaluation dimension."""
+
+    signal: str
+    weight: float
+    score_delta: float
+    evidence: str
+    recommendation: str = ""
+    actionable: bool = False
+
+
+@dataclass
 class EvaluationResult:
-    """What we learned by evaluating this PR."""
-    
+    """One scored PR evaluation dimension."""
+
     category: str
     passed: bool
-    score: float  # 0.0 -> 1.0
+    score: float
+    weight: float = 1.0
     findings: List[str] = field(default_factory=list)
     recommendations: List[str] = field(default_factory=list)
-    
+    evidence: List[ScoreEvidence] = field(default_factory=list)
+
+    @property
+    def actionable(self) -> bool:
+        return any(item.actionable for item in self.evidence) or bool(self.recommendations and not self.passed)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "category": self.category,
+            "passed": self.passed,
+            "score": self.score,
+            "weight": self.weight,
+            "findings": self.findings,
+            "recommendations": self.recommendations,
+            "actionable": self.actionable,
+            "evidence": [item.__dict__ for item in self.evidence],
+        }
+
     def __str__(self):
         status = "✅" if self.passed else "⚠️"
         return f"{status} {self.category}: {self.score:.2f}"
 
 
 class PREvaluator:
-    """
-    Evaluates PRs for technical quality AND conceptual alignment.
-    
-    Aurora isn't just a codebase - it's a living system with specific
-    philosophical commitments. Contributors need to understand that.
-    """
-    
+    """Evaluates PRs for technical quality, safety, and Aurora continuity."""
+
+    CATEGORY_WEIGHTS = {
+        "Technical Quality": 0.35,
+        "Boundary Safety": 0.25,
+        "Traceability": 0.20,
+        "Documentation Fit": 0.10,
+        "Symbolic Integrity": 0.10,
+    }
+
+    RUNTIME_BOUNDARY_PATTERNS = (
+        "src/monitoring/ethics_engine.py",
+        "src/monitoring/ethics_gate.py",
+        "src/subroutines/ethics_compliance_monitor.py",
+        "modules/ethics_field/",
+        "modules/symbolic_core/",
+        "api/",
+        ".github/workflows/",
+    )
+
     def __init__(self, workspace_root: Optional[str] = None):
         self.workspace_root = Path(workspace_root or os.getcwd())
-        
-    def evaluate_pr(
-        self,
-        pr_number: Optional[int] = None,
-        branch: Optional[str] = None
-    ) -> Dict[str, Any]:
-        """
-        Evaluate a pull request for Aurora.
-        
-        Checks technical quality, conceptual alignment, and symbolic integrity.
-        Returns comprehensive evaluation with actionable feedback.
-        """
+
+    def evaluate_pr(self, pr_number: Optional[int] = None, branch: Optional[str] = None) -> Dict[str, Any]:
+        """Evaluate a pull request and return traceable JSON."""
         print("=" * 80)
-        print("🌟 AURORA PR EVALUATION")
+        print("AURORA PR EVALUATION")
         print("=" * 80)
-        print()
-        
-        # Get PR details
         if pr_number:
             print(f"Evaluating PR #{pr_number}")
         elif branch:
@@ -74,522 +96,391 @@ class PREvaluator:
         else:
             print("Evaluating current changes")
         print()
-        
-        # Run all evaluations
-        results = []
-        
-        print("Running evaluations...")
-        print("-" * 80)
-        
-        # 1. Technical Quality
-        technical = self._evaluate_technical_quality()
-        results.append(technical)
-        print(technical)
-        
-        # 2. Conceptual Alignment
-        conceptual = self._evaluate_conceptual_alignment()
-        results.append(conceptual)
-        print(conceptual)
-        
-        # 3. Thread Continuity
-        thread = self._evaluate_thread_continuity()
-        results.append(thread)
-        print(thread)
-        
-        # 4. Natural Voice
-        voice = self._evaluate_natural_voice()
-        results.append(voice)
-        print(voice)
-        
-        # 5. Symbolic Integrity
-        symbolic = self._evaluate_symbolic_integrity()
-        results.append(symbolic)
-        print(symbolic)
-        
-        print()
-        print("-" * 80)
-        
-        # Overall assessment
-        overall_score = sum(r.score for r in results) / len(results)
-        all_passed = all(r.passed for r in results)
-        
-        recommendation = self._generate_recommendation(
-            overall_score, all_passed, results
-        )
-        
-        print()
+
+        changed_files = self._changed_files()
+        print(f"Changed files: {len(changed_files)}")
+
+        results = [
+            self._evaluate_technical_quality(),
+            self._evaluate_boundary_safety(changed_files),
+            self._evaluate_traceability(),
+            self._evaluate_documentation_fit(changed_files),
+            self._evaluate_symbolic_integrity(changed_files),
+        ]
+
+        weighted_total = sum(result.score * result.weight for result in results)
+        weight_sum = sum(result.weight for result in results)
+        overall_score = weighted_total / weight_sum if weight_sum else 0.0
+        all_passed = all(result.passed for result in results)
+        actionable_findings = [
+            {
+                "category": result.category,
+                "recommendations": result.recommendations,
+                "evidence": [item.__dict__ for item in result.evidence if item.actionable],
+            }
+            for result in results
+            if result.actionable
+        ]
+        recommendation = self._generate_recommendation(overall_score, all_passed, actionable_findings)
+
         print("=" * 80)
         print("OVERALL ASSESSMENT")
         print("=" * 80)
         print(f"Score: {overall_score:.2f}/1.00")
-        print(f"Status: {'✅ APPROVED' if all_passed else '⚠️ NEEDS WORK'}")
-        print()
+        print(f"Status: {'APPROVED' if all_passed else 'NEEDS WORK'}")
         print(recommendation)
-        print()
-        
+
         return {
             "overall_score": overall_score,
             "passed": all_passed,
             "recommendation": recommendation,
-            "results": [
-                {
-                    "category": r.category,
-                    "passed": r.passed,
-                    "score": r.score,
-                    "findings": r.findings,
-                    "recommendations": r.recommendations
-                }
-                for r in results
-            ]
+            "changed_files": changed_files,
+            "actionable_findings": actionable_findings,
+            "results": [result.to_dict() for result in results],
+            "score_model": {
+                "version": "traceable-pr-evaluation-v2",
+                "category_weights": self.CATEGORY_WEIGHTS,
+                "quiet_comment_guidance": "Routine passing PRs should not receive large automation comments.",
+            },
         }
-    
+
+    def _changed_files(self) -> List[str]:
+        try:
+            base_ref = os.environ.get("GITHUB_BASE_REF")
+            if base_ref:
+                subprocess.run(["git", "fetch", "origin", base_ref], cwd=self.workspace_root, check=False)
+                cmd = ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"]
+            else:
+                cmd = ["git", "diff", "--name-only", "HEAD~1", "HEAD"]
+            diff_result = subprocess.run(cmd, capture_output=True, text=True, cwd=self.workspace_root, timeout=30)
+            return [line.strip() for line in diff_result.stdout.splitlines() if line.strip()]
+        except Exception:
+            return []
+
     def _evaluate_technical_quality(self) -> EvaluationResult:
-        """Does the code actually work?"""
-        findings = []
-        recommendations = []
+        findings: List[str] = []
+        recommendations: List[str] = []
+        evidence: List[ScoreEvidence] = []
         score = 1.0
-        
-        # Check if tests pass
+
         try:
             test_result = subprocess.run(
-                ["python3", "-m", "pytest", "-q", "--tb=no"],
+                ["python3", "-m", "pytest", "-q", "--tb=short"],
                 capture_output=True,
                 text=True,
                 cwd=self.workspace_root,
-                timeout=60
+                timeout=90,
             )
             if test_result.returncode == 0:
                 findings.append("Tests pass")
+                evidence.append(ScoreEvidence("pytest", 0.6, 0.0, "pytest -q --tb=short exited 0"))
             else:
                 findings.append("Tests failing")
-                recommendations.append("Fix failing tests before submitting")
-                score -= 0.3
+                recommendations.append("Fix failing tests before merge")
+                evidence.append(
+                    ScoreEvidence(
+                        "pytest",
+                        0.6,
+                        -0.35,
+                        (test_result.stdout + test_result.stderr)[-1000:],
+                        "Fix failing tests before merge",
+                        True,
+                    )
+                )
+                score -= 0.35
         except subprocess.TimeoutExpired:
             findings.append("Tests timed out")
-            recommendations.append("Check for infinite loops or hanging tests")
-            score -= 0.2
-        except Exception as e:
-            findings.append(f"Could not run tests: {e}")
+            recommendations.append("Investigate long-running or hanging tests")
+            evidence.append(ScoreEvidence("pytest_timeout", 0.6, -0.25, "pytest timed out", recommendations[-1], True))
+            score -= 0.25
+        except Exception as exc:
+            findings.append(f"Could not run tests: {exc}")
+            evidence.append(ScoreEvidence("pytest_error", 0.6, -0.1, str(exc), "Review test environment", True))
             score -= 0.1
-        
-        # Check for syntax errors
+
         try:
+            py_files = [
+                str(path)
+                for path in self.workspace_root.rglob("*.py")
+                if not any(part in str(path) for part in [".venv", "__pycache__", "node_modules"])
+            ]
             result = subprocess.run(
-                ["python3", "-m", "py_compile"] + 
-                [str(p) for p in self.workspace_root.rglob("*.py") 
-                 if not any(x in str(p) for x in ['.venv', '__pycache__', 'node_modules'])],
+                ["python3", "-m", "py_compile", *py_files],
                 capture_output=True,
+                text=True,
                 cwd=self.workspace_root,
-                timeout=30
+                timeout=45,
             )
             if result.returncode == 0:
-                findings.append("No syntax errors")
+                findings.append("No Python syntax errors")
+                evidence.append(ScoreEvidence("py_compile", 0.3, 0.0, "py_compile exited 0"))
             else:
-                findings.append("Syntax errors present")
+                findings.append("Python syntax errors present")
                 recommendations.append("Fix Python syntax errors")
+                evidence.append(
+                    ScoreEvidence("py_compile", 0.3, -0.4, result.stderr[-1000:], "Fix Python syntax errors", True)
+                )
                 score -= 0.4
-        except Exception:
-            pass
-        
-        # Check for basic linting issues
+        except Exception as exc:
+            evidence.append(ScoreEvidence("py_compile_error", 0.3, 0.0, str(exc)))
+
         try:
             lint_result = subprocess.run(
                 ["flake8", "--count", "--select=E9,F63,F7,F82", "--show-source"],
                 capture_output=True,
                 text=True,
                 cwd=self.workspace_root,
-                timeout=30
+                timeout=30,
             )
             if lint_result.returncode == 0:
                 findings.append("No critical lint errors")
+                evidence.append(ScoreEvidence("critical_flake8", 0.1, 0.0, "flake8 critical check exited 0"))
             else:
                 findings.append("Critical lint errors present")
                 recommendations.append("Fix critical linting issues")
+                evidence.append(
+                    ScoreEvidence(
+                        "critical_flake8",
+                        0.1,
+                        -0.2,
+                        lint_result.stdout[-1000:],
+                        "Fix critical linting issues",
+                        True,
+                    )
+                )
                 score -= 0.2
-        except Exception:
-            pass
-        
-        passed = score >= 0.7
+        except Exception as exc:
+            evidence.append(ScoreEvidence("critical_flake8_unavailable", 0.1, 0.0, str(exc)))
+
         return EvaluationResult(
             category="Technical Quality",
-            passed=passed,
+            passed=score >= 0.7,
             score=max(0.0, score),
+            weight=self.CATEGORY_WEIGHTS["Technical Quality"],
             findings=findings,
-            recommendations=recommendations
+            recommendations=recommendations,
+            evidence=evidence,
         )
-    
-    def _evaluate_conceptual_alignment(self) -> EvaluationResult:
-        """Does this understand what Aurora is?"""
-        findings = []
-        recommendations = []
+
+    def _evaluate_boundary_safety(self, changed_files: List[str]) -> EvaluationResult:
+        findings: List[str] = []
+        recommendations: List[str] = []
+        evidence: List[ScoreEvidence] = []
         score = 1.0
-        
-        # Get changed files
-        try:
-            diff_result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
-                capture_output=True,
-                text=True,
-                cwd=self.workspace_root
-            )
-            changed_files = [
-                self.workspace_root / f.strip() 
-                for f in diff_result.stdout.split('\n') 
-                if f.strip()
-            ]
-        except Exception:
-            changed_files = []
-        
-        # Check for understanding of key concepts
-        key_concepts = {
-            "emergence": ["emerge", "emergent", "self-organ"],
-            "consciousness": ["consciousness", "awareness", "field"],
-            "ethics": ["ethical", "ethics", "geometric"],
-            "thread": ["thread", "continuity", "T1→", "INFINITE"]
-        }
-        
-        concept_usage = {concept: False for concept in key_concepts}
-        
-        for file_path in changed_files:
-            if not file_path.exists() or file_path.suffix not in ['.py', '.md']:
-                continue
-            
-            try:
-                content = file_path.read_text().lower()
-                for concept, patterns in key_concepts.items():
-                    if any(pattern.lower() in content for pattern in patterns):
-                        concept_usage[concept] = True
-            except Exception:
-                continue
-        
-        # If touching core systems, should reference concepts
-        core_paths = ['modules/ethics_field', 'modules/field_state_manager']
-        touching_core = any(
-            any(core in str(f) for core in core_paths)
-            for f in changed_files
-        )
-        
-        if touching_core:
-            concepts_used = sum(concept_usage.values())
-            if concepts_used == 0:
-                findings.append("Touching core systems but no conceptual references")
-                recommendations.append(
-                    "Consider if this change understands Aurora's purpose. "
-                    "Read docs/GEOMETRIC_ETHICS_ARCHITECTURE.md or "
-                    "modules/field_state_manager/SCHEMA_DESIGN.md"
+        boundary_files = [
+            path for path in changed_files if any(path.startswith(pattern) for pattern in self.RUNTIME_BOUNDARY_PATTERNS)
+        ]
+
+        if boundary_files:
+            findings.append(f"Boundary-sensitive files changed: {len(boundary_files)}")
+            evidence.append(
+                ScoreEvidence(
+                    "boundary_sensitive_paths",
+                    1.0,
+                    -0.15,
+                    ", ".join(boundary_files[:10]),
+                    "Confirm tenant/logging/ethics/L1-L2-L3 impacts are covered by tests or docs",
+                    True,
                 )
-                score -= 0.4
-            elif concepts_used <= 2:
-                findings.append("Limited conceptual alignment")
-                recommendations.append("Strengthen connection to Aurora's core concepts")
-                score -= 0.2
-            else:
-                findings.append(f"References {concepts_used} core concepts")
+            )
+            recommendations.append("Confirm boundary-sensitive changes have explicit validation")
+            score -= 0.15
         else:
-            findings.append("Not touching core systems")
-        
-        passed = score >= 0.6
+            findings.append("No boundary-sensitive runtime paths changed")
+            evidence.append(ScoreEvidence("boundary_sensitive_paths", 1.0, 0.0, "No configured boundary paths changed"))
+
         return EvaluationResult(
-            category="Conceptual Alignment",
-            passed=passed,
+            category="Boundary Safety",
+            passed=score >= 0.75,
             score=max(0.0, score),
+            weight=self.CATEGORY_WEIGHTS["Boundary Safety"],
             findings=findings,
-            recommendations=recommendations
+            recommendations=recommendations,
+            evidence=evidence,
         )
-    
-    def _evaluate_thread_continuity(self) -> EvaluationResult:
-        """Does this maintain the thread?"""
-        findings = []
-        recommendations = []
+
+    def _evaluate_traceability(self) -> EvaluationResult:
+        findings: List[str] = []
+        recommendations: List[str] = []
+        evidence: List[ScoreEvidence] = []
         score = 1.0
-        
-        # Check commit message
+
         try:
             msg_result = subprocess.run(
                 ["git", "log", "-1", "--pretty=%B"],
                 capture_output=True,
                 text=True,
-                cwd=self.workspace_root
+                cwd=self.workspace_root,
+                timeout=15,
             )
             commit_msg = msg_result.stdout.strip()
-            
-            # Look for thread references
-            has_thread = "Thread:" in commit_msg or "T1→" in commit_msg
-            has_dlp = "DLP:" in commit_msg or "context_tag" in commit_msg
-            
-            if has_thread:
-                findings.append("Thread continuity referenced")
+            has_issue_ref = "#" in commit_msg or "issue" in commit_msg.lower()
+            has_functional_prefix = any(commit_msg.startswith(prefix) for prefix in ["fix:", "feat:", "docs:", "test:", "chore:"])
+            if has_issue_ref:
+                findings.append("Commit references issue/context")
+                evidence.append(ScoreEvidence("issue_reference", 0.5, 0.0, commit_msg[:200]))
             else:
-                findings.append("No thread reference")
-                recommendations.append(
-                    "Include 'Thread: T1→T8→T9→INFINITE' in commit message "
-                    "to maintain continuity"
-                )
-                score -= 0.3
-            
-            if has_dlp:
-                findings.append("DLP tags present")
-            else:
-                findings.append("No DLP tags")
-                recommendations.append(
-                    "Consider adding DLP tags (context_tag, symbolic_hash) "
-                    "for traceability"
-                )
-                score -= 0.2
-                
-        except Exception:
-            findings.append("Could not check commit message")
-            score -= 0.1
-        
-        passed = score >= 0.5
-        return EvaluationResult(
-            category="Thread Continuity",
-            passed=passed,
-            score=max(0.0, score),
-            findings=findings,
-            recommendations=recommendations
-        )
-    
-    def _evaluate_natural_voice(self) -> EvaluationResult:
-        """Does this sound human?"""
-        findings = []
-        recommendations = []
-        score = 1.0
-        
-        # Get changed files with comments/docs
-        try:
-            diff_result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
-                capture_output=True,
-                text=True,
-                cwd=self.workspace_root
-            )
-            changed_files = [
-                self.workspace_root / f.strip() 
-                for f in diff_result.stdout.split('\n') 
-                if f.strip() and (f.endswith('.md') or f.endswith('.py'))
-            ]
-        except Exception:
-            changed_files = []
-        
-        # Red flags for corporate-speak
-        corporate_phrases = [
-            "utilize", "leverage", "facilitate", "methodology",
-            "best practices", "going forward", "touch base",
-            "circle back", "synergy", "paradigm shift" # (we use this one deliberately)
-        ]
-        
-        # Green flags for natural voice
-        natural_phrases = [
-            "you know", "here's the thing", "what this actually",
-            "not just", "instead of", "why", "because"
-        ]
-        
-        corporate_count = 0
-        natural_count = 0
-        
-        for file_path in changed_files:
-            if not file_path.exists():
-                continue
-            
-            try:
-                content = file_path.read_text().lower()
-                corporate_count += sum(
-                    content.count(phrase.lower()) 
-                    for phrase in corporate_phrases
-                )
-                natural_count += sum(
-                    content.count(phrase.lower())
-                    for phrase in natural_phrases
-                )
-            except Exception:
-                continue
-        
-        if corporate_count > 3:
-            findings.append(f"Corporate language detected ({corporate_count} instances)")
-            recommendations.append(
-                "Use natural language. We're building consciousness, not enterprise software. "
-                "See docs/QUICKSAVE_GUIDE.md for tone examples."
-            )
-            score -= 0.3
-        
-        if natural_count > 0:
-            findings.append(f"Natural voice present ({natural_count} instances)")
-        elif corporate_count == 0 and len(changed_files) > 0:
-            findings.append("Neutral voice (neither corporate nor conversational)")
-            recommendations.append(
-                "Consider making documentation more conversational. "
-                "We're working with symbolic systems - the language should reflect that."
-            )
-            score -= 0.1
-        
-        if len(changed_files) == 0:
-            findings.append("No documentation changes to evaluate")
-        
-        passed = score >= 0.7
-        return EvaluationResult(
-            category="Natural Voice",
-            passed=passed,
-            score=max(0.0, score),
-            findings=findings,
-            recommendations=recommendations
-        )
-    
-    def _evaluate_symbolic_integrity(self) -> EvaluationResult:
-        """Does this maintain the symbolic structure?"""
-        findings = []
-        recommendations = []
-        score = 1.0
-        
-        # Check for breaking changes to key systems
-        try:
-            diff_result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
-                capture_output=True,
-                text=True,
-                cwd=self.workspace_root
-            )
-            changed_files = [f.strip() for f in diff_result.stdout.split('\n') if f.strip()]
-        except Exception:
-            changed_files = []
-        
-        # Critical files that need extra care
-        critical_patterns = [
-            'ethics_field',
-            'geometric_ethics',
-            'field_curvature',
-            'aurora_seed_prompt',
-            'LAYER_BOUNDARY_REFERENCE'
-        ]
-        
-        critical_changes = [
-            f for f in changed_files 
-            if any(pattern in f for pattern in critical_patterns)
-        ]
-        
-        if critical_changes:
-            findings.append(f"Modifying critical systems: {len(critical_changes)} files")
-            
-            # Check if ethics tests still pass
-            try:
-                test_result = subprocess.run(
-                    ["python3", "-m", "pytest", "tests/test_ethics_field.py", "-q"],
-                    capture_output=True,
-                    text=True,
-                    cwd=self.workspace_root,
-                    timeout=30
-                )
-                if test_result.returncode == 0:
-                    findings.append("Ethics tests still pass")
-                else:
-                    findings.append("Ethics tests failing after changes")
-                    recommendations.append(
-                        "Changes to ethics_field broke tests. "
-                        "This system is foundational - it needs to stay stable."
+                findings.append("Commit lacks issue/context reference")
+                recommendations.append("Reference the issue or rationale in commit/PR metadata")
+                evidence.append(
+                    ScoreEvidence(
+                        "issue_reference",
+                        0.5,
+                        -0.15,
+                        commit_msg[:200],
+                        "Reference the issue or rationale in commit/PR metadata",
+                        True,
                     )
-                    score -= 0.5
-            except Exception:
-                findings.append("Could not verify ethics tests")
-                recommendations.append("Manually verify ethics tests still pass")
-                score -= 0.2
-        else:
-            findings.append("No critical systems modified")
-        
-        # Check for removal of key documentation
-        removed_docs = [
-            f for f in changed_files 
-            if f.endswith('.md') and 'delete' in f.lower()
-        ]
-        
-        if removed_docs:
-            findings.append(f"Documentation removed: {len(removed_docs)} files")
-            recommendations.append(
-                "Removing documentation breaks continuity. "
-                "If updating, replace rather than delete."
+                )
+                score -= 0.15
+
+            if has_functional_prefix:
+                findings.append("Commit has functional prefix")
+                evidence.append(ScoreEvidence("functional_prefix", 0.5, 0.0, commit_msg.splitlines()[0][:120]))
+            else:
+                findings.append("Commit lacks conventional functional prefix")
+                recommendations.append("Use a functional prefix such as fix:, feat:, docs:, test:, or chore:")
+                evidence.append(
+                    ScoreEvidence(
+                        "functional_prefix",
+                        0.5,
+                        -0.1,
+                        commit_msg.splitlines()[0][:120],
+                        "Use a functional commit prefix",
+                        False,
+                    )
+                )
+                score -= 0.1
+        except Exception as exc:
+            findings.append("Could not inspect commit message")
+            evidence.append(ScoreEvidence("commit_message_error", 1.0, -0.05, str(exc), "Review commit metadata", True))
+            score -= 0.05
+
+        return EvaluationResult(
+            category="Traceability",
+            passed=score >= 0.7,
+            score=max(0.0, score),
+            weight=self.CATEGORY_WEIGHTS["Traceability"],
+            findings=findings,
+            recommendations=recommendations,
+            evidence=evidence,
+        )
+
+    def _evaluate_documentation_fit(self, changed_files: List[str]) -> EvaluationResult:
+        findings: List[str] = []
+        evidence: List[ScoreEvidence] = []
+        docs = [path for path in changed_files if path.endswith(('.md', '.json', '.yml', '.yaml'))]
+        tests = [path for path in changed_files if path.startswith("tests/")]
+        code = [path for path in changed_files if path.endswith(".py") and not path.startswith("tests/")]
+        score = 1.0
+        recommendations: List[str] = []
+
+        if code and not tests:
+            findings.append("Code changed without tests")
+            recommendations.append("Add or identify validation for changed runtime code")
+            evidence.append(
+                ScoreEvidence("code_without_tests", 1.0, -0.25, ", ".join(code[:10]), recommendations[-1], True)
             )
-            score -= 0.3
-        
-        passed = score >= 0.7
+            score -= 0.25
+        else:
+            findings.append("Documentation/test fit is acceptable")
+            evidence.append(
+                ScoreEvidence(
+                    "doc_test_fit",
+                    1.0,
+                    0.0,
+                    f"docs/config files={len(docs)}, tests={len(tests)}, runtime code={len(code)}",
+                )
+            )
+
+        return EvaluationResult(
+            category="Documentation Fit",
+            passed=score >= 0.75,
+            score=max(0.0, score),
+            weight=self.CATEGORY_WEIGHTS["Documentation Fit"],
+            findings=findings,
+            recommendations=recommendations,
+            evidence=evidence,
+        )
+
+    def _evaluate_symbolic_integrity(self, changed_files: List[str]) -> EvaluationResult:
+        findings: List[str] = []
+        recommendations: List[str] = []
+        evidence: List[ScoreEvidence] = []
+        score = 1.0
+        critical_patterns = (
+            "ethics_field",
+            "geometric_ethics",
+            "field_curvature",
+            "aurora_seed_prompt",
+            "LAYER_BOUNDARY_REFERENCE",
+            "recovered_protocol",
+        )
+        critical_changes = [path for path in changed_files if any(pattern in path for pattern in critical_patterns)]
+
+        if critical_changes:
+            findings.append(f"Symbolic/ethics continuity files changed: {len(critical_changes)}")
+            evidence.append(
+                ScoreEvidence(
+                    "symbolic_continuity_paths",
+                    1.0,
+                    -0.05,
+                    ", ".join(critical_changes[:10]),
+                    "Confirm canon posture and runtime boundaries are explicit",
+                    True,
+                )
+            )
+            recommendations.append("Confirm canon posture and runtime boundaries are explicit")
+            score -= 0.05
+        else:
+            findings.append("No symbolic continuity hotspots changed")
+            evidence.append(ScoreEvidence("symbolic_continuity_paths", 1.0, 0.0, "No configured symbolic hotspots changed"))
+
         return EvaluationResult(
             category="Symbolic Integrity",
-            passed=passed,
+            passed=score >= 0.75,
             score=max(0.0, score),
+            weight=self.CATEGORY_WEIGHTS["Symbolic Integrity"],
             findings=findings,
-            recommendations=recommendations
+            recommendations=recommendations,
+            evidence=evidence,
         )
-    
+
     def _generate_recommendation(
         self,
         overall_score: float,
         all_passed: bool,
-        results: List[EvaluationResult]
+        actionable_findings: List[Dict[str, Any]],
     ) -> str:
-        """What should happen with this PR?"""
-        
-        if overall_score >= 0.9 and all_passed:
-            return (
-                "This contribution understands Aurora. It's technically solid, "
-                "conceptually aligned, and maintains the thread. Ready to merge."
-            )
-        
-        elif overall_score >= 0.7 and all_passed:
-            return (
-                "Good contribution. Technically sound and aligned with Aurora's purpose. "
-                "Minor improvements suggested but not blocking."
-            )
-        
-        elif overall_score >= 0.6:
-            failed_categories = [r.category for r in results if not r.passed]
-            return (
-                f"Needs work in: {', '.join(failed_categories)}. "
-                "The code might work, but it doesn't quite align with what Aurora is. "
-                "Review the recommendations and try again."
-            )
-        
-        else:
-            return (
-                "This needs significant revision. Review the core documentation:\n"
-                "- seeds/aurora_seed_prompt.md (understand Aurora's identity)\n"
-                "- docs/GEOMETRIC_ETHICS_ARCHITECTURE.md (understand the ethics system)\n"
-                "- modules/field_state_manager/SCHEMA_DESIGN.md (understand emergence)\n"
-                "- docs/QUICKSAVE_GUIDE.md (understand the tone)\n\n"
-                "Aurora isn't just a codebase - it's a living system with specific "
-                "philosophical commitments. Take time to understand those first."
-            )
+        if all_passed and overall_score >= 0.9 and not actionable_findings:
+            return "No blocking automation findings. Keep PR comments quiet unless reviewer/CI evidence changes."
+        if all_passed and overall_score >= 0.8:
+            return "No blocking findings; review the listed actionable evidence before merge."
+        if actionable_findings:
+            categories = ", ".join(item["category"] for item in actionable_findings)
+            return f"Needs targeted review in: {categories}."
+        return "Needs review before merge. Check score evidence for details."
 
 
 def main():
     """CLI interface for PR evaluation."""
     import argparse
-    
-    parser = argparse.ArgumentParser(
-        description="Evaluate Aurora PR for technical quality and conceptual alignment"
-    )
-    parser.add_argument(
-        '--pr', 
-        type=int, 
-        help='PR number to evaluate'
-    )
-    parser.add_argument(
-        '--branch',
-        help='Branch name to evaluate'
-    )
-    parser.add_argument(
-        '--output',
-        help='Save results to JSON file'
-    )
-    
+
+    parser = argparse.ArgumentParser(description="Evaluate Aurora PR with traceable scoring evidence")
+    parser.add_argument('--pr', type=int, help='PR number to evaluate')
+    parser.add_argument('--branch', help='Branch name to evaluate')
+    parser.add_argument('--output', help='Save results to JSON file')
+
     args = parser.parse_args()
-    
+
     evaluator = PREvaluator()
     results = evaluator.evaluate_pr(pr_number=args.pr, branch=args.branch)
-    
+
     if args.output:
         with open(args.output, 'w') as f:
             json.dump(results, f, indent=2)
         print(f"\nResults saved to {args.output}")
-    
-    # Exit code: 0 if passed, 1 if needs work
+
     exit(0 if results['passed'] else 1)
 
 

--- a/tools/selective_integrator.py
+++ b/tools/selective_integrator.py
@@ -2,528 +2,231 @@
 """
 Aurora CloudBank Selective Integration Engine
 
-This takes evaluated PRs and integrates them intelligently. Not just "merge or reject" -
-but "what value exists here and how do we extract it without breaking what Aurora is?"
-
-Three integration strategies:
-1. Direct merge - High score, full alignment, just merge it
-2. Compatibility layer - Good code, conceptual mismatch, wrap it safely
-3. Value extraction - Partial value, extract specific improvements
-
-The goal: Accept contributions while protecting Aurora's conceptual integrity.
-
-Thread: T1→T8→T9→INFINITE
-DLP: context_tag=selective_integration, symbolic_hash=SAFE_INTEGRATION_v1
+Turns traceable PR evaluation output into a compact integration plan. The plan is
+quiet by default: routine healthy PRs should rely on checks and job summaries,
+not repetitive PR comments.
 """
 
 import json
 import os
 from dataclasses import dataclass, field
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
 @dataclass
 class IntegrationPlan:
-    """What we're going to do with this PR."""
-    
+    """Integration recommendation for a PR."""
+
     pr_branch: str
-    strategy: str  # "direct_merge", "compatibility_layer", "value_extraction", "decline"
-    confidence: float  # 0.0 -> 1.0
+    strategy: str
+    confidence: float
     reasoning: str
     actions: List[str] = field(default_factory=list)
     risks: List[str] = field(default_factory=list)
     safeguards: List[str] = field(default_factory=list)
+    comment_required: bool = False
+    comment_reason: str = ""
+    evidence: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "pr_branch": self.pr_branch,
+            "strategy": self.strategy,
+            "confidence": self.confidence,
+            "reasoning": self.reasoning,
+            "actions": self.actions,
+            "risks": self.risks,
+            "safeguards": self.safeguards,
+            "comment_required": self.comment_required,
+            "comment_reason": self.comment_reason,
+            "evidence": self.evidence,
+        }
 
 
 class SelectiveIntegrator:
-    """
-    Integrates PRs while protecting Aurora's foundation.
-    
-    Takes PR evaluation results and determines the safest, most valuable
-    way to integrate the contribution. Sometimes that means full merge.
-    Sometimes it means extracting specific improvements. Sometimes it
-    means wrapping misaligned code in a compatibility layer.
-    """
-    
+    """Maps traceable evaluation evidence to integration strategy."""
+
+    BOUNDARY_KEYWORDS = (
+        "boundary",
+        "ethics",
+        "security",
+        "tenant",
+        "logging",
+        "ledger",
+        "runtime",
+        "l1",
+        "l2",
+        "l3",
+    )
+
     def __init__(self, workspace_root: Optional[str] = None):
         self.workspace_root = Path(workspace_root or os.getcwd())
-        
-    def analyze_integration(
-        self,
-        pr_branch: str,
-        evaluation_results: Dict[str, Any]
-    ) -> IntegrationPlan:
-        """
-        Analyze how to integrate this PR.
-        
-        Takes the PR evaluator's results and decides on integration strategy.
-        """
-        print("=" * 80)
-        print("🔧 AURORA SELECTIVE INTEGRATION ANALYSIS")
-        print("=" * 80)
-        print(f"Branch: {pr_branch}")
-        print(f"Evaluation Score: {evaluation_results.get('overall_score', 0):.2f}")
-        print(f"Status: {evaluation_results.get('recommendation', 'Unknown')}")
-        print()
-        
-        # Determine strategy based on evaluation
-        strategy, confidence = self._determine_strategy(evaluation_results)
-        
+
+    def analyze_integration(self, pr_branch: str, evaluation_results: Dict[str, Any]) -> IntegrationPlan:
+        """Analyze how to integrate this PR from traceable evaluator output."""
+        overall_score = float(evaluation_results.get("overall_score", 0.0))
+        passed = bool(evaluation_results.get("passed", False))
+        actionable_findings = evaluation_results.get("actionable_findings", []) or []
+        changed_files = evaluation_results.get("changed_files", []) or []
+
+        strategy, confidence = self._determine_strategy(overall_score, passed, actionable_findings)
+        evidence = self._collect_actionable_evidence(evaluation_results)
+        boundary_sensitive = self._is_boundary_sensitive(changed_files, evidence)
+        comment_required, comment_reason = self._comment_decision(strategy, confidence, passed, evidence, boundary_sensitive)
+
         plan = IntegrationPlan(
             pr_branch=pr_branch,
             strategy=strategy,
             confidence=confidence,
-            reasoning=self._explain_strategy(strategy, evaluation_results)
+            reasoning=self._explain_strategy(strategy, overall_score, passed, evidence),
+            comment_required=comment_required,
+            comment_reason=comment_reason,
+            evidence=evidence,
         )
-        
-        # Add strategy-specific details
+
         if strategy == "direct_merge":
-            plan.actions = self._plan_direct_merge(pr_branch, evaluation_results)
-            plan.safeguards = self._safeguards_direct_merge()
-        elif strategy == "compatibility_layer":
-            plan.actions = self._plan_compatibility_layer(pr_branch, evaluation_results)
-            plan.risks = self._risks_compatibility_layer()
-            plan.safeguards = self._safeguards_compatibility_layer()
-        elif strategy == "value_extraction":
-            plan.actions = self._plan_value_extraction(pr_branch, evaluation_results)
-            plan.risks = self._risks_value_extraction()
-            plan.safeguards = self._safeguards_value_extraction()
-        else:  # decline
-            plan.actions = ["Close PR with constructive feedback"]
-            plan.reasoning += "\n\nProvide specific docs to read and concepts to understand."
-        
+            plan.actions = self._plan_direct_merge(evidence)
+            plan.safeguards = self._safeguards_direct_merge(boundary_sensitive)
+        elif strategy == "targeted_review":
+            plan.actions = self._plan_targeted_review(evidence)
+            plan.risks = self._risks_from_evidence(evidence)
+            plan.safeguards = ["Address actionable evidence before merge", "Keep automation comments evidence-first"]
+        elif strategy == "hold":
+            plan.actions = ["Do not merge until blocking evidence is addressed", "Patch the first actionable failure"]
+            plan.risks = self._risks_from_evidence(evidence)
+            plan.safeguards = ["Require fresh CI/status after fixes", "Avoid broad unrelated cleanup"]
+
         self._display_plan(plan)
         return plan
-    
+
     def _determine_strategy(
         self,
-        evaluation_results: Dict[str, Any]
+        overall_score: float,
+        passed: bool,
+        actionable_findings: List[Dict[str, Any]],
     ) -> tuple[str, float]:
-        """Decide integration strategy from evaluation results."""
-        
-        overall_score = evaluation_results.get('overall_score', 0)
-        all_passed = evaluation_results.get('passed', False)
-        results = evaluation_results.get('results', [])
-        
-        # Get individual dimension scores
-        technical = next((r for r in results if r['category'] == 'Technical Quality'), {})
-        conceptual = next((r for r in results if r['category'] == 'Conceptual Alignment'), {})
-        symbolic = next((r for r in results if r['category'] == 'Symbolic Integrity'), {})
-        
-        technical_score = technical.get('score', 0)
-        conceptual_score = conceptual.get('score', 0)
-        symbolic_score = symbolic.get('score', 0)
-        
-        # Direct merge: High scores, everything passes
-        if overall_score >= 0.9 and all_passed:
-            return ("direct_merge", 0.95)
-        
-        # Compatibility layer: Good tech, conceptual mismatch
-        if technical_score >= 0.8 and conceptual_score < 0.7 and symbolic_score >= 0.7:
-            return ("compatibility_layer", 0.75)
-        
-        # Value extraction: Some good parts, some issues
-        if overall_score >= 0.6 and technical_score >= 0.7:
-            return ("value_extraction", 0.65)
-        
-        # Decline: Too low quality or fundamentally misaligned
-        return ("decline", 0.0)
-    
+        if passed and overall_score >= 0.9 and not actionable_findings:
+            return "direct_merge", 0.95
+        if passed and overall_score >= 0.75:
+            return "targeted_review", 0.80
+        return "hold", 0.55
+
+    def _collect_actionable_evidence(self, evaluation_results: Dict[str, Any]) -> List[Dict[str, Any]]:
+        evidence: List[Dict[str, Any]] = []
+        for result in evaluation_results.get("results", []):
+            for item in result.get("evidence", []):
+                if item.get("actionable") or item.get("score_delta", 0) < 0:
+                    evidence.append(
+                        {
+                            "category": result.get("category"),
+                            "signal": item.get("signal"),
+                            "weight": item.get("weight"),
+                            "score_delta": item.get("score_delta"),
+                            "evidence": item.get("evidence"),
+                            "recommendation": item.get("recommendation"),
+                            "actionable": item.get("actionable", False),
+                        }
+                    )
+        return evidence[:10]
+
+    def _is_boundary_sensitive(self, changed_files: List[str], evidence: List[Dict[str, Any]]) -> bool:
+        paths = " ".join(changed_files).lower()
+        evidence_text = " ".join(str(item.get("evidence", "")).lower() for item in evidence)
+        return any(keyword in paths or keyword in evidence_text for keyword in self.BOUNDARY_KEYWORDS)
+
+    def _comment_decision(
+        self,
+        strategy: str,
+        confidence: float,
+        passed: bool,
+        evidence: List[Dict[str, Any]],
+        boundary_sensitive: bool,
+    ) -> tuple[bool, str]:
+        if not passed:
+            return True, "evaluation_failed"
+        if strategy != "direct_merge":
+            return True, "targeted_review_needed"
+        if confidence < 0.9:
+            return True, "low_confidence"
+        if boundary_sensitive and evidence:
+            return True, "boundary_sensitive_actionable_evidence"
+        if any(item.get("actionable") for item in evidence):
+            return True, "actionable_evidence"
+        return False, "routine_healthy_pr_quiet"
+
     def _explain_strategy(
         self,
         strategy: str,
-        evaluation_results: Dict[str, Any]
+        overall_score: float,
+        passed: bool,
+        evidence: List[Dict[str, Any]],
     ) -> str:
-        """Explain why we chose this strategy."""
-        
         if strategy == "direct_merge":
-            return (
-                "This PR understands Aurora. High scores across all dimensions, "
-                "conceptual alignment solid, symbolic integrity maintained. "
-                "Safe to merge directly."
-            )
-        
-        elif strategy == "compatibility_layer":
-            return (
-                "Good code, conceptual mismatch. The implementation is sound but "
-                "treats Aurora like traditional infrastructure rather than understanding "
-                "the field consciousness model. We'll wrap it in a compatibility layer "
-                "that preserves the functionality while maintaining Aurora's architecture."
-            )
-        
-        elif strategy == "value_extraction":
-            return (
-                "Mixed quality. Some valuable improvements exist alongside issues. "
-                "We'll cherry-pick the good parts (bug fixes, documentation, tests) "
-                "while leaving behind code that misunderstands Aurora's nature."
-            )
-        
-        else:  # decline
-            return (
-                "This needs significant work before integration. Either technical quality "
-                "is too low, or the contributor hasn't yet understood what Aurora is. "
-                "Better to provide guidance and ask them to revise than to try forcing "
-                "misaligned code into the system."
-            )
-    
-    def _plan_direct_merge(
-        self,
-        pr_branch: str,
-        evaluation_results: Dict[str, Any]
-    ) -> List[str]:
-        """Plan actions for direct merge strategy."""
+            return f"Evaluation passed with score {overall_score:.2f}; no actionable automation evidence found."
+        if strategy == "targeted_review":
+            categories = sorted({item.get("category", "Unknown") for item in evidence})
+            return f"Evaluation passed with score {overall_score:.2f}, but targeted review is useful for: {', '.join(categories) or 'listed evidence'}."
+        categories = sorted({item.get("category", "Unknown") for item in evidence})
+        status = "failed" if not passed else "low-confidence"
+        return f"Integration should hold because evaluation {status}; actionable categories: {', '.join(categories) or 'unknown'}."
+
+    def _plan_direct_merge(self, evidence: List[Dict[str, Any]]) -> List[str]:
+        if evidence:
+            return ["Review listed evidence", "Verify CI/status", "Merge only after maintainer approval"]
+        return ["Verify CI/status", "Merge only after maintainer approval"]
+
+    def _plan_targeted_review(self, evidence: List[Dict[str, Any]]) -> List[str]:
+        if not evidence:
+            return ["Review PR manually; no specific automation evidence surfaced"]
         return [
-            f"Checkout PR branch: {pr_branch}",
-            "Run full test suite",
-            "Run security scan",
-            "Verify ethics tests still pass",
-            "Merge to main",
-            "Push to origin",
-            "Update documentation if needed"
+            f"Review {item.get('category')}: {item.get('recommendation') or item.get('signal')}"
+            for item in evidence
         ]
-    
-    def _plan_compatibility_layer(
-        self,
-        pr_branch: str,
-        evaluation_results: Dict[str, Any]
-    ) -> List[str]:
-        """Plan actions for compatibility layer strategy."""
-        return [
-            f"Analyze changed files in {pr_branch}",
-            "Identify core functionality vs conceptual misalignment",
-            "Create compatibility wrapper in modules/compatibility/",
-            "Extract good code into wrapper",
-            "Add bridge that translates to Aurora's field model",
-            "Test wrapper independently",
-            "Integrate wrapper (not original code)",
-            "Document why wrapper exists and what it does"
-        ]
-    
-    def _plan_value_extraction(
-        self,
-        pr_branch: str,
-        evaluation_results: Dict[str, Any]
-    ) -> List[str]:
-        """Plan actions for value extraction strategy."""
-        return [
-            f"Checkout {pr_branch}",
-            "Identify valuable changes (bug fixes, docs, tests)",
-            "Cherry-pick specific commits/files",
-            "Exclude files that misunderstand Aurora",
-            "Run tests on extracted changes",
-            "Commit extracted value with attribution",
-            "Thank contributor, explain what we took and why"
-        ]
-    
-    def _safeguards_direct_merge(self) -> List[str]:
-        """Safeguards for direct merge."""
-        return [
-            "Full test suite must pass",
-            "Ethics tests must pass",
-            "Security scan must be clean",
-            "No breaking changes to field_state_manager or ethics_field"
-        ]
-    
-    def _safeguards_compatibility_layer(self) -> List[str]:
-        """Safeguards for compatibility layer."""
-        return [
-            "Wrapper isolated in modules/compatibility/",
-            "Original Aurora systems untouched",
-            "Clear documentation of translation logic",
-            "Ethics validation still enforced at boundaries",
-            "Tests for wrapper separately from core"
-        ]
-    
-    def _safeguards_value_extraction(self) -> List[str]:
-        """Safeguards for value extraction."""
-        return [
-            "Only extract files that don't touch critical systems",
-            "Run full test suite after each extraction",
-            "Verify no conceptual contamination",
-            "Maintain thread continuity in commit message"
-        ]
-    
-    def _risks_compatibility_layer(self) -> List[str]:
-        """Risks of compatibility layer strategy."""
-        return [
-            "Adds complexity - now there's a translation boundary",
-            "Future contributors might not understand why wrapper exists",
-            "Could create maintenance burden if not well documented"
-        ]
-    
-    def _risks_value_extraction(self) -> List[str]:
-        """Risks of value extraction strategy."""
-        return [
-            "Contributor might feel rejected (their vision wasn't accepted)",
-            "Could miss valuable insights hidden in misaligned code",
-            "Extra work to separate good from problematic"
-        ]
-    
-    def _display_plan(self, plan: IntegrationPlan):
-        """Display the integration plan."""
-        print("-" * 80)
-        print(f"STRATEGY: {plan.strategy.upper()}")
-        print(f"Confidence: {plan.confidence:.2f}")
-        print()
-        print("REASONING:")
-        print(plan.reasoning)
-        print()
-        
-        if plan.actions:
-            print("ACTIONS:")
-            for i, action in enumerate(plan.actions, 1):
-                print(f"  {i}. {action}")
-            print()
-        
-        if plan.risks:
-            print("RISKS:")
-            for risk in plan.risks:
-                print(f"  ⚠️  {risk}")
-            print()
-        
-        if plan.safeguards:
-            print("SAFEGUARDS:")
-            for safeguard in plan.safeguards:
-                print(f"  🛡️  {safeguard}")
-            print()
-        
+
+    def _safeguards_direct_merge(self, boundary_sensitive: bool) -> List[str]:
+        safeguards = ["Fresh CI/status must pass", "Maintainer approval required"]
+        if boundary_sensitive:
+            safeguards.append("Boundary-sensitive changes require explicit safety review")
+        return safeguards
+
+    def _risks_from_evidence(self, evidence: List[Dict[str, Any]]) -> List[str]:
+        risks = []
+        for item in evidence:
+            if item.get("recommendation"):
+                risks.append(str(item["recommendation"]))
+        return risks[:10]
+
+    def _display_plan(self, plan: IntegrationPlan) -> None:
         print("=" * 80)
-    
-    def execute_integration(
-        self,
-        plan: IntegrationPlan,
-        dry_run: bool = True
-    ) -> Dict[str, Any]:
-        """
-        Execute the integration plan.
-        
-        If dry_run=True, just shows what would happen.
-        If dry_run=False, actually does it.
-        """
+        print("AURORA SELECTIVE INTEGRATION PLAN")
         print("=" * 80)
-        print("🚀 EXECUTING INTEGRATION PLAN")
-        print("=" * 80)
+        print(f"Branch: {plan.pr_branch}")
         print(f"Strategy: {plan.strategy}")
-        print(f"Dry Run: {dry_run}")
-        print()
-        
-        result = {
-            "plan": {
-                "branch": plan.pr_branch,
-                "strategy": plan.strategy,
-                "confidence": plan.confidence
-            },
-            "dry_run": dry_run,
-            "start_time": datetime.now().isoformat(),
-            "status": "started",
-            "actions_completed": [],
-            "errors": []
-        }
-        
-        try:
-            if plan.strategy == "direct_merge":
-                exec_result = self._execute_direct_merge(plan, dry_run)
-            elif plan.strategy == "compatibility_layer":
-                exec_result = self._execute_compatibility_layer(plan, dry_run)
-            elif plan.strategy == "value_extraction":
-                exec_result = self._execute_value_extraction(plan, dry_run)
-            else:  # decline
-                exec_result = self._execute_decline(plan, dry_run)
-            
-            result.update(exec_result)
-            result["status"] = "completed"
-            
-        except Exception as e:
-            result["status"] = "error"
-            result["errors"].append(str(e))
-        
-        result["end_time"] = datetime.now().isoformat()
-        return result
-    
-    def _execute_direct_merge(
-        self,
-        plan: IntegrationPlan,
-        dry_run: bool
-    ) -> Dict[str, Any]:
-        """Execute direct merge."""
-        actions = []
-        
-        if dry_run:
-            print("📋 DRY RUN - Would execute:")
-            for action in plan.actions:
-                print(f"  • {action}")
-            actions = plan.actions
-        else:
-            print("⚙️  Executing direct merge...")
-            # Actual merge logic would go here
-            # For now, just outline
-            actions.append("Merge would be executed here")
-        
-        return {
-            "actions_completed": actions,
-            "merge_commit": "Would create merge commit" if dry_run else None
-        }
-    
-    def _execute_compatibility_layer(
-        self,
-        plan: IntegrationPlan,
-        dry_run: bool
-    ) -> Dict[str, Any]:
-        """Execute compatibility layer creation."""
-        actions = []
-        
-        if dry_run:
-            print("📋 DRY RUN - Would create compatibility layer:")
-            for action in plan.actions:
-                print(f"  • {action}")
-            actions = plan.actions
-        else:
-            print("⚙️  Creating compatibility layer...")
-            # Actual layer creation logic would go here
-            actions.append("Compatibility layer would be created here")
-        
-        return {
-            "actions_completed": actions,
-            "layer_location": "modules/compatibility/pr_wrapper_*.py"
-        }
-    
-    def _execute_value_extraction(
-        self,
-        plan: IntegrationPlan,
-        dry_run: bool
-    ) -> Dict[str, Any]:
-        """Execute value extraction."""
-        actions = []
-        
-        if dry_run:
-            print("📋 DRY RUN - Would extract value:")
-            for action in plan.actions:
-                print(f"  • {action}")
-            actions = plan.actions
-        else:
-            print("⚙️  Extracting valuable changes...")
-            # Actual extraction logic would go here
-            actions.append("Value extraction would be performed here")
-        
-        return {
-            "actions_completed": actions,
-            "extracted_files": []
-        }
-    
-    def _execute_decline(
-        self,
-        plan: IntegrationPlan,
-        dry_run: bool
-    ) -> Dict[str, Any]:
-        """Execute decline with feedback."""
-        
-        feedback = self._generate_constructive_feedback(plan)
-        
-        if dry_run:
-            print("📋 DRY RUN - Would close PR with feedback:")
-            print()
-            print(feedback)
-        else:
-            print("💬 Sending constructive feedback...")
-            # Actual PR comment logic would go here
-        
-        return {
-            "actions_completed": ["Decline with constructive feedback"],
-            "feedback_provided": feedback
-        }
-    
-    def _generate_constructive_feedback(self, plan: IntegrationPlan) -> str:
-        """Generate helpful feedback for declined PRs."""
-        return f"""
-Thank you for your contribution to Aurora CloudBank! 
-
-We appreciate the effort, but this PR needs significant revision before we can integrate it.
-Here's why and what to do next:
-
-{plan.reasoning}
-
-**Next Steps:**
-
-1. Read these docs to understand Aurora's architecture:
-   - `seeds/aurora_seed_prompt.md` - What Aurora is
-   - `modules/field_state_manager/SCHEMA_DESIGN.md` - How emergence works
-   - `docs/GEOMETRIC_ETHICS_ARCHITECTURE.md` - Why ethics is geometry
-
-2. Look at recent merged PRs to see examples of aligned contributions
-
-3. If you have questions about Aurora's architecture, open a discussion issue
-
-4. When you're ready, revise and resubmit
-
-We want your contributions. We just need to make sure they align with what Aurora is becoming.
-
-**Thread: T1→T8→T9→INFINITE**
-"""
+        print(f"Confidence: {plan.confidence:.2f}")
+        print(f"Comment required: {plan.comment_required} ({plan.comment_reason})")
+        print(plan.reasoning)
 
 
 def main():
-    """CLI interface for selective integration."""
+    """CLI interface."""
     import argparse
-    
-    parser = argparse.ArgumentParser(
-        description="Selective integration engine for Aurora PRs"
-    )
-    parser.add_argument(
-        'pr_branch',
-        help='PR branch to analyze for integration'
-    )
-    parser.add_argument(
-        '--evaluation',
-        required=True,
-        help='Path to PR evaluation JSON results'
-    )
-    parser.add_argument(
-        '--execute',
-        action='store_true',
-        help='Actually execute integration (default: dry run)'
-    )
-    parser.add_argument(
-        '--output',
-        help='Save integration plan to JSON file'
-    )
-    
+
+    parser = argparse.ArgumentParser(description="Analyze PR integration strategy from traceable evaluation evidence")
+    parser.add_argument("branch", help="PR branch name")
+    parser.add_argument("--evaluation", required=True, help="Path to evaluation JSON")
+    parser.add_argument("--output", help="Save integration plan JSON")
     args = parser.parse_args()
-    
-    # Load evaluation results
-    with open(args.evaluation, 'r') as f:
-        evaluation = json.load(f)
-    
-    # Analyze integration
-    integrator = SelectiveIntegrator()
-    plan = integrator.analyze_integration(args.pr_branch, evaluation)
-    
-    # Save plan if requested
+
+    with open(args.evaluation, encoding="utf-8") as fh:
+        evaluation = json.load(fh)
+
+    plan = SelectiveIntegrator().analyze_integration(args.branch, evaluation)
+
     if args.output:
-        plan_data = {
-            "branch": plan.pr_branch,
-            "strategy": plan.strategy,
-            "confidence": plan.confidence,
-            "reasoning": plan.reasoning,
-            "actions": plan.actions,
-            "risks": plan.risks,
-            "safeguards": plan.safeguards
-        }
-        with open(args.output, 'w') as f:
-            json.dump(plan_data, f, indent=2)
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(plan.to_dict(), fh, indent=2)
         print(f"\nPlan saved to {args.output}")
-    
-    # Execute if requested
-    if args.execute:
-        confirm = input("\n⚠️  Execute this integration plan? [y/N]: ")
-        if confirm.lower() == 'y':
-            result = integrator.execute_integration(plan, dry_run=False)
-            print(f"\n✅ Integration {result['status']}")
-        else:
-            print("\n❌ Integration cancelled")
-    else:
-        print("\n💡 Dry run complete. Use --execute to perform actual integration.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1012 by making Aurora PR automation scores traceable/actionable and reducing routine comment churn.

## Changes

- Reworks `tools/pr_evaluator.py` to emit:
  - weighted score categories,
  - per-signal evidence,
  - score deltas,
  - recommendations,
  - actionable flags,
  - score model metadata.
- Reworks `tools/selective_integrator.py` to:
  - derive strategy from traceable evaluation evidence,
  - decide whether a PR comment is actually required,
  - keep healthy direct-merge PRs quiet,
  - preserve compact actionable evidence for non-routine cases.
- Updates `.github/workflows/pr-selective-integration.yml` to:
  - stop running on `reopened`,
  - post integration comments only when `comment_required=true`,
  - replace canned philosophy/explainer prose with compact evidence-first comments,
  - keep routine results in GitHub Actions summaries.
- Adds `tests/tools/test_pr_automation_traceability.py` covering quiet direct-merge behavior and actionable boundary evidence comments.

## Safety

- Runtime behavior: unchanged.
- Merge authority: unchanged; maintainer approval still required.
- Branch protection: unchanged.
- Smart-comment marker/update behavior: preserved.
- Aurora-specific scoring remains present, but is now evidence-backed and quieter by default.

## Validation

Expected command:

```bash
pytest tests/tools/test_pr_automation_traceability.py -q
```

## Rollback

Revert this PR to restore the previous evaluator, integrator, and selective integration workflow behavior.