### PR TITLE
fix(ci): only swallow the duplicate-assignee 422, re-throw other validation errors

### DIFF
--- a/.github/workflows/auto-assign-and-review.yml
+++ b/.github/workflows/auto-assign-and-review.yml
@@ -47,7 +47,11 @@ jobs:
               });
               console.log(`Assigned to repository owner: ${owner}`);
             } catch (error) {
-              if (error.status === 422) {
+              // Only swallow the duplicate-assignee 422 ("Assignee has already been taken").
+              // Any other 422 (e.g. a non-assignable owner/org) must still fail so a broken
+              // assignment configuration stays visible.
+              const alreadyAssigned = error.status === 422 && /already been taken/i.test(error.message || "");
+              if (alreadyAssigned) {
                 console.log(`Owner ${owner} is already assigned; nothing to do.`);
               } else {
                 throw error;
@@ -87,7 +91,9 @@ jobs:
                 });
                 console.log(`Assigned to ${labelAssignments[labelName].join(', ')} based on label: ${labelName}`);
               } catch (error) {
-                if (error.status === 422) {
+                // Only swallow the duplicate-assignee 422; re-throw any other validation error.
+                const alreadyAssigned = error.status === 422 && /already been taken/i.test(error.message || "");
+                if (alreadyAssigned) {
                   console.log(`Assignee(s) for label ${labelName} already set; nothing to do.`);
                 } else {
                   throw error;


### PR DESCRIPTION
## Summary

Follow-up to #1172 (auto-assign 422 idempotency fix), addressing a [Codex review comment](https://github.com/AUo959/aurora-cloudbank-symbolic/pull/1172) on that PR.

#1172 made the `assign-to-owner` and `label-based-assignment` jobs swallow **any** HTTP 422 from `addAssignees`. Only the duplicate-assignee case (`"Assignee has already been taken"`) is actually benign. A different 422 — e.g. an owner/org that isn't assignable — would now be reported as success, silently leaving the issue/PR unassigned and removing the only signal that the assignment config is broken.

### Fix

Narrow both handlers to suppress **only** the duplicate-assignee 422 and re-throw everything else:

```js
const alreadyAssigned = error.status === 422 && /already been taken/i.test(error.message || "");
if (alreadyAssigned) { /* no-op */ } else { throw error; }
```

So the original recurring failure (owner already assigned → green) stays fixed, while genuine validation failures surface again.

### Validation

- YAML parses cleanly (`yaml.safe_load`).
- One file changed (+8/−2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGkjuRd8nbBXkfMr6SA8k3)_