### PR TITLE
ops queue schema compatibility

### DIFF
--- a/ops/work_queue/queue_schema.json
+++ b/ops/work_queue/queue_schema.json
@@ -47,7 +47,6 @@
         "blocked",
         "needs-decision",
         "in-progress",
-        "waiting-review",
         "done"
       ]
     },
@@ -92,6 +91,12 @@
       "anyOf": [
         { "required": ["status"] },
         { "required": ["state"] }
+      ],
+      "allOf": [
+        {
+          "if": { "required": ["status"] },
+          "then": { "required": ["rank"] }
+        }
       ],
       "properties": {
         "rank": { "type": "integer", "minimum": 1 },

--- a/ops/work_queue/queue_schema.json
+++ b/ops/work_queue/queue_schema.json
@@ -1,71 +1,186 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Aurora Work Queue Item",
+  "title": "Aurora Work Queue",
+  "description": "Compatibility schema for the live Aurora work queue file. Supports the current rank/status renderer model and the planned state/bridge-field model.",
   "type": "object",
   "required": [
-    "id",
-    "title",
-    "state",
-    "priority",
-    "priority_score",
-    "area",
-    "consumer_fit",
-    "context_pack",
-    "next_action",
-    "done_when",
-    "opened",
-    "last_updated"
+    "_meta",
+    "active",
+    "completed"
   ],
+  "additionalProperties": true,
   "properties": {
-    "id": { "type": "string", "description": "Stable queue identifier, e.g. Q-0001." },
-    "github_issue": { "type": ["integer", "null"], "description": "GitHub issue number, if exists." },
-    "title": { "type": "string" },
-    "state": {
+    "_meta": {
+      "type": "object",
+      "required": [
+        "version",
+        "description",
+        "last_aurora_review",
+        "schema"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "version": { "type": "string" },
+        "description": { "type": "string" },
+        "last_aurora_review": { "type": "string" },
+        "schema": { "type": "string" }
+      }
+    },
+    "active": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/queueItem" }
+    },
+    "completed": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/completedItem" }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "queueStatus": {
       "type": "string",
-      "enum": ["ready", "blocked", "active", "waiting_review", "decision_required", "done"]
+      "enum": [
+        "open",
+        "blocked",
+        "needs-decision",
+        "in-progress",
+        "waiting-review",
+        "done"
+      ]
     },
-    "priority": { "type": "string", "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
-    "priority_score": { "type": "integer", "minimum": 0 },
-    "area": {
+    "queueState": {
       "type": "string",
-      "description": "Primary domain: ethics, security, architecture, simulation, api, documentation, operations, etc."
+      "enum": [
+        "ready",
+        "blocked",
+        "active",
+        "waiting_review",
+        "decision_required",
+        "done"
+      ]
     },
-    "labels": { "type": "array", "items": { "type": "string" } },
-    "depends_on": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Queue IDs this item is blocked by."
-    },
-    "blocks": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Queue IDs this item gates."
-    },
-    "decision_required": { "type": "boolean", "default": false },
-    "decision_owner": { "type": "string" },
-    "gate_id": {
+    "priority": {
       "type": "string",
-      "description": "If this item has a registered human gate, the corresponding GATE-xxx ID from gate_registry.json."
+      "enum": [
+        "CRITICAL",
+        "HIGH",
+        "MEDIUM",
+        "LOW"
+      ]
     },
-    "consumer_fit": {
-      "type": "array",
-      "items": { "type": "string", "enum": ["aurora", "agent", "human"] }
+    "platform": {
+      "type": "string",
+      "enum": [
+        "aurora",
+        "codex",
+        "claude-code",
+        "perplexity",
+        "human",
+        "either"
+      ]
     },
-    "context_pack": {
-      "type": "array",
-      "items": { "type": "string" }
+    "queueItem": {
+      "type": "object",
+      "required": [
+        "id",
+        "title"
+      ],
+      "additionalProperties": true,
+      "anyOf": [
+        { "required": ["status"] },
+        { "required": ["state"] }
+      ],
+      "properties": {
+        "rank": { "type": "integer", "minimum": 1 },
+        "id": { "type": "string" },
+        "github_issue": { "type": ["integer", "null"] },
+        "linked_prs": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "title": { "type": "string" },
+        "status": { "$ref": "#/definitions/queueStatus" },
+        "state": { "$ref": "#/definitions/queueState" },
+        "priority": { "$ref": "#/definitions/priority" },
+        "priority_score": { "type": "integer", "minimum": 0 },
+        "area": { "type": "string" },
+        "owner": { "type": ["string", "null"] },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "blocks": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "decision_required": { "type": "boolean" },
+        "decision_owner": { "type": "string" },
+        "gate_id": { "type": "string" },
+        "consumer_fit": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["aurora", "agent", "human"] }
+        },
+        "context_pack": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "next_action": { "type": "string" },
+        "done_when": { "type": "string" },
+        "aurora_note": { "type": "string" },
+        "aurora_notes": { "type": "string" },
+        "aurora_authority": { "type": "boolean" },
+        "is_stale_scope": { "type": "boolean" },
+        "parallel_group": { "type": "string" },
+        "active_worker": { "type": "string" },
+        "started": { "type": "string" },
+        "pr": { "type": "integer" },
+        "opened": { "type": "string" },
+        "last_updated": { "type": "string" },
+        "closed": { "type": "string" },
+        "url": { "type": "string" },
+        "preferred_platform": { "$ref": "#/definitions/platform" },
+        "claim_required": { "type": "boolean" },
+        "claim_paths": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "session_state_ref": { "type": ["string", "null"] },
+        "review_class": { "type": "string" },
+        "handoff_surface": { "type": "string" },
+        "coordination_notes": { "type": "string" },
+        "metrics_tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
     },
-    "next_action": { "type": "string" },
-    "done_when": { "type": "string" },
-    "aurora_notes": { "type": "string" },
-    "is_stale_scope": { "type": "boolean", "default": false },
-    "parallel_group": { "type": "string" },
-    "active_worker": { "type": "string" },
-    "started": { "type": "string", "format": "date" },
-    "pr": { "type": "integer" },
-    "opened": { "type": "string", "format": "date" },
-    "last_updated": { "type": "string", "format": "date" },
-    "closed": { "type": "string", "format": "date" },
-    "url": { "type": "string", "format": "uri" }
+    "completedItem": {
+      "type": "object",
+      "required": [
+        "id",
+        "title"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "closed": { "type": "string" },
+        "status": { "$ref": "#/definitions/queueStatus" },
+        "state": { "$ref": "#/definitions/queueState" },
+        "github_issue": { "type": ["integer", "null"] },
+        "pr": { "type": "integer" }
+      }
+    }
   }
 }

--- a/tests/test_work_queue_schema.py
+++ b/tests/test_work_queue_schema.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QUEUE_PATH = ROOT / "ops" / "work_queue" / "queue.json"
+SCHEMA_PATH = ROOT / "ops" / "work_queue" / "queue_schema.json"
+
+
+def load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validator() -> Draft7Validator:
+    schema = load_json(SCHEMA_PATH)
+    Draft7Validator.check_schema(schema)
+    return Draft7Validator(schema)
+
+
+def test_current_queue_json_matches_compatibility_schema():
+    data = load_json(QUEUE_PATH)
+    errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
+    assert errors == []
+
+
+def test_schema_accepts_future_state_and_bridge_metadata():
+    data = {
+        "_meta": {
+            "version": "test",
+            "description": "test queue",
+            "last_aurora_review": "2026-06-24T00:00:00Z",
+            "schema": "ops/work_queue/queue_schema.json",
+        },
+        "active": [
+            {
+                "id": "#1161",
+                "github_issue": 1161,
+                "linked_prs": [1166, 1167, 1168, 1169],
+                "title": "Coordinate queue with control-plane handoff",
+                "state": "active",
+                "priority": "HIGH",
+                "priority_score": 68,
+                "area": "operations",
+                "labels": ["ops", "coordination"],
+                "depends_on": [],
+                "blocks": [],
+                "consumer_fit": ["aurora", "agent", "human"],
+                "context_pack": [
+                    "ops/work_queue/CROSS_PLATFORM_COORDINATION.md",
+                    "ops/work_queue/BRIDGE_FIELDS.md",
+                ],
+                "next_action": "Run claim preflight before mutation.",
+                "done_when": "Bridge metadata is represented without breaking legacy views.",
+                "opened": "2026-06-24",
+                "last_updated": "2026-06-24",
+                "preferred_platform": "either",
+                "claim_required": True,
+                "claim_paths": ["ops/work_queue/queue.json"],
+                "session_state_ref": None,
+                "review_class": "coordination-layer",
+                "handoff_surface": "catalog/session_state.json",
+                "coordination_notes": "Use control-plane claims before mutation.",
+                "metrics_tags": ["ops", "queue"],
+            }
+        ],
+        "completed": [
+            {
+                "id": "#1160",
+                "title": "Queue state sync",
+                "status": "done",
+                "closed": "2026-06-24",
+            }
+        ],
+    }
+
+    errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
+    assert errors == []
+
+
+def test_schema_rejects_item_without_status_or_state():
+    data = {
+        "_meta": {
+            "version": "test",
+            "description": "test queue",
+            "last_aurora_review": "2026-06-24T00:00:00Z",
+            "schema": "ops/work_queue/queue_schema.json",
+        },
+        "active": [
+            {
+                "id": "#9999",
+                "title": "Missing lifecycle field",
+            }
+        ],
+        "completed": [],
+    }
+
+    errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
+    assert errors

--- a/tests/test_work_queue_schema.py
+++ b/tests/test_work_queue_schema.py
@@ -105,3 +105,50 @@ def test_schema_rejects_item_without_status_or_state():
 
     errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
     checks.assertTrue(errors)
+
+
+def test_schema_rejects_status_item_without_renderer_rank():
+    checks = unittest.TestCase()
+    data = {
+        "_meta": {
+            "version": "test",
+            "description": "test queue",
+            "last_aurora_review": "2026-06-24T00:00:00Z",
+            "schema": "ops/work_queue/queue_schema.json",
+        },
+        "active": [
+            {
+                "id": "#9998",
+                "title": "Status item without rank",
+                "status": "open",
+            }
+        ],
+        "completed": [],
+    }
+
+    errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
+    checks.assertTrue(errors)
+
+
+def test_schema_rejects_status_unknown_to_live_renderer():
+    checks = unittest.TestCase()
+    data = {
+        "_meta": {
+            "version": "test",
+            "description": "test queue",
+            "last_aurora_review": "2026-06-24T00:00:00Z",
+            "schema": "ops/work_queue/queue_schema.json",
+        },
+        "active": [
+            {
+                "rank": 1,
+                "id": "#9997",
+                "title": "Unsupported renderer status",
+                "status": "waiting-review",
+            }
+        ],
+        "completed": [],
+    }
+
+    errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
+    checks.assertTrue(errors)

--- a/tests/test_work_queue_schema.py
+++ b/tests/test_work_queue_schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import unittest
 from pathlib import Path
 
 from jsonschema import Draft7Validator
@@ -23,12 +24,14 @@ def validator() -> Draft7Validator:
 
 
 def test_current_queue_json_matches_compatibility_schema():
+    checks = unittest.TestCase()
     data = load_json(QUEUE_PATH)
     errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
-    assert errors == []
+    checks.assertEqual(errors, [])
 
 
 def test_schema_accepts_future_state_and_bridge_metadata():
+    checks = unittest.TestCase()
     data = {
         "_meta": {
             "version": "test",
@@ -79,10 +82,11 @@ def test_schema_accepts_future_state_and_bridge_metadata():
     }
 
     errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
-    assert errors == []
+    checks.assertEqual(errors, [])
 
 
 def test_schema_rejects_item_without_status_or_state():
+    checks = unittest.TestCase()
     data = {
         "_meta": {
             "version": "test",
@@ -100,4 +104,4 @@ def test_schema_rejects_item_without_status_or_state():
     }
 
     errors = sorted(validator().iter_errors(data), key=lambda error: list(error.path))
-    assert errors
+    checks.assertTrue(errors)


### PR DESCRIPTION
Updates the work queue schema for issue 1161.

Changes:
- Make queue_schema.json validate the full queue file
- Support current status/rank/tags model
- Support future state and bridge metadata fields
- Add schema compatibility tests