### PR TITLE
fix(ci): make auto-assign jobs idempotent to duplicate-assignee 422

### DIFF
--- a/.github/workflows/auto-assign-and-review.yml
+++ b/.github/workflows/auto-assign-and-review.yml
@@ -34,16 +34,25 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issueNumber = context.issue.number;
-            
-            // Assign to repository owner as fallback/triage
-            await github.rest.issues.addAssignees({
-              owner,
-              repo,
-              issue_number: issueNumber,
-              assignees: [owner]
-            });
-            
-            console.log(`Assigned to repository owner: ${owner}`);
+
+            // Assign to repository owner as fallback/triage.
+            // Idempotent: a 422 "Assignee has already been taken" just means the
+            // owner is already assigned (e.g. owner-authored PR), which is not a failure.
+            try {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                assignees: [owner]
+              });
+              console.log(`Assigned to repository owner: ${owner}`);
+            } catch (error) {
+              if (error.status === 422) {
+                console.log(`Owner ${owner} is already assigned; nothing to do.`);
+              } else {
+                throw error;
+              }
+            }
 
   # Label-based assignment for priority issues
   label-based-assignment:
@@ -68,14 +77,22 @@ jobs:
             };
             
             if (labelAssignments[labelName]) {
-              await github.rest.issues.addAssignees({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                assignees: labelAssignments[labelName]
-              });
-              
-              console.log(`Assigned to ${labelAssignments[labelName].join(', ')} based on label: ${labelName}`);
+              // Idempotent: ignore 422 when the assignee is already set.
+              try {
+                await github.rest.issues.addAssignees({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  assignees: labelAssignments[labelName]
+                });
+                console.log(`Assigned to ${labelAssignments[labelName].join(', ')} based on label: ${labelName}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  console.log(`Assignee(s) for label ${labelName} already set; nothing to do.`);
+                } else {
+                  throw error;
+                }
+              }
             } else {
               console.log(`No assignment rule for label: ${labelName}`);
             }


### PR DESCRIPTION
## Summary

Single-file fix for a latent bug in `.github/workflows/auto-assign-and-review.yml` that flips PRs to a red **`ci: failed`** state even when every substantive check passes.

This supersedes #1171 with a clean, single-purpose branch off `main` (that PR's branch carried 12 unrelated epic commits). **One file changed.**

### Root cause

The `assign-to-owner` and `label-based-assignment` jobs called `github.rest.issues.addAssignees(...)` with no error handling. When the owner (or label assignee) is **already assigned** — the normal case for owner-authored PRs, or after a prior `labeled` event — GitHub returns:

```
HTTP 422  Validation Failed:
"Could not add assignees: Validation failed: Assignee has already been taken"
```

The unhandled promise rejection failed the `assign-to-owner` job, flipping the PR's CI label to `ci: failed`.

### Evidence

Observed on **#1158**: 26 of 27 checks passed; the only failure was `assign-to-owner` with the 422 above (the PR was already assigned to `AUo959`). Verified the fix live on #1171 — the same `assign-to-owner` job ran **green**.

### Fix

Wrap both `addAssignees` calls in `try/catch` that treats a **422** as a no-op (logs and continues) and re-throws anything else. Assignment is now idempotent, so an already-assigned PR no longer fails CI.

### Validation

- YAML parses cleanly (`yaml.safe_load`).
- No change to happy-path behavior — only the duplicate-assignee 422 is swallowed.
- Confirmed working on a real run (#1171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGkjuRd8nbBXkfMr6SA8k3)_