### PR TITLE
fix(ci): make auto-assign jobs idempotent to duplicate-assignee 422

### DIFF
--- a/.github/workflows/auto-assign-and-review.yml
+++ b/.github/workflows/auto-assign-and-review.yml
@@ -34,16 +34,25 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issueNumber = context.issue.number;
-            
-            // Assign to repository owner as fallback/triage
-            await github.rest.issues.addAssignees({
-              owner,
-              repo,
-              issue_number: issueNumber,
-              assignees: [owner]
-            });
-            
-            console.log(`Assigned to repository owner: ${owner}`);
+
+            // Assign to repository owner as fallback/triage.
+            // Idempotent: a 422 "Assignee has already been taken" just means the
+            // owner is already assigned (e.g. owner-authored PR), which is not a failure.
+            try {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                assignees: [owner]
+              });
+              console.log(`Assigned to repository owner: ${owner}`);
+            } catch (error) {
+              if (error.status === 422) {
+                console.log(`Owner ${owner} is already assigned; nothing to do.`);
+              } else {
+                throw error;
+              }
+            }
 
   # Label-based assignment for priority issues
   label-based-assignment:
@@ -68,14 +77,22 @@ jobs:
             };
             
             if (labelAssignments[labelName]) {
-              await github.rest.issues.addAssignees({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                assignees: labelAssignments[labelName]
-              });
-              
-              console.log(`Assigned to ${labelAssignments[labelName].join(', ')} based on label: ${labelName}`);
+              // Idempotent: ignore 422 when the assignee is already set.
+              try {
+                await github.rest.issues.addAssignees({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  assignees: labelAssignments[labelName]
+                });
+                console.log(`Assigned to ${labelAssignments[labelName].join(', ')} based on label: ${labelName}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  console.log(`Assignee(s) for label ${labelName} already set; nothing to do.`);
+                } else {
+                  throw error;
+                }
+              }
             } else {
               console.log(`No assignment rule for label: ${labelName}`);
             }


### PR DESCRIPTION
## Summary

Fixes a latent bug in `.github/workflows/auto-assign-and-review.yml` that flips PRs to a red **`ci: failed`** state even when every substantive check passes.

### Root cause

The `assign-to-owner` and `label-based-assignment` jobs called `github.rest.issues.addAssignees(...)` with no error handling. When the owner (or label assignee) is **already assigned** — the normal case for owner-authored PRs, or after a prior `labeled` event already assigned them — GitHub returns:

```
HTTP 422  Validation Failed:
"Could not add assignees: Validation failed: Assignee has already been taken"
```

The unhandled promise rejection failed the `assign-to-owner` job, which flipped the PR's CI label to `ci: failed`.

### Evidence

Observed on **PR #1158**: 26 of 27 checks passed (`test`, `build`, `security`, `CodeQL`, `SonarCloud`, `code_quality`, `CI Check`, …). The **only** failing job was `assign-to-owner`, with the 422 above — the PR was already assigned to `AUo959`. The test-plan content was fine; the red was pure automation noise. The same flaw would hit any PR already assigned to its target.

### Fix

Wrap both `addAssignees` calls in `try/catch` that treats a **422** as a no-op (logs and continues) and re-throws anything else. The assignment is now idempotent, so an already-assigned PR no longer fails CI.

### Validation

- YAML parses cleanly (`yaml.safe_load`).
- No change to assignment behavior on the happy path — only the duplicate-assignee error is now swallowed.

### Note on branch scope

This PR is opened from the designated epic branch `claude/epic-euler-cqwhzm`, which also carries prior review/queue commits ahead of `main`. The CI fix is the final commit (`8211f3e`); if a tight single-purpose PR is preferred, the workflow fix can be cherry-picked onto a fresh branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGkjuRd8nbBXkfMr6SA8k3)_