### PR TITLE
feat(section-8/1150): sanitized canonical fixture examples for recovered protocols

### DIFF
--- a/docs/ethics/recovered_protocols/fixtures/README.md
+++ b/docs/ethics/recovered_protocols/fixtures/README.md
@@ -1,0 +1,73 @@
+# Recovered Protocol Fixtures
+
+This directory contains **sanitized canonical example fixtures** for each recovered ethics protocol. They serve as the authoritative reference shape for schema validation, test tooling, and onboarding.
+
+## What a fixture is
+
+A fixture is a single-protocol JSON document that:
+- Contains **all required fields** from `custody_record.schema.json` and the per-protocol structure defined in `recovered_protocol_manifest.schema.json`
+- Represents the **correct shape** of a fully-populated entry — not a live custody record
+- Uses `PENDING` for all hash/date fields that have not yet been verified
+- Is **schema-valid** at all times — if a fixture fails schema validation, it is a bug in the fixture, not the schema
+
+## What a fixture is not
+
+- Not a live custody record — do not treat PENDING fields as verified
+- Not runtime authorization — no fixture here activates enforcement wiring
+- Not the live manifest — the live manifest is at `docs/ethics/recovered_protocols/recovered_protocol_manifest.json`
+
+## Intake rules
+
+1. **One file per protocol.** Filename must be `{protocol_id}.fixture.json`.
+2. **All 11 `custody_record` fields must be present.** Missing fields are a schema error.
+3. **Hash fields must be `PENDING` or a valid 64-char lowercase hex string.** No freeform strings.
+4. **`verification_date` must be `PENDING` or `YYYY-MM-DD`.** No other formats.
+5. **`promotion_decision` must be a valid enum value.** See `custody_record.schema.json` for the full list.
+6. **SHADOWFAX only:** `source_classification` must be `missing_dependency` and `promotion_decision` must be `blocked_pending_bundle_location`. This is schema-enforced.
+7. **Moriarty only:** `unresolved_blockers` must include the HARD BLOCK annotation until containment tests pass.
+
+## Filling a fixture when real custody data becomes available
+
+When a source package is located and hash-verified:
+
+1. Update `source_package_name` to the real package name.
+2. Update `source_package_sha256` to the verified 64-char hex hash.
+3. Update `internal_file_path` to the real path inside the package.
+4. Update `internal_file_sha256` to the verified 64-char hex hash.
+5. Update `verification_date` to `YYYY-MM-DD`.
+6. Update `reviewer_or_agent_surface` to the reviewer's name or agent surface ID.
+7. Remove resolved items from `unresolved_blockers`. If all blockers are resolved, set to `[]`.
+8. Update `promotion_decision` per the wiring gate in `recovered_protocol_manifest.json`.
+9. Re-run schema validation before committing.
+
+Do **not** update `promotion_decision` to `approved_for_runtime_wiring` without operator approval and all wiring gate conditions met.
+
+## Validation
+
+```bash
+# Validate a single fixture's custody_record
+ajv validate \
+  -s docs/ethics/recovered_protocols/schemas/custody_record.schema.json \
+  -d docs/ethics/recovered_protocols/fixtures/sherlock.fixture.json \
+  --spec=draft2020
+
+# Validate the live manifest (which embeds all custody_records)
+ajv validate \
+  -s docs/ethics/recovered_protocols/schemas/recovered_protocol_manifest.schema.json \
+  -d docs/ethics/recovered_protocols/recovered_protocol_manifest.json \
+  --spec=draft2020
+```
+
+## SHADOWFAX notice
+
+The SHADOWFAX standalone bundle has not been located. `shadowfax.fixture.json` has:
+- `source_classification: missing_dependency`
+- `promotion_decision: blocked_pending_bundle_location`
+
+This state is schema-enforced (see `custody_record.schema.json` `if/then` branch). Any change to SHADOWFAX's `promotion_decision` requires the bundle to be located, hash-verified, and operator-approved first.
+
+## Schema references
+
+- `../schemas/custody_record.schema.json` — validates the `custody_record` object
+- `../schemas/recovered_protocol_manifest.schema.json` — validates the full manifest
+- `../schemas/validate_manifest.test.json` — test fixture with positive and negative cases

--- a/docs/ethics/recovered_protocols/fixtures/moriarty.fixture.json
+++ b/docs/ethics/recovered_protocols/fixtures/moriarty.fixture.json
@@ -1,0 +1,48 @@
+{
+  "_fixture_meta": {
+    "fixture_for": "moriarty",
+    "description": "Canonical sanitized example for the Moriarty recovered protocol. HARD BLOCK on wiring is preserved in unresolved_blockers until containment tests pass. All hash and date fields are PENDING.",
+    "schema_refs": [
+      "../schemas/custody_record.schema.json",
+      "../schemas/recovered_protocol_manifest.schema.json"
+    ],
+    "intake_status": "sanitized_canonical_example",
+    "validation_command": "ajv validate -s docs/ethics/recovered_protocols/schemas/custody_record.schema.json -d docs/ethics/recovered_protocols/fixtures/moriarty.fixture.json --spec=draft2020",
+    "sanitization_notes": "No real source packages, file paths, or hashes are present. The HARD BLOCK annotation in unresolved_blockers is preserved from the live manifest and must not be removed until containment tests pass and operator approval is given."
+  },
+  "protocol_id": "moriarty",
+  "role": "Anomaly containment, quarantine, review-only translation, ethics audit, anchor validation, and rollback-over-compromise posture.",
+  "custody_record": {
+    "source_package_name": "PENDING",
+    "source_package_sha256": "PENDING",
+    "internal_file_path": "PENDING",
+    "internal_file_sha256": "PENDING",
+    "observed_version": "unverified-recovered-candidate",
+    "observed_status": "recovered_candidate",
+    "source_classification": "recovered_candidate",
+    "verification_date": "PENDING",
+    "reviewer_or_agent_surface": "PENDING",
+    "unresolved_blockers": [
+      "Exact source package name and hash not yet verified.",
+      "Internal file path and hash not yet verified.",
+      "Runtime containment boundaries not yet tested — HARD BLOCK on wiring."
+    ],
+    "promotion_decision": "pending_custody_verification"
+  },
+  "allowed_actions": ["identify_anomaly_candidate", "recommend_quarantine", "perform_anchor_check", "recommend_rollback"],
+  "forbidden_actions": [
+    "treat_containment_as_narrative_escalation",
+    "adjudicate_own_actions",
+    "bypass_appeal",
+    "mutate_l1_state"
+  ],
+  "layer_boundaries": {
+    "l1": "No direct L1 mutation or device/environment control.",
+    "l2": "May recommend quarantine for simulation artifacts only under review.",
+    "l3": "May inspect symbolic continuity anchors without rewriting them.",
+    "cross_layer_rules": [
+      "Quarantine recommendation must occur before interpretation.",
+      "Containment cannot become enforcement until tests and appeal paths exist."
+    ]
+  }
+}

--- a/docs/ethics/recovered_protocols/fixtures/shadowfax.fixture.json
+++ b/docs/ethics/recovered_protocols/fixtures/shadowfax.fixture.json
@@ -1,0 +1,48 @@
+{
+  "_fixture_meta": {
+    "fixture_for": "shadowfax",
+    "description": "Canonical sanitized example for the SHADOWFAX recovered protocol. source_classification is missing_dependency and promotion_decision is blocked_pending_bundle_location — both are schema-enforced via the if/then constraint in custody_record.schema.json. The standalone SHADOWFAX bundle has not been located. No wiring decision may be made until the bundle is found and hash-verified.",
+    "schema_refs": [
+      "../schemas/custody_record.schema.json",
+      "../schemas/recovered_protocol_manifest.schema.json"
+    ],
+    "intake_status": "sanitized_canonical_example",
+    "validation_command": "ajv validate -s docs/ethics/recovered_protocols/schemas/custody_record.schema.json -d docs/ethics/recovered_protocols/fixtures/shadowfax.fixture.json --spec=draft2020",
+    "sanitization_notes": "No real source packages, file paths, or hashes are present. The missing_dependency classification and blocked_pending_bundle_location promotion_decision are correct and schema-enforced. Do not change promotion_decision without locating the standalone bundle and obtaining operator approval."
+  },
+  "protocol_id": "shadowfax",
+  "role": "Stillness, supervisory review, paradox escalation, and boundary-instability oversight.",
+  "custody_record": {
+    "source_package_name": "PENDING",
+    "source_package_sha256": "PENDING",
+    "internal_file_path": "PENDING",
+    "internal_file_sha256": "PENDING",
+    "observed_version": "unverified-partial-lineage",
+    "observed_status": "sealed_bundle_reference",
+    "source_classification": "missing_dependency",
+    "verification_date": "PENDING",
+    "reviewer_or_agent_surface": "PENDING",
+    "unresolved_blockers": [
+      "Standalone SHADOWFAX bundle not yet located — HARD BLOCK on any wiring decision.",
+      "Exact source package name and hash not yet verified.",
+      "Internal file path and hash not yet verified."
+    ],
+    "promotion_decision": "blocked_pending_bundle_location"
+  },
+  "allowed_actions": [
+    "recommend_stillness",
+    "escalate_paradox_for_review",
+    "flag_boundary_instability",
+    "request_supervisory_review"
+  ],
+  "forbidden_actions": ["bypass_evidence", "erase_review_paths", "convert_instability_into_proof", "override_without_audit"],
+  "layer_boundaries": {
+    "l1": "May recommend pause/escalation only after review.",
+    "l2": "May flag simulation boundary instability as non-canonical evidence.",
+    "l3": "May flag THREADCORE paradox or continuity instability for review.",
+    "cross_layer_rules": [
+      "Stillness cannot bypass audit.",
+      "Boundary instability is not proof by itself."
+    ]
+  }
+}

--- a/docs/ethics/recovered_protocols/fixtures/sherlock.fixture.json
+++ b/docs/ethics/recovered_protocols/fixtures/sherlock.fixture.json
@@ -1,0 +1,43 @@
+{
+  "_fixture_meta": {
+    "fixture_for": "sherlock",
+    "description": "Canonical sanitized example for the Sherlock recovered protocol. All custody_record fields present and schema-valid. Hash and date fields are PENDING until real custody verification is performed.",
+    "schema_refs": [
+      "../schemas/custody_record.schema.json",
+      "../schemas/recovered_protocol_manifest.schema.json"
+    ],
+    "intake_status": "sanitized_canonical_example",
+    "validation_command": "ajv validate -s docs/ethics/recovered_protocols/schemas/custody_record.schema.json -d docs/ethics/recovered_protocols/fixtures/sherlock.fixture.json --spec=draft2020",
+    "sanitization_notes": "No real source packages, file paths, or hashes are present. PENDING is the correct value for all unverified fields."
+  },
+  "protocol_id": "sherlock",
+  "role": "Investigation, traceability, causal mapping, transparency reporting, and doctrine verification.",
+  "custody_record": {
+    "source_package_name": "PENDING",
+    "source_package_sha256": "PENDING",
+    "internal_file_path": "PENDING",
+    "internal_file_sha256": "PENDING",
+    "observed_version": "unverified-recovered-candidate",
+    "observed_status": "recovered_candidate",
+    "source_classification": "recovered_candidate",
+    "verification_date": "PENDING",
+    "reviewer_or_agent_surface": "PENDING",
+    "unresolved_blockers": [
+      "Exact source package name and hash not yet verified.",
+      "Internal file path and hash not yet verified.",
+      "Protocol-specific schema not yet promoted."
+    ],
+    "promotion_decision": "pending_custody_verification"
+  },
+  "allowed_actions": ["investigate", "trace", "verify_doctrine", "produce_transparency_report"],
+  "forbidden_actions": ["mutate_subject_state", "enforce_containment", "adjudicate_appeals"],
+  "layer_boundaries": {
+    "l1": "May produce operator-readable reports only after review.",
+    "l2": "May analyze simulation artifacts as evidence candidates.",
+    "l3": "May reference THREADCORE continuity and doctrine traces.",
+    "cross_layer_rules": [
+      "No L2-to-L1 promotion without custody review.",
+      "Investigation output is not enforcement authority."
+    ]
+  }
+}

--- a/docs/ethics/recovered_protocols/fixtures/tribunal.fixture.json
+++ b/docs/ethics/recovered_protocols/fixtures/tribunal.fixture.json
@@ -1,0 +1,43 @@
+{
+  "_fixture_meta": {
+    "fixture_for": "tribunal",
+    "description": "Canonical sanitized example for the Tribunal recovered protocol. All custody_record fields present and schema-valid. Hash and date fields are PENDING until real custody verification is performed.",
+    "schema_refs": [
+      "../schemas/custody_record.schema.json",
+      "../schemas/recovered_protocol_manifest.schema.json"
+    ],
+    "intake_status": "sanitized_canonical_example",
+    "validation_command": "ajv validate -s docs/ethics/recovered_protocols/schemas/custody_record.schema.json -d docs/ethics/recovered_protocols/fixtures/tribunal.fixture.json --spec=draft2020",
+    "sanitization_notes": "No real source packages, file paths, or hashes are present. PENDING is the correct value for all unverified fields."
+  },
+  "protocol_id": "tribunal",
+  "role": "Dispute and appeal adjudication for memory, narrative integrity, drift, and containment questions.",
+  "custody_record": {
+    "source_package_name": "PENDING",
+    "source_package_sha256": "PENDING",
+    "internal_file_path": "PENDING",
+    "internal_file_sha256": "PENDING",
+    "observed_version": "unverified-recovered-candidate",
+    "observed_status": "recovered_candidate",
+    "source_classification": "recovered_candidate",
+    "verification_date": "PENDING",
+    "reviewer_or_agent_surface": "PENDING",
+    "unresolved_blockers": [
+      "Exact source package name and hash not yet verified.",
+      "Internal file path and hash not yet verified.",
+      "Quorum and appeal semantics not yet verified."
+    ],
+    "promotion_decision": "pending_custody_verification"
+  },
+  "allowed_actions": ["adjudicate_dispute", "review_containment_appeal", "record_ruling", "recommend_reopen"],
+  "forbidden_actions": ["perform_primary_investigation", "secretly_enforce_containment", "rule_without_evidence"],
+  "layer_boundaries": {
+    "l1": "May produce reviewed adjudication records only.",
+    "l2": "May adjudicate simulation disputes without promoting them to L1 canon.",
+    "l3": "May review symbolic drift disputes with evidence bundles.",
+    "cross_layer_rules": [
+      "No ruling without minimum evidence.",
+      "Adjudication cannot secretly enforce containment."
+    ]
+  }
+}

--- a/docs/ethics/recovered_protocols/fixtures/watson.fixture.json
+++ b/docs/ethics/recovered_protocols/fixtures/watson.fixture.json
@@ -1,0 +1,43 @@
+{
+  "_fixture_meta": {
+    "fixture_for": "watson",
+    "description": "Canonical sanitized example for the Watson recovered protocol. All custody_record fields present and schema-valid. Hash and date fields are PENDING until real custody verification is performed.",
+    "schema_refs": [
+      "../schemas/custody_record.schema.json",
+      "../schemas/recovered_protocol_manifest.schema.json"
+    ],
+    "intake_status": "sanitized_canonical_example",
+    "validation_command": "ajv validate -s docs/ethics/recovered_protocols/schemas/custody_record.schema.json -d docs/ethics/recovered_protocols/fixtures/watson.fixture.json --spec=draft2020",
+    "sanitization_notes": "No real source packages, file paths, or hashes are present. PENDING is the correct value for all unverified fields."
+  },
+  "protocol_id": "watson",
+  "role": "Context retention, rigidity moderation, evidence correlation, and operator-readable briefing.",
+  "custody_record": {
+    "source_package_name": "PENDING",
+    "source_package_sha256": "PENDING",
+    "internal_file_path": "PENDING",
+    "internal_file_sha256": "PENDING",
+    "observed_version": "unverified-recovered-candidate",
+    "observed_status": "recovered_candidate",
+    "source_classification": "recovered_candidate",
+    "verification_date": "PENDING",
+    "reviewer_or_agent_surface": "PENDING",
+    "unresolved_blockers": [
+      "Exact source package name and hash not yet verified.",
+      "Internal file path and hash not yet verified.",
+      "Protocol-specific schema not yet promoted."
+    ],
+    "promotion_decision": "pending_custody_verification"
+  },
+  "allowed_actions": ["retain_context", "correlate_evidence", "generate_operator_brief", "moderate_rigidity"],
+  "forbidden_actions": ["alter_sherlock_logs", "enforce_containment", "adjudicate_disputes"],
+  "layer_boundaries": {
+    "l1": "May brief operators with reviewed context only.",
+    "l2": "May correlate simulation context as non-canonical evidence.",
+    "l3": "May correlate THREADCORE continuity material without mutating it.",
+    "cross_layer_rules": [
+      "Briefs cannot promote recovered candidates into runtime canon.",
+      "Context moderation cannot alter source logs."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #1150 — Protocol fixture intake.

Adds `docs/ethics/recovered_protocols/fixtures/` with six files: a README and one canonical fixture per protocol.

---

## Files

### `fixtures/README.md`
- Defines what a fixture is and is not
- Intake rules (one file per protocol, all 11 fields required, hash pattern, enum constraints)
- Step-by-step instructions for filling a fixture when real custody data becomes available
- SHADOWFAX hard-block notice
- `ajv` validation commands for both single-fixture and full-manifest validation

### Per-protocol fixtures

| File | Key notes |
|---|---|
| `sherlock.fixture.json` | `recovered_candidate`, all PENDING |
| `watson.fixture.json` | `recovered_candidate`, all PENDING |
| `moriarty.fixture.json` | `recovered_candidate`, HARD BLOCK annotation preserved in `unresolved_blockers` |
| `tribunal.fixture.json` | `recovered_candidate`, quorum/appeal blocker preserved |
| `shadowfax.fixture.json` | `source_classification: missing_dependency`, `promotion_decision: blocked_pending_bundle_location` (schema-enforced) |

Each fixture includes a `_fixture_meta` block with:
- `fixture_for` — protocol ID
- `schema_refs` — pointers to both schema files added in #1149
- `intake_status: sanitized_canonical_example`
- `validation_command` — exact `ajv` CLI invocation
- `sanitization_notes` — explains what was and wasn't included

---

## What this unblocks

With #1150 merged, issues #1151 (runtime mapping design), #1152 (Moriarty containment tests), and #1153 (Tribunal appeal tests) all have schema-valid fixture examples to target.

## Non-goals

No runtime enforcement. No hash values fabricated. All PENDING fields are intentional. No change to the live manifest.

## Dependency chain

- Blocked by #1148 ✅ (merged #1154)
- Blocked by #1149 ✅ (merged #1155)
- Unblocks #1151, #1152, #1153