### PR TITLE
fix(sim): emergent events emitted after assignment — first-tick emergence was structurally impossible

### DIFF
--- a/simulation/orion_station_simulation_v2.py
+++ b/simulation/orion_station_simulation_v2.py
@@ -374,8 +374,10 @@ class OrionSimulationV2:
     def tick(self) -> None:
         """Execute one simulation tick"""
         tick = self.ticks
-        events = self.aurora.maybe_emit_events(tick, self.agents, self.tasks)
+        # Assign before emitting: emergent events key off working agents, so
+        # emitting first made first-tick emergence structurally impossible.
         self._coordinate_assignments()
+        events = self.aurora.maybe_emit_events(tick, self.agents, self.tasks)
         progress = self._apply_work(events)
         self._log_and_transcript(tick, events, progress)
         self.ticks += 1

--- a/tests/test_orion_simulation.py
+++ b/tests/test_orion_simulation.py
@@ -22,3 +22,27 @@ def test_transcript_contains_kickoff_message():
     assert transcript, "Transcript should not be empty"
     # First tick should include Alex Thorn kickoff note
     assert any("Alex Thorn" in line for line in transcript)
+
+
+@pytest.mark.unit
+@pytest.mark.simulation
+def test_first_tick_emergence_is_possible():
+    """Regression: events were emitted before assignment, so working-agent
+    emergence (swarm_sync, collaboration_boost, cross_pollination) could
+    never fire on the first tick of any run."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "simulation"))
+    from orion_station_simulation_v2 import OrionSimulationV2
+
+    working_kinds = {"swarm_sync", "collaboration_boost", "cross_pollination"}
+    for seed in range(30):
+        sim = OrionSimulationV2(seed=seed, enable_emergent=True)
+        sim.run(max_ticks=1)
+        if any(e.tick == 0 and e.kind in working_kinds for e in sim.aurora.events):
+            return
+    raise AssertionError(
+        "no working-agent emergence on tick 0 across 30 seeds — "
+        "events are likely emitted before assignments again"
+    )


### PR DESCRIPTION
## Summary

`OrionSimulationV2.tick()` emitted emergent events **before** `_coordinate_assignments()`. Since swarm_sync / collaboration_boost / cross_pollination key off agents with `assigned_task`, working-agent emergence could never fire on tick 0 of any run, and every run was biased against emergence (found during the first 4-hour watch-block run: zero events). Reorder: assign first, then emit, so events apply to the same tick's work.

## Test plan

- New regression test `test_first_tick_emergence_is_possible` (30-seed sweep): **fails on old ordering, passes with fix** — verified both directions locally
- Existing sim tests pass (3 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)