### PR TITLE
fix(mesh): 404 for unknown agent ids on /api/mesh/agents routes

### DIFF
--- a/src/servers/l2_integration_server.py
+++ b/src/servers/l2_integration_server.py
@@ -189,7 +189,8 @@ def create_app(project_root: Path | None = None) -> FastAPI:
         try:
             agent = mesh_runtime.get_agent(agent_id)
             return {"success": True, **agent}
-        except KeyError:
+        except (KeyError, ValueError):
+            # MeshRuntime._resolve_manifest raises ValueError for unknown ids
             raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
         except Exception as e:
             logger.error("mesh_get_agent failed for %s: %s", str(agent_id)[:100], str(e)[:100])
@@ -204,7 +205,8 @@ def create_app(project_root: Path | None = None) -> FastAPI:
         try:
             agent = mesh_runtime.activate_agent(agent_id)
             return {"success": True, "agent_id": agent["agent_id"], "status": "connected"}
-        except KeyError:
+        except (KeyError, ValueError):
+            # MeshRuntime._resolve_manifest raises ValueError for unknown ids
             raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
         except Exception as e:
             logger.error("mesh_activate_agent failed for %s: %s", str(agent_id)[:100], str(e)[:100])


### PR DESCRIPTION
## Summary

Fixes the 404 half of #1020: `GET /api/mesh/agents/{id}` and `POST /api/mesh/agents/{id}/activate` returned **500** for unknown agent ids because `MeshRuntime._resolve_manifest` raises `ValueError`, while the handlers only caught `KeyError`. Both handlers now catch `(KeyError, ValueError)` → 404.

Deliberately narrow: the `test_mesh_agents_list` hardcoded-count failure (`total == 6` vs the 47-agent crew) stays with the in-flight test adaptation (Codex's lane) and is tracked in #1020.

## Test plan

- `pytest tests/test_mesh_router_v1.py` → both `*_unknown_returns_404` tests now pass; 8/9 green locally (residual is the known count expectation, untouched here)
- CI-equivalent critical tier unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
