### PR TITLE
test(ord): pin salvage threshold behaviors

### DIFF
--- a/tests/ord/test_ord_inspection_policy.py
+++ b/tests/ord/test_ord_inspection_policy.py
@@ -73,6 +73,21 @@ class TestOrdInspectionPolicy(unittest.TestCase):
         self.assertEqual(QuarantineDecision.QUARANTINE, report.decision)
         self.assertTrue(report.human_review_required)
 
+    def test_encoding_anomaly_requests_normalization(self) -> None:
+        report = self.policy.inspect(
+            InspectionInput(
+                mission_id="tv-105",
+                structure_valid=True,
+                contamination_detected=False,
+                drift_score=0.001,
+                ethics_violations=[],
+                encoding_anomaly=True,
+            )
+        )
+        self.assertEqual(QuarantineDecision.SANITIZE, report.decision)
+        self.assertEqual([SanitizationAction.NORMALIZE_ENCODING], report.requires_sanitization)
+        self.assertFalse(report.human_review_required)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ord/test_ord_policy_engine.py
+++ b/tests/ord/test_ord_policy_engine.py
@@ -107,6 +107,32 @@ class TestOrdPolicyEngine(unittest.TestCase):
         self.assertIsNotNone(order.transport_requirement)
         self.assertEqual(SensitivityClass.RESTRICTED, order.transport_requirement.sensitivity)
 
+    def test_high_risk_mission_enables_quantum_seal_controls(self) -> None:
+        mission = MissionBrief(
+            mission_id="tv-004f",
+            tool_name="fetch_url",
+            risk_level=self.engine.registry.quantum_seal_threshold,
+            destination="https://example.net/data",
+        )
+        order = self.engine.create_dispatch_order(mission)
+        self.assertEqual(
+            [DroneType.DELTA_SCOUT, DroneType.SHADOWFAX, DroneType.GAMMA_SWARM, DroneType.WISP],
+            order.drones_required,
+        )
+        self.assertTrue(order.special_instructions["delta_scout"]["full_scan"])
+        self.assertEqual(
+            self.engine.registry.quantum_seal_threshold,
+            order.special_instructions["delta_scout"]["threat_abort_threshold"],
+        )
+        self.assertEqual(
+            self.engine.registry.drift_threshold,
+            order.special_instructions["shadowfax"]["drift_threshold"],
+        )
+        self.assertTrue(order.special_instructions["shadowfax"]["quarantine_on_drift"])
+        self.assertIsNotNone(order.transport_requirement)
+        self.assertTrue(order.transport_requirement.quantum_seal_required)
+        self.assertTrue(order.special_instructions["wisp"]["quantum_seal"])
+
     def test_deterministic_receipt(self) -> None:
         mission = MissionBrief(
             mission_id="tv-005",


### PR DESCRIPTION
## Summary
- Add test-only salvage coverage for ORD high-risk quantum-seal dispatch controls.
- Add inspection coverage for encoding anomalies requiring NORMALIZE_ENCODING.
- Preserve the current policy-layer shape; no legacy ORD runtime source copied.

## Validation
- PYTHONPYCACHEPREFIX=/tmp/cloudbank_pycache python3 -m pytest -q tests/ord -p no:cacheprovider
- Result: 17 passed, with existing system-Python pytest config warnings for unknown asyncio options.

## Salvage Lane
P2 from the Aurora salvage docket. Legacy ORD fleet source remains backup_only; this PR carries forward only missing owner-surface tests.