### PR TITLE
feat(ord): ORD-Series Drone Fleet policy family (recovered Promotion Workbench v0.5.0)

### DIFF
--- a/docs/ord/L1L2_SYSTEM__ORD_DroneDispatch__REFactorPlan__v0.5.0__2026-03-10.md
+++ b/docs/ord/L1L2_SYSTEM__ORD_DroneDispatch__REFactorPlan__v0.5.0__2026-03-10.md
@@ -1,0 +1,8 @@
+# L1L2_SYSTEM__ORD_DroneDispatch__REFactorPlan__v0.5.0__2026-03-10
+
+1. Freeze the threshold registry schema and ownership model.
+2. Add loader validation for malformed or incomplete registry values.
+3. Split packaging policy from transport policy if Wisp grows beyond delivery guarantees.
+4. Add adapter contracts for destination trust evidence and contamination evidence.
+5. Add golden receipts for canonical mission profiles.
+6. Remove symbolic pilot naming from executable surfaces unless explicitly needed as metadata.

--- a/docs/ord/L1L2_SYSTEM__ORD_DroneDispatch__SPEC__v0.5.0__2026-03-10.md
+++ b/docs/ord/L1L2_SYSTEM__ORD_DroneDispatch__SPEC__v0.5.0__2026-03-10.md
@@ -1,0 +1,67 @@
+# L1L2_SYSTEM__ORD_DroneDispatch__SPEC__v0.5.0__2026-03-10
+
+Status: draft_specification  
+Anchor: EOS_SEED_ORION  
+Ethics: Picard_Delta_3  
+Source basis: `staging/legacy_pack/SOURCE__Recovered__ORD_DroneDispatch__v0.1__2026-03-10.py`
+
+## Purpose
+
+ORD Drone Dispatch is a policy-governed mission router for assigning pre-flight and post-flight controls around a payload operation.
+
+This v0.5.0 pass promotes a clearer architecture statement: **ORD is a deterministic policy family governed by an external threshold registry, plus adapter boundaries and receipts.**
+
+## Stable module family
+
+- `modules/ord/ord_policy_engine.py`
+- `modules/ord/ord_inspection_policy.py`
+- `modules/ord/ord_receipts.py`
+- `modules/ord/ord_threshold_registry.py`
+
+## New governance seam
+
+Threshold ownership now lives in `governance/ORD_THRESHOLD_REGISTRY__v0.5.0__2026-03-10.json`.
+
+Controlled values:
+- reconnaissance threshold
+- inspection threshold
+- secure transport threshold
+- drift threshold
+- quantum seal threshold
+- quarantine violation count
+
+This is the main architectural improvement over v0.4.0. Dispatch and inspection logic now consume reviewable governance values instead of quietly embedding them.
+
+## Canonical system statement
+
+ORD SHOULD be treated as a **policy orchestration layer with pure decision cores, a governance-backed threshold registry, and environment adapters**.
+
+## Hard invariants
+
+- **No L1/L2 bleed:** symbolic identities are metadata, not operational dependencies.
+- **Ethics before integration:** inspection must be able to block integration.
+- **Governance before threshold drift:** threshold values must be reviewable outside runtime logic.
+- **Pure-policy separability:** dispatch and inspection decisions must run without network access.
+- **Receipt discipline:** mission-level output must be serializable into audit-friendly records.
+- **Adapter isolation:** environment-specific bridges belong behind interfaces.
+- **Deterministic ordering:** normalized action lists and serializations must be stable.
+
+## Promotion posture
+
+Promote now as:
+- architecture reference
+- specification candidate
+- governance-backed policy-library candidate
+- testable dispatch and inspection core
+
+Do not promote yet as:
+- station control software
+- autonomous L1 deployment artifact
+- validated perimeter security product
+
+## Open decisions
+
+1. Whether sensitivity classes should remain `STANDARD / CONFIDENTIAL / RESTRICTED` or expand.
+2. Whether Wisp remains a transport-only role or becomes a packaging-policy family.
+3. Which threshold changes require dual approval versus single-owner review.
+4. Which inspection findings must be adapter-provided instead of inferred from payload metadata.

--- a/docs/ord/L1L2_SYSTEM__ORD_DroneDispatch__TEST_VECTOR_SET__v0.5.0__2026-03-10.md
+++ b/docs/ord/L1L2_SYSTEM__ORD_DroneDispatch__TEST_VECTOR_SET__v0.5.0__2026-03-10.md
@@ -1,0 +1,12 @@
+# L1L2_SYSTEM__ORD_DroneDispatch__TEST_VECTOR_SET__v0.5.0__2026-03-10
+
+- TV-001: external write mission -> Delta Scout + Shadowfax + Wisp
+- TV-002: low-risk internal read -> no drones
+- TV-003: untrusted extraction -> Delta Scout + Shadowfax + Gamma Swarm + Wisp
+- TV-004: token-bearing parameters -> restricted sensitivity
+- TV-101: ethics-only finding -> sanitize with ethics patch
+- TV-102: drift exceeds registry threshold -> quarantine + human review
+- TV-103: structure invalid + contamination -> sanitize with repair actions
+- TV-104: drift + ethics -> quarantine + human review
+- TV-201: registry metadata should appear in dispatch special instructions
+- TV-202: default inspection policy should consume registry drift threshold when input leaves it blank

--- a/modules/ord/README.md
+++ b/modules/ord/README.md
@@ -1,0 +1,29 @@
+# ORD-Series Drone Fleet — Policy Family
+
+The Orion Station autonomous MCP validation layer, policy side. Recovered
+from the ORION_ORD Promotion Workbench v0.5.0 (2026-03-10) and integrated
+per its own promotion queue:
+
+| Component | Role |
+|---|---|
+| `ord_threshold_registry.py` | Governance-backed policy config seam (defaults mirror `governance/ORD_THRESHOLD_REGISTRY__v0.5.0__2026-03-10.json`) |
+| `ord_policy_engine.py` | Dispatch core — builds `DispatchOrder`s from `MissionBrief`s (which drones fly for which mission risk/destination/sensitivity) |
+| `ord_inspection_policy.py` | Inspection core — quarantine and sanitization decisions (ORD-3 Shadowfax doctrine) |
+| `ord_receipts.py` | Audit support — canonical JSON + SHA-256 receipts |
+
+The fleet **entity** layer (ORD-1 Gamma Swarm / ORD-2 Delta Scout /
+ORD-3 Shadowfax registry accessors) already lives in `src/entities/fleet/`.
+This package supplies the policy decisions those entities execute.
+
+Security posture (review-fix lineage carried in from the workbench):
+hostname-based destination authority checks, token-aware sensitivity
+classification across nested parameters, URL-spoofing and keyword-boundary
+regression tests (`tests/ord/`, marked `critical`).
+
+Posture per the workbench: governance-backed policy-library candidate.
+Wiring it into live MCP dispatch surfaces is a separate, explicit step.
+
+Specs: `docs/ord/` (SPEC, RefactorPlan, TEST_VECTOR_SET, all v0.5.0).
+Legacy recovered sources remain in workspace staging only
+(`_staging/orion_ord_review_fix/package/staging/legacy_pack/`), per the
+promotion queue.

--- a/modules/ord/__init__.py
+++ b/modules/ord/__init__.py
@@ -1,0 +1,59 @@
+"""ORD-Series Drone Fleet — governance-backed policy family.
+
+The station's autonomous MCP validation layer (L1 Orion Station, security /
+validation infrastructure):
+
+- ORD-1 Gamma Swarm — response sanitization & error correction
+- ORD-2 Delta Scout — pre-flight reconnaissance & threat assessment
+- ORD-3 Shadowfax  — response inspection & quarantine decisions
+
+This package is the policy layer (threshold registry, dispatch policy
+engine, inspection policy, audit receipts). The fleet entity layer lives in
+``src/entities/fleet`` (drone registry accessors). Specs: ``docs/ord/``.
+
+Recovered from the ORION_ORD Promotion Workbench v0.5.0 (2026-03-10)
+salvage; integrated 2026-06-12.
+"""
+
+from modules.ord.ord_inspection_policy import (
+    InspectionInput,
+    InspectionReport,
+    OrdInspectionPolicy,
+    QuarantineDecision,
+    SanitizationAction,
+)
+from modules.ord.ord_policy_engine import (
+    DispatchOrder,
+    DispatchPolicy,
+    DroneType,
+    MissionBrief,
+    OrdPolicyEngine,
+    SensitivityClass,
+    TransportRequirement,
+)
+from modules.ord.ord_receipts import canonical_json, canonical_sha256
+from modules.ord.ord_threshold_registry import (
+    EscalationRule,
+    ThresholdRegistry,
+    load_default_registry,
+)
+
+__all__ = [
+    "DispatchOrder",
+    "DispatchPolicy",
+    "DroneType",
+    "EscalationRule",
+    "InspectionInput",
+    "InspectionReport",
+    "MissionBrief",
+    "OrdInspectionPolicy",
+    "OrdPolicyEngine",
+    "QuarantineDecision",
+    "SanitizationAction",
+    "SensitivityClass",
+    "ThresholdRegistry",
+    "TransportRequirement",
+    "canonical_json",
+    "canonical_sha256",
+    "load_default_registry",
+]

--- a/modules/ord/governance/ORD_THRESHOLD_REGISTRY__v0.5.0__2026-03-10.json
+++ b/modules/ord/governance/ORD_THRESHOLD_REGISTRY__v0.5.0__2026-03-10.json
@@ -1,0 +1,46 @@
+{
+  "registry_id": "ORD_THRESHOLD_REGISTRY",
+  "version": "0.5.0",
+  "status": "draft_governance_candidate",
+  "scope": "ORD dispatch, inspection, transport, and escalation policy",
+  "thresholds": {
+    "reconnaissance_threshold": 0.4,
+    "inspection_threshold": 0.4,
+    "secure_transport_threshold": 0.4,
+    "drift_threshold": 0.005,
+    "quantum_seal_threshold": 0.6,
+    "quarantine_violation_count": 3
+  },
+  "sensitivity_keywords": {
+    "auth": "RESTRICTED",
+    "credential": "RESTRICTED",
+    "key": "RESTRICTED",
+    "secret": "RESTRICTED",
+    "token": "RESTRICTED"
+  },
+  "sensitivity_match_mode": "tokenized_structured_match",
+  "escalation_rules": [
+    {
+      "rule_id": "ER-001",
+      "when": "drift_score >= drift_threshold",
+      "action": "require_human_review",
+      "rationale": "semantic drift can silently break provenance"
+    },
+    {
+      "rule_id": "ER-002",
+      "when": "ethics_violation_count > 0 and drift_score >= drift_threshold",
+      "action": "force_quarantine",
+      "rationale": "compound ethics and drift failure should not auto-integrate"
+    },
+    {
+      "rule_id": "ER-003",
+      "when": "risk_level >= secure_transport_threshold or restricted sensitivity",
+      "action": "require_secure_transport",
+      "rationale": "sensitive payloads need stable packaging guarantees"
+    }
+  ],
+  "ownership": {
+    "threshold_owner": "L3 governance / ORD review board",
+    "code_role": "consume registry, do not silently redefine it"
+  }
+}

--- a/modules/ord/governance/ORD_THRESHOLD_REGISTRY__v0.5.0__2026-03-10.md
+++ b/modules/ord/governance/ORD_THRESHOLD_REGISTRY__v0.5.0__2026-03-10.md
@@ -1,0 +1,35 @@
+# ORD_THRESHOLD_REGISTRY__v0.5.0__2026-03-10
+
+Status: draft_governance_candidate  
+Anchor: EOS_SEED_ORION  
+Ethics: Picard_Delta_3
+
+## Purpose
+
+This registry externalizes the main ORD thresholds so dispatch and inspection logic stop hiding governance decisions in code.
+
+## Controlled values
+
+- `reconnaissance_threshold = 0.40`
+- `inspection_threshold = 0.40`
+- `secure_transport_threshold = 0.40`
+- `drift_threshold = 0.005`
+- `quantum_seal_threshold = 0.60`
+- `quarantine_violation_count = 3`
+
+## Why this matters
+
+v0.4.0 still worked, but the thresholds lived inside code like tiny policy goblins wearing fake moustaches. This pass moves them into reviewable governance.
+
+## Rules
+
+1. Code may consume this registry.
+2. Code may not silently redefine these values.
+3. Threshold changes require a version bump and receipt note.
+4. Drift + ethics failure remains an explicit escalation path.
+5. Restricted-sensitivity markers force secure transport consideration.
+6. Sensitivity markers should be matched on token boundaries over structured keys and values, not arbitrary substrings.
+
+## Open follow-up
+
+Threshold ownership should be assigned to a named review function before any L1-adjacent deployment use.

--- a/modules/ord/ord_inspection_policy.py
+++ b/modules/ord/ord_inspection_policy.py
@@ -1,0 +1,190 @@
+"""Deterministic ORD inspection and quarantine policy.
+
+Status: draft_policy_library
+Anchor: EOS_SEED_ORION
+Ethics: Picard_Delta_3
+
+This module converts normalized inspection findings into quarantine,
+sanitization, and escalation decisions without relying on external services.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+from modules.ord.ord_threshold_registry import ThresholdRegistry, load_default_registry
+
+
+class QuarantineDecision(Enum):
+    INTEGRATE = "integrate"
+    SANITIZE = "sanitize"
+    QUARANTINE = "quarantine"
+    REJECT = "reject"
+
+
+class SanitizationAction(Enum):
+    STRIP_MALICIOUS = "strip_malicious_code"
+    REDACT_PII = "redact_pii"
+    FIX_STRUCTURE = "fix_malformed_structure"
+    APPLY_ETHICS_PATCH = "apply_ethics_patch"
+    NORMALIZE_ENCODING = "normalize_encoding"
+
+
+@dataclass(frozen=True)
+class InspectionInput:
+    mission_id: str
+    structure_valid: bool
+    contamination_detected: bool
+    contamination_type: Optional[str] = None
+    drift_score: float = 0.001
+    drift_threshold: Optional[float] = None
+    ethics_violations: List[str] = field(default_factory=list)
+    pii_detected: bool = False
+    encoding_anomaly: bool = False
+
+
+@dataclass(frozen=True)
+class InspectionReport:
+    mission_id: str
+    decision: QuarantineDecision
+    structure_valid: bool
+    contamination_detected: bool
+    contamination_type: Optional[str]
+    drift_score: float
+    ethics_compliant: bool
+    ethics_violations: List[str]
+    requires_sanitization: List[SanitizationAction]
+    human_review_required: bool
+    reason: str
+
+
+class OrdInspectionPolicy:
+    def __init__(self, threshold_registry: Optional[ThresholdRegistry] = None) -> None:
+        self.registry = threshold_registry or load_default_registry()
+
+    def inspect(self, inspection_input: InspectionInput) -> InspectionReport:
+        sanitization_needed: List[SanitizationAction] = []
+        violations: List[str] = []
+        effective_drift_threshold = (
+            inspection_input.drift_threshold
+            if inspection_input.drift_threshold is not None
+            else self.registry.drift_threshold
+        )
+
+        if not inspection_input.structure_valid:
+            sanitization_needed.append(SanitizationAction.FIX_STRUCTURE)
+            violations.append("structure_invalid")
+
+        if inspection_input.contamination_detected:
+            sanitization_needed.append(SanitizationAction.STRIP_MALICIOUS)
+            violations.append(f"contamination:{inspection_input.contamination_type or 'unknown'}")
+
+        drift_exceeded = inspection_input.drift_score >= effective_drift_threshold
+        if drift_exceeded:
+            violations.append(
+                f"drift_exceeded:{inspection_input.drift_score:.6f}>={effective_drift_threshold:.6f}"
+            )
+
+        ethics_compliant = len(inspection_input.ethics_violations) == 0
+        if not ethics_compliant:
+            sanitization_needed.append(SanitizationAction.APPLY_ETHICS_PATCH)
+            violations.extend([f"ethics:{item}" for item in inspection_input.ethics_violations])
+
+        if inspection_input.pii_detected:
+            sanitization_needed.append(SanitizationAction.REDACT_PII)
+            violations.append("pii_detected")
+
+        if inspection_input.encoding_anomaly:
+            sanitization_needed.append(SanitizationAction.NORMALIZE_ENCODING)
+            violations.append("encoding_anomaly")
+
+        sanitization_needed = self._stable_unique_actions(sanitization_needed)
+        decision, reason, human_review = self._determine_decision(
+            contamination=inspection_input.contamination_detected,
+            drift_exceeded=drift_exceeded,
+            ethics_compliant=ethics_compliant,
+            violations=violations,
+            sanitization_needed=sanitization_needed,
+        )
+
+        return InspectionReport(
+            mission_id=inspection_input.mission_id,
+            decision=decision,
+            structure_valid=inspection_input.structure_valid,
+            contamination_detected=inspection_input.contamination_detected,
+            contamination_type=inspection_input.contamination_type,
+            drift_score=inspection_input.drift_score,
+            ethics_compliant=ethics_compliant,
+            ethics_violations=list(inspection_input.ethics_violations),
+            requires_sanitization=sanitization_needed,
+            human_review_required=human_review,
+            reason=reason,
+        )
+
+    def _determine_decision(
+        self,
+        contamination: bool,
+        drift_exceeded: bool,
+        ethics_compliant: bool,
+        violations: List[str],
+        sanitization_needed: List[SanitizationAction],
+    ) -> tuple[QuarantineDecision, str, bool]:
+        if contamination and SanitizationAction.STRIP_MALICIOUS not in sanitization_needed:
+            return (
+                QuarantineDecision.REJECT,
+                "Critical contamination detected, cannot sanitize",
+                False,
+            )
+
+        if len(violations) >= self.registry.quarantine_violation_count or (
+            drift_exceeded and not ethics_compliant and self.registry.human_review_drift_plus_ethics
+        ):
+            return (
+                QuarantineDecision.QUARANTINE,
+                f"Multiple violations require human review: {', '.join(violations[:3])}",
+                True,
+            )
+
+        if drift_exceeded:
+            return (
+                QuarantineDecision.QUARANTINE,
+                "Semantic drift exceeds threshold, requires human validation",
+                True,
+            )
+
+        if sanitization_needed:
+            actions = ", ".join(action.value for action in sanitization_needed)
+            return (
+                QuarantineDecision.SANITIZE,
+                f"Sanitization required: {actions}",
+                False,
+            )
+
+        return (
+            QuarantineDecision.INTEGRATE,
+            "All validation checks passed",
+            False,
+        )
+
+    @staticmethod
+    def _stable_unique_actions(actions: List[SanitizationAction]) -> List[SanitizationAction]:
+        order = {action: idx for idx, action in enumerate(SanitizationAction)}
+        deduped = []
+        seen = set()
+        for action in actions:
+            if action not in seen:
+                seen.add(action)
+                deduped.append(action)
+        deduped.sort(key=lambda item: order[item])
+        return deduped
+
+
+__all__ = [
+    "InspectionInput",
+    "InspectionReport",
+    "OrdInspectionPolicy",
+    "QuarantineDecision",
+    "SanitizationAction",
+]

--- a/modules/ord/ord_policy_engine.py
+++ b/modules/ord/ord_policy_engine.py
@@ -1,0 +1,254 @@
+"""Deterministic ORD dispatch policy engine.
+
+Status: draft_policy_library
+Anchor: EOS_SEED_ORION
+Ethics: Picard_Delta_3
+
+This module intentionally removes environment-specific dependencies from the
+recovered ORD prototype. It exposes a pure policy surface suitable for unit
+tests, receipts, and later adapter injection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import urlsplit
+
+from modules.ord.ord_threshold_registry import ThresholdRegistry, load_default_registry
+
+
+class DroneType(Enum):
+    GAMMA_SWARM = "ORD-1 Gamma Swarm"
+    DELTA_SCOUT = "ORD-2 Delta Scout"
+    SHADOWFAX = "ORD-3 Shadowfax"
+    WISP = "ORD-4 Wisp"
+
+
+class SensitivityClass(Enum):
+    STANDARD = "STANDARD"
+    CONFIDENTIAL = "CONFIDENTIAL"
+    RESTRICTED = "RESTRICTED"
+
+
+@dataclass(frozen=True)
+class MissionBrief:
+    mission_id: str
+    tool_name: str
+    risk_level: float
+    destination: str
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TransportRequirement:
+    encryption: str
+    tamper_evident: bool
+    sensitivity: SensitivityClass
+    quantum_seal_required: bool
+
+
+@dataclass(frozen=True)
+class DispatchOrder:
+    mission_id: str
+    drones_required: List[DroneType]
+    deployment_phase: Dict[str, List[DroneType]]
+    priority: int
+    transport_requirement: Optional[TransportRequirement]
+    special_instructions: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DispatchPolicy:
+    threshold_registry: ThresholdRegistry = field(default_factory=load_default_registry)
+    write_tools: List[str] = field(default_factory=lambda: [
+        "create_branch", "create_or_update_file", "push_files",
+        "create_issue", "create_pull_request", "add_issue_comment",
+        "update_issue", "update_pull_request",
+    ])
+    destructive_tools: List[str] = field(default_factory=lambda: [
+        "delete_file", "merge_pull_request", "close_issue",
+    ])
+    data_extraction_tools: List[str] = field(default_factory=lambda: [
+        "fetch_url", "get_file_contents", "search_files",
+    ])
+    sensitive_tools: List[str] = field(default_factory=lambda: [
+        "push_files", "create_or_update_file",
+    ])
+    trusted_domains: List[str] = field(default_factory=lambda: [
+        "api.github.com", "github.com", "api.anthropic.com", "claude.ai",
+    ])
+    internal_patterns: List[str] = field(default_factory=lambda: [
+        "localhost", "127.0.0.1", "aurora-internal", "orion-station",
+    ])
+
+
+class OrdPolicyEngine:
+    def __init__(self, policy: Optional[DispatchPolicy] = None) -> None:
+        self.policy = policy or DispatchPolicy()
+        self.registry = self.policy.threshold_registry
+
+    def create_dispatch_order(self, mission: MissionBrief) -> DispatchOrder:
+        drones_required: List[DroneType] = []
+        pre_flight: List[DroneType] = []
+        post_flight: List[DroneType] = []
+        special_instructions: Dict[str, Any] = {
+            "threshold_registry": {
+                "registry_id": self.registry.registry_id,
+                "version": self.registry.version,
+            }
+        }
+
+        is_external = not self._is_internal_destination(mission.destination)
+        is_trusted = self._is_trusted_destination(mission.destination)
+
+        if self._requires_reconnaissance(mission.tool_name, is_external, is_trusted, mission.risk_level):
+            self._append_unique(drones_required, DroneType.DELTA_SCOUT)
+            self._append_unique(pre_flight, DroneType.DELTA_SCOUT)
+            special_instructions["delta_scout"] = {
+                "full_scan": mission.risk_level >= self.registry.quantum_seal_threshold,
+                "ssl_verify": True,
+                "latency_threshold_ms": 5000,
+                "threat_abort_threshold": self.registry.quantum_seal_threshold,
+            }
+
+        if self._requires_inspection(mission.tool_name, is_external, mission.risk_level):
+            self._append_unique(drones_required, DroneType.SHADOWFAX)
+            self._append_unique(post_flight, DroneType.SHADOWFAX)
+            special_instructions["shadowfax"] = {
+                "drift_threshold": self.registry.drift_threshold,
+                "ethics_scan": True,
+                "structure_validation": True,
+                "quarantine_on_drift": mission.risk_level >= self.registry.quantum_seal_threshold,
+            }
+
+        if self._requires_sanitization(mission.tool_name, is_trusted, mission.risk_level):
+            self._append_unique(drones_required, DroneType.GAMMA_SWARM)
+            self._append_unique(post_flight, DroneType.GAMMA_SWARM)
+            special_instructions["gamma_swarm"] = {
+                "strip_scripts": True,
+                "redact_pii": self._pii_detection_enabled(mission.tool_name),
+                "fix_malformed": True,
+                "aggressive_mode": not is_trusted,
+            }
+
+        transport_requirement = None
+        if self._requires_secure_transport(mission.tool_name, mission.risk_level, mission.parameters):
+            self._append_unique(drones_required, DroneType.WISP)
+            self._append_unique(post_flight, DroneType.WISP)
+            transport_requirement = TransportRequirement(
+                encryption="AES-256",
+                tamper_evident=True,
+                quantum_seal_required=mission.risk_level >= self.registry.quantum_seal_threshold,
+                sensitivity=self.classify_data_sensitivity(mission.tool_name, mission.parameters),
+            )
+            special_instructions["wisp"] = {
+                "encryption": transport_requirement.encryption,
+                "tamper_evident": transport_requirement.tamper_evident,
+                "quantum_seal": transport_requirement.quantum_seal_required,
+                "data_sensitivity": transport_requirement.sensitivity.value,
+            }
+
+        return DispatchOrder(
+            mission_id=mission.mission_id,
+            drones_required=drones_required,
+            deployment_phase={"pre_flight": pre_flight, "post_flight": post_flight},
+            priority=self._compute_priority(mission.risk_level, mission.tool_name),
+            transport_requirement=transport_requirement,
+            special_instructions=special_instructions,
+        )
+
+    def classify_data_sensitivity(self, tool_name: str, parameters: Mapping[str, Any]) -> SensitivityClass:
+        registry_label = self.registry.sensitivity_for_value(parameters)
+        if registry_label == SensitivityClass.RESTRICTED.value:
+            return SensitivityClass.RESTRICTED
+        if tool_name in self.policy.sensitive_tools:
+            return SensitivityClass.CONFIDENTIAL
+        return SensitivityClass.STANDARD
+
+    def _is_internal_destination(self, destination: str) -> bool:
+        scheme, hostname = self._destination_authority(destination)
+        internal_names = {pattern.lower() for pattern in self.policy.internal_patterns}
+        return scheme in internal_names or hostname in internal_names
+
+    def _is_trusted_destination(self, destination: str) -> bool:
+        _, hostname = self._destination_authority(destination)
+        return any(
+            hostname == domain.lower() or hostname.endswith(f".{domain.lower()}")
+            for domain in self.policy.trusted_domains
+        )
+
+    def _requires_reconnaissance(self, tool_name: str, is_external: bool, is_trusted: bool, risk_level: float) -> bool:
+        return (
+            is_external
+            or (is_external and not is_trusted)
+            or tool_name in self.policy.write_tools
+            or tool_name in self.policy.destructive_tools
+            or risk_level >= self.registry.reconnaissance_threshold
+        )
+
+    def _requires_inspection(self, tool_name: str, is_external: bool, risk_level: float) -> bool:
+        return (
+            is_external
+            or tool_name in self.policy.write_tools
+            or risk_level >= self.registry.inspection_threshold
+        )
+
+    def _requires_sanitization(self, tool_name: str, is_trusted: bool, risk_level: float) -> bool:
+        return tool_name in self.policy.data_extraction_tools and (
+            not is_trusted or risk_level >= self.registry.inspection_threshold
+        )
+
+    def _requires_secure_transport(self, tool_name: str, risk_level: float, parameters: Mapping[str, Any]) -> bool:
+        return (
+            risk_level >= self.registry.secure_transport_threshold
+            or tool_name in self.policy.sensitive_tools
+            or self.registry.sensitivity_for_value(parameters) == SensitivityClass.RESTRICTED.value
+        )
+
+    def _pii_detection_enabled(self, tool_name: str) -> bool:
+        return tool_name in self.policy.data_extraction_tools
+
+    def _compute_priority(self, risk_level: float, tool_name: str) -> int:
+        base = 1
+        if tool_name in self.policy.destructive_tools:
+            base += 4
+        elif tool_name in self.policy.write_tools:
+            base += 2
+        base += min(5, int(risk_level * 5))
+        return max(1, min(10, base))
+
+    @staticmethod
+    def _append_unique(items: List[DroneType], item: DroneType) -> None:
+        if item not in items:
+            items.append(item)
+
+    @staticmethod
+    def _destination_authority(destination: str) -> tuple[str, str]:
+        parsed = urlsplit(destination)
+        scheme = parsed.scheme.lower()
+        hostname = (parsed.hostname or "").lower()
+        if hostname:
+            return scheme, hostname
+
+        raw = destination.strip().lower()
+        if "://" not in raw:
+            authority = raw.split("/", 1)[0]
+            authority = authority.split("?", 1)[0]
+            authority = authority.split("#", 1)[0]
+            authority = authority.split(":", 1)[0]
+            return "", authority
+
+        return scheme, ""
+
+
+__all__ = [
+    "DispatchOrder",
+    "DispatchPolicy",
+    "DroneType",
+    "MissionBrief",
+    "OrdPolicyEngine",
+    "SensitivityClass",
+    "TransportRequirement",
+]

--- a/modules/ord/ord_receipts.py
+++ b/modules/ord/ord_receipts.py
@@ -1,0 +1,32 @@
+"""Deterministic receipt helpers for ORD policy runs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+import hashlib
+import json
+from enum import Enum
+from typing import Any
+
+
+def _normalize(value: Any) -> Any:
+    if is_dataclass(value):
+        return _normalize(asdict(value))
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {key: _normalize(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_normalize(item) for item in value]
+    return value
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(_normalize(value), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = ["canonical_json", "canonical_sha256"]

--- a/modules/ord/ord_threshold_registry.py
+++ b/modules/ord/ord_threshold_registry.py
@@ -1,0 +1,96 @@
+"""Governance-backed ORD threshold registry.
+
+This module isolates threshold values and escalation rules from the policy
+engines so operational posture can be reviewed as configuration rather than
+smuggled in as quiet code assumptions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class EscalationRule:
+    rule_id: str
+    when: str
+    action: str
+    rationale: str
+
+
+@dataclass(frozen=True)
+class ThresholdRegistry:
+    registry_id: str = "ORD_THRESHOLD_REGISTRY"
+    version: str = "0.5.0"
+    reconnaissance_threshold: float = 0.40
+    inspection_threshold: float = 0.40
+    secure_transport_threshold: float = 0.40
+    drift_threshold: float = 0.005
+    quarantine_violation_count: int = 3
+    quantum_seal_threshold: float = 0.60
+    human_review_drift_plus_ethics: bool = True
+    sensitivity_keywords: Dict[str, str] = field(default_factory=lambda: {
+        "secret": "RESTRICTED",
+        "token": "RESTRICTED",
+        "auth": "RESTRICTED",
+        "credential": "RESTRICTED",
+        "key": "RESTRICTED",
+    })
+    escalation_rules: List[EscalationRule] = field(default_factory=lambda: [
+        EscalationRule(
+            rule_id="ER-001",
+            when="drift_score >= drift_threshold",
+            action="require_human_review",
+            rationale="semantic drift can silently break provenance",
+        ),
+        EscalationRule(
+            rule_id="ER-002",
+            when="ethics_violation_count > 0 and drift_score >= drift_threshold",
+            action="force_quarantine",
+            rationale="compound ethics and drift failure should not auto-integrate",
+        ),
+        EscalationRule(
+            rule_id="ER-003",
+            when="risk_level >= secure_transport_threshold or restricted sensitivity",
+            action="require_secure_transport",
+            rationale="sensitive payloads need stable packaging guarantees",
+        ),
+    ])
+
+    def sensitivity_for_value(self, value: Any) -> Optional[str]:
+        for token in self._iter_sensitivity_tokens(value):
+            label = self.sensitivity_keywords.get(token)
+            if label is not None:
+                return label
+        return None
+
+    def sensitivity_for_blob(self, parameter_blob: str) -> Optional[str]:
+        return self.sensitivity_for_value(parameter_blob)
+
+    @staticmethod
+    def _iter_sensitivity_tokens(value: Any) -> List[str]:
+        if isinstance(value, dict):
+            tokens: List[str] = []
+            for key in sorted(value):
+                tokens.extend(ThresholdRegistry._split_tokens(str(key)))
+                tokens.extend(ThresholdRegistry._iter_sensitivity_tokens(value[key]))
+            return tokens
+        if isinstance(value, (list, tuple, set)):
+            tokens: List[str] = []
+            for item in value:
+                tokens.extend(ThresholdRegistry._iter_sensitivity_tokens(item))
+            return tokens
+        return ThresholdRegistry._split_tokens(str(value))
+
+    @staticmethod
+    def _split_tokens(text: str) -> List[str]:
+        return re.findall(r"[a-z0-9]+", text.lower())
+
+
+def load_default_registry() -> ThresholdRegistry:
+    return ThresholdRegistry()
+
+
+__all__ = ["EscalationRule", "ThresholdRegistry", "load_default_registry"]

--- a/tests/ord/test_ord_inspection_policy.py
+++ b/tests/ord/test_ord_inspection_policy.py
@@ -1,0 +1,78 @@
+import unittest
+
+import pytest
+
+from modules.ord.ord_inspection_policy import (
+    InspectionInput,
+    OrdInspectionPolicy,
+    QuarantineDecision,
+    SanitizationAction,
+)
+
+
+pytestmark = pytest.mark.critical
+
+class TestOrdInspectionPolicy(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = OrdInspectionPolicy()
+
+    def test_ethics_violation_sanitize(self) -> None:
+        report = self.policy.inspect(
+            InspectionInput(
+                mission_id="tv-101",
+                structure_valid=True,
+                contamination_detected=False,
+                drift_score=0.001,
+                ethics_violations=["potential_secret_exposure"],
+            )
+        )
+        self.assertEqual(QuarantineDecision.SANITIZE, report.decision)
+        self.assertIn(SanitizationAction.APPLY_ETHICS_PATCH, report.requires_sanitization)
+        self.assertFalse(report.human_review_required)
+
+    def test_drift_exceeded_quarantine(self) -> None:
+        report = self.policy.inspect(
+            InspectionInput(
+                mission_id="tv-102",
+                structure_valid=True,
+                contamination_detected=False,
+                drift_score=0.009,
+                ethics_violations=[],
+            )
+        )
+        self.assertEqual(QuarantineDecision.QUARANTINE, report.decision)
+        self.assertTrue(report.human_review_required)
+
+    def test_structure_and_contamination_sanitize(self) -> None:
+        report = self.policy.inspect(
+            InspectionInput(
+                mission_id="tv-103",
+                structure_valid=False,
+                contamination_detected=True,
+                contamination_type="script_injection",
+                drift_score=0.001,
+                ethics_violations=[],
+            )
+        )
+        self.assertEqual(QuarantineDecision.SANITIZE, report.decision)
+        self.assertEqual(
+            [SanitizationAction.STRIP_MALICIOUS, SanitizationAction.FIX_STRUCTURE],
+            report.requires_sanitization,
+        )
+
+    def test_combined_drift_and_ethics_requires_review(self) -> None:
+        report = self.policy.inspect(
+            InspectionInput(
+                mission_id="tv-104",
+                structure_valid=True,
+                contamination_detected=False,
+                drift_score=0.009,
+                ethics_violations=["potential_key_exposure"],
+            )
+        )
+        self.assertEqual(QuarantineDecision.QUARANTINE, report.decision)
+        self.assertTrue(report.human_review_required)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ord/test_ord_policy_engine.py
+++ b/tests/ord/test_ord_policy_engine.py
@@ -1,0 +1,124 @@
+import unittest
+
+import pytest
+
+from modules.ord.ord_policy_engine import DroneType, MissionBrief, OrdPolicyEngine, SensitivityClass
+from modules.ord.ord_receipts import canonical_json, canonical_sha256
+
+
+pytestmark = pytest.mark.critical
+
+class TestOrdPolicyEngine(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = OrdPolicyEngine()
+
+    def test_external_write_mission(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-001",
+            tool_name="create_or_update_file",
+            risk_level=0.55,
+            destination="https://github.com/example/repo",
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertIn(DroneType.DELTA_SCOUT, order.drones_required)
+        self.assertIn(DroneType.SHADOWFAX, order.drones_required)
+        self.assertIn(DroneType.WISP, order.drones_required)
+        self.assertGreaterEqual(order.priority, 5)
+
+    def test_low_risk_internal_read(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-002",
+            tool_name="read_file",
+            risk_level=0.10,
+            destination="orion-station://registry",
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertEqual([], order.drones_required)
+        self.assertEqual(1, order.priority)
+
+    def test_untrusted_extraction(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-003",
+            tool_name="fetch_url",
+            risk_level=0.45,
+            destination="https://example.net/data",
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertEqual(
+            [DroneType.DELTA_SCOUT, DroneType.SHADOWFAX, DroneType.GAMMA_SWARM, DroneType.WISP],
+            order.drones_required,
+        )
+
+    def test_sensitivity_classification(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-004",
+            tool_name="fetch_url",
+            risk_level=0.20,
+            destination="https://github.com/example/repo",
+            parameters={"token": "redacted"},
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertIsNotNone(order.transport_requirement)
+        self.assertEqual(SensitivityClass.RESTRICTED, order.transport_requirement.sensitivity)
+
+    def test_query_string_does_not_spoof_internal_destination(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-004b",
+            tool_name="fetch_url",
+            risk_level=0.10,
+            destination="https://evil.example/?next=localhost",
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertEqual(
+            [DroneType.DELTA_SCOUT, DroneType.SHADOWFAX, DroneType.GAMMA_SWARM],
+            order.drones_required,
+        )
+
+    def test_spoofed_trusted_domain_does_not_bypass_sanitization(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-004c",
+            tool_name="fetch_url",
+            risk_level=0.10,
+            destination="https://github.com.evil.example/path",
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertIn(DroneType.GAMMA_SWARM, order.drones_required)
+
+    def test_keyword_boundary_does_not_mark_benign_text_restricted(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-004d",
+            tool_name="fetch_url",
+            risk_level=0.10,
+            destination="https://example.net/search",
+            parameters={"query": "monkey business"},
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertIsNone(order.transport_requirement)
+
+    def test_nested_sensitive_keys_still_require_secure_transport(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-004e",
+            tool_name="fetch_url",
+            risk_level=0.10,
+            destination="https://example.net/data",
+            parameters={"metadata": {"api_key": "redacted"}},
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertIsNotNone(order.transport_requirement)
+        self.assertEqual(SensitivityClass.RESTRICTED, order.transport_requirement.sensitivity)
+
+    def test_deterministic_receipt(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-005",
+            tool_name="fetch_url",
+            risk_level=0.45,
+            destination="https://example.net/data",
+        )
+        order_a = self.engine.create_dispatch_order(mission)
+        order_b = self.engine.create_dispatch_order(mission)
+        self.assertEqual(canonical_json(order_a), canonical_json(order_b))
+        self.assertEqual(canonical_sha256(order_a), canonical_sha256(order_b))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ord/test_ord_threshold_registry.py
+++ b/tests/ord/test_ord_threshold_registry.py
@@ -1,0 +1,42 @@
+import unittest
+
+import pytest
+
+from modules.ord.ord_inspection_policy import InspectionInput, OrdInspectionPolicy, QuarantineDecision
+from modules.ord.ord_policy_engine import MissionBrief, OrdPolicyEngine
+from modules.ord.ord_threshold_registry import load_default_registry
+
+
+pytestmark = pytest.mark.critical
+
+class TestOrdThresholdRegistry(unittest.TestCase):
+    def test_dispatch_includes_registry_metadata(self) -> None:
+        engine = OrdPolicyEngine()
+        order = engine.create_dispatch_order(
+            MissionBrief(
+                mission_id="tv-201",
+                tool_name="fetch_url",
+                risk_level=0.41,
+                destination="https://example.net/data",
+            )
+        )
+        self.assertEqual("ORD_THRESHOLD_REGISTRY", order.special_instructions["threshold_registry"]["registry_id"])
+        self.assertEqual("0.5.0", order.special_instructions["threshold_registry"]["version"])
+
+    def test_default_inspection_uses_registry_threshold(self) -> None:
+        policy = OrdInspectionPolicy()
+        report = policy.inspect(
+            InspectionInput(
+                mission_id="tv-202",
+                structure_valid=True,
+                contamination_detected=False,
+                drift_score=load_default_registry().drift_threshold,
+                drift_threshold=None,
+            )
+        )
+        self.assertEqual(QuarantineDecision.QUARANTINE, report.decision)
+        self.assertTrue(report.human_review_required)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Integrates the **ORD-Series Drone Fleet policy family** — the Orion Station autonomous MCP validation layer, policy side — recovered from the ORION_ORD Promotion Workbench v0.5.0 (`_staging/orion_ord_review_fix`, 2026-03-10), which existed in exactly one uncommitted copy in the workspace.

Layout follows the workbench's own `PROMOTION_QUEUE.md`:

- `modules/ord/ord_threshold_registry.py` — governance-backed policy config seam (+ `governance/ORD_THRESHOLD_REGISTRY__v0.5.0` JSON/MD)
- `modules/ord/ord_policy_engine.py` — dispatch core (`MissionBrief` → `DispatchOrder`)
- `modules/ord/ord_inspection_policy.py` — inspection/quarantine core (ORD-3 Shadowfax doctrine)
- `modules/ord/ord_receipts.py` — canonical JSON + SHA-256 audit receipts
- `docs/ord/` — SPEC, RefactorPlan, TEST_VECTOR_SET (all v0.5.0)
- `tests/ord/` — 15 tests, marked `critical` (now gate in CI Check)

The fleet **entity** layer already lives in `src/entities/fleet/` (ORD-1 Gamma Swarm, ORD-2 Delta Scout, ORD-3 Shadowfax registry accessors); this supplies the policy decisions those entities execute. Carries the workbench review-fix hardening: hostname-based destination authority, token-aware sensitivity classification, URL-spoofing + keyword-boundary regressions.

Posture per the workbench: **governance-backed policy-library candidate** — wiring into live MCP dispatch surfaces is deliberately a separate step. Legacy recovered sources stay in workspace staging per the promotion queue.

## Test plan

- `pytest tests/ord/ -q` → 15 passed
- CI-equivalent critical tier → 143 passed, 1 skipped (was 128)
- `flake8 --select=E9,F63,F7,F82` on new paths → clean
- `import modules.ord` → 17 exports OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
