### PR TITLE
docs queue bridge metrics rebased

### DIFF
--- a/ops/work_queue/BRIDGE_FIELDS.md
+++ b/ops/work_queue/BRIDGE_FIELDS.md
@@ -1,0 +1,110 @@
+# Aurora Queue Bridge Fields
+
+**Status:** Draft field reference  
+**Tracked in:** #1161  
+**Purpose:** Define non-breaking metadata that lets queue items coordinate with the ORIONCORE control-plane layer.
+
+---
+
+## Why this exists
+
+The current queue data model can prioritize work, but future automation needs enough metadata to route an item through:
+
+1. live GitHub refresh,
+2. duplicate PR/branch checks,
+3. platform routing,
+4. session-claim or issue-broker preflight,
+5. durable handoff when paused,
+6. peer-review classification when the work is floor-touching.
+
+Bridge fields should be additive. Existing renderers may ignore them until they are explicitly upgraded.
+
+---
+
+## Recommended bridge fields
+
+| Field | Type | Required now? | Meaning |
+|---|---:|---:|---|
+| `github_issue` | integer or null | No | Numeric GitHub issue backing the queue item |
+| `linked_prs` | array of integers | No | Known PRs implementing or reviewing the queue item |
+| `preferred_platform` | string | No | `codex`, `claude-code`, `perplexity`, `human`, or `either` |
+| `claim_required` | boolean | No | Whether mutation must run through claim/broker preflight |
+| `claim_paths` | array of strings | No | Intended mutation paths for overlap checks |
+| `session_state_ref` | string or null | No | Control-plane handoff id if active/suspended |
+| `review_class` | string | No | Peer-review / risk class |
+| `handoff_surface` | string | No | Durable handoff target, usually `catalog/session_state.json` |
+| `coordination_notes` | string | No | Human-readable safety/routing note |
+| `metrics_tags` | array of strings | No | Tags for metrics grouping |
+
+---
+
+## Example: docs-only queue item
+
+```json
+{
+  "id": "#1139",
+  "github_issue": 1139,
+  "preferred_platform": "either",
+  "claim_required": true,
+  "claim_paths": ["docs/ethics/README.md"],
+  "session_state_ref": null,
+  "review_class": "documentation-significant",
+  "handoff_surface": "catalog/session_state.json",
+  "coordination_notes": "Refresh issue and check for existing ethics README PR before creating a branch.",
+  "metrics_tags": ["docs", "ethics", "navigation"]
+}
+```
+
+---
+
+## Example: coordination-layer item
+
+```json
+{
+  "id": "#1161",
+  "github_issue": 1161,
+  "linked_prs": [1166],
+  "preferred_platform": "either",
+  "claim_required": true,
+  "claim_paths": [
+    "ops/work_queue/CROSS_PLATFORM_COORDINATION.md",
+    "ops/work_queue/QUEUE_GUIDE.md",
+    "ops/work_queue/COORDINATION_METRICS.md"
+  ],
+  "session_state_ref": null,
+  "review_class": "coordination-layer",
+  "handoff_surface": "catalog/session_state.json",
+  "coordination_notes": "Treat changes to queue/control-plane authority, claims, or review gates as coordination-layer floor work unless proven mechanical.",
+  "metrics_tags": ["ops", "coordination", "queue"]
+}
+```
+
+---
+
+## Compatibility rule
+
+Bridge fields must not change queue ordering, blocker semantics, or generated views until the renderer and schema explicitly support them.
+
+A safe migration order is:
+
+1. Document fields.
+2. Add fields to representative queue entries.
+3. Update schema to allow optional bridge fields.
+4. Update renderer to display a compact bridge section only when useful.
+5. Add read-only metrics collection.
+6. Add CI enforcement only after generated output is deterministic.
+
+---
+
+## Safety rule
+
+Bridge fields are evidence-routing metadata. They do not authorize mutation.
+
+Before mutation, agents still need:
+
+- live GitHub refresh,
+- issue/PR overlap check,
+- branch/worktree check,
+- claim or broker preflight when paths are mutable,
+- review classification for floor-touching changes,
+- explicit merge authority before merging.

--- a/ops/work_queue/COORDINATION_METRICS.md
+++ b/ops/work_queue/COORDINATION_METRICS.md
@@ -1,0 +1,110 @@
+# Aurora Dev Coordination Metrics
+
+**Status:** Metrics skeleton  
+**Tracked in:** #1161  
+**Depends on:** `ops/work_queue/CROSS_PLATFORM_COORDINATION.md`  
+**Purpose:** Measure whether the queue and coordination spine improve development flow.
+
+---
+
+## Measurement principle
+
+The coordination spine is useful only if it reduces stale state, duplicate work, unsafe mutation, unclear handoffs, and review lag.
+
+This file defines the initial measurable signals. Future automation can render this file from queue, GitHub, control-plane handoff, and claim data.
+
+---
+
+## Current metrics table
+
+| Metric | Definition | Source surfaces | Desired trend | Current collection |
+|---|---|---|---|---|
+| Queue drift count | Queue entries whose status disagrees with live GitHub issue or PR state | `queue.json`, GitHub issues or PRs | Down to zero | Manual review |
+| Time-to-safe-next-action | Steps from session start to a claim-safe task recommendation | session log, queue, broker output | Down | Not yet automated |
+| Claim conflict count | Path conflicts detected before editing | control-plane claims | Visible and actionable | Not yet automated |
+| Duplicate PR avoidance | Existing branch or PR detected before new work begins | GitHub PRs and branches | Up initially, then stable | Manual review |
+| Blocked-item aging | Queue items blocked beyond threshold | `queue.json`, GitHub issue state | Down | Not yet automated |
+| Review debt age | Floor-touching changes awaiting review | control-plane review ledger or session state | Down | Not yet automated |
+| PR cycle time | Queue active to PR open to merged or closed | `queue.json`, GitHub PR timestamps | Down | Not yet automated |
+| Handoff success | Suspended task resumed without missing context | handoff state, PR or issue comments | Up | Manual review |
+| Generated-view drift | Whether generated queue views match `queue.json` | `sync_queue.py --check` | Zero | Queue Validation CI |
+| CI validation success | Coordination PRs passing required checks | GitHub Actions | Up | GitHub Actions |
+
+---
+
+## Future machine-readable shape
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "YYYY-MM-DDTHH:MM:SSZ",
+  "repo": "AUo959/aurora-cloudbank-symbolic",
+  "queue_ref": "ops/work_queue/queue.json",
+  "control_plane_ref": "AUo959/Aurora_ORIONCORE_Directory_Main/catalog/session_state.json",
+  "metrics": {
+    "queue_drift_count": null,
+    "time_to_safe_next_action_steps": null,
+    "claim_conflict_count": null,
+    "duplicate_pr_avoidance_count": null,
+    "blocked_item_aging_count": null,
+    "review_debt_age_days_max": null,
+    "pr_cycle_time_days_median": null,
+    "handoff_success_count": null,
+    "generated_view_drift_count": null,
+    "ci_validation_success_rate": null
+  },
+  "observations": [],
+  "blocked": [
+    "Automated metrics collector not yet implemented.",
+    "Control-plane inputs must be passed explicitly."
+  ]
+}
+```
+
+---
+
+## Minimum viable collector
+
+Suggested path:
+
+- `ops/work_queue/collect_coordination_metrics.py`
+
+Suggested inputs:
+
+- `ops/work_queue/queue.json`
+- generated queue views
+- GitHub issue or PR state for queue items with `github_issue` or `pr`
+- optional control-plane handoff export, passed explicitly as a path
+
+Suggested outputs:
+
+- `ops/work_queue/COORDINATION_METRICS.md`
+- optional JSON: `ops/work_queue/coordination_metrics.json`
+
+---
+
+## Safety boundaries
+
+The metrics collector should remain read-only. It should report evidence and gaps; it should not change repo, queue, claim, GitHub, or runtime state.
+
+---
+
+## Initial manual baseline
+
+Current known baseline from the June 24 queue audit:
+
+- Queue drift was observed: #1147, #1148, #1149, and #1150 remained active in queue state after closure or completion evidence.
+- Queue Validation exists and runs when `ops/work_queue/**` changes.
+- Coordination spine contract landed under #1161 via PR #1166.
+- Automated bridge fields and metrics collection are not yet implemented.
+
+---
+
+## Next implementation step
+
+After PR #1160 and PR #1166 land:
+
+1. Add non-breaking bridge metadata to representative queue entries.
+2. Add a read-only metrics collector skeleton.
+3. Render this metrics file from collector output.
+4. Add CI check mode only after output is deterministic.


### PR DESCRIPTION
Docs update for issue 1161.

Adds BRIDGE_FIELDS.md and COORDINATION_METRICS.md under ops/work_queue.