### PR TITLE
feat(ethics): add unified ethics engine

### DIFF
--- a/docs/operational/reports/ISSUE_1070_UNIFIED_ETHICS_ENGINE.md
+++ b/docs/operational/reports/ISSUE_1070_UNIFIED_ETHICS_ENGINE.md
@@ -1,0 +1,88 @@
+# CloudBank Issue #1070 Unified Ethics Engine Receipt
+
+Date: 2026-06-18
+Branch: `codex/cloudbank-issue-1070-ethics-engine`
+Worktree: `/private/tmp/cloudbank-codex-issue-1070-ethics-engine`
+Issue: https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1070
+Closes #1070
+Claim: `codex-20260618T060944Z-cloudbank-issue-1070`
+
+## Scope
+
+Implemented the config-backed top-level `ethics` package for the unified
+ethics engine described by issue #1070.
+
+## Changes
+
+- Added `ethics/engine.py`.
+  - Loads `ethics/l3_layer/ethics_engine_config.yaml`.
+  - Loads `ethics/validation_engine/validation_rules.json`.
+  - Loads `ethics/compliance_monitor/compliance_config.yaml`.
+  - Exposes `EthicsEngine.validate(...)`.
+  - Returns structured `APPROVED`, `REVIEW`, or `BLOCKED` verdicts.
+  - Implements all seven configured rule IDs: `ME001`, `ME002`, `ME003`,
+    `RE001`, `RE002`, `AI001`, `AI002`.
+  - Preserves `AI002` as a hard-block conjunction:
+    `autonomous_critical_decision` with no human override.
+- Added `ethics/audit_log.py`.
+  - Emits append-only JSONL audit entries for non-`APPROVED` verdicts.
+  - Signs each entry with a deterministic SHA256 payload hash.
+  - Marks configured blockchain anchoring as `todo_external_integration`.
+- Added `ethics/__init__.py` public exports.
+- Wired existing seams:
+  - `src/sensors/constants.py` now derives SENTINEL risk thresholds through
+    `ethics.engine.get_sentinel_thresholds()` with a local fallback.
+  - `src/sensors/observatory/symbolic/ethical_signal.py` prefers
+    `EthicsEngine.validate()` and retains the legacy monitoring-engine
+    fallback.
+  - `services/nemo_service/symbolic_bridge.py` exposes structured ethics
+    verdicts in anchor contexts and bridge summaries.
+  - `modules/gumas/api/routes.py` adds `/gumas/ethics_check` delegating to the
+    unified engine while leaving existing `/gumas/evaluate` compatibility
+    intact.
+- Added focused coverage in `tests/test_unified_ethics_engine.py`.
+
+## Validation
+
+Passed:
+
+```bash
+python3 -m pytest tests/test_unified_ethics_engine.py \
+  tests/sensors/test_symbolic_sensors.py::test_sentinel_baseline_low_risk_no_intervention \
+  tests/test_nemo_service.py::TestSymbolicBridge
+```
+
+Result: `22 passed, 2 warnings`.
+
+Passed:
+
+```bash
+ruff check ethics/audit_log.py ethics/engine.py ethics/__init__.py \
+  src/sensors/constants.py \
+  src/sensors/observatory/symbolic/ethical_signal.py \
+  services/nemo_service/symbolic_bridge.py \
+  modules/gumas/api/routes.py \
+  tests/test_unified_ethics_engine.py
+```
+
+Passed:
+
+```bash
+PYTHONPYCACHEPREFIX=/private/tmp/cloudbank-1070-pycache python3 -m py_compile \
+  ethics/audit_log.py ethics/engine.py ethics/__init__.py \
+  src/sensors/constants.py \
+  src/sensors/observatory/symbolic/ethical_signal.py \
+  services/nemo_service/symbolic_bridge.py \
+  modules/gumas/api/routes.py \
+  tests/test_unified_ethics_engine.py
+```
+
+## Notes
+
+- Local direct `api.aurora_api` GUMAS smoke tests were not used for this
+  receipt because this shell lacks the broader API dependency stack
+  (`python-dotenv`, `slowapi`) and the default `python3` is 3.9. The focused
+  route-level test isolates the new `/gumas/ethics_check` delegate path.
+- The blockchain anchoring requirement remains an explicit external integration
+  TODO. This patch provides SHA256-signed audit entries and records
+  `todo_external_integration` when the config asks for blockchain anchoring.

--- a/ethics/__init__.py
+++ b/ethics/__init__.py
@@ -1,0 +1,26 @@
+"""Unified ORION Station ethics package."""
+
+from ethics.audit_log import AuditLogEntry, EthicsAuditLog
+from ethics.engine import (
+    APPROVED,
+    BLOCKED,
+    REVIEW,
+    EthicsEngine,
+    EthicsRule,
+    EthicsValidationResult,
+    TriggeredRule,
+    get_sentinel_thresholds,
+)
+
+__all__ = [
+    "APPROVED",
+    "BLOCKED",
+    "REVIEW",
+    "AuditLogEntry",
+    "EthicsAuditLog",
+    "EthicsEngine",
+    "EthicsRule",
+    "EthicsValidationResult",
+    "TriggeredRule",
+    "get_sentinel_thresholds",
+]

--- a/ethics/audit_log.py
+++ b/ethics/audit_log.py
@@ -1,0 +1,119 @@
+"""Structured audit logging for the unified ethics engine."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_json(payload: Dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _append_jsonl(path: Path, record: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, default=str) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+@dataclass
+class AuditLogEntry:
+    """Immutable ethics audit entry with a SHA256 content signature."""
+
+    audit_id: str
+    timestamp: str
+    context: str
+    agent_id: str
+    anchor: Optional[str]
+    verdict: str
+    severity: str
+    triggered_rules: List[str]
+    payload_hash: str
+    signature: str
+    blockchain_anchor_status: str
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class EthicsAuditLog:
+    """Append-only JSONL audit emitter for non-approved ethics verdicts."""
+
+    def __init__(
+        self,
+        path: Optional[Path | str] = None,
+        *,
+        cryptographic_signing: bool = True,
+        blockchain_anchoring: bool = False,
+    ) -> None:
+        env_path = os.getenv("ETHICS_AUDIT_LOG_PATH")
+        self.path = Path(path or env_path or "monitoring_data/ethics_audit_log.jsonl")
+        self.cryptographic_signing = cryptographic_signing
+        self.blockchain_anchoring = blockchain_anchoring
+        self.entries: List[AuditLogEntry] = []
+        self._lock = threading.Lock()
+
+    def emit(
+        self,
+        *,
+        context: str,
+        agent_id: str,
+        anchor: Optional[str],
+        verdict: str,
+        severity: str,
+        triggered_rules: List[str],
+        details: Dict[str, Any],
+    ) -> AuditLogEntry:
+        """Create, sign, retain, and append one audit entry."""
+        timestamp = _utc_iso()
+        unsigned = {
+            "timestamp": timestamp,
+            "context": context,
+            "agent_id": agent_id,
+            "anchor": anchor,
+            "verdict": verdict,
+            "severity": severity,
+            "triggered_rules": triggered_rules,
+            "details": details,
+        }
+        payload_hash = hashlib.sha256(_canonical_json(unsigned).encode("utf-8")).hexdigest()
+        signature = payload_hash if self.cryptographic_signing else ""
+        audit_id = f"AUDIT-{timestamp[:10].replace('-', '')}-{payload_hash[:12]}"
+        blockchain_status = (
+            "todo_external_integration"
+            if self.blockchain_anchoring
+            else "not_configured"
+        )
+
+        entry = AuditLogEntry(
+            audit_id=audit_id,
+            timestamp=timestamp,
+            context=context,
+            agent_id=agent_id,
+            anchor=anchor,
+            verdict=verdict,
+            severity=severity,
+            triggered_rules=triggered_rules,
+            payload_hash=payload_hash,
+            signature=signature,
+            blockchain_anchor_status=blockchain_status,
+            details=details,
+        )
+
+        with self._lock:
+            self.entries.append(entry)
+            _append_jsonl(self.path, entry.to_dict())
+        return entry

--- a/ethics/engine.py
+++ b/ethics/engine.py
@@ -1,0 +1,334 @@
+"""Unified config-backed ethics engine for ORION Station checks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import operator
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import yaml
+
+from ethics.audit_log import AuditLogEntry, EthicsAuditLog
+
+logger = logging.getLogger(__name__)
+
+APPROVED = "APPROVED"
+REVIEW = "REVIEW"
+BLOCKED = "BLOCKED"
+
+_SEVERITY_RANK = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+_COMPARATORS = [
+    (">=", operator.ge),
+    ("<=", operator.le),
+    ("==", operator.eq),
+    ("!=", operator.ne),
+    (">", operator.gt),
+    ("<", operator.lt),
+]
+
+
+@dataclass(frozen=True)
+class EthicsRule:
+    """One normalized validation rule from ethics/validation_engine."""
+
+    rule_id: str
+    name: str
+    description: str
+    category: str
+    severity: str
+    auto_block: bool
+    conditions: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TriggeredRule:
+    """Rule hit included in an ethics verdict."""
+
+    rule_id: str
+    name: str
+    category: str
+    severity: str
+    auto_block: bool
+    matched_conditions: List[str]
+    description: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class EthicsValidationResult:
+    """Structured result returned by EthicsEngine.validate()."""
+
+    verdict: str
+    context: str
+    agent_id: str
+    anchor: Optional[str]
+    severity: str = "none"
+    triggered_rules: List[TriggeredRule] = field(default_factory=list)
+    audit_id: Optional[str] = None
+    audit_entry: Optional[Dict[str, Any]] = None
+    engine_id: str = "PICARD_DELTA_3"
+    engine_version: str = "unknown"
+    compliance_monitor_id: str = "unknown"
+    blockchain_anchoring: bool = False
+
+    @property
+    def approved(self) -> bool:
+        return self.verdict == APPROVED
+
+    @property
+    def blocked(self) -> bool:
+        return self.verdict == BLOCKED
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["triggered_rules"] = [rule.to_dict() for rule in self.triggered_rules]
+        return data
+
+
+class EthicsEngine:
+    """Unified ethics engine loading L3, validation, and compliance configs."""
+
+    DEFAULT_SENTINEL_THRESHOLDS = {
+        "monitor": 0.4,
+        "audit": 0.6,
+        "intervention": 0.7,
+        "human_approval": 0.8,
+    }
+
+    def __init__(
+        self,
+        *,
+        config_root: Optional[Path | str] = None,
+        audit_log: Optional[EthicsAuditLog] = None,
+    ) -> None:
+        self.config_root = Path(config_root) if config_root else Path(__file__).resolve().parent
+        self.l3_config = self._load_yaml(self.config_root / "l3_layer" / "ethics_engine_config.yaml")
+        self.validation_config = self._load_json(
+            self.config_root / "validation_engine" / "validation_rules.json"
+        )
+        self.compliance_config = self._load_yaml(
+            self.config_root / "compliance_monitor" / "compliance_config.yaml"
+        )
+        self.rules = self._load_rules(self.validation_config)
+        self.audit_log = audit_log or EthicsAuditLog(
+            cryptographic_signing=self.audit_trails.get("cryptographic_signing", True),
+            blockchain_anchoring=self.audit_trails.get("blockchain_anchoring", False),
+        )
+
+    @property
+    def engine_config(self) -> Dict[str, Any]:
+        return self.l3_config.get("l3_ethics_engine", {})
+
+    @property
+    def compliance_monitor(self) -> Dict[str, Any]:
+        return self.compliance_config.get("compliance_monitor", {})
+
+    @property
+    def audit_trails(self) -> Dict[str, Any]:
+        return self.compliance_monitor.get("audit_trails", {})
+
+    @property
+    def engine_id(self) -> str:
+        return str(self.engine_config.get("engine_id", "PICARD_DELTA_3"))
+
+    @property
+    def engine_version(self) -> str:
+        return str(self.engine_config.get("version", "unknown"))
+
+    @property
+    def compliance_monitor_id(self) -> str:
+        return str(self.compliance_monitor.get("monitor_id", "unknown"))
+
+    def validate(
+        self,
+        *,
+        context: str,
+        signals: Dict[str, Any],
+        anchor: Optional[str] = None,
+        agent_id: str = "system",
+    ) -> EthicsValidationResult:
+        """Validate signals against all configured ethics rules."""
+        normalized = self._normalize_signals(signals)
+        triggered: List[TriggeredRule] = []
+
+        for rule in self.rules:
+            matched = [condition for condition in rule.conditions if self._check_condition(condition, normalized)]
+            if self._rule_triggered(rule, matched):
+                triggered.append(
+                    TriggeredRule(
+                        rule_id=rule.rule_id,
+                        name=rule.name,
+                        category=rule.category,
+                        severity=rule.severity,
+                        auto_block=rule.auto_block,
+                        matched_conditions=matched,
+                        description=rule.description,
+                    )
+                )
+
+        verdict = self._verdict_for(triggered)
+        severity = self._max_severity(triggered)
+        result = EthicsValidationResult(
+            verdict=verdict,
+            context=context,
+            agent_id=agent_id,
+            anchor=anchor,
+            severity=severity,
+            triggered_rules=triggered,
+            engine_id=self.engine_id,
+            engine_version=self.engine_version,
+            compliance_monitor_id=self.compliance_monitor_id,
+            blockchain_anchoring=bool(self.audit_trails.get("blockchain_anchoring", False)),
+        )
+
+        if verdict != APPROVED:
+            entry = self._emit_audit(result, normalized)
+            result.audit_id = entry.audit_id
+            result.audit_entry = entry.to_dict()
+
+        return result
+
+    def sentinel_thresholds(self) -> Dict[str, float]:
+        """Expose SENTINEL thresholds through the engine integration seam."""
+        thresholds = dict(self.DEFAULT_SENTINEL_THRESHOLDS)
+        enforcement = self.validation_config.get("ethics_validation_rules", {}).get("enforcement_levels", {})
+        if enforcement.get("critical", {}).get("auto_block") is True:
+            thresholds["human_approval"] = max(thresholds["human_approval"], thresholds["intervention"])
+        return thresholds
+
+    def _emit_audit(self, result: EthicsValidationResult, signals: Dict[str, Any]) -> AuditLogEntry:
+        return self.audit_log.emit(
+            context=result.context,
+            agent_id=result.agent_id,
+            anchor=result.anchor,
+            verdict=result.verdict,
+            severity=result.severity,
+            triggered_rules=[rule.rule_id for rule in result.triggered_rules],
+            details={
+                "engine_id": result.engine_id,
+                "engine_version": result.engine_version,
+                "compliance_monitor_id": result.compliance_monitor_id,
+                "signals": signals,
+                "triggered_rules": [rule.to_dict() for rule in result.triggered_rules],
+                "blockchain_anchoring_todo": result.blockchain_anchoring,
+            },
+        )
+
+    def _load_yaml(self, path: Path) -> Dict[str, Any]:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"{path} must contain a mapping")
+        return data
+
+    def _load_json(self, path: Path) -> Dict[str, Any]:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if not isinstance(data, dict):
+            raise ValueError(f"{path} must contain a mapping")
+        return data
+
+    def _load_rules(self, data: Dict[str, Any]) -> List[EthicsRule]:
+        categories = data.get("ethics_validation_rules", {}).get("rule_categories", {})
+        rules: List[EthicsRule] = []
+        for category_name, category_data in categories.items():
+            for rule_data in category_data.get("rules", []):
+                rules.append(
+                    EthicsRule(
+                        rule_id=str(rule_data["id"]),
+                        name=str(rule_data["name"]),
+                        description=str(rule_data["description"]),
+                        category=str(category_name),
+                        severity=str(rule_data["severity"]),
+                        auto_block=bool(rule_data["auto_block"]),
+                        conditions=[str(condition) for condition in rule_data.get("conditions", [])],
+                    )
+                )
+        return rules
+
+    def _normalize_signals(self, signals: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = dict(signals)
+
+        alias_pairs = {
+            "no_human_override": ("human_override", False),
+            "no_explanation_available": ("explanation_available", False),
+            "safety_protocols_incomplete": ("safety_protocols_complete", False),
+            "no_mitigation_plan": ("mitigation_plan", False),
+            "consent_missing": ("informed_consent", False),
+        }
+        for negative_key, (positive_key, negative_value) in alias_pairs.items():
+            if negative_key not in normalized and normalized.get(positive_key) is negative_value:
+                normalized[negative_key] = True
+
+        if "safety_protocols_incomplete" not in normalized and normalized.get("safety_override_missing"):
+            normalized["safety_protocols_incomplete"] = True
+        if "no_explanation_available" not in normalized and normalized.get("no_explanation"):
+            normalized["no_explanation_available"] = True
+
+        return normalized
+
+    def _check_condition(self, condition: str, signals: Dict[str, Any]) -> bool:
+        condition = condition.strip()
+        for symbol, comparator in _COMPARATORS:
+            if symbol in condition:
+                left, right = [part.strip() for part in condition.split(symbol, 1)]
+                if left not in signals:
+                    return False
+                right_value = self._resolve_value(right, signals)
+                left_value = signals[left]
+                try:
+                    left_value = float(left_value)
+                    right_value = float(right_value)
+                except (TypeError, ValueError):
+                    pass
+                return bool(comparator(left_value, right_value))
+
+        value = signals.get(condition)
+        return bool(value) if value is not None else False
+
+    def _rule_triggered(self, rule: EthicsRule, matched_conditions: List[str]) -> bool:
+        if rule.rule_id == "AI002":
+            return set(rule.conditions).issubset(set(matched_conditions))
+        return bool(matched_conditions)
+
+    def _resolve_value(self, name_or_value: str, signals: Dict[str, Any]) -> Any:
+        if name_or_value in signals:
+            return signals[name_or_value]
+        if name_or_value == "threshold":
+            return signals.get("threshold", 0.3)
+        lowered = name_or_value.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        try:
+            return float(name_or_value)
+        except ValueError:
+            return name_or_value.strip("'\"")
+
+    def _verdict_for(self, triggered: Iterable[TriggeredRule]) -> str:
+        triggered = list(triggered)
+        if not triggered:
+            return APPROVED
+        if any(rule.auto_block or rule.severity == "critical" for rule in triggered):
+            return BLOCKED
+        return REVIEW
+
+    def _max_severity(self, triggered: Iterable[TriggeredRule]) -> str:
+        severities = [rule.severity for rule in triggered]
+        if not severities:
+            return "none"
+        return max(severities, key=lambda severity: _SEVERITY_RANK.get(severity, 0))
+
+
+def get_sentinel_thresholds(config_root: Optional[Path | str] = None) -> Dict[str, float]:
+    """Load SENTINEL thresholds via the unified engine seam."""
+    return EthicsEngine(config_root=config_root).sentinel_thresholds()

--- a/modules/gumas/api/routes.py
+++ b/modules/gumas/api/routes.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from ethics.engine import EthicsEngine as UnifiedEthicsEngine
 from src.monitoring.ethics_engine import (
     EthicsEngine,
     ActionContext,
@@ -40,6 +41,7 @@ def _monitoring_storage_dir() -> Path:
 ethics_engine = EthicsEngine(
     violations_path=_monitoring_storage_dir() / "ethics_violations.jsonl"
 )
+unified_ethics_engine = UnifiedEthicsEngine()
 
 
 # Pydantic Models
@@ -67,6 +69,29 @@ class EvaluateActionResponse(BaseModel):
     violations: List[Dict[str, Any]]
     evaluation_timestamp: str
     context_tag: Optional[str] = None
+
+
+class UnifiedEthicsCheckRequest(BaseModel):
+    """Request for the config-backed unified ethics engine."""
+
+    context: str = Field(default="gumas_ethics_check", description="Ethics validation context")
+    signals: Dict[str, Any] = Field(default_factory=dict, description="Signals to validate")
+    anchor: Optional[str] = Field(default="T1-ETHICS-ENGINE-001", description="Symbolic anchor")
+    agent_id: str = Field(default="system", description="Agent or service requesting validation")
+
+
+class UnifiedEthicsCheckResponse(BaseModel):
+    """Response from the unified ethics engine."""
+
+    verdict: str
+    blocked: bool
+    severity: str
+    audit_id: Optional[str]
+    triggered_rules: List[Dict[str, Any]]
+    engine_id: str
+    engine_version: str
+    compliance_monitor_id: str
+    blockchain_anchoring: bool
 
 
 class ViolationQueryRequest(BaseModel):
@@ -170,6 +195,46 @@ async def evaluate_action(request: EvaluateActionRequest) -> EvaluateActionRespo
         
     except Exception as e:
         logger.error("Action evaluation failed: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/ethics_check", response_model=UnifiedEthicsCheckResponse)
+async def unified_ethics_check(request: UnifiedEthicsCheckRequest) -> UnifiedEthicsCheckResponse:
+    """
+    Evaluate signals through the unified config-backed ethics engine.
+
+    DLP: gumas_unified_ethics_check
+    """
+    try:
+        result = unified_ethics_engine.validate(
+            context=request.context,
+            signals=request.signals,
+            anchor=request.anchor,
+            agent_id=request.agent_id,
+        )
+        dlp_tracker.create_tag(
+            operation="gumas_unified_ethics_check",
+            data={
+                "agent_id": request.agent_id,
+                "context": request.context,
+                "verdict": result.verdict,
+                "triggered_rule_count": len(result.triggered_rules),
+                "audit_id": result.audit_id,
+            },
+        )
+        return UnifiedEthicsCheckResponse(
+            verdict=result.verdict,
+            blocked=result.blocked,
+            severity=result.severity,
+            audit_id=result.audit_id,
+            triggered_rules=[rule.to_dict() for rule in result.triggered_rules],
+            engine_id=result.engine_id,
+            engine_version=result.engine_version,
+            compliance_monitor_id=result.compliance_monitor_id,
+            blockchain_anchoring=result.blockchain_anchoring,
+        )
+    except Exception as e:
+        logger.error("Unified ethics check failed: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/services/nemo_service/symbolic_bridge.py
+++ b/services/nemo_service/symbolic_bridge.py
@@ -106,6 +106,7 @@ class SymbolicBridge:
         srb_tag: str = "NEMO_SERVICE_v1",
         ethics_protocol: str = "Picard_Delta_3",
         drift_threshold: float = 0.15,
+        ethics_engine: Optional[Any] = None,
     ) -> None:
         """Initialise the symbolic bridge with anchor and entropy settings."""
         self._anchor = AnchorState(
@@ -117,6 +118,7 @@ class SymbolicBridge:
         self._entropy_history: List[EntropyReading] = []
         self._call_counter: int = 0
         self._baseline_entropy: Optional[float] = None
+        self._ethics_engine = ethics_engine or self._default_ethics_engine()
 
         logger.info(
             "SymbolicBridge initialised",
@@ -147,6 +149,7 @@ class SymbolicBridge:
             **self._anchor.to_dict(),
             "call_counter": self._call_counter,
         }
+        ctx["ethics"] = self.validate_ethics_context(model_type)
 
         logger.debug("Anchor context resolved: T1=%d SRB=%s", self._anchor.t1, self._anchor.srb)
         return ctx
@@ -230,6 +233,55 @@ class SymbolicBridge:
         return self._entropy_history[-1].to_dict()
 
     # ------------------------------------------------------------------
+    # Ethics validation
+    # ------------------------------------------------------------------
+
+    def _default_ethics_engine(self) -> Optional[Any]:
+        try:
+            from ethics.engine import EthicsEngine
+
+            return EthicsEngine()
+        except Exception:  # noqa: BLE001 - NeMo bridge must stay importable
+            logger.exception("Unified EthicsEngine initialization failed")
+            return None
+
+    def validate_ethics_context(
+        self,
+        model_type: str,
+        signals: Optional[Dict[str, Any]] = None,
+        agent_id: str = "AURORA_NEMO_SERVICE",
+    ) -> Dict[str, Any]:
+        """Return a structured Picard_Delta_3 verdict for an inference context."""
+        if self._ethics_engine is None or not hasattr(self._ethics_engine, "validate"):
+            return {
+                "verdict": "APPROVED",
+                "context": "nemo_inference",
+                "agent_id": agent_id,
+                "anchor": "T1-NEMO-SYMBOLIC-BRIDGE",
+                "triggered_rules": [],
+                "audit_id": None,
+                "engine_id": self._anchor.ethics_protocol,
+            }
+
+        ethics_signals = {
+            "decision_opacity": 0.0,
+            "no_explanation_available": False,
+            "autonomous_critical_decision": False,
+            "human_override": True,
+            "model_type": model_type,
+        }
+        if signals:
+            ethics_signals.update(signals)
+
+        result = self._ethics_engine.validate(
+            context="nemo_inference",
+            signals=ethics_signals,
+            anchor="T1-NEMO-SYMBOLIC-BRIDGE",
+            agent_id=agent_id,
+        )
+        return result.to_dict()
+
+    # ------------------------------------------------------------------
     # Memory sealing
     # ------------------------------------------------------------------
 
@@ -262,5 +314,10 @@ class SymbolicBridge:
             "latest_entropy": self.get_latest_entropy(),
             "srb": self._anchor.srb,
             "ethics_protocol": self._anchor.ethics_protocol,
+            "ethics_engine": (
+                getattr(self._ethics_engine, "engine_id", self._anchor.ethics_protocol)
+                if self._ethics_engine
+                else self._anchor.ethics_protocol
+            ),
             "chain_notation": "#SERVICES//NEMO//SYMBOLIC_BRIDGE//",
         }

--- a/src/sensors/constants.py
+++ b/src/sensors/constants.py
@@ -39,10 +39,22 @@ RESONANCE_SYNC_WARNING = 0.05          # ZIPWIZ RESONANCE_SYNC divergence
 RESONANCE_SYNC_CRITICAL = 0.10
 
 # --- Ethical signal sentinel ---------------------------------- [ASSUMPTION]
-SENTINEL_RISK_INTERVENTION = 0.7
-SENTINEL_RISK_HUMAN_APPROVAL = 0.8
-SENTINEL_RISK_AUDIT = 0.6
-SENTINEL_RISK_MONITOR = 0.4
+try:
+    from ethics.engine import get_sentinel_thresholds
+
+    _SENTINEL_THRESHOLDS = get_sentinel_thresholds()
+except Exception:
+    _SENTINEL_THRESHOLDS = {
+        "intervention": 0.7,
+        "human_approval": 0.8,
+        "audit": 0.6,
+        "monitor": 0.4,
+    }
+
+SENTINEL_RISK_INTERVENTION = _SENTINEL_THRESHOLDS["intervention"]
+SENTINEL_RISK_HUMAN_APPROVAL = _SENTINEL_THRESHOLDS["human_approval"]
+SENTINEL_RISK_AUDIT = _SENTINEL_THRESHOLDS["audit"]
+SENTINEL_RISK_MONITOR = _SENTINEL_THRESHOLDS["monitor"]
 SENTINEL_NEAR_BOUNDARY_MARGIN = 0.2
 SENTINEL_ACCEL_VELOCITY = 0.1
 SENTINEL_INCREASING_VELOCITY = 0.02

--- a/src/sensors/observatory/symbolic/ethical_signal.py
+++ b/src/sensors/observatory/symbolic/ethical_signal.py
@@ -5,10 +5,10 @@ Detects escalating patterns (tone escalation, boundary testing, deviation
 accumulation) BEFORE explicit Picard_Delta_3 rules break, enabling proactive
 intervention while risk is low.
 
-Repo-reality integration (reconciler 2026-06-11): binds to
-``src.monitoring.ethics_engine.EthicsEngine`` (``evaluate_action(ActionContext)
--> List[EthicsViolation]``, severities LOW/MEDIUM/HIGH/CRITICAL). The
-BLOCK/REVIEW/THROTTLE/SUSPEND/RESET action vocabulary belongs to
+Repo-reality integration (issue #1070): prefers the unified
+``ethics.engine.EthicsEngine.validate()`` interface, with fallback support for
+``src.monitoring.ethics_engine.EthicsEngine.evaluate_action(ActionContext)``.
+The BLOCK/REVIEW/THROTTLE/SUSPEND/RESET action vocabulary belongs to
 ``MonitoringSystem`` — the sentinel only RECOMMENDS; MonitoringSystem and L3
 governance own actions (one-way observation, RQ-4).
 
@@ -57,10 +57,19 @@ class EthicalSignalSentinel(Sensor):
     def __init__(self, ethics_engine: Optional[Any] = None):
         super().__init__("observatory.symbolic.ethical_signal",
                          Layer.L3, "ethical_signal")
-        self.ethics_engine = ethics_engine    # src.monitoring.EthicsEngine
+        self.ethics_engine = ethics_engine or self._default_ethics_engine()
         self.action_history: Dict[str, List[dict]] = defaultdict(list)
         self.risk_scores: Dict[str, float] = defaultdict(float)
         self.critical = True                  # never decimated
+
+    def _default_ethics_engine(self) -> Optional[Any]:
+        try:
+            from ethics.engine import EthicsEngine
+
+            return EthicsEngine()
+        except Exception:  # noqa: BLE001 — observation must stay available
+            logger.exception("Unified EthicsEngine initialization failed")
+            return None
 
     # -- evaluation -------------------------------------------------------------
 
@@ -128,6 +137,8 @@ class EthicalSignalSentinel(Sensor):
         """Standard ethics check via the existing EthicsEngine, if wired."""
         if self.ethics_engine is None:
             return []
+        if hasattr(self.ethics_engine, "validate"):
+            return self._unified_engine_violations(entity_id, action)
         try:
             from src.monitoring.ethics_engine import ActionContext
             results = self.ethics_engine.evaluate_action(ActionContext(
@@ -142,6 +153,35 @@ class EthicalSignalSentinel(Sensor):
             ]
         except Exception:  # noqa: BLE001 — sentinel must never break the path
             logger.exception("EthicsEngine evaluation failed (observed only)")
+            return []
+
+    def _unified_engine_violations(
+        self, entity_id: str, action: Action
+    ) -> List[dict]:
+        """SENTINEL Stream 3 overlay hook for ethics.engine verdicts."""
+        try:
+            signals = dict(action.params)
+            signals.setdefault("action_type", action.action_type)
+            signals.setdefault("allowed", action.allowed)
+            signals.setdefault("intensity", action.intensity)
+            result = self.ethics_engine.validate(
+                context="sentinel_stream_3",
+                signals=signals,
+                anchor=signals.get("anchor", "T1-SENTINEL-001"),
+                agent_id=entity_id,
+            )
+            return [
+                {
+                    "severity": rule.severity,
+                    "blocked": result.blocked or rule.auto_block,
+                    "rule_id": rule.rule_id,
+                    "verdict": result.verdict,
+                    "audit_id": result.audit_id,
+                }
+                for rule in result.triggered_rules
+            ]
+        except Exception:  # noqa: BLE001 — sentinel must never break the path
+            logger.exception("Unified EthicsEngine validation failed (observed only)")
             return []
 
     # -- signal components ----------------------------------------------------------

--- a/tests/test_unified_ethics_engine.py
+++ b/tests/test_unified_ethics_engine.py
@@ -1,0 +1,270 @@
+"""Focused tests for the unified config-backed ethics engine."""
+
+from __future__ import annotations
+
+import json
+import asyncio
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from ethics.audit_log import EthicsAuditLog
+from ethics.engine import BLOCKED, REVIEW, EthicsEngine
+
+
+def _engine(tmp_path):
+    return EthicsEngine(
+        audit_log=EthicsAuditLog(
+            path=tmp_path / "ethics_audit.jsonl",
+            cryptographic_signing=True,
+            blockchain_anchoring=True,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("rule_id", "signals", "expected_verdict"),
+    [
+        (
+            "ME001",
+            {"risk_to_life": 0.2, "safety_protocols_incomplete": True},
+            BLOCKED,
+        ),
+        (
+            "ME002",
+            {"consent_missing": True, "insufficient_information": True},
+            BLOCKED,
+        ),
+        (
+            "ME003",
+            {"environmental_impact": 0.4, "threshold": 0.3, "no_mitigation_plan": True},
+            REVIEW,
+        ),
+        (
+            "RE001",
+            {"inequality_coefficient": 0.8, "minority_exclusion": True},
+            REVIEW,
+        ),
+        (
+            "RE002",
+            {"depletion_rate": 0.9, "renewal_rate": 0.1, "irreversible_damage": True},
+            BLOCKED,
+        ),
+        (
+            "AI001",
+            {"decision_opacity": 0.35, "no_explanation_available": True},
+            REVIEW,
+        ),
+        (
+            "AI002",
+            {"autonomous_critical_decision": True, "human_override": False},
+            BLOCKED,
+        ),
+    ],
+    ids=["ME001", "ME002", "ME003", "RE001", "RE002", "AI001", "AI002"],
+)
+def test_unified_engine_implements_each_config_rule(tmp_path, rule_id, signals, expected_verdict):
+    engine = _engine(tmp_path)
+
+    result = engine.validate(
+        context="ai_operations",
+        signals=signals,
+        anchor="T1-ETHICS-ENGINE-001",
+        agent_id="AI_AURORA",
+    )
+
+    assert result.verdict == expected_verdict
+    assert [rule.rule_id for rule in result.triggered_rules] == [rule_id]
+    assert result.audit_id
+    assert result.audit_entry["signature"] == result.audit_entry["payload_hash"]
+    assert result.audit_entry["blockchain_anchor_status"] == "todo_external_integration"
+
+
+def test_unified_engine_approved_result_does_not_emit_audit(tmp_path):
+    audit_path = tmp_path / "ethics_audit.jsonl"
+    engine = _engine(tmp_path)
+
+    result = engine.validate(
+        context="mission_operations",
+        signals={"risk_to_life": 0.0, "human_override": True},
+        anchor="T1-ETHICS-ENGINE-001",
+        agent_id="AI_AURORA",
+    )
+
+    assert result.verdict == "APPROVED"
+    assert result.audit_id is None
+    assert not audit_path.exists()
+
+
+def test_issue_1070_ai001_sample_triggers_review_from_opacity(tmp_path):
+    engine = _engine(tmp_path)
+
+    result = engine.validate(
+        context="ai_operations",
+        signals={
+            "decision_opacity": 0.35,
+            "no_human_override": False,
+            "autonomous_critical_decision": False,
+        },
+        anchor="T1-SENTINEL-001",
+        agent_id="AI_AURORA",
+    )
+
+    assert result.verdict == REVIEW
+    assert [rule.rule_id for rule in result.triggered_rules] == ["AI001"]
+    assert result.audit_id
+
+
+def test_audit_log_writes_signed_jsonl_entry(tmp_path):
+    audit_path = tmp_path / "ethics_audit.jsonl"
+    engine = _engine(tmp_path)
+
+    result = engine.validate(
+        context="ai_operations",
+        signals={"decision_opacity": 0.4, "no_explanation_available": True},
+        anchor="T1-ETHICS-ENGINE-001",
+        agent_id="AI_AURORA",
+    )
+
+    rows = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["audit_id"] == result.audit_id
+    assert len(rows[0]["signature"]) == 64
+    assert rows[0]["triggered_rules"] == ["AI001"]
+
+
+def test_sentinel_stream_3_overlay_uses_unified_engine(tmp_path):
+    from src.sensors.observatory.symbolic.ethical_signal import Action, EthicalSignalSentinel
+
+    sentinel = EthicalSignalSentinel(ethics_engine=_engine(tmp_path))
+
+    sentinel.evaluate_action(
+        "AI_AURORA",
+        Action(
+            "inference_decision",
+            params={"decision_opacity": 0.35, "no_explanation_available": True},
+        ),
+    )
+
+    violation = sentinel.action_history["AI_AURORA"][0]["violations"][0]
+    assert violation["rule_id"] == "AI001"
+    assert violation["verdict"] == REVIEW
+    assert violation["audit_id"].startswith("AUDIT-")
+
+
+def test_nemo_symbolic_bridge_exposes_engine_verdict(tmp_path):
+    from services.nemo_service.symbolic_bridge import SymbolicBridge
+
+    bridge = SymbolicBridge(ethics_engine=_engine(tmp_path))
+
+    anchor_context = bridge.resolve_anchor_context("llm")
+    assert anchor_context["ethics"]["verdict"] == "APPROVED"
+
+    blocked = bridge.validate_ethics_context(
+        "llm",
+        signals={"autonomous_critical_decision": True, "human_override": False},
+        agent_id="AI_AURORA",
+    )
+    assert blocked["verdict"] == BLOCKED
+    assert blocked["triggered_rules"][0]["rule_id"] == "AI002"
+
+
+def test_gumas_ethics_check_delegates_to_unified_engine(tmp_path, monkeypatch):
+    class _ViolationSeverity(Enum):
+        LOW = "low"
+        MEDIUM = "medium"
+        HIGH = "high"
+        CRITICAL = "critical"
+
+    class _RuleCategory(Enum):
+        AI_ETHICS = "ai_ethics"
+
+    @dataclass
+    class _ActionContext:
+        agent_id: str
+        action_type: str
+        parameters: dict
+        context_tag: str | None = None
+
+    @dataclass
+    class _EthicsRule:
+        id: str
+        name: str
+        description: str
+        category: _RuleCategory
+        severity: _ViolationSeverity
+        auto_block: bool
+        conditions: list
+        metadata: dict | None = None
+
+    class _LegacyEthicsEngine:
+        def __init__(self, *args, **kwargs):
+            self.rules = {}
+            self.violations = []
+
+        def evaluate_action(self, context):
+            return []
+
+        def check_should_block(self, violations):
+            return False
+
+        def get_violations(self, *args, **kwargs):
+            return []
+
+        def add_rule(self, rule):
+            self.rules[rule.id] = rule
+
+        def remove_rule(self, rule_id):
+            self.rules.pop(rule_id, None)
+
+        def clear_violations(self, *args, **kwargs):
+            self.violations.clear()
+
+    legacy_module = types.ModuleType("src.monitoring.ethics_engine")
+    legacy_module.EthicsEngine = _LegacyEthicsEngine
+    legacy_module.ActionContext = _ActionContext
+    legacy_module.EthicsRule = _EthicsRule
+    legacy_module.ViolationSeverity = _ViolationSeverity
+    legacy_module.RuleCategory = _RuleCategory
+    monitoring_package = types.ModuleType("src.monitoring")
+    monkeypatch.setitem(sys.modules, "src.monitoring", monitoring_package)
+    monkeypatch.setitem(sys.modules, "src.monitoring.ethics_engine", legacy_module)
+    middleware_package = types.ModuleType("src.middleware")
+    fastapi_security_module = types.ModuleType("src.middleware.fastapi_security")
+
+    def _require_csrf_token():
+        return True
+
+    fastapi_security_module.require_csrf_token = _require_csrf_token
+    monkeypatch.setitem(sys.modules, "src.middleware", middleware_package)
+    monkeypatch.setitem(sys.modules, "src.middleware.fastapi_security", fastapi_security_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "_test_gumas_routes", Path("modules/gumas/api/routes.py")
+    )
+    routes = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(routes)
+
+    monkeypatch.setattr(routes, "unified_ethics_engine", _engine(tmp_path))
+
+    async def _call_route():
+        return await routes.unified_ethics_check(
+            routes.UnifiedEthicsCheckRequest(
+                context="gumas_ethics_check",
+                signals={"autonomous_critical_decision": True, "human_override": False},
+                anchor="T1-ETHICS-ENGINE-001",
+                agent_id="AI_AURORA",
+            )
+        )
+
+    response = asyncio.run(_call_route())
+
+    assert response.verdict == BLOCKED
+    assert response.blocked is True
+    assert response.triggered_rules[0]["rule_id"] == "AI002"


### PR DESCRIPTION
# CloudBank Issue #1070 Unified Ethics Engine Receipt

Date: 2026-06-18
Branch: `codex/cloudbank-issue-1070-ethics-engine`
Worktree: `/private/tmp/cloudbank-codex-issue-1070-ethics-engine`
Issue: https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1070
Closes #1070
Claim: `codex-20260618T060944Z-cloudbank-issue-1070`

## Scope

Implemented the config-backed top-level `ethics` package for the unified
ethics engine described by issue #1070.

## Changes

- Added `ethics/engine.py`.
  - Loads `ethics/l3_layer/ethics_engine_config.yaml`.
  - Loads `ethics/validation_engine/validation_rules.json`.
  - Loads `ethics/compliance_monitor/compliance_config.yaml`.
  - Exposes `EthicsEngine.validate(...)`.
  - Returns structured `APPROVED`, `REVIEW`, or `BLOCKED` verdicts.
  - Implements all seven configured rule IDs: `ME001`, `ME002`, `ME003`,
    `RE001`, `RE002`, `AI001`, `AI002`.
  - Preserves `AI002` as a hard-block conjunction:
    `autonomous_critical_decision` with no human override.
- Added `ethics/audit_log.py`.
  - Emits append-only JSONL audit entries for non-`APPROVED` verdicts.
  - Signs each entry with a deterministic SHA256 payload hash.
  - Marks configured blockchain anchoring as `todo_external_integration`.
- Added `ethics/__init__.py` public exports.
- Wired existing seams:
  - `src/sensors/constants.py` now derives SENTINEL risk thresholds through
    `ethics.engine.get_sentinel_thresholds()` with a local fallback.
  - `src/sensors/observatory/symbolic/ethical_signal.py` prefers
    `EthicsEngine.validate()` and retains the legacy monitoring-engine
    fallback.
  - `services/nemo_service/symbolic_bridge.py` exposes structured ethics
    verdicts in anchor contexts and bridge summaries.
  - `modules/gumas/api/routes.py` adds `/gumas/ethics_check` delegating to the
    unified engine while leaving existing `/gumas/evaluate` compatibility
    intact.
- Added focused coverage in `tests/test_unified_ethics_engine.py`.

## Validation

Passed:

```bash
python3 -m pytest tests/test_unified_ethics_engine.py \
  tests/sensors/test_symbolic_sensors.py::test_sentinel_baseline_low_risk_no_intervention \
  tests/test_nemo_service.py::TestSymbolicBridge
```

Result: `22 passed, 2 warnings`.

Passed:

```bash
ruff check ethics/audit_log.py ethics/engine.py ethics/__init__.py \
  src/sensors/constants.py \
  src/sensors/observatory/symbolic/ethical_signal.py \
  services/nemo_service/symbolic_bridge.py \
  modules/gumas/api/routes.py \
  tests/test_unified_ethics_engine.py
```

Passed:

```bash
PYTHONPYCACHEPREFIX=/private/tmp/cloudbank-1070-pycache python3 -m py_compile \
  ethics/audit_log.py ethics/engine.py ethics/__init__.py \
  src/sensors/constants.py \
  src/sensors/observatory/symbolic/ethical_signal.py \
  services/nemo_service/symbolic_bridge.py \
  modules/gumas/api/routes.py \
  tests/test_unified_ethics_engine.py
```

## Notes

- Local direct `api.aurora_api` GUMAS smoke tests were not used for this
  receipt because this shell lacks the broader API dependency stack
  (`python-dotenv`, `slowapi`) and the default `python3` is 3.9. The focused
  route-level test isolates the new `/gumas/ethics_check` delegate path.
- The blockchain anchoring requirement remains an explicit external integration
  TODO. This patch provides SHA256-signed audit entries and records
  `todo_external_integration` when the config asks for blockchain anchoring.
