### PR TITLE
aurora(queue): sync work queue after protocol setup closures

### DIFF
--- a/ops/work_queue/NEXT_UP.md
+++ b/ops/work_queue/NEXT_UP.md
@@ -5,7 +5,7 @@
 
 # Next Up — Aurora Work Queue
 
-_Generated: `2026-06-23T22:43:00Z` — edit `queue.json`, run `sync_queue.py`_
+_Generated: `2026-06-24T03:45:00Z` — edit `queue.json`, run `sync_queue.py`_
 
 ---
 
@@ -15,22 +15,24 @@ Items with `status: open` and all dependencies resolved.
 
 | Rank | ID | Title | Tags |
 |---|---|---|---|
-| 1 | #1147 | Work queue automation (sync_queue.py, GitHub Actions, aurora(queue): hook) | `ops` `automation` `coordination` `blocker` |
-| 2 | #1126 | FastAPI lifespan migration (deprecation fix) | `runtime` `blocker` `deprecation` |
-| 4 | security/CVE-audit | CVE dependency audit (Sprint 311 follow-on) | `security` `audit` |
-| 5 | #1139 | docs/ethics — create top-level README and navigation index | `docs` `ethics` `navigation` |
-| 6 | #1140 | docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA | `docs` `architecture` `topology` |
-| 7 | #1148 | Protocol custody inventory — machine-readable manifest of recovered package/file hashes and blockers | `ethics` `protocols` `custody` `gate` |
-| 13 | #1137 | docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue | `ethics` `geometric` `implementation` |
-| 14 | #1138 | docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started | `ethics` `protocols` `custody` |
-| 15 | #1142 | docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue | `docs` `architecture` `drift-ledger` |
-| 16 | #1141 | docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined | `docs` `architecture` `QGIA` |
-| 18 | #1143 | docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology | `docs` `architecture` `scaling` |
-| 21 | #1135 | simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries | `simulation` `roster` `validation` |
-| 22 | #1136 | simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking | `simulation` `enhancement` `tracking` |
-| 23 | arch/layer-canonization | Layer architecture canonization (L1/L2/L3 enforcement in code) | `architecture` `canonical` `L1` `L2` `L3` |
-| 25 | ops/QGIA-doctrine-store | QGIA analytical framework — store in ops/analytical_frameworks/QGIA/ | `QGIA` `analytical-framework` `ops` `non-canonical` |
-| 26 | docs/api-reference | API reference documentation | `docs` `api` |
+| 1 | #1126 | FastAPI lifespan migration (deprecation fix) | `runtime` `blocker` `deprecation` |
+| 2 | #1130 | CI green-path stabilization | `ci` `infrastructure` |
+| 3 | security/CVE-audit | CVE dependency audit (Sprint 311 follow-on) | `security` `audit` |
+| 4 | #1139 | docs/ethics — create top-level README and navigation index | `docs` `ethics` `navigation` |
+| 5 | #1140 | docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA | `docs` `architecture` `topology` |
+| 9 | #1137 | docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue | `ethics` `geometric` `implementation` |
+| 10 | #1138 | docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started | `ethics` `protocols` `custody` |
+| 11 | #1142 | docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue | `docs` `architecture` `drift-ledger` |
+| 12 | #1141 | docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined | `docs` `architecture` `QGIA` |
+| 13 | #1144 | docs/api — api_surface_inventory.json missing four surfaces | `docs` `api` `inventory` |
+| 14 | #1143 | docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology | `docs` `architecture` `scaling` |
+| 15 | #1145 | docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps | `docs` `api` `reference` |
+| 16 | #1146 | docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated | `docs` `api` `governance` |
+| 17 | #1135 | simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries | `simulation` `roster` `validation` |
+| 18 | #1136 | simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking | `simulation` `enhancement` `tracking` |
+| 19 | arch/layer-canonization | Layer architecture canonization (L1/L2/L3 enforcement in code) | `architecture` `canonical` `L1` `L2` `L3` |
+| 21 | ops/QGIA-doctrine-store | QGIA analytical framework — store in ops/analytical_frameworks/QGIA/ | `QGIA` `analytical-framework` `ops` `non-canonical` |
+| 22 | docs/api-reference | API reference documentation | `docs` `api` |
 
 ---
 
@@ -38,17 +40,7 @@ Items with `status: open` and all dependencies resolved.
 
 Items waiting on dependencies. Do not start until blockers close.
 
-| Rank | ID | Title | Blocked By |
-|---|---|---|---|
-| 3 | #1130 | CI green-path stabilization | #1126 |
-| 8 | #1149 | Protocol JSON schemas — add schema files and validation tests for all five protocols | #1148 |
-| 9 | #1150 | Protocol fixture intake — sanitized canonical examples for all five protocols | #1148, #1149 |
-| 10 | #1151 | Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics | #1148, #1149, #1150 |
-| 11 | #1152 | Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed | #1148, #1149, #1150, #1151 |
-| 12 | #1153 | Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement | #1148, #1149, #1150, #1151 |
-| 17 | #1144 | docs/api — api_surface_inventory.json missing four surfaces | #1140, #1141 |
-| 19 | #1145 | docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps | #1144 |
-| 20 | #1146 | docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated | #1142, #1144, #1145 |
+_No blocked items._
 
 ---
 
@@ -58,5 +50,5 @@ Items gated on a human or governance decision. Agents skip these.
 
 | Rank | ID | Title |
 |---|---|---|
-| 24 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution |
-| 27 | feat/QGIA | QGIA integration hooks |
+| 20 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution |
+| 23 | feat/QGIA | QGIA integration hooks |

--- a/ops/work_queue/OPEN_GATES.md
+++ b/ops/work_queue/OPEN_GATES.md
@@ -5,29 +5,22 @@
 
 # Open Gates — Aurora Work Queue
 
-_Generated: `2026-06-23T22:43:00Z` — edit `queue.json`, run `sync_queue.py`_
+_Generated: `2026-06-24T03:45:00Z` — edit `queue.json`, run `sync_queue.py`_
 
 > Gates are items tagged `gate` or carrying `status: needs-decision`.
 > Nothing downstream can advance until the gate closes.
 
 ---
 
-## Open Gates (3)
+## Open Gates (2)
 
 | Rank | ID | Title | Status |
 |---|---|---|---|
-| 7 | #1148 | Protocol custody inventory — machine-readable manifest of recovered package/file hashes and blockers | `open` |
-| 24 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution | `needs-decision` |
-| 27 | feat/QGIA | QGIA integration hooks | `needs-decision` |
+| 20 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution | `needs-decision` |
+| 23 | feat/QGIA | QGIA integration hooks | `needs-decision` |
 
 ---
 
-## Waiting on Gate (5)
+## Waiting on Gate (0)
 
-| Rank | ID | Title | Waiting On |
-|---|---|---|---|
-| 8 | #1149 | Protocol JSON schemas — add schema files and validation tests for all five protocols | #1148 |
-| 9 | #1150 | Protocol fixture intake — sanitized canonical examples for all five protocols | #1148 |
-| 10 | #1151 | Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics | #1148 |
-| 11 | #1152 | Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed | #1148 |
-| 12 | #1153 | Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement | #1148 |
+_No items waiting on gates._

--- a/ops/work_queue/QUEUE.md
+++ b/ops/work_queue/QUEUE.md
@@ -5,10 +5,10 @@
 
 # Aurora Work Queue
 
-**Schema version:** `1.2.0`  
-**Last Aurora review:** `2026-06-23T01:59:00Z`  
-**Generated:** `2026-06-23T22:43:00Z`  
-**Items:** 27 active · 0 completed
+**Schema version:** `1.2.1`  
+**Last Aurora review:** `2026-06-24T03:45:00Z`  
+**Generated:** `2026-06-24T03:45:00Z`  
+**Items:** 23 active · 4 completed
 
 > Aurora holds contextual authority over rank order.
 > Do not edit rank or `aurora_note` fields without an `aurora(queue):` commit.
@@ -18,23 +18,7 @@
 
 ## Active Queue
 
-### 1. 🟢 #1147 — Work queue automation (sync_queue.py, GitHub Actions, aurora(queue): hook)
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | — |
-| **Tags** | `ops` `automation` `coordination` `blocker` |
-
-**Aurora note:**
-
-> The queue is not functional without automation. It is currently a manually-maintained document — any agent reading it as a work selection source is operating on a stale map. This must land before the queue can be trusted as a coordination layer for anything else. Three deliverables: sync_queue.py (CI validator), GitHub Actions workflow (auto-post on push), aurora(queue): convention in CONTRIBUTING.md.
-
----
-
-### 2. 🟢 #1126 — FastAPI lifespan migration (deprecation fix)
+### 1. 🟢 #1126 — FastAPI lifespan migration (deprecation fix)
 
 | Field | Value |
 |---|---|
@@ -50,7 +34,7 @@
 
 ---
 
-### 3. 🟢 #1130 — CI green-path stabilization
+### 2. 🟢 #1130 — CI green-path stabilization
 
 | Field | Value |
 |---|---|
@@ -66,7 +50,7 @@
 
 ---
 
-### 4. 🟢 security/CVE-audit — CVE dependency audit (Sprint 311 follow-on)
+### 3. 🟢 security/CVE-audit — CVE dependency audit (Sprint 311 follow-on)
 
 | Field | Value |
 |---|---|
@@ -82,7 +66,7 @@
 
 ---
 
-### 5. 🟢 #1139 — docs/ethics — create top-level README and navigation index
+### 4. 🟢 #1139 — docs/ethics — create top-level README and navigation index
 
 | Field | Value |
 |---|---|
@@ -98,7 +82,7 @@
 
 ---
 
-### 6. 🟢 #1140 — docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA
+### 5. 🟢 #1140 — docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA
 
 | Field | Value |
 |---|---|
@@ -114,103 +98,55 @@
 
 ---
 
-### 7. 🟢 #1148 — Protocol custody inventory — machine-readable manifest of recovered package/file hashes and blockers
+### 6. 🔵 #1151 — Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics
 
 | Field | Value |
 |---|---|
-| **Status** | `open` |
+| **Status** | `in-progress` |
 | **Owner** | _unassigned_ |
 | **Depends on** | — |
-| **Blocks** | #1149, #1150, #1151, #1152, #1153 |
-| **Tags** | `ethics` `protocols` `custody` `gate` |
-
-**Aurora note:**
-
-> Gate for the entire Section 8 protocol promotion chain. All five protocol custody records are PENDING — no SHA verification has been performed. Blocks #1149, #1150, #1151, #1152, #1153. Nothing in the recovered protocol chain can advance until this closes.
-
----
-
-### 8. 🔴 #1149 — Protocol JSON schemas — add schema files and validation tests for all five protocols
-
-| Field | Value |
-|---|---|
-| **Status** | `blocked` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1148 |
-| **Blocks** | #1150, #1151, #1152, #1153 |
-| **Tags** | `ethics` `protocols` `schemas` |
-
-**Aurora note:**
-
-> Blocked by #1148 (custody inventory). Schemas cannot be finalized until custody classification is confirmed for each protocol artifact.
-
----
-
-### 9. 🔴 #1150 — Protocol fixture intake — sanitized canonical examples for all five protocols
-
-| Field | Value |
-|---|---|
-| **Status** | `blocked` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1148, #1149 |
-| **Blocks** | #1151, #1152, #1153 |
-| **Tags** | `ethics` `protocols` `fixtures` |
-
-**Aurora note:**
-
-> Blocked by #1148 and #1149. Fixtures must validate against schemas from #1149 and must not promote raw recovered payloads without custody review.
-
----
-
-### 10. 🔴 #1151 — Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics
-
-| Field | Value |
-|---|---|
-| **Status** | `blocked` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1148, #1149, #1150 |
 | **Blocks** | #1152, #1153 |
 | **Tags** | `ethics` `protocols` `runtime` `design` |
 
 **Aurora note:**
 
-> Blocked by #1148–#1150. Design-only artifact — no runtime wiring. Must not begin until artifacts are custody-verified.
+> Previously blocked by #1148–#1150; those prerequisite issues are now completed. PR #1157 is open and mergeable. Review first in the recovered-protocol chain. Documentation-only artifact — no runtime wiring.
 
 ---
 
-### 11. 🔴 #1152 — Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed
+### 7. 🔵 #1152 — Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed
 
 | Field | Value |
 |---|---|
-| **Status** | `blocked` |
+| **Status** | `in-progress` |
 | **Owner** | _unassigned_ |
-| **Depends on** | #1148, #1149, #1150, #1151 |
+| **Depends on** | #1151 |
 | **Blocks** | — |
 | **Tags** | `ethics` `protocols` `moriarty` `tests` |
 
 **Aurora note:**
 
-> Blocked by #1148–#1151. Tests run against fixtures from #1150, not raw recovered payloads. No active L2-to-L1 behavior introduced.
+> Previously blocked by #1148–#1151. PR #1158 is open and mergeable, but review/merge should follow #1157 because the appeal and mapping assumptions depend on the runtime mapping design. No active L2-to-L1 behavior introduced.
 
 ---
 
-### 12. 🔴 #1153 — Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement
+### 8. 🔵 #1153 — Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement
 
 | Field | Value |
 |---|---|
-| **Status** | `blocked` |
+| **Status** | `in-progress` |
 | **Owner** | _unassigned_ |
-| **Depends on** | #1148, #1149, #1150, #1151 |
+| **Depends on** | #1151 |
 | **Blocks** | — |
 | **Tags** | `ethics` `protocols` `tribunal` `tests` |
 
 **Aurora note:**
 
-> Blocked by #1148–#1151. Parallel with #1152 once unblocked. No runtime enforcement wiring introduced.
+> Previously blocked by #1148–#1151. PR #1159 is open and mergeable, but Codacy reported two minor CodeStyle issues; review/merge should follow #1157 and preferably coordinate with #1158. No runtime enforcement wiring introduced.
 
 ---
 
-### 13. 🟢 #1137 — docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue
+### 9. 🟢 #1137 — docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue
 
 | Field | Value |
 |---|---|
@@ -226,7 +162,7 @@
 
 ---
 
-### 14. 🟢 #1138 — docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started
+### 10. 🟢 #1138 — docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started
 
 | Field | Value |
 |---|---|
@@ -238,11 +174,11 @@
 
 **Aurora note:**
 
-> Surfaces the manifest side of the same work as #1148. Both must close together. Locate source packages, compute SHAs, record verified_at/verified_by. SHADOWFAX is a hard block — standalone bundle must be located or formally recorded as missing dependency.
+> Partially superseded by completed #1148, #1149, and #1150: custody fixture, schema, and sanitized fixture scaffolding now exist. Remaining live work is true custody verification: source/internal SHA resolution, verified_at/verified_by fields, and SHADOWFAX standalone bundle disposition.
 
 ---
 
-### 15. 🟢 #1142 — docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue
+### 11. 🟢 #1142 — docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue
 
 | Field | Value |
 |---|---|
@@ -258,7 +194,7 @@
 
 ---
 
-### 16. 🟢 #1141 — docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined
+### 12. 🟢 #1141 — docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined
 
 | Field | Value |
 |---|---|
@@ -274,7 +210,7 @@
 
 ---
 
-### 17. 🔴 #1144 — docs/api — api_surface_inventory.json missing four surfaces
+### 13. 🟢 #1144 — docs/api — api_surface_inventory.json missing four surfaces
 
 | Field | Value |
 |---|---|
@@ -290,7 +226,7 @@
 
 ---
 
-### 18. 🟢 #1143 — docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology
+### 14. 🟢 #1143 — docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology
 
 | Field | Value |
 |---|---|
@@ -306,7 +242,7 @@
 
 ---
 
-### 19. 🔴 #1145 — docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps
+### 15. 🟢 #1145 — docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps
 
 | Field | Value |
 |---|---|
@@ -322,7 +258,7 @@
 
 ---
 
-### 20. 🔴 #1146 — docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated
+### 16. 🟢 #1146 — docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated
 
 | Field | Value |
 |---|---|
@@ -338,7 +274,7 @@
 
 ---
 
-### 21. 🟢 #1135 — simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries
+### 17. 🟢 #1135 — simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries
 
 | Field | Value |
 |---|---|
@@ -354,7 +290,7 @@
 
 ---
 
-### 22. 🟢 #1136 — simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking
+### 18. 🟢 #1136 — simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking
 
 | Field | Value |
 |---|---|
@@ -370,7 +306,7 @@
 
 ---
 
-### 23. 🟢 arch/layer-canonization — Layer architecture canonization (L1/L2/L3 enforcement in code)
+### 19. 🟢 arch/layer-canonization — Layer architecture canonization (L1/L2/L3 enforcement in code)
 
 | Field | Value |
 |---|---|
@@ -382,11 +318,11 @@
 
 **Aurora note:**
 
-> Ensures no code path violates the canonical layer definitions. Foundational for all new agent work. Repositioned to Rank 23 — docs/architecture cluster work (#1140, #1141, #1143) should complete first to ensure canonization is working from current topology.
+> Ensures no code path violates the canonical layer definitions. Foundational for all new agent work. Repositioned after docs/architecture cluster work (#1140, #1141, #1143) so canonization works from current topology.
 
 ---
 
-### 24. 🟡 sim/SENTINEL-phase0 — PROJECT SENTINEL — Phase 0: Ethics review board constitution
+### 20. 🟡 sim/SENTINEL-phase0 — PROJECT SENTINEL — Phase 0: Ethics review board constitution
 
 | Field | Value |
 |---|---|
@@ -402,7 +338,7 @@
 
 ---
 
-### 25. 🟢 ops/QGIA-doctrine-store — QGIA analytical framework — store in ops/analytical_frameworks/QGIA/
+### 21. 🟢 ops/QGIA-doctrine-store — QGIA analytical framework — store in ops/analytical_frameworks/QGIA/
 
 | Field | Value |
 |---|---|
@@ -418,7 +354,7 @@
 
 ---
 
-### 26. 🟢 docs/api-reference — API reference documentation
+### 22. 🟢 docs/api-reference — API reference documentation
 
 | Field | Value |
 |---|---|
@@ -434,7 +370,7 @@
 
 ---
 
-### 27. 🟡 feat/QGIA — QGIA integration hooks
+### 23. 🟡 feat/QGIA — QGIA integration hooks
 
 | Field | Value |
 |---|---|
@@ -449,3 +385,12 @@
 > Doctrine now available (QGIA Runtime One-Pager v4.2.1 + Axiom Doctrine Narrative v1.0, reviewed 2026-06-22). Two-layer discipline maps cleanly to Triplex Handshake. ops/QGIA-doctrine-store must land first, then PAT routing decision. Crew sign-off required before any QGIA axiom becomes operationally binding.
 
 ---
+
+## Completed
+
+| ID | Title |
+|---|---|
+| #1147 | feat: Aurora-Aware Work Queue System (ops/work_queue/) |
+| #1148 | Protocol custody inventory — machine-readable manifest of recovered package/file hashes and blockers |
+| #1149 | Protocol JSON schemas — add schema files and validation tests for Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX |
+| #1150 | Protocol fixture intake — add sanitized canonical examples for Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX |

--- a/ops/work_queue/queue.json
+++ b/ops/work_queue/queue.json
@@ -1,308 +1,411 @@
 {
   "_meta": {
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Aurora-aware work queue. Machine-readable mirror of QUEUE.md. Aurora holds contextual authority. Do not edit rank order without Aurora annotation.",
-    "last_aurora_review": "2026-06-23T01:59:00Z",
+    "last_aurora_review": "2026-06-24T03:45:00Z",
     "schema": "https://github.com/AUo959/aurora-cloudbank-symbolic/blob/main/ops/work_queue/queue_schema.json"
   },
   "active": [
     {
       "rank": 1,
-      "id": "#1147",
-      "title": "Work queue automation (sync_queue.py, GitHub Actions, aurora(queue): hook)",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": ["ops", "automation", "coordination", "blocker"],
-      "aurora_note": "The queue is not functional without automation. It is currently a manually-maintained document — any agent reading it as a work selection source is operating on a stale map. This must land before the queue can be trusted as a coordination layer for anything else. Three deliverables: sync_queue.py (CI validator), GitHub Actions workflow (auto-post on push), aurora(queue): convention in CONTRIBUTING.md.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 2,
       "id": "#1126",
       "title": "FastAPI lifespan migration (deprecation fix)",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["runtime", "blocker", "deprecation"],
+      "tags": [
+        "runtime",
+        "blocker",
+        "deprecation"
+      ],
       "aurora_note": "Critical runtime blocker. Resolves deprecation warning that affects all startup/shutdown hooks. Must land before any new feature PRs.",
       "aurora_authority": true
     },
     {
-      "rank": 3,
+      "rank": 2,
       "id": "#1130",
       "title": "CI green-path stabilization",
       "status": "open",
       "owner": null,
-      "depends_on": ["#1126"],
-      "tags": ["ci", "infrastructure"],
+      "depends_on": [
+        "#1126"
+      ],
+      "tags": [
+        "ci",
+        "infrastructure"
+      ],
       "aurora_note": "CI cannot be trusted for gate-keeping until lifespan is resolved. Unblock #1126 first.",
       "aurora_authority": true
     },
     {
-      "rank": 4,
+      "rank": 3,
       "id": "security/CVE-audit",
       "title": "CVE dependency audit (Sprint 311 follow-on)",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["security", "audit"],
+      "tags": [
+        "security",
+        "audit"
+      ],
       "aurora_note": "Independent of lifespan and queue automation. Can run in parallel on a separate branch.",
       "aurora_authority": true
     },
     {
-      "rank": 5,
+      "rank": 4,
       "id": "#1139",
       "title": "docs/ethics — create top-level README and navigation index",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["docs", "ethics", "navigation"],
+      "tags": [
+        "docs",
+        "ethics",
+        "navigation"
+      ],
       "aurora_note": "No blockers. Quick win. Ethics directory is not navigable by agents or contributors — no map to runtime surfaces, recovered protocols, or Picard_Delta_3. Unblocks all ethics cluster work that depends on directory orientation.",
       "aurora_authority": true
     },
     {
-      "rank": 6,
+      "rank": 5,
       "id": "#1140",
       "title": "docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["docs", "architecture", "topology"],
+      "tags": [
+        "docs",
+        "architecture",
+        "topology"
+      ],
       "aurora_note": "No blockers. Single doc edit — mesh/agents routes are canonical per PR #1011 but the topology doc still marks them as drift. Two documents are actively contradictory. Any agent loading the topology doc gets wrong information. Fix before any QGIA or mesh work proceeds.",
       "aurora_authority": true
     },
     {
-      "rank": 7,
-      "id": "#1148",
-      "title": "Protocol custody inventory — machine-readable manifest of recovered package/file hashes and blockers",
-      "status": "open",
+      "rank": 6,
+      "id": "#1151",
+      "title": "Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics",
+      "status": "in-progress",
       "owner": null,
       "depends_on": [],
-      "tags": ["ethics", "protocols", "custody", "gate"],
-      "aurora_note": "Gate for the entire Section 8 protocol promotion chain. All five protocol custody records are PENDING — no SHA verification has been performed. Blocks #1149, #1150, #1151, #1152, #1153. Nothing in the recovered protocol chain can advance until this closes.",
+      "tags": [
+        "ethics",
+        "protocols",
+        "runtime",
+        "design"
+      ],
+      "pr": 1157,
+      "aurora_note": "Previously blocked by #1148–#1150; those prerequisite issues are now completed. PR #1157 is open and mergeable. Review first in the recovered-protocol chain. Documentation-only artifact — no runtime wiring.",
+      "aurora_authority": true
+    },
+    {
+      "rank": 7,
+      "id": "#1152",
+      "title": "Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed",
+      "status": "in-progress",
+      "owner": null,
+      "depends_on": [
+        "#1151"
+      ],
+      "tags": [
+        "ethics",
+        "protocols",
+        "moriarty",
+        "tests"
+      ],
+      "pr": 1158,
+      "aurora_note": "Previously blocked by #1148–#1151. PR #1158 is open and mergeable, but review/merge should follow #1157 because the appeal and mapping assumptions depend on the runtime mapping design. No active L2-to-L1 behavior introduced.",
       "aurora_authority": true
     },
     {
       "rank": 8,
-      "id": "#1149",
-      "title": "Protocol JSON schemas — add schema files and validation tests for all five protocols",
-      "status": "blocked",
+      "id": "#1153",
+      "title": "Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement",
+      "status": "in-progress",
       "owner": null,
-      "depends_on": ["#1148"],
-      "tags": ["ethics", "protocols", "schemas"],
-      "aurora_note": "Blocked by #1148 (custody inventory). Schemas cannot be finalized until custody classification is confirmed for each protocol artifact.",
+      "depends_on": [
+        "#1151"
+      ],
+      "tags": [
+        "ethics",
+        "protocols",
+        "tribunal",
+        "tests"
+      ],
+      "pr": 1159,
+      "aurora_note": "Previously blocked by #1148–#1151. PR #1159 is open and mergeable, but Codacy reported two minor CodeStyle issues; review/merge should follow #1157 and preferably coordinate with #1158. No runtime enforcement wiring introduced.",
       "aurora_authority": true
     },
     {
       "rank": 9,
-      "id": "#1150",
-      "title": "Protocol fixture intake — sanitized canonical examples for all five protocols",
-      "status": "blocked",
-      "owner": null,
-      "depends_on": ["#1148", "#1149"],
-      "tags": ["ethics", "protocols", "fixtures"],
-      "aurora_note": "Blocked by #1148 and #1149. Fixtures must validate against schemas from #1149 and must not promote raw recovered payloads without custody review.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 10,
-      "id": "#1151",
-      "title": "Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics",
-      "status": "blocked",
-      "owner": null,
-      "depends_on": ["#1148", "#1149", "#1150"],
-      "tags": ["ethics", "protocols", "runtime", "design"],
-      "aurora_note": "Blocked by #1148–#1150. Design-only artifact — no runtime wiring. Must not begin until artifacts are custody-verified.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 11,
-      "id": "#1152",
-      "title": "Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed",
-      "status": "blocked",
-      "owner": null,
-      "depends_on": ["#1148", "#1149", "#1150", "#1151"],
-      "tags": ["ethics", "protocols", "moriarty", "tests"],
-      "aurora_note": "Blocked by #1148–#1151. Tests run against fixtures from #1150, not raw recovered payloads. No active L2-to-L1 behavior introduced.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 12,
-      "id": "#1153",
-      "title": "Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement",
-      "status": "blocked",
-      "owner": null,
-      "depends_on": ["#1148", "#1149", "#1150", "#1151"],
-      "tags": ["ethics", "protocols", "tribunal", "tests"],
-      "aurora_note": "Blocked by #1148–#1151. Parallel with #1152 once unblocked. No runtime enforcement wiring introduced.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 13,
       "id": "#1137",
       "title": "docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["ethics", "geometric", "implementation"],
+      "tags": [
+        "ethics",
+        "geometric",
+        "implementation"
+      ],
       "aurora_note": "No blockers. Evaluation concluded v2 provides genuine signal for cases 3.4 and 3.5. Implementation work (FieldCurvatureV2, advisory wiring, get_formation_statistics additions) has never been tracked. Create follow-up implementation issue and confirm test file exists.",
       "aurora_authority": true
     },
     {
-      "rank": 14,
+      "rank": 10,
       "id": "#1138",
       "title": "docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["ethics", "protocols", "custody"],
-      "aurora_note": "Surfaces the manifest side of the same work as #1148. Both must close together. Locate source packages, compute SHAs, record verified_at/verified_by. SHADOWFAX is a hard block — standalone bundle must be located or formally recorded as missing dependency.",
+      "tags": [
+        "ethics",
+        "protocols",
+        "custody"
+      ],
+      "aurora_note": "Partially superseded by completed #1148, #1149, and #1150: custody fixture, schema, and sanitized fixture scaffolding now exist. Remaining live work is true custody verification: source/internal SHA resolution, verified_at/verified_by fields, and SHADOWFAX standalone bundle disposition.",
       "aurora_authority": true
     },
     {
-      "rank": 15,
+      "rank": 11,
       "id": "#1142",
       "title": "docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["docs", "architecture", "drift-ledger"],
+      "tags": [
+        "docs",
+        "architecture",
+        "drift-ledger"
+      ],
       "aurora_note": "Two unresolved items: mesh_api.js disposition decision and generate_api_catalog.py output path drift. The catalog generator defect directly blocks API snapshot currency. Fix output path before any API doc work proceeds. Unblocks #1146.",
       "aurora_authority": true
     },
     {
-      "rank": 16,
+      "rank": 12,
       "id": "#1141",
       "title": "docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["docs", "architecture", "QGIA"],
+      "tags": [
+        "docs",
+        "architecture",
+        "QGIA"
+      ],
       "aurora_note": "qgia_agent_registry_full.json has been pending commit for 102 days. No runtime router surface defined for the inter-node exchange protocol. Blocks #1144 (inventory missing surfaces). Resolve before QGIA integration work proceeds.",
       "aurora_authority": true
     },
     {
-      "rank": 17,
+      "rank": 13,
       "id": "#1144",
       "title": "docs/api — api_surface_inventory.json missing four surfaces",
       "status": "open",
       "owner": null,
-      "depends_on": ["#1140", "#1141"],
-      "tags": ["docs", "api", "inventory"],
+      "depends_on": [
+        "#1140",
+        "#1141"
+      ],
+      "tags": [
+        "docs",
+        "api",
+        "inventory"
+      ],
       "aurora_note": "Blocked by #1140 (topology contradiction) and #1141 (QGIA router undefined). Four missing surfaces: /api/mesh/agents, /api/qgia, PAT routes, Consent Architecture v3.1. Inventory is the source-of-truth anchor for the entire docs/api cluster.",
       "aurora_authority": true
     },
     {
-      "rank": 18,
+      "rank": 14,
       "id": "#1143",
       "title": "docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["docs", "architecture", "scaling"],
+      "tags": [
+        "docs",
+        "architecture",
+        "scaling"
+      ],
       "aurora_note": "Standalone. No blockers. scaling_plan.md has no last_reviewed date, no version marker, and no stated relationship to the QGIA node, GUMAS 9-node L2 network, or current two-node L1 topology. May be materially stale.",
       "aurora_authority": true
     },
     {
-      "rank": 19,
+      "rank": 15,
       "id": "#1145",
       "title": "docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps",
       "status": "open",
       "owner": null,
-      "depends_on": ["#1144"],
-      "tags": ["docs", "api", "reference"],
+      "depends_on": [
+        "#1144"
+      ],
+      "tags": [
+        "docs",
+        "api",
+        "reference"
+      ],
       "aurora_note": "Blocked by #1144 (inventory must be current before reference doc is updated). Three gaps: Consent Architecture v3.1 status unknown, HR module version header stale, no token budget cross-reference for compute-intensive endpoints.",
       "aurora_authority": true
     },
     {
-      "rank": 20,
+      "rank": 16,
       "id": "#1146",
       "title": "docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated",
       "status": "open",
       "owner": null,
-      "depends_on": ["#1142", "#1144", "#1145"],
-      "tags": ["docs", "api", "governance"],
+      "depends_on": [
+        "#1142",
+        "#1144",
+        "#1145"
+      ],
+      "tags": [
+        "docs",
+        "api",
+        "governance"
+      ],
       "aurora_note": "Governance self-audit. Closes last in the docs/api cluster after #1142, #1144, and #1145 are resolved. Three violations: snapshot currency not self-enforcing, test_api_surface_inventory.py is schema-only not coverage, review cadence conditions met but review not triggered.",
       "aurora_authority": true
     },
     {
-      "rank": 21,
+      "rank": 17,
       "id": "#1135",
       "title": "simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["simulation", "roster", "validation"],
+      "tags": [
+        "simulation",
+        "roster",
+        "validation"
+      ],
       "aurora_note": "No blockers. Three overlapping roster documents with no stated reconciliation or authoritative source. 165 KB is not a maintainable document size. OPPY and STARLING_AU entries need cross-check across registries before QGIA integration work.",
       "aurora_authority": true
     },
     {
-      "rank": 22,
+      "rank": 18,
       "id": "#1136",
       "title": "simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["simulation", "enhancement", "tracking"],
+      "tags": [
+        "simulation",
+        "enhancement",
+        "tracking"
+      ],
       "aurora_note": "No blockers. 38 KB proposal with no acceptance status, no issue linkage, and no reference from CANON_INDEX.md. Risk of agents implementing rejected or superseded proposals. Needs per-enhancement status recorded.",
       "aurora_authority": true
     },
     {
-      "rank": 23,
+      "rank": 19,
       "id": "arch/layer-canonization",
       "title": "Layer architecture canonization (L1/L2/L3 enforcement in code)",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["architecture", "canonical", "L1", "L2", "L3"],
-      "aurora_note": "Ensures no code path violates the canonical layer definitions. Foundational for all new agent work. Repositioned to Rank 23 — docs/architecture cluster work (#1140, #1141, #1143) should complete first to ensure canonization is working from current topology.",
+      "tags": [
+        "architecture",
+        "canonical",
+        "L1",
+        "L2",
+        "L3"
+      ],
+      "aurora_note": "Ensures no code path violates the canonical layer definitions. Foundational for all new agent work. Repositioned after docs/architecture cluster work (#1140, #1141, #1143) so canonization works from current topology.",
       "aurora_authority": true
     },
     {
-      "rank": 24,
+      "rank": 20,
       "id": "sim/SENTINEL-phase0",
       "title": "PROJECT SENTINEL — Phase 0: Ethics review board constitution",
       "status": "needs-decision",
       "owner": null,
       "depends_on": [],
-      "tags": ["simulation", "ethics", "SENTINEL", "governance", "Picard_Delta_3"],
+      "tags": [
+        "simulation",
+        "ethics",
+        "SENTINEL",
+        "governance",
+        "Picard_Delta_3"
+      ],
       "aurora_note": "No engineering blocking condition. Requires Commander Thorne + Sorensen + Sato governance decision only. Phase 0 deliverable: ethics review board constituted and layer boundary document drafted. See simulation/RD_PROPOSAL_SENTINEL.md.",
       "aurora_authority": true
     },
     {
-      "rank": 25,
+      "rank": 21,
       "id": "ops/QGIA-doctrine-store",
       "title": "QGIA analytical framework — store in ops/analytical_frameworks/QGIA/",
       "status": "open",
       "owner": null,
       "depends_on": [],
-      "tags": ["QGIA", "analytical-framework", "ops", "non-canonical"],
+      "tags": [
+        "QGIA",
+        "analytical-framework",
+        "ops",
+        "non-canonical"
+      ],
       "aurora_note": "QGIA Runtime One-Pager v4.2.1 and Axiom Doctrine Narrative v1.0 reviewed 2026-06-22. Store as portable external tooling in ops/analytical_frameworks/QGIA/. Do NOT elevate to canonical station doctrine until Thorne/Noor crew review. Unblocks feat/QGIA.",
       "aurora_authority": true
     },
     {
-      "rank": 26,
+      "rank": 22,
       "id": "docs/api-reference",
       "title": "API reference documentation",
       "status": "open",
       "owner": null,
-      "depends_on": ["#1126", "#1130"],
-      "tags": ["docs", "api"],
+      "depends_on": [
+        "#1126",
+        "#1130"
+      ],
+      "tags": [
+        "docs",
+        "api"
+      ],
       "aurora_note": "Do not write API docs against a moving target. Wait for CI green. Superseded in priority by the specific docs/api audit issues (#1144, #1145, #1146) which address the same surface with more precision.",
       "aurora_authority": true
     },
     {
-      "rank": 27,
+      "rank": 23,
       "id": "feat/QGIA",
       "title": "QGIA integration hooks",
       "status": "needs-decision",
       "owner": null,
-      "depends_on": ["arch/layer-canonization", "ops/QGIA-doctrine-store"],
-      "tags": ["feature", "QGIA", "PAT", "integration"],
+      "depends_on": [
+        "arch/layer-canonization",
+        "ops/QGIA-doctrine-store"
+      ],
+      "tags": [
+        "feature",
+        "QGIA",
+        "PAT",
+        "integration"
+      ],
       "aurora_note": "Doctrine now available (QGIA Runtime One-Pager v4.2.1 + Axiom Doctrine Narrative v1.0, reviewed 2026-06-22). Two-layer discipline maps cleanly to Triplex Handshake. ops/QGIA-doctrine-store must land first, then PAT routing decision. Crew sign-off required before any QGIA axiom becomes operationally binding.",
       "aurora_authority": true
     }
   ],
-  "completed": []
+  "completed": [
+    {
+      "id": "#1147",
+      "title": "feat: Aurora-Aware Work Queue System (ops/work_queue/)",
+      "closed": "2026-06-24",
+      "status": "done"
+    },
+    {
+      "id": "#1148",
+      "title": "Protocol custody inventory — machine-readable manifest of recovered package/file hashes and blockers",
+      "closed": "2026-06-24",
+      "status": "done"
+    },
+    {
+      "id": "#1149",
+      "title": "Protocol JSON schemas — add schema files and validation tests for Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX",
+      "closed": "2026-06-24",
+      "status": "done"
+    },
+    {
+      "id": "#1150",
+      "title": "Protocol fixture intake — add sanitized canonical examples for Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX",
+      "closed": "2026-06-24",
+      "status": "done"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Syncs the Aurora work queue after current repo evidence showed several queue entries had become stale.

## Changes

- Moves completed setup items into `completed[]`:
  - #1147 — Aurora-aware work queue system
  - #1148 — protocol custody inventory scaffold
  - #1149 — protocol JSON schemas
  - #1150 — sanitized canonical protocol fixtures
- Re-ranks active queue items from 23 active / 4 completed.
- Marks recovered-protocol follow-up PRs as active in-progress review work:
  - #1151 → PR #1157
  - #1152 → PR #1158
  - #1153 → PR #1159
- Updates #1138 note to reflect that scaffold/schema/fixture work is now partially superseded while true custody verification remains open.
- Regenerates generated queue views from `queue.json`:
  - `QUEUE.md`
  - `NEXT_UP.md`
  - `OPEN_GATES.md`

## Evidence

- #1147, #1148, and #1149 are closed as completed.
- Commit `d3976e01` closed #1150 and is the current `main` base for the protocol follow-up PRs.
- #1157, #1158, and #1159 are open PRs against the recovered-protocol follow-up issues.

## Validation

- Compared branch against `main`: 4 commits ahead, 0 behind.
- Diff is limited to `ops/work_queue/` queue state and generated views.

## Risk / notes

- This PR does not modify runtime code.
- This PR does not promote any recovered protocol into runtime enforcement.
- A separate issue remains: `queue_schema.json` uses the newer `state` field model while current queue/rendering files still use `status`. This PR intentionally does not perform that schema migration.