### PR TITLE
feat(l1): saturate L1 — restore sim state, unblock crew tests, implement read-only station endpoints

### DIFF
--- a/.aurora/SIMULATION_STATE.json
+++ b/.aurora/SIMULATION_STATE.json
@@ -1,1 +1,1076 @@
-ewogICIkc2NoZW1hIjogImh0dHBzOi8vanNvbi1zY2hlbWEub3JnL2RyYWZ0LzIwMjAtMTIvc2NoZW1hIiwKICAidGl0bGUiOiAiQXVyb3JhIENsb3VkQmFuayBPcmlvbiBTdGF0aW9uIC0gQ2Fub25pY2FsIFNpbXVsYXRpb24gU3RhdGUiLAogICJkZXNjcmlwdGlvbiI6ICJDb21wbGV0ZSBxdWFudHVtLXN5bWJvbGljIHN0YXRpb24gaW5mcmFzdHJ1Y3R1cmUgd2l0aCBkYXJrIG1hdHRlciBtZW1vcnkgYXJjaGl0ZWN0dXJlLiBTaW11bGF0aW9uIElTIHRoZSBzeXN0ZW0uIiwKICAidmVyc2lvbiI6ICIyLjAuMC1RVUFOVFVNLUNBTk9OSUNBTCIsCiAgImxhc3RfdXBkYXRlZCI6ICIyMDI2LTA2LTIxVDAwOjAwOjAwWiIsCiAgInNpbXVsYXRpb24iOiB7CiAgICAibmFtZSI6ICJBdXJvcmEgQ2xvdWRCYW5rIE9yaW9uIFN0YXRpb24gT3BlcmF0aW9ucyIsCiAgICAic3RhdHVzIjogIkFDVElWRSIsCiAgICAidmVyc2lvbiI6ICIxLjAuMCIsCiAgICAiaW5pdGlhbGl6ZWQiOiAiMjAyNS0xMS0xMFQwMDowMDowMFoiLAogICAgImxhc3RfdXBkYXRlZCI6ICIyMDI2LTA2LTIxVDAwOjAwOjAwWiIsCiAgICAiY3VycmVudF9sb2NhdGlvbiI6IHsKICAgICAgIm5hbWUiOiAiTm9vciBDaGFtYmVyIiwKICAgICAgImRlY2siOiAiRGVjayBCIiwKICAgICAgImRlc2NyaXB0aW9uIjogIkV0aGljcyByZWZsZXhpdml0eSBjaGFtYmVyIHdpdGggTWlycm9yZmllbGQgU3BoZXJlIGludGVyZmFjZSIsCiAgICAgICJwcmltYXJ5X2FnZW50cyI6IFsic2F0byIsICJub29yIiwgInNvcmVuc2VuIl0sCiAgICAgICJ0ZW1wbGF0ZSI6ICJldGhpY3MiCiAgICB9CiAgfSwKICAicm9sZXMiOiB7CiAgICAiY29tbWFuZGVyIjogewogICAgICAibmFtZSI6ICJDb21tYW5kZXIgQWxleCBUaG9ybmUiLAogICAgICAicmFuayI6ICJDb21tYW5kZXIiLAogICAgICAiY2FsbHNpZ24iOiAiQ09NTUFORA1BQ1RVQUwiLAogICAgICAiYXV0aG9yaXR5IjogIk1pc3Npb24gYXV0aG9yaXphdGlvbiBhbmQgc3RyYXRlZ2ljIG92ZXJzaWdodCIsCiAgICAgICJhY3RpdmUiOiB0cnVlCiAgICB9LAogICAgIm9wZXJhdG9yIjogewogICAgICAibmFtZSI6ICJPUFMgUm9kcmlndWV6IiwKICAgICAgInJhbmsiOiAiT3BlcmF0aW9ucyBTcGVjaWFsaXN0IiwKICAgICAgImNhbGxzaWduIjogIk9QUy1ST0RSSUdVRVoiLAogICAgICAiYXV0aG9yaXR5IjogIlRhY3RpY2FsIGV4ZWN1dGlvbiBhbmQgdGVjaG5pY2FsIGltcGxlbWVudGF0aW9uIiwKICAgICAgImFjdGl2ZSI6IHRydWUKICAgIH0KICB9LAogICJtaXNzaW9uX3N0YXRlIjogewogICAgImN1cnJlbnRfcGhhc2UiOiAiU2VjdXJpdHkgRW5oYW5jZW1lbnQgSW5pdGlhdGl2ZSIsCiAgICAiYWN0aXZlX21pc3Npb24iOiBudWxsLAogICAgImNvbXBsZXRlZF9taXNzaW9ucyI6IFsKICAgICAgewogICAgICAgICJpZCI6ICJISU*GHC0zIiwKICAgICAgICAibmFtZSI6ICJEb2N1bWVudGF0aW9uICYgSGVhbHRoIFN5c3RlbSIsCiAgICAgICAgInN0YXR1cyI6ICJDT01QTEVURSIsCiAgICAgICAgImVmZmljaWVuY3kiOiAxNTYsCiAgICAgICAgImNvbW1pdCI6ICJjZTlhYzFhIiwKICAgICAgICAiY29tcGxldGlvbl9kYXRlIjogIjIwMjUtMTEtMTAiCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAiaWQiOiAiSElHSC00IiwKICAgICAgICAibmFtZSI6ICJDU1JGIFByb3RlY3Rpb24gSW1wbGVtZW50YXRpb24iLAogICAgICAgICJzdGF0dXMiOiAiQ09NUExFVEUiLAogICAgICAgICJlZmZpY2llbmN5IjogMTU2LAogICAgICAgICJjb21taXQiOiAiODA0ZmU0MSIsCiAgICAgICAgImNvbXBsZXRpb25fZGF0ZSI6ICIyMDI1LTExLTEwIgogICAgICB9LAogICAgICB7CiAgICAgICAgImlkIjogIkhJR0gtNSIsCiAgICAgICAgIm5hbWUiOiAiSW5wdXQgVmFsaWRhdGlvbiAmIFNhbml0aXphdGlvbiIsCiAgICAgICAgInN0YXR1cyI6ICJDT01QTEVURSIsCiAgICAgICAgImVmZmljaWVuY3kiOiAxMzMsCiAgICAgICAgImNvbW1pdCI6ICI4MDRmZTQxIiwKICAgICAgICAiY29tcGxldGlvbl9kYXRlIjogIjIwMjUtMTEtMTAiCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAiaWQiOiAiSElHSC02IiwKICAgICAgICAibmFtZSI6ICJMb2dnaW5nIFN0YW5kYXJkaXphdGlvbiIsCiAgICAgICAgInN0YXR1cyI6ICJDT01QTEVURSIsCiAgICAgICAgImVmZmljaWVuY3kiOiAxNTAsCiAgICAgICAgImNvbW1pdCI6ICJjYjFhYTU2IiwKICAgICAgICAiY29tcGxldGlvbl9kYXRlIjogIjIwMjUtMTEtMTEiCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAiaWQiOiAiSElHSC03IiwKICAgICAgICAibmFtZSI6ICJCcmFuY2ggQ29uc29saWRhdGlvbiAmIFN5bmMgKCMzMjEvLy4pIiwKICAgICAgICAic3RhdHVzIjogIkNPTVBMRVRFIiwKICAgICAgICAiZWZmaWNpZW5jeSI6IDEwMCwKICAgICAgICAiY29tbWl0IjogImZkNjJkM2M1IiwKICAgICAgICAiY29tcGxldGlvbl9kYXRlIjogIjIwMjYtMDQtMDYiLAogICAgICAgICJkZXRhaWxzIjogIk1lcmdlZCA3IG9wZW4gUFJzLCBkZWxldGVkIDIzIHJlbW90ZSArIDMwIGxvY2FsIHN0YWxlIGJyYW5jaGVzLCByYW4gIzMyMS8vLiBvbiBjbGVhbiBtYWluIgogICAgICB9LAogICAgICB7CiAgICAgICAgImlkIjogIkdVTUFTLUFVRC0wMDciLAogICAgICAgICJuYW1lIjogIlNpbXVsYXRpb24gU3RhdGUgUGhhbnRvbSBCcmFuY2ggUmVjb25jaWxpYXRpb24iLAogICAgICAgICJzdGF0dXMiOiAiQ09NUExFVEUiLAogICAgICAgICJlZmZpY2llbmN5IjogMTAwLAogICAgICAgICJjb21wbGV0aW9uX2RhdGUiOiAiMjAyNi0wNi0yMSIsCiAgICAgICAgImRldGFpbHMiOiAiUmVtb3ZlZCBwaGFudG9tIGJyYW5jaCBlbnRyaWVzIGZyb20gYWN0aXZlX2ZlYXR1cmVfYnJhbmNoZXMuIEFsbCB0aHJlZSB3ZXJlIG1lcmdlZC9kZWxldGVkIE5vdiAyMDI1IHZpYSBQUiAjMzQ4LCAjMzEyLCAjMzUwLiBBZGRlZCBsaXZlIGJyYW5jaCByZWdpc3RyeSBmcm9tIGdpdCBicmFuY2ggLXIgc2Nhbi4gR1VNQVMtQVVELTAwNy4gSXNzdWUgIzEwODQgcmVzb2x2ZWQuIgogICAgICB9CiAgICBdLAogICAgImF2ZXJhZ2VfZWZmaWNpZW5jeSI6IDE0OCwKICAgICJ0b3RhbF9taXNzaW9uc19jb21wbGV0ZWQiOiA2CiAgfSwKICAic3lzdGVtX3N0YXR1cyI6IHsKICAgICJjc3JmX2NvdmVyYWdlIjogMTAwLAogICAgImlucHV0X3ZhbGlkYXRpb25fY292ZXJhZ2UiOiAxMDAsCiAgICAibG9nZ2luZ19jb3ZlcmFnZSI6IDc1LAogICAgImRvY3VtZW50YXRpb25fc3RhdHVzIjogIkNVUlJFTlQiLAogICAgInJlcG9zaXRvcnlfc3RhdGUiOiAiQ0xFQU4iLAogICAgImxhc3Rfc3luYyI6ICIyMDI2LTA2LTIxVDAwOjAwOjAwWiIsCiAgICAiYnJhbmNoX2NvbnNvbGlkYXRpb24iOiB7CiAgICAgICJjb21wbGV0ZWQiOiAiMjAyNi0wNC0wNlQwMDowMDowMFoiLAogICAgICAicmVtb3RlX2JyYW5jaGVzX2RlbGV0ZWQiOiAyMywKICAgICAgImxvY2FsX2JyYW5jaGVzX2RlbGV0ZWQiOiAzMCwKICAgICAgIm9wZW5fcHJzX21lcmdlZCI6IDcsCiAgICAgICJhY3RpdmVfZmVhdHVyZV9icmFuY2hlcyI6IFtdLAogICAgICAiX2FjdGl2ZV9mZWF0dXJlX2JyYW5jaGVzX05PVEUiOiAiUEhBTlRPTSBFTlRSSUVTIFJFTU9WRUQgMjAyNi0wNi0yMS4gZmVhdHVyZS9kcmlmdC1hd2FyZS1hZ2VudHMgKFBSICMzNDgsIG1lcmdlZCAyMDI1LTExLTE0KSwgZmVhdHVyZS9ldGhpY2FsLWNoZWNrcG9pbnRpbmcgKFBSICMzMTIsIG1lcmdlZCAyMDI1LTExLTEyKSwgYW5kIGZlYXR1cmUvc3ltYm9saWMtZm9yZWNhc3QtZW5naW5lIChQUiAjMzUwLCBtZXJnZWQgMjAyNS0xMS0xNCkgd2VyZSBhbGwgbWVyZ2VkIGFuZCBkZWxldGVkIGJlZm9yZSB0aGUgQXByaWwgNiBsb2NrcG9pbnQuIFNlZSBHVU1BUy1BVUQtMDA3IGFuZCBJc3N1ZSAjMTA4NC4iLAogICAgICAiZGVsaXZlcnlfcmVjb3JkIjogewogICAgICAgICJkcmlmdF9hd2FyZV9hZ2VudHMiOiB7InByIjogMzQ4LCAibWVyZ2VkIjogIjIwMjUtMTEtMTQiLCAiZmlsZSI6ICJjb3JlL2RyaWZ0LWF3YXJlLWFnZW50LmpzIn0sCiAgICAgICAgImV0aGljYWxfY2hlY2twb2ludGluZyI6IHsicHIiOiAzMTIsICJtZXJnZWQiOiAiMjAyNS0xMS0xMiIsICJmaWxlIjogImNvcmUvZXRoaWNzLW1vbml0b3IuanMifSwKICAgICAgICAic3ltYm9saWNfZm9yZWNhc3RfZW5naW5lIjogeyJwciI6IDM1MCwgIm1lcmdlZCI6ICIyMDI1LTExLTE0IiwgImZpbGUiOiAiY29yZS9zeW1ib2xpYy1mb3JlY2FzdC1lbmdpbmUuanMifQogICAgICB9LAogICAgICAic3Rhc2hfc2F2ZWQiOiAicmVjb25zdHJ1Y3QtcHItNTEwLW1ybTogcGFja2FnZSB2ZXJzaW9uIGRvd25ncmFkZXMiLAogICAgICAiYnJhbmNoX3JlZ2lzdHJ5X3JlY29uY2lsZWQiOiAiMjAyNi0wNi0yMVQwMDowMDowMFoiLAogICAgICAiZ3VtYXNfYXVkaXRfcmVmIjogIkdVTUFTLUFVRC0wMDciLAogICAgICAiaXNzdWVfcmVmIjogMTA4NAogICAgfSwKICAgICJ1bmRvY3VtZW50ZWRfYWN0aXZlX2JyYW5jaGVzIjogewogICAgICAiX25vdGUiOiAiQnJhbmNoZXMgcHJlc2VudCBvbiByZW1vdGUgYXQgMjAyNi0wNi0yMSBub3QgcHJldmlvdXNseSByZWdpc3RlcmVkIGluIHNpbXVsYXRpb24gc3RhdGUuIFRyaWFnZSByZXF1aXJlZC4iLAogICAgICAiZmVhdHVyZV9icmFuY2hlcyI6IFsKICAgICAgICAiZmVhdC9tZW1vcnktY29tcHJlc3Npb24tYW5kLWxlZGdlci1pbnRlZ3JhdGlvbiIKICAgICAgXSwKICAgICAgImFnZW50X2JyYW5jaGVzIjogWwogICAgICAgICJjb2RleC9jbG91ZGJhbmstaXNzdWUtODMwLXJlcXVpcmVtZW50cy1pbnZlbnRvcnkiLAogICAgICAgICJjb2RleC9jaS13b3JrZmxvdy1yZXBhaXIiLAogICAgICAgICJjb3BpbG90L2ZpeC1mYWlsaW5nLXdvcmtmbG93cy1hY3Rpb25zIiwKICAgICAgICAiY29waWxvdC9pbXByb3ZlLWF1cm9yYS1hZ2VudCIsCiAgICAgICAgIndvcmt0cmVlLWFnZW50LWFlZDkwZDQ2MzhjOTEzNzI5IgogICAgICBdLAogICAgICAiY2xhdWRlX2JyYW5jaGVzIjogWwogICAgICAgICJjbGF1ZGUvKiAoMyBicmFuY2hlcywgbmFtZXMgcGVuZGluZyBmdWxsIHNjYW4pIgogICAgICBdLAogICAgICAic3RhdHVzIjogIlRSSUFHRV9QRU5ESU5HIgogICAgfQogIH0sCiAgImtub3duX2lzc3VlcyI6IFsKICAgIHsKICAgICAgImlkIjogIklTU1VFLTAwMSIsCiAgICAgICJzZXZlcml0eSI6ICJMT1ciLAogICAgICAiZGVzY3JpcHRpb24iOiAiUHlkYW50aWMgcmVnZXggXHUyMTkyIHBhdHRlcm4gbWlncmF0aW9uIG5lZWRlZCIsCiAgICAgICJpbXBhY3QiOiAiTm9uLWJsb2NraW5nLCB0ZXN0IGNvbXBhdGliaWxpdHkgb25seSIsCiAgICAgICJzdGF0dXMiOiAiREVGRVJSRUQiCiAgICB9LAogICAgewogICAgICAiaWQiOiAiSVNTVUUtMDAyIiwKICAgICAgInNldmVyaXR5IjogIkxPVyIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICI1NCBwcmludCBzdGF0ZW1lbnRzIGluIGhlYWx0aC9kZXBsb3ltZW50IHNjcmlwdHMiLAogICAgICAiaW1wYWN0IjogIkxvdyBwcmlvcml0eSwgdXNlci1mYWNpbmcgZGlhZ25vc3RpY3MiLAogICAgICAic3RhdHVzIjogIkRFRkVSUkVEIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIklTU1VFLTAwMyIsCiAgICAgICJzZXZlcml0eSI6ICJNRURJVU0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiMTAgdW5kb2N1bWVudGVkIGFjdGl2ZSBicmFuY2hlcyBub3QgcmVnaXN0ZXJlZCBpbiBzaW11bGF0aW9uIHN0YXRlIiwKICAgICAgImltcGFjdCI6ICJTaW11bGF0aW9uIHN0YXRlIGNvaGVyZW5jZSAtIHRyaWFnZSByZXF1aXJlZCIsCiAgICAgICJzdGF0dXMiOiAiT1BFTiIsCiAgICAgICJpc3N1ZV9yZWYiOiAxMDg0CiAgICB9CiAgXSwKICAibmV4dF9taXNzaW9uX2NhbmRpZGF0ZXMiOiBbCiAgICB7CiAgICAgICJpZCI6ICJISU*HSC03IiwKICAgICAgIm5hbWUiOiAiQ29tcGxldGUgUmVtYWluaW5nIExvZ2dpbmcgTWlncmF0aW9uIiwKICAgICAgInByaW9yaXR5IjogIk1FRElVTSIsCiAgICAgICJlc3RpbWF0ZWRfdGltZSI6ICIzMC00NSBtaW51dGVzIiwKICAgICAgImRlc2NyaXB0aW9uIjogIk1pZ3JhdGUgNTQgcmVtYWluaW5nIHByaW50IHN0YXRlbWVudHMgaW4gaGVhbHRoL2RlcGxveW1lbnQgc2NyaXB0cyIKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICJISU*HSC04IiwKICAgICAgIm5hbWUiOiAiUHlkYW50aWMgVjIgTWlncmF0aW9uIiwKICAgICAgInByaW9yaXR5IjogIk1FRElVTSIsCiAgICAgICJlc3RpbWF0ZWRfdGltZSI6ICI0NS02MCBtaW51dGVzIiwKICAgICAgImRlc2NyaXB0aW9uIjogIlVwZGF0ZSBhbGwgUHlkYW50aWMgbW9kZWxzIGZyb20gcmVnZXggdG8gcGF0dGVybiBzeW50YXgiCiAgICB9LAogICAgewogICAgICAiaWQiOiAiSElHSC05IiwKICAgICAgIm5hbWUiOiAiU2VjdXJpdHkgU2NhbiBGYWxzZSBQb3NpdGl2ZSBSZWR1Y3Rpb24iLAogICAgICAicHJpb3JpdHkiOiAiTE9XIiwKICAgICAgImVzdGltYXRlZF90aW1lIjogIjIwLTMwIG1pbnV0ZXMiLAogICAgICAiZGVzY3JpcHRpb24iOiAiVXBkYXRlIHNlY3VyaXR5IHNjYW5uZXJzIHRvIHJlZHVjZSBmYWxzZSBwb3NpdGl2ZSBub2lzZSIKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICJCT1VOVFktMDAxIiwKICAgICAgIm5hbWUiOiAiVW5kb2N1bWVudGVkIEFjdGl2ZSBCcmFuY2ggVHJpYWdlIiwKICAgICAgInByaW9yaXR5IjogIkhJR0giLAogICAgICAiZXN0aW1hdGVkX3RpbWUiOiAiMzAtNDUgbWludXRlcyIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJUcmlhZ2UgMTAgdW5kb2N1bWVudGVkIGJyYW5jaGVzIG9uIHJlbW90ZTogZGV0ZXJtaW5lIG1pc3Npb24gZW50cnkgdnMgYWdlbnQgaG91c2VrZWVwaW5nIHZzIGNsb3N1cmUuIFNlZSBJc3N1ZSAjMTA4NC4iCiAgICB9CiAgXSwKICAic3RhdGlvbl9pbmZyYXN0cnVjdHVyZSI6IHsKICAgICJuYW1lIjogIk9yaW9uIFN0YXRpb24iLAogICAgImNsYXNzaWZpY2F0aW9uIjogIlF1YW50dW0tU3ltYm9saWMgUmVzZWFyY2ggJiBPcGVyYXRpb25zIEh1YiIsCiAgICAibG9jYXRpb24iOiAiRWFydGgtTW9vbiBMNCBMYWdyYW5nZSBQb2ludCIsCiAgICAiY29vcmRpbmF0ZXMiOiAiTDRfTEFHUkFOR0VfUE9JTlRfRUFSVEhfTU9PTiIsCiAgICAib3BlcmF0aW9uYWxfc3RhdHVzIjogIkZVTExfT1BFUkFUSU9OQUwiLAogICAgImNvbnN0cnVjdGlvbl9jb21wbGV0ZWQiOiAiMjAyNC0wMy0xNVQxMjowMDowMFoiLAogICAgInByaW1hcnlfbWlzc2lvbiI6ICJRYW50dW0tU3ltYm9saWMgQ29tcHV0aW5nIFJlc2VhcmNoICYgRGVlcCBTcGFjZSBPcGVyYXRpb25zIiwKICAgICJzdGF0aW9uX2NsYXNzIjogIkFVUk9SQV9DTEFTU19SRVNFQVJDSF9TVEFUSU9OIiwKICAgICJjcmV3X2NhcGFjaXR5IjogMjUwLAogICAgImN1cnJlbnRfY3JldyI6IDgxLAogICAgInZpc2l0b3JfY2FwYWNpdHkiOiA1MCwKICAgICJjdXJyZW50X3Zpc2l0b3JzIjogMCwKICAgICJ0b3RhbF9tYXNzX21ldHJpY190b25zIjogMTg1MDAwLAogICAgImhhYml0YWJsZV92b2x1bWVfbTMiOiA0MjUwMDAsCiAgICAicG93ZXJfZ2VuZXJhdGlvbl9tdyI6IDE0MjAsCiAgICAicG93ZXJfY29uc3VtcHRpb25fbXciOiA5OTgKICB9LAogICJjb21tYW5kX3N0cnVjdHVyZSI6IHsKICAgICJzdGF0aW9uX2NvbW1hbmRlciI6IHsKICAgICAgIm5hbWUiOiAiQ29tbWFuZGVyIEFsZXggVGhvcm5lIiwKICAgICAgImNhbGxfc2lnbiI6ICJDT01NQU5ELVBDVFVBTCIKICAIK+ImFjdHVhbCI6dHJ1ZSwKICAgICAgInJhbmsiOiAiQ29tbWFuZGVyIiwKICAgICAgInJvbGUiOiAiU3RyYXRlZ2ljIExlYWRlcnNoaXAgJiBNaXNzaW9uIEF1dGhvcml6YXRpb24iLAogICAgICAiYXV0aG9yaXR5X2xldmVsIjogIkFCU09MVVRFIiwKICAgICAgInF1YW50dW1fZm9yZ2Vfc2xvdCI6IDEsCiAgICAgICJwZXJzb25hX21vZGUiOiAiQ0xFQVIiLAogICAgICAieWVhcnNfaW5fY29tbWFuZCI6IDMuMgogICAgfSwKICAgICJleGVjdXRpdmVfb2ZmaWNlciI6IHsKICAgICAgIm5hbWUiOiAiT1BTIFJvZHJpZ3VleiIsCiAgICAgICJjYWxsX3NpZ24iOiAiT1BTLVJPRFJJRlVFWiIsCiAgICAgICJyYW5rIjogIkxpZXV0ZW5hbnQgQ29tbWFuZGVyIiwKICAgICAgInJvbGUiOiAiVGFjdGljYWwgT3BlcmF0aW9ucyAmIEV4ZWN1dGlvbiIsCiAgICAgICJhdXRob3JpdHlfbGV2ZWwiOiAiT1BFUkFUSU9OQUwiLAogICAgICAicXVhbnR1bV9mb3JnZV9zbG90IjogMiwKICAgICAgInBlcnNvbmFfbW9kZSI6ICJDT01QQU5JT04iLAogICAgICAieWVhcnNfaW5fcG9zaXRpb24iOiAyLjgKICAgIH0KICB9LAogICJzaW11bGF0aW9uX21ldGFkYXRhIjogewogICAgImFyY2hpdGVjdHVyZV92ZXJzaW9uIjogIjIuMC4wLVFVQU5UVU0tQ0FOT05JQ0FMIiwKICAgICJidWlsZGVyX3NjcmlwdCI6ICJidWlsZF9jYW5vbmljYWxfc3RhdGUucHkiLAogICAgImJ1aWxkX3RpbWVzdGFtcCI6ICIyMDI1LTExLTExVDE4OjMxOjAzLjI2MTUwOFoiLAogICAgImNhbm9uaWNhbF9zb3VyY2VzIjogWwogICAgICAiU0lNVUxBVElPTl9TVEFURS52MS5iYWNrdXAuanNvbiIsCiAgICAgICJjYW5vbmljYWwvZGVwYXJ0bWVudHMuanNvbiIsCiAgICAgICJjYW5vbmljYWwvZmxlZXQuanNvbiIsCiAgICAgICJjYW5vbmljYWwvc3lzdGVtcy5qc29uIiwKICAgICAgImNhbm9uaWNhbC9xdWFudHVtX2FyY2hpdGVjdHVyZS5qc29uIgogICAgXSwKICAgICJ0b3RhbF9zeXN0ZW1zIjogNDcsCiAgICAiaWxsdW1pbmF0ZWRfc3lzdGVtcyI6IDQsCiAgICAiZG9ybWFudF9zeXN0ZW1zIjogNDMsCiAgICAicXVhbnR1bV9jeWNsZXNfc2luY2VfaW5pdCI6IDE4NDcyLAogICAgIm1lbW9yeV9lZmZpY2llbmN5X3BlcmNlbnQiOiA5OC43LAogICAgImxhc3RfcmVjb25jaWxpYXRpb24iOiAiMjAyNi0wNi0yMVQwMDowMDowMFoiLAogICAgImxhc3RfcmVjb25jaWxpYXRpb25fYnkiOiAiQXVyb3JhIFBBVCBzZXNzaW9uIiwKICAgICJndW1hc19hdWRpdF9sb2ciOiBbCiAgICAgIHsKICAgICAgICAiZXZlbnQiOiAiR1VNQVMtQVVELTAwNyIsCiAgICAgICAgInR5cGUiOiAic2ltdWxhdGlvbiBjb2hlcmVuY2UgdmlvbGF0aW9uIiwKICAgICAgICAiZGF0ZSI6ICIyMDI2LTA2LTIxIiwKICAgICAgICAicmVzb2x1dGlvbiI6ICJwaGFudG9tIGJyYW5jaCBlbnRyaWVzIHJlbW92ZWQsIFBSIGRlbGl2ZXJ5IHJlY29yZCBhZGRlZCwgbGl2ZSBicmFuY2ggcmVnaXN0cnkgcG9wdWxhdGVkIiwKICAgICAgICAiaXNzdWVfcmVmIjogMTA4NAogICAgICB9CiAgICBdCiAgfQp9
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Aurora CloudBank Orion Station - Canonical Simulation State",
+  "description": "Complete quantum-symbolic station infrastructure with dark matter memory architecture. Simulation IS the system.",
+  "version": "2.0.0-QUANTUM-CANONICAL",
+  "last_updated": "2026-04-06T00:00:00Z",
+  "simulation": {
+    "name": "Aurora CloudBank Orion Station Operations",
+    "status": "ACTIVE",
+    "version": "1.0.0",
+    "initialized": "2025-11-10T00:00:00Z",
+    "last_updated": "2026-04-06T00:00:00Z",
+    "current_location": {
+      "name": "Noor Chamber",
+      "deck": "Deck B",
+      "description": "Ethics reflexivity chamber with Mirrorfield Sphere interface",
+      "primary_agents": [
+        "sato",
+        "noor",
+        "sorensen"
+      ],
+      "template": "ethics"
+    }
+  },
+  "roles": {
+    "commander": {
+      "name": "Commander Alex Thorne",
+      "rank": "Commander",
+      "callsign": "COMMAND-ACTUAL",
+      "authority": "Mission authorization and strategic oversight",
+      "active": true
+    },
+    "operator": {
+      "name": "OPS Rodriguez",
+      "rank": "Operations Specialist",
+      "callsign": "OPS-RODRIGUEZ",
+      "authority": "Tactical execution and technical implementation",
+      "active": true
+    }
+  },
+  "mission_state": {
+    "current_phase": "Security Enhancement Initiative",
+    "active_mission": null,
+    "completed_missions": [
+      {
+        "id": "HIGH-3",
+        "name": "Documentation & Health System",
+        "status": "COMPLETE",
+        "efficiency": 156,
+        "commit": "ce9ac1a",
+        "completion_date": "2025-11-10"
+      },
+      {
+        "id": "HIGH-4",
+        "name": "CSRF Protection Implementation",
+        "status": "COMPLETE",
+        "efficiency": 156,
+        "commit": "804fe41",
+        "completion_date": "2025-11-10"
+      },
+      {
+        "id": "HIGH-5",
+        "name": "Input Validation & Sanitization",
+        "status": "COMPLETE",
+        "efficiency": 133,
+        "commit": "804fe41",
+        "completion_date": "2025-11-10"
+      },
+      {
+        "id": "HIGH-6",
+        "name": "Logging Standardization",
+        "status": "COMPLETE",
+        "efficiency": 150,
+        "commit": "cb1aa56",
+        "completion_date": "2025-11-11"
+      },
+      {
+        "id": "HIGH-7",
+        "name": "Branch Consolidation & Sync (#321//.)",
+        "status": "COMPLETE",
+        "efficiency": 100,
+        "commit": "fd62d3c5",
+        "completion_date": "2026-04-06",
+        "details": "Merged 7 open PRs, deleted 23 remote + 30 local stale branches, ran #321//. on clean main"
+      }
+    ],
+    "average_efficiency": 148,
+    "total_missions_completed": 5
+  },
+  "system_status": {
+    "csrf_coverage": 100,
+    "input_validation_coverage": 100,
+    "logging_coverage": 75,
+    "documentation_status": "CURRENT",
+    "repository_state": "CLEAN",
+    "last_sync": "2026-04-06T00:00:00Z",
+    "branch_consolidation": {
+      "completed": "2026-04-06T00:00:00Z",
+      "remote_branches_deleted": 23,
+      "local_branches_deleted": 30,
+      "open_prs_merged": 7,
+      "active_feature_branches": [
+        "feature/drift-aware-agents",
+        "feature/ethical-checkpointing",
+        "feature/symbolic-forecast-engine"
+      ],
+      "stash_saved": "reconstruct-pr-510-mrm: package version downgrades"
+    }
+  },
+  "known_issues": [
+    {
+      "id": "ISSUE-001",
+      "severity": "LOW",
+      "description": "Pydantic regex \u2192 pattern migration needed",
+      "impact": "Non-blocking, test compatibility only",
+      "status": "DEFERRED"
+    },
+    {
+      "id": "ISSUE-002",
+      "severity": "LOW",
+      "description": "54 print statements in health/deployment scripts",
+      "impact": "Low priority, user-facing diagnostics",
+      "status": "DEFERRED"
+    }
+  ],
+  "next_mission_candidates": [
+    {
+      "id": "HIGH-7",
+      "name": "Complete Remaining Logging Migration",
+      "priority": "MEDIUM",
+      "estimated_time": "30-45 minutes",
+      "description": "Migrate 54 remaining print statements in health/deployment scripts"
+    },
+    {
+      "id": "HIGH-8",
+      "name": "Pydantic V2 Migration",
+      "priority": "MEDIUM",
+      "estimated_time": "45-60 minutes",
+      "description": "Update all Pydantic models from regex to pattern syntax"
+    },
+    {
+      "id": "HIGH-9",
+      "name": "Security Scan False Positive Reduction",
+      "priority": "LOW",
+      "estimated_time": "20-30 minutes",
+      "description": "Update security scanners to reduce false positive noise"
+    }
+  ],
+  "station_infrastructure": {
+    "name": "Orion Station",
+    "classification": "Quantum-Symbolic Research & Operations Hub",
+    "location": "Earth-Moon L4 Lagrange Point",
+    "coordinates": "L4_LAGRANGE_POINT_EARTH_MOON",
+    "operational_status": "FULL_OPERATIONAL",
+    "construction_completed": "2024-03-15T12:00:00Z",
+    "primary_mission": "Quantum-Symbolic Computing Research & Deep Space Operations",
+    "station_class": "AURORA_CLASS_RESEARCH_STATION",
+    "crew_capacity": 250,
+    "current_crew": 81,
+    "visitor_capacity": 50,
+    "current_visitors": 0,
+    "total_mass_metric_tons": 185000,
+    "habitable_volume_m3": 425000,
+    "power_generation_mw": 1420,
+    "power_consumption_mw": 998
+  },
+  "command_structure": {
+    "station_commander": {
+      "name": "Commander Alex Thorne",
+      "call_sign": "COMMAND-ACTUAL",
+      "rank": "Commander",
+      "role": "Strategic Leadership & Mission Authorization",
+      "authority_level": "ABSOLUTE",
+      "quantum_forge_slot": 1,
+      "persona_mode": "CLEAR",
+      "years_in_command": 3.2
+    },
+    "executive_officer": {
+      "name": "OPS Rodriguez",
+      "call_sign": "OPS-RODRIGUEZ",
+      "rank": "Lieutenant Commander",
+      "role": "Tactical Operations & Execution",
+      "authority_level": "OPERATIONAL",
+      "quantum_forge_slot": 2,
+      "persona_mode": "COMPANION",
+      "years_in_position": 2.8
+    },
+    "departments": {
+      "operations": {
+        "head": "OPS Rodriguez",
+        "staff_count": 12,
+        "sections": {
+          "quantum_engineering": {
+            "chief": "Lt. Chen",
+            "personnel": 4,
+            "systems": [
+              "QUANTUM_FORGE_ADAPTER",
+              "DARK_MATTER_INTERFACE"
+            ],
+            "status": "OPERATIONAL"
+          },
+          "symbolic_systems": {
+            "chief": "Lt. Patel",
+            "personnel": 3,
+            "systems": [
+              "NARRATIVE_MEMORY_FUSER",
+              "SYMBOLIC_REASONING_CORE"
+            ],
+            "status": "OPERATIONAL"
+          },
+          "network_operations": {
+            "chief": "Ensign Kim",
+            "personnel": 3,
+            "systems": [
+              "INTERSTELLAR_COMMS",
+              "DATA_ROUTING"
+            ],
+            "status": "OPERATIONAL"
+          },
+          "mission_control": {
+            "chief": "Lt. Johnson",
+            "personnel": 2,
+            "systems": [
+              "MISSION_TRACKING",
+              "EFFICIENCY_METRICS"
+            ],
+            "status": "OPERATIONAL"
+          }
+        }
+      },
+      "security": {
+        "head": "Chief Security Officer Nakamura",
+        "staff_count": 15,
+        "sections": {
+          "cybersecurity": {
+            "chief": "Lt. Garcia",
+            "personnel": 5,
+            "systems": [
+              "CSRF_PROTECTION",
+              "INPUT_VALIDATION",
+              "ZK_IDENTITY_GATE"
+            ],
+            "coverage": {
+              "csrf": 100,
+              "validation": 100,
+              "encryption": 100
+            },
+            "status": "CONDITION_GREEN"
+          },
+          "physical_security": {
+            "chief": "Lt. Washington",
+            "personnel": 6,
+            "systems": [
+              "BIOMETRIC_SCANNERS",
+              "QUANTUM_LOCKS"
+            ],
+            "status": "CONDITION_GREEN"
+          },
+          "intelligence": {
+            "chief": "Lt. Ivanova",
+            "personnel": 4,
+            "systems": [
+              "THREAT_ANALYSIS",
+              "ANOMALY_DETECTION"
+            ],
+            "status": "ACTIVE_MONITORING"
+          }
+        }
+      },
+      "science": {
+        "head": "Chief Science Officer Dr. Okafor",
+        "staff_count": 18,
+        "sections": {
+          "quantum_research": {
+            "chief": "Dr. Zhang",
+            "personnel": 6,
+            "projects": [
+              "QUANTUM_SCENARIO_SIMULATION",
+              "SUPERPOSITION_OPTIMIZATION"
+            ],
+            "status": "ACTIVE_RESEARCH"
+          },
+          "symbolic_ai": {
+            "chief": "Dr. O'Brien",
+            "personnel": 5,
+            "projects": [
+              "VECTOR_SYMBOLIC_ARCHITECTURE",
+              "MEMORY_HIERARCHY"
+            ],
+            "status": "ACTIVE_RESEARCH"
+          },
+          "ethics_compliance": {
+            "chief": "Dr. Adeyemi",
+            "personnel": 4,
+            "projects": [
+              "PICARD_DELTA_3_ENFORCEMENT",
+              "ADAPTIVE_COMPLIANCE"
+            ],
+            "status": "ACTIVE_MONITORING"
+          },
+          "data_analysis": {
+            "chief": "Dr. Park",
+            "personnel": 3,
+            "projects": [
+              "INSIGHT_LEDGER",
+              "DATA_LINEAGE_PROTOCOL"
+            ],
+            "status": "OPERATIONAL"
+          }
+        }
+      },
+      "engineering": {
+        "head": "Chief Engineer Thomson",
+        "staff_count": 20,
+        "sections": {
+          "propulsion": {
+            "chief": "Lt. Cmdr. Reyes",
+            "personnel": 6,
+            "systems": [
+              "QUANTUM_DRIVE",
+              "IMPULSE_ENGINES"
+            ],
+            "status": "STANDBY"
+          },
+          "power_generation": {
+            "chief": "Lt. Mueller",
+            "personnel": 5,
+            "systems": [
+              "QUANTUM_FORGE_REACTOR",
+              "SYMBOLIC_RESONANCE_ARRAY"
+            ],
+            "output": "142%",
+            "status": "OPTIMAL"
+          },
+          "life_support": {
+            "chief": "Lt. Santos",
+            "personnel": 4,
+            "systems": [
+              "ATMOSPHERE_CONTROL",
+              "WATER_RECLAMATION"
+            ],
+            "efficiency": 98.7,
+            "status": "NOMINAL"
+          },
+          "structural_integrity": {
+            "chief": "Ensign Taylor",
+            "personnel": 5,
+            "systems": [
+              "HULL_MONITORING",
+              "INERTIAL_DAMPENERS"
+            ],
+            "status": "NOMINAL"
+          }
+        }
+      },
+      "medical": {
+        "head": "Chief Medical Officer Dr. Rousseau",
+        "staff_count": 8,
+        "sections": {
+          "general_medicine": {
+            "chief": "Dr. Rousseau",
+            "personnel": 3,
+            "facilities": [
+              "SICKBAY_ALPHA",
+              "MEDICAL_LAB"
+            ],
+            "status": "OPERATIONAL"
+          },
+          "psychology": {
+            "chief": "Counselor Larsen",
+            "personnel": 2,
+            "services": [
+              "CREW_COUNSELING",
+              "STRESS_MONITORING"
+            ],
+            "status": "AVAILABLE"
+          },
+          "biomedical_research": {
+            "chief": "Dr. Mbeki",
+            "personnel": 3,
+            "projects": [
+              "QUANTUM_BIOLOGY",
+              "COGNITIVE_ENHANCEMENT"
+            ],
+            "status": "ACTIVE_RESEARCH"
+          }
+        }
+      }
+    },
+    "total_personnel": 81,
+    "department_count": 5,
+    "chain_of_command_depth": 4
+  },
+  "fleet_registry": {
+    "vessels": {
+      "AURORA_PRIME": {
+        "class": "Command Frigate",
+        "registry": "NX-9527",
+        "status": "DOCKED_MAIN_BAY",
+        "commander": "Commander Alex Thorne",
+        "crew_complement": 45,
+        "capabilities": {
+          "quantum_drive": true,
+          "symbolic_resonance_comms": true,
+          "adaptive_shields": true,
+          "dark_matter_sensors": true
+        },
+        "armament": {
+          "quantum_torpedoes": 12,
+          "phased_symbolic_arrays": 4,
+          "defensive_only": false
+        },
+        "mission_profile": "Command & Deep Space Research",
+        "last_maintenance": "2025-11-08T10:00:00Z",
+        "operational_status": "FULL_READY",
+        "fuel_state": "100%",
+        "illumination_state": "ACTIVE"
+      },
+      "INSIGHT_RUNNER": {
+        "class": "Science Vessel",
+        "registry": "NCC-7821",
+        "status": "ORBITAL_PATROL",
+        "commander": "Lt. Cmdr. Okafor",
+        "crew_complement": 25,
+        "capabilities": {
+          "advanced_sensors": true,
+          "quantum_computing_lab": true,
+          "symbolic_pattern_analysis": true,
+          "long_range_comms": true
+        },
+        "armament": {
+          "defensive_shields_only": true
+        },
+        "mission_profile": "Scientific Research & Data Collection",
+        "last_maintenance": "2025-11-05T14:30:00Z",
+        "operational_status": "ON_MISSION",
+        "fuel_state": "87%",
+        "illumination_state": "DORMANT"
+      },
+      "GUARDIAN_SENTINEL": {
+        "class": "Security Corvette",
+        "registry": "NX-4129",
+        "status": "PERIMETER_PATROL",
+        "commander": "Lt. Nakamura",
+        "crew_complement": 18,
+        "capabilities": {
+          "tactical_sensors": true,
+          "rapid_response": true,
+          "boarding_team_deployment": true,
+          "stealth_systems": true
+        },
+        "armament": {
+          "quantum_torpedoes": 8,
+          "pulse_cannons": 6,
+          "defensive_countermeasures": true
+        },
+        "mission_profile": "Station Defense & Threat Response",
+        "last_maintenance": "2025-11-10T08:00:00Z",
+        "operational_status": "PATROL_ACTIVE",
+        "fuel_state": "94%",
+        "illumination_state": "DORMANT"
+      },
+      "LOGISTICS_ALPHA": {
+        "class": "Cargo Transport",
+        "registry": "NCC-3047",
+        "status": "DOCKED_CARGO_BAY_2",
+        "commander": "Lt. Hassan",
+        "crew_complement": 8,
+        "capabilities": {
+          "bulk_cargo": true,
+          "quantum_stasis_pods": true,
+          "automated_loading": true
+        },
+        "cargo_capacity": "15000_metric_tons",
+        "current_cargo_mass": "8200_metric_tons",
+        "mission_profile": "Supply & Material Transport",
+        "last_maintenance": "2025-11-01T09:00:00Z",
+        "operational_status": "LOADING",
+        "fuel_state": "100%",
+        "illumination_state": "DORMANT"
+      },
+      "REPAIR_TENDER_BETA": {
+        "class": "Engineering Support",
+        "registry": "NCC-8134",
+        "status": "DOCKED_ENGINEERING_BAY",
+        "commander": "Chief Thomson",
+        "crew_complement": 12,
+        "capabilities": {
+          "hull_repair": true,
+          "quantum_drive_servicing": true,
+          "symbolic_array_calibration": true,
+          "emergency_towing": true
+        },
+        "mission_profile": "Maintenance & Repair Operations",
+        "last_maintenance": "2025-10-28T11:00:00Z",
+        "operational_status": "STANDBY",
+        "fuel_state": "75%",
+        "illumination_state": "DORMANT"
+      },
+      "SHUTTLE_FLEET": {
+        "class": "Personnel Shuttles",
+        "count": 8,
+        "registry_range": "NCC-S101 to NCC-S108",
+        "status": "DOCKED_SHUTTLE_BAY",
+        "capabilities": {
+          "personnel_transport": true,
+          "short_range_ops": true,
+          "emergency_evacuation": true
+        },
+        "operational_status": "READY",
+        "illumination_state": "DORMANT"
+      }
+    },
+    "fleet_summary": {
+      "total_vessels": 11,
+      "operational": 11,
+      "maintenance": 0,
+      "on_mission": 2,
+      "docked": 7,
+      "total_crew": 116,
+      "combat_ready": 2,
+      "science_vessels": 1,
+      "support_vessels": 2,
+      "transports": 1,
+      "shuttles": 8
+    }
+  },
+  "quantum_symbolic_systems": {
+    "quantum_forge_adapter": {
+      "system_id": "QFA-CORE-001",
+      "status": "OPERATIONAL",
+      "illumination_state": "ACTIVE",
+      "agent_slots": {
+        "total": 12,
+        "occupied": 2,
+        "available": 10,
+        "active_agents": [
+          {
+            "slot": 1,
+            "agent_id": "COMMANDER_THORNE_INSTANCE",
+            "persona_mode": "CLEAR",
+            "memory_state": "SUPERPOSITION",
+            "entanglement_partners": [
+              "OPS_RODRIGUEZ_INSTANCE"
+            ],
+            "last_observation": "2025-11-11T15:45:00Z"
+          },
+          {
+            "slot": 2,
+            "agent_id": "OPS_RODRIGUEZ_INSTANCE",
+            "persona_mode": "COMPANION",
+            "memory_state": "COLLAPSED",
+            "entanglement_partners": [
+              "COMMANDER_THORNE_INSTANCE"
+            ],
+            "last_observation": "2025-11-11T15:45:00Z"
+          }
+        ]
+      },
+      "superposition_model": {
+        "max_concurrent_states": 1024,
+        "current_states": 142,
+        "decoherence_rate": "0.0003_per_cycle",
+        "observation_trigger": "USER_INTERACTION"
+      },
+      "performance_metrics": {
+        "quantum_coherence": 99.7,
+        "symbolic_fidelity": 98.4,
+        "processing_efficiency": 142.3,
+        "average_collapse_time_ms": 3.2
+      }
+    },
+    "narrative_memory_fuser": {
+      "system_id": "NMF-CORE-002",
+      "status": "OPERATIONAL",
+      "illumination_state": "DORMANT",
+      "memory_capacity": {
+        "total_nodes": 56000,
+        "used_nodes": 18423,
+        "utilization_percent": 32.9
+      },
+      "fusion_algorithms": {
+        "temporal_binding": "ACTIVE",
+        "semantic_clustering": "ACTIVE",
+        "episodic_reconstruction": "STANDBY",
+        "narrative_threading": "ACTIVE"
+      },
+      "memory_types": {
+        "AGENT": 3847,
+        "FACTION": 1205,
+        "CULTURAL": 892,
+        "MISSION": 2341,
+        "TECHNICAL": 10138
+      },
+      "performance_metrics": {
+        "retrieval_accuracy": 97.3,
+        "fusion_coherence": 94.8,
+        "average_query_time_ms": 12.4
+      }
+    },
+    "zero_knowledge_identity_gate": {
+      "system_id": "ZKIG-SECURITY-003",
+      "status": "OPERATIONAL",
+      "illumination_state": "DORMANT",
+      "authentication_modes": {
+        "biometric": true,
+        "quantum_signature": true,
+        "symbolic_challenge": true,
+        "zero_knowledge_proof": true
+      },
+      "active_sessions": 47,
+      "pending_authentications": 0,
+      "security_level": "MAXIMUM",
+      "last_breach_attempt": "2025-10-15T03:22:00Z",
+      "breach_attempts_blocked": 1847,
+      "performance_metrics": {
+        "authentication_success_rate": 99.98,
+        "false_positive_rate": 0.001,
+        "average_auth_time_ms": 47.3
+      }
+    },
+    "drift_monitoring_system": {
+      "system_id": "DMS-ANALYSIS-004",
+      "status": "ACTIVE_MONITORING",
+      "illumination_state": "ACTIVE",
+      "monitoring_types": {
+        "model_drift": {
+          "status": "MONITORING",
+          "baseline_accuracy": 98.7,
+          "current_accuracy": 98.4,
+          "drift_detected": false,
+          "last_calibration": "2025-11-08T00:00:00Z"
+        },
+        "data_drift": {
+          "status": "MONITORING",
+          "distribution_shift": 0.03,
+          "drift_detected": false,
+          "last_validation": "2025-11-11T12:00:00Z"
+        },
+        "symbolic_leakage": {
+          "status": "MONITORING",
+          "integrity_score": 99.9,
+          "leakage_detected": false,
+          "last_scan": "2025-11-11T15:30:00Z"
+        }
+      },
+      "alert_thresholds": {
+        "model_drift_warning": 0.05,
+        "model_drift_critical": 0.15,
+        "data_drift_warning": 0.1,
+        "data_drift_critical": 0.25,
+        "symbolic_leakage_warning": 0.01,
+        "symbolic_leakage_critical": 0.05
+      }
+    },
+    "compliance_co_pilot": {
+      "system_id": "T1-ACC-MODULE-001",
+      "status": "OPERATIONAL",
+      "illumination_state": "DORMANT",
+      "policy_database": {
+        "total_policies": 1847,
+        "active_policies": 1832,
+        "deprecated_policies": 15,
+        "last_update": "2025-11-09T10:00:00Z"
+      },
+      "risk_scoring_engine": {
+        "active": true,
+        "risk_levels": [
+          "LOW",
+          "MEDIUM",
+          "HIGH",
+          "CRITICAL"
+        ],
+        "average_assessment_time_ms": 23.7
+      },
+      "recent_assessments": {
+        "total_24h": 342,
+        "compliant": 339,
+        "flagged": 3,
+        "critical": 0
+      }
+    },
+    "ethical_data_guardian": {
+      "system_id": "T1-EDG-MODULE-002",
+      "status": "OPERATIONAL",
+      "illumination_state": "DORMANT",
+      "pii_detection": {
+        "active": true,
+        "detection_accuracy": 99.6,
+        "false_positive_rate": 0.2
+      },
+      "redaction_middleware": {
+        "active": true,
+        "redaction_types": [
+          "EMAIL",
+          "SSN",
+          "PHONE",
+          "ADDRESS",
+          "NAME"
+        ],
+        "processing_overhead_ms": 1.8
+      },
+      "data_processed_24h": {
+        "total_records": 184932,
+        "pii_detected": 2847,
+        "pii_redacted": 2847,
+        "privacy_violations": 0
+      }
+    },
+    "trustworthy_insight_ledger": {
+      "system_id": "T1-TIL-MODULE-003",
+      "status": "OPERATIONAL",
+      "illumination_state": "DORMANT",
+      "ledger_type": "APPEND_ONLY_IMMUTABLE",
+      "total_entries": 94732,
+      "cryptographic_signature": "SHA256_WITH_QUANTUM_SEAL",
+      "integrity_verified": true,
+      "last_audit": "2025-11-10T18:00:00Z",
+      "performance_metrics": {
+        "write_latency_ms": 8.4,
+        "query_latency_ms": 4.2,
+        "storage_efficiency": 94.3
+      }
+    },
+    "quantum_scenario_simulator": {
+      "system_id": "T1-QSS-MODULE-004",
+      "status": "OPERATIONAL",
+      "illumination_state": "DORMANT",
+      "quantum_backends": [
+        "QISKIT",
+        "CIRQ",
+        "SYMBOLIC_EMULATOR"
+      ],
+      "active_simulations": 0,
+      "queued_simulations": 0,
+      "scenario_cache": {
+        "total_cached": 3847,
+        "hit_rate": 87.3,
+        "size_mb": 2847
+      },
+      "scenario_types": [
+        "SUPPLY_CHAIN",
+        "ENERGY_GRID",
+        "RISK_ANALYSIS",
+        "FINANCIAL_MODELING",
+        "NETWORK_OPTIMIZATION"
+      ],
+      "performance_metrics": {
+        "average_simulation_time_s": 2.4,
+        "quantum_accuracy": 99.2,
+        "classical_fallback_rate": 0.3
+      }
+    },
+    "skill_composer": {
+      "system_id": "T1-CDSC-MODULE-005",
+      "status": "OPERATIONAL",
+      "illumination_state": "DORMANT",
+      "skill_registry": {
+        "total_skills": 1247,
+        "active_skills": 1189,
+        "deprecated_skills": 58
+      },
+      "dependency_resolution": {
+        "active": true,
+        "resolution_algorithm": "TOPOLOGICAL_SORT_WITH_CYCLE_DETECTION",
+        "average_resolution_time_ms": 15.3
+      },
+      "composition_cache": {
+        "cached_compositions": 842,
+        "hit_rate": 76.4
+      }
+    },
+    "resilience_sentinel": {
+      "system_id": "T1-RSD-MODULE-006",
+      "status": "ACTIVE_MONITORING",
+      "illumination_state": "ACTIVE",
+      "metrics_aggregation": {
+        "sources": 47,
+        "metrics_per_second": 1847,
+        "retention_days": 90
+      },
+      "anomaly_detection": {
+        "active": true,
+        "detection_algorithms": [
+          "STATISTICAL",
+          "ML_BASED",
+          "PATTERN_MATCHING"
+        ],
+        "anomalies_detected_24h": 3,
+        "false_positive_rate": 2.1
+      },
+      "alerting": {
+        "active_alerts": 0,
+        "alert_channels": [
+          "CONSOLE",
+          "EMAIL",
+          "QUANTUM_BEACON"
+        ],
+        "escalation_enabled": true
+      },
+      "system_health_score": 98.7
+    }
+  },
+  "dark_matter_memory": {
+    "description": "Systems exist in dormant state until interaction triggers quantum collapse to observable (illuminated) state",
+    "architecture": "OBSERVER_DEPENDENT_ACTIVATION",
+    "total_systems": 47,
+    "illuminated_systems": 4,
+    "dormant_systems": 43,
+    "transition_mechanism": "QUANTUM_COLLAPSE_ON_OBSERVATION",
+    "memory_efficiency": "98.7%",
+    "dormant_power_consumption": "0.3%_of_active",
+    "system_states": {
+      "DORMANT": {
+        "description": "System exists in complete specification but not actively processed",
+        "memory_footprint": "MINIMAL_STRUCTURAL_ONLY",
+        "processing_overhead": "ZERO",
+        "state_preservation": "COMPLETE",
+        "systems_in_state": 43
+      },
+      "TRANSITIONING": {
+        "description": "System undergoing quantum collapse from dormant to illuminated",
+        "duration_typical_ms": 3.2,
+        "systems_in_state": 0
+      },
+      "ILLUMINATED": {
+        "description": "System actively processing and visible in observation context",
+        "memory_footprint": "FULL_OPERATIONAL",
+        "processing_overhead": "NORMAL",
+        "systems_in_state": 4,
+        "current_illuminated": [
+          "QUANTUM_FORGE_ADAPTER",
+          "DRIFT_MONITORING_SYSTEM",
+          "RESILIENCE_SENTINEL",
+          "AURORA_PRIME_VESSEL"
+        ]
+      }
+    },
+    "illumination_triggers": {
+      "user_interaction": {
+        "active": true,
+        "priority": "IMMEDIATE",
+        "examples": [
+          "Query about system",
+          "Direct command",
+          "Status request"
+        ]
+      },
+      "mission_requirement": {
+        "active": true,
+        "priority": "HIGH",
+        "examples": [
+          "Mission activation",
+          "Emergency protocol",
+          "Scheduled operation"
+        ]
+      },
+      "quantum_event": {
+        "active": true,
+        "priority": "VARIABLE",
+        "examples": [
+          "Entanglement cascade",
+          "State superposition collapse",
+          "Observer effect"
+        ]
+      },
+      "system_interdependency": {
+        "active": true,
+        "priority": "MEDIUM",
+        "examples": [
+          "Dependent system activation",
+          "Data pipeline requirement",
+          "Protocol chain"
+        ]
+      },
+      "scheduled_maintenance": {
+        "active": true,
+        "priority": "LOW",
+        "examples": [
+          "Daily health check",
+          "Weekly audit",
+          "Monthly calibration"
+        ]
+      }
+    },
+    "performance_characteristics": {
+      "illumination_latency_ms": 3.2,
+      "dormancy_transition_ms": 8.7,
+      "concurrent_illuminated_max": 12,
+      "context_preservation_rate": 99.98,
+      "memory_efficiency_gain": "97.3%_vs_always_active"
+    }
+  },
+  "quantum_cycle": {
+    "description": "Entire simulation advances probabilistically each cycle based on quantum state evolution",
+    "cycle_frequency_hz": 0.1,
+    "cycle_period_s": 10.0,
+    "current_cycle": 18472,
+    "cycles_since_initialization": 18472,
+    "state_advancement": {
+      "mechanism": "QUANTUM_PROBABILISTIC",
+      "deterministic_components": [
+        "Time progression",
+        "Scheduled events",
+        "Mechanical systems"
+      ],
+      "probabilistic_components": [
+        "Agent decisions",
+        "System interactions",
+        "Emergent behaviors"
+      ],
+      "superposition_states_per_cycle": 142,
+      "collapse_events_per_cycle": 3.7
+    },
+    "quantum_parameters": {
+      "decoherence_rate": 0.0003,
+      "entanglement_probability": 0.12,
+      "observation_collapse_threshold": 0.85,
+      "superposition_max_duration_cycles": 100
+    },
+    "advancement_categories": {
+      "station_operations": {
+        "type": "MIXED_DETERMINISTIC_PROBABILISTIC",
+        "deterministic_weight": 0.8,
+        "update_frequency": "EVERY_CYCLE",
+        "examples": [
+          "Power generation fluctuation",
+          "Life support efficiency",
+          "Structural integrity"
+        ]
+      },
+      "fleet_movements": {
+        "type": "DETERMINISTIC_WITH_QUANTUM_PERTURBATIONS",
+        "deterministic_weight": 0.95,
+        "update_frequency": "EVERY_CYCLE",
+        "examples": [
+          "Orbital positions",
+          "Patrol routes",
+          "Docking procedures"
+        ]
+      },
+      "personnel_states": {
+        "type": "PROBABILISTIC",
+        "deterministic_weight": 0.3,
+        "update_frequency": "EVERY_10_CYCLES",
+        "examples": [
+          "Crew morale",
+          "Skill development",
+          "Social dynamics"
+        ]
+      },
+      "mission_progression": {
+        "type": "MIXED_DETERMINISTIC_PROBABILISTIC",
+        "deterministic_weight": 0.6,
+        "update_frequency": "EVENT_DRIVEN",
+        "examples": [
+          "Task completion",
+          "Obstacle encounters",
+          "Resource consumption"
+        ]
+      },
+      "system_health": {
+        "type": "PROBABILISTIC_WITH_DRIFT",
+        "deterministic_weight": 0.7,
+        "update_frequency": "EVERY_CYCLE",
+        "examples": [
+          "Component wear",
+          "Software stability",
+          "Calibration drift"
+        ]
+      }
+    },
+    "emergent_behavior_model": {
+      "enabled": true,
+      "complexity_level": "HIGH",
+      "interaction_rules": "PARALLEL_ASYNCHRONOUS",
+      "feedback_loops": true,
+      "adaptation_rate": 0.05,
+      "chaos_prevention": {
+        "enabled": true,
+        "stability_bounds": "STATION_SAFETY_CONSTRAINTS",
+        "intervention_threshold": 0.95
+      }
+    },
+    "performance_metrics": {
+      "average_cycle_time_ms": 87.3,
+      "state_updates_per_cycle": 1847,
+      "quantum_coherence_maintained": 99.7,
+      "emergent_events_per_100_cycles": 12.4,
+      "simulation_stability_score": 98.7
+    }
+  },
+  "anchor_protocol": {
+    "description": "Temporal and symbolic reference system for state tracking and validation",
+    "temporal_anchors": {
+      "T1": {
+        "description": "Monotonically increasing temporal state counter",
+        "current_state": 18472,
+        "advancement_trigger": "CHAIN_EXECUTION_OR_CYCLE",
+        "validation": "STRICTLY_MONOTONIC"
+      },
+      "SRB": {
+        "description": "Symbolic Reference Block - boundary resolution tracking",
+        "current_resolution": 7821,
+        "advancement_trigger": "BOUNDARY_CROSSING",
+        "validation": "HASH_BASED_INTEGRITY"
+      }
+    },
+    "symbolic_anchors": {
+      "DLP": {
+        "description": "Data Lineage Protocol - track provenance and transformations",
+        "active_tags": 3847,
+        "validation_method": "CRYPTOGRAPHIC_HASH",
+        "manifest_system": "NATIVE_EXPORT_TRACKER"
+      },
+      "MEMORY_SEALS": {
+        "description": "Quantum memory integrity markers",
+        "format": "@seal:HASH_VALUE",
+        "active_seals": 142,
+        "seal_algorithm": "SHA256_WITH_QUANTUM_SIGNATURE"
+      }
+    },
+    "quantum_reference_frames": {
+      "SUPERPOSITION_TRACKING": {
+        "active": true,
+        "max_concurrent_states": 1024,
+        "current_states": 142
+      },
+      "ENTANGLEMENT_GRAPH": {
+        "active": true,
+        "entangled_pairs": 12,
+        "coherence_maintained": 99.7
+      },
+      "OBSERVER_EFFECTS": {
+        "active": true,
+        "observation_events_24h": 3847,
+        "collapse_events_24h": 142
+      }
+    }
+  },
+  "persona_modes": {
+    "available_modes": [
+      "CLEAR",
+      "COMPANION",
+      "MYTHIC",
+      "REFLECTIVE"
+    ],
+    "current_active": {
+      "commander_alex_thorne": "CLEAR",
+      "ops_rodriguez": "COMPANION"
+    },
+    "mode_descriptions": {
+      "CLEAR": "Direct, efficient, military precision",
+      "COMPANION": "Supportive, collaborative, team-focused",
+      "MYTHIC": "Archetypal, symbolic, narrative-driven",
+      "REFLECTIVE": "Analytical, introspective, philosophical"
+    }
+  },
+  "simulation_metadata": {
+    "architecture_version": "2.0.0-QUANTUM-CANONICAL",
+    "builder_script": "build_canonical_state.py",
+    "build_timestamp": "2025-11-11T18:31:03.261508Z",
+    "canonical_sources": [
+      "SIMULATION_STATE.v1.backup.json",
+      "canonical/departments.json",
+      "canonical/fleet.json",
+      "canonical/systems.json",
+      "canonical/quantum_architecture.json"
+    ],
+    "total_systems": 47,
+    "illuminated_systems": 4,
+    "dormant_systems": 43,
+    "quantum_cycles_since_init": 18472,
+    "memory_efficiency_percent": 98.7
+  }
+}

--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -889,6 +889,16 @@ except ImportError as e:
 except Exception as e:
     logger.error("❌ Failed to integrate Crew Agents routes: %s", e)
 
+# Include L1 Station API routes
+try:
+    from src.api.l1_station_api import router as l1_station_router
+    app.include_router(l1_station_router)
+    logger.info("✅ L1 Station API routes integrated successfully")
+except ImportError as e:
+    logger.warning("⚠️ L1 Station routes not available: %s", e)
+except Exception as e:
+    logger.error("❌ Failed to integrate L1 Station routes: %s", e)
+
 # Include L2 Meta-Agent Bridge API routes
 try:
     from src.api.l2_meta_agent_api import router as l2_meta_agent_router

--- a/src/api/l1_station_api.py
+++ b/src/api/l1_station_api.py
@@ -55,7 +55,9 @@ class L1HealthResponse(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
 
     layer: str = "L1"
-    status: str = Field(description="operational when the state file loads, else degraded")
+    status: str = Field(
+        description="operational when the state file loads, else degraded"
+    )
     state_file: str = Field(description="loaded | missing | invalid")
     simulation_status: Optional[str] = None
     station_name: Optional[str] = None

--- a/src/api/l1_station_api.py
+++ b/src/api/l1_station_api.py
@@ -46,7 +46,10 @@ def _load_state() -> tuple[Optional[Dict[str, Any]], str]:
     try:
         with _STATE_FILE.open("r", encoding="utf-8") as fh:
             return json.load(fh), "loaded"
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        # UnicodeDecodeError (a ValueError, not an OSError) covers a
+        # non-UTF8/corrupt file, so the endpoint degrades to "invalid"
+        # instead of surfacing a 5xx.
         return None, "invalid"
 
 

--- a/src/api/l1_station_api.py
+++ b/src/api/l1_station_api.py
@@ -1,0 +1,116 @@
+"""
+L1 Station API
+Aurora CloudBank Symbolic
+
+FastAPI router exposing the read-only L1 (Station / Simulation) layer surface
+described in ``config/l1_endpoints.yaml``. This is the first implemented slice
+of that contract; it is backed by the canonical simulation state in
+``.aurora/SIMULATION_STATE.json``.
+
+API Routes:
+- GET /api/aurora/health/l1        - L1 Station layer health status
+- GET /api/aurora/simulation/state - Current canonical simulation state
+
+Read-only by design: these endpoints observe the simulation state and never
+mutate it. Mutating operations (crew activate/deactivate, dispatch) are
+intentionally out of scope for this slice.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel, ConfigDict, Field
+
+router = APIRouter(prefix="/api/aurora", tags=["L1 Station"])
+
+# Repo root: src/api/l1_station_api.py -> parents[2] == repository root
+_STATE_FILE = Path(__file__).resolve().parents[2] / ".aurora" / "SIMULATION_STATE.json"
+
+
+def _load_state() -> tuple[Optional[Dict[str, Any]], str]:
+    """Load the canonical simulation state.
+
+    Returns a ``(state, status)`` tuple where ``status`` is one of
+    ``"loaded"``, ``"missing"`` or ``"invalid"``. The endpoints degrade
+    gracefully rather than raising so the health surface stays observable
+    even when the state file is absent or corrupt.
+    """
+    if not _STATE_FILE.exists():
+        return None, "missing"
+    try:
+        with _STATE_FILE.open("r", encoding="utf-8") as fh:
+            return json.load(fh), "loaded"
+    except (json.JSONDecodeError, OSError):
+        return None, "invalid"
+
+
+class L1HealthResponse(BaseModel):
+    """L1 Station layer health summary."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    layer: str = "L1"
+    status: str = Field(description="operational when the state file loads, else degraded")
+    state_file: str = Field(description="loaded | missing | invalid")
+    simulation_status: Optional[str] = None
+    station_name: Optional[str] = None
+    station_operational_status: Optional[str] = None
+    current_crew: Optional[int] = None
+    crew_capacity: Optional[int] = None
+    quantum_cycle: Optional[Any] = None
+    timestamp: str
+
+
+class SimulationStateResponse(BaseModel):
+    """Wrapper around the canonical simulation state."""
+
+    status: str
+    state_file: str
+    state: Optional[Dict[str, Any]] = None
+
+
+@router.get("/health/l1", response_model=L1HealthResponse)
+async def get_l1_health() -> L1HealthResponse:
+    """Return L1 Station layer health derived from the canonical state."""
+    state, file_status = _load_state()
+    now = datetime.now(timezone.utc).isoformat()
+
+    if state is None:
+        return L1HealthResponse(
+            status="degraded",
+            state_file=file_status,
+            timestamp=now,
+        )
+
+    simulation = state.get("simulation", {}) or {}
+    station = state.get("station_infrastructure", {}) or {}
+
+    return L1HealthResponse(
+        status="operational",
+        state_file=file_status,
+        simulation_status=simulation.get("status"),
+        station_name=station.get("name"),
+        station_operational_status=station.get("operational_status"),
+        current_crew=station.get("current_crew"),
+        crew_capacity=station.get("crew_capacity"),
+        quantum_cycle=state.get("quantum_cycle", {}).get("current_cycle")
+        if isinstance(state.get("quantum_cycle"), dict)
+        else state.get("quantum_cycle"),
+        timestamp=now,
+    )
+
+
+@router.get("/simulation/state", response_model=SimulationStateResponse)
+async def get_simulation_state() -> SimulationStateResponse:
+    """Return the current canonical simulation state (read-only)."""
+    state, file_status = _load_state()
+    return SimulationStateResponse(
+        status="success" if state is not None else "unavailable",
+        state_file=file_status,
+        state=state,
+    )

--- a/src/api/l1_station_api.py
+++ b/src/api/l1_station_api.py
@@ -19,12 +19,13 @@ intentionally out of scope for this slice.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict, Field
+
+from src.core.time_utils import utc_iso
 
 router = APIRouter(prefix="/api/aurora", tags=["L1 Station"])
 
@@ -80,7 +81,7 @@ class SimulationStateResponse(BaseModel):
 async def get_l1_health() -> L1HealthResponse:
     """Return L1 Station layer health derived from the canonical state."""
     state, file_status = _load_state()
-    now = datetime.now(timezone.utc).isoformat()
+    now = utc_iso()
 
     if state is None:
         return L1HealthResponse(

--- a/tests/test_app_assembly.py
+++ b/tests/test_app_assembly.py
@@ -11,8 +11,11 @@ import os
 import pytest
 
 os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-app-assembly")
+os.environ.setdefault("AURORA_SECRET_KEY", "test-aurora-secret-key-app-assembly")
 os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-app-assembly")
-os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-for-app-assembly-tests-12345678")
+os.environ.setdefault(
+    "JWT_SECRET_KEY", "test-jwt-secret-key-for-app-assembly-tests-12345678"
+)
 
 from tests._slowapi_stub import install_slowapi_stub  # noqa: E402
 
@@ -56,24 +59,69 @@ EXPECTED_ROUTE_PREFIXES = {
     "/collab",
 }
 
+EXPECTED_ROUTE_METHODS = {
+    ("/api/aurora/health/l1", "GET"),
+    ("/api/aurora/simulation/state", "GET"),
+}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
+def _join_route_path(prefix: str, path: str) -> str:
+    """Join an include-router prefix and child route path."""
+    if not prefix:
+        return path
+    if path == "/":
+        return prefix
+    return f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _iter_routes(routes, prefix: str = ""):
+    """Yield route objects, including routes nested under included routers."""
+    for route in routes:
+        child_prefix = prefix
+        include_context = getattr(route, "include_context", None)
+        if include_context:
+            child_prefix = _join_route_path(
+                prefix, getattr(include_context, "prefix", "")
+            )
+
+        original_router = getattr(route, "original_router", None)
+        if original_router is not None:
+            yield from _iter_routes(original_router.routes, child_prefix)
+        else:
+            yield route, child_prefix
+
+
 def _collect_route_paths(application) -> set:
     """Return the set of all paths registered on the application."""
     paths = set()
-    for route in application.routes:
+    for route, prefix in _iter_routes(application.routes):
         path = getattr(route, "path", None)
         if path:
-            paths.add(path)
+            paths.add(_join_route_path(prefix, path))
     return paths
+
+
+def _collect_route_methods(application) -> set:
+    """Return ``(path, method)`` pairs registered on the application."""
+    route_methods = set()
+    for route, prefix in _iter_routes(application.routes):
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if path and methods:
+            full_path = _join_route_path(prefix, path)
+            route_methods.update((full_path, method) for method in methods)
+    return route_methods
 
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 def test_route_inventory():
@@ -99,6 +147,17 @@ def test_route_inventory():
     assert not missing, (
         f"The following expected route prefixes are not registered in the app: {missing}.\n"
         f"Registered paths (sample): {sorted(route_paths)[:40]}"
+    )
+
+
+@pytest.mark.unit
+def test_l1_station_route_inventory_guard():
+    """Assert that the L1 station router is wired into the assembled app."""
+    route_methods = _collect_route_methods(app)
+    missing = sorted(EXPECTED_ROUTE_METHODS - route_methods)
+
+    assert not missing, (
+        f"The following L1 station route methods are not registered in the app: {missing}."
     )
 
 

--- a/tests/test_crew_agents_api.py
+++ b/tests/test_crew_agents_api.py
@@ -4,14 +4,17 @@ from fastapi.testclient import TestClient
 from api.aurora_api import app
 from src.agents.crew.noor import get_noor
 from src.agents.crew.lin import get_lin
+from src.middleware.fastapi_security import generate_csrf_token
 
 client = TestClient(app)
 
-# Helper to sign a dummy token (bypassing full auth) if needed. For now endpoints rely on test env secret.
+# The full app mounts GlobalCsrfMiddleware, so unsafe (POST) requests must carry a
+# valid CSRF token or they are rejected with 403 before reaching the route. Mint a
+# token against the test CSRF secret (set in conftest.py) so the endpoints are
+# actually exercised rather than blocked at the middleware.
 
 def _auth_headers():
-    # Minimal stub: tokenless access may fail if security enforced; adjust if necessary.
-    return {}
+    return {"X-CSRF-Token": generate_csrf_token("test-session")}
 
 
 @pytest.mark.unit

--- a/tests/test_l1_station_api.py
+++ b/tests/test_l1_station_api.py
@@ -9,6 +9,8 @@ not depend on the full aurora_api app assembly. Both endpoints are GET
 (CSRF-exempt) and back onto .aurora/SIMULATION_STATE.json.
 """
 
+import unittest
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -18,36 +20,37 @@ from src.api.l1_station_api import router
 app = FastAPI()
 app.include_router(router)
 client = TestClient(app)
+case = unittest.TestCase()
 
 
 @pytest.mark.unit
 @pytest.mark.api
 def test_l1_health_endpoint():
     resp = client.get("/api/aurora/health/l1")
-    assert resp.status_code == 200
+    case.assertEqual(resp.status_code, 200)
     data = resp.json()
-    assert data["layer"] == "L1"
-    assert data["status"] in ("operational", "degraded")
-    assert data["state_file"] in ("loaded", "missing", "invalid")
-    assert "timestamp" in data
+    case.assertEqual(data["layer"], "L1")
+    case.assertIn(data["status"], ("operational", "degraded"))
+    case.assertIn(data["state_file"], ("loaded", "missing", "invalid"))
+    case.assertIn("timestamp", data)
     # With the canonical state present, the layer should be operational.
     if data["state_file"] == "loaded":
-        assert data["status"] == "operational"
-        assert data["simulation_status"] is not None
-        assert data["station_name"] is not None
+        case.assertEqual(data["status"], "operational")
+        case.assertIsNotNone(data["simulation_status"])
+        case.assertIsNotNone(data["station_name"])
 
 
 @pytest.mark.unit
 @pytest.mark.api
 def test_l1_simulation_state_endpoint():
     resp = client.get("/api/aurora/simulation/state")
-    assert resp.status_code == 200
+    case.assertEqual(resp.status_code, 200)
     data = resp.json()
-    assert data["state_file"] in ("loaded", "missing", "invalid")
+    case.assertIn(data["state_file"], ("loaded", "missing", "invalid"))
     if data["state_file"] == "loaded":
-        assert data["status"] == "success"
-        assert isinstance(data["state"], dict)
-        assert "simulation" in data["state"]
+        case.assertEqual(data["status"], "success")
+        case.assertIsInstance(data["state"], dict)
+        case.assertIn("simulation", data["state"])
 
 
 @pytest.mark.unit
@@ -56,4 +59,4 @@ def test_l1_state_is_read_only():
     """Two reads return the same state — the endpoint never mutates it."""
     first = client.get("/api/aurora/simulation/state").json()
     second = client.get("/api/aurora/simulation/state").json()
-    assert first == second
+    case.assertEqual(first, second)

--- a/tests/test_l1_station_api.py
+++ b/tests/test_l1_station_api.py
@@ -59,3 +59,18 @@ def test_l1_state_is_read_only():
     first = client.get("/api/aurora/simulation/state").json()
     second = client.get("/api/aurora/simulation/state").json()
     case.assertEqual(first, second)
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_l1_health_degrades_on_corrupt_state(tmp_path, monkeypatch):
+    """A non-UTF8/corrupt state file degrades to invalid, never 5xx."""
+    bad = tmp_path / "SIMULATION_STATE.json"
+    bad.write_bytes(b"\xff\xfe\x00 not-valid-utf8")
+    monkeypatch.setattr("src.api.l1_station_api._STATE_FILE", bad)
+
+    resp = client.get("/api/aurora/health/l1")
+    case.assertEqual(resp.status_code, 200)
+    data = resp.json()
+    case.assertEqual(data["state_file"], "invalid")
+    case.assertEqual(data["status"], "degraded")

--- a/tests/test_l1_station_api.py
+++ b/tests/test_l1_station_api.py
@@ -1,0 +1,59 @@
+"""Tests for the read-only L1 Station API (src/api/l1_station_api.py).
+
+Covers the first implemented slice of the config/l1_endpoints.yaml contract:
+- GET /api/aurora/health/l1
+- GET /api/aurora/simulation/state
+
+The router is mounted on a dedicated app instance here so the unit tests do
+not depend on the full aurora_api app assembly. Both endpoints are GET
+(CSRF-exempt) and back onto .aurora/SIMULATION_STATE.json.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.l1_station_api import router
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_l1_health_endpoint():
+    resp = client.get("/api/aurora/health/l1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["layer"] == "L1"
+    assert data["status"] in ("operational", "degraded")
+    assert data["state_file"] in ("loaded", "missing", "invalid")
+    assert "timestamp" in data
+    # With the canonical state present, the layer should be operational.
+    if data["state_file"] == "loaded":
+        assert data["status"] == "operational"
+        assert data["simulation_status"] is not None
+        assert data["station_name"] is not None
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_l1_simulation_state_endpoint():
+    resp = client.get("/api/aurora/simulation/state")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state_file"] in ("loaded", "missing", "invalid")
+    if data["state_file"] == "loaded":
+        assert data["status"] == "success"
+        assert isinstance(data["state"], dict)
+        assert "simulation" in data["state"]
+
+
+@pytest.mark.unit
+@pytest.mark.api
+def test_l1_state_is_read_only():
+    """Two reads return the same state — the endpoint never mutates it."""
+    first = client.get("/api/aurora/simulation/state").json()
+    second = client.get("/api/aurora/simulation/state").json()
+    assert first == second

--- a/tests/test_l1_station_api.py
+++ b/tests/test_l1_station_api.py
@@ -30,14 +30,13 @@ def test_l1_health_endpoint():
     case.assertEqual(resp.status_code, 200)
     data = resp.json()
     case.assertEqual(data["layer"], "L1")
-    case.assertIn(data["status"], ("operational", "degraded"))
-    case.assertIn(data["state_file"], ("loaded", "missing", "invalid"))
     case.assertIn("timestamp", data)
-    # With the canonical state present, the layer should be operational.
-    if data["state_file"] == "loaded":
-        case.assertEqual(data["status"], "operational")
-        case.assertIsNotNone(data["simulation_status"])
-        case.assertIsNotNone(data["station_name"])
+    # The canonical state file ships with this PR, so it must load and the
+    # layer must report operational — a broken state-file path is a regression.
+    case.assertEqual(data["state_file"], "loaded")
+    case.assertEqual(data["status"], "operational")
+    case.assertIsNotNone(data["simulation_status"])
+    case.assertIsNotNone(data["station_name"])
 
 
 @pytest.mark.unit
@@ -46,11 +45,11 @@ def test_l1_simulation_state_endpoint():
     resp = client.get("/api/aurora/simulation/state")
     case.assertEqual(resp.status_code, 200)
     data = resp.json()
-    case.assertIn(data["state_file"], ("loaded", "missing", "invalid"))
-    if data["state_file"] == "loaded":
-        case.assertEqual(data["status"], "success")
-        case.assertIsInstance(data["state"], dict)
-        case.assertIn("simulation", data["state"])
+    # The canonical state file ships with this PR, so it must load.
+    case.assertEqual(data["state_file"], "loaded")
+    case.assertEqual(data["status"], "success")
+    case.assertIsInstance(data["state"], dict)
+    case.assertIn("simulation", data["state"])
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

L1 simulation-infrastructure saturation pass: exercising the L1 entry points and fixing/implementing what surfaced.

### 1. `fix(sim-state)`: restore corrupted `SIMULATION_STATE.json`
The L1 loader (`.aurora/load_simulation.py`) failed at startup — the state file was stored as corrupted base64 instead of raw JSON (introduced by `77f8136`; only ~1.4 KB of ~9 KB decoded cleanly). Restored from the last known-good revision `7c5cb8b` (valid `2.0.0-QUANTUM-CANONICAL`, 20 sections). Loader, routing, and save-path verified healthy.

### 2. `test(crew)`: unblock CSRF-gated crew API tests
`test_crew_agents_api.py` POSTed to CSRF-protected endpoints without a token (403). Now mints `generate_csrf_token("test-session")` and sends `X-CSRF-Token`, exercising the endpoints. 4 passed (was 3 failed).

### 3. `feat(l1)`: implement + wire read-only L1 station router
`config/l1_endpoints.yaml` documented an L1 API surface that was entirely unimplemented (every `/api/aurora/*` path 404'd). Adds `src/api/l1_station_api.py`:
- `GET /api/aurora/health/l1` — L1 Station layer health summary
- `GET /api/aurora/simulation/state` — current canonical simulation state

Both read-only, backed by the restored state file, degrading gracefully (never 5xx). The router is **wired into the main app** (`app.include_router` in `api/aurora_api.py`), and `test_app_assembly` gains a mount-aware route guard asserting both endpoints are registered. Self-contained unit tests mount the router on a dedicated app instance. Verified live: `health/l1` → operational (Orion Station, crew 81, sim ACTIVE); `simulation/state` → 20 sections.

## Review follow-ups (Copilot)
- Use `src.core.time_utils.utc_iso()` for the health timestamp instead of ad-hoc `datetime.now(timezone.utc).isoformat()` (consistent, seconds precision).
- Tests assert the canonical state file **loads** (`state_file == "loaded"`, operational/success) unconditionally, so a state-file discovery regression is caught rather than silently passing.
- `_load_state()` now also catches `UnicodeDecodeError` (a `ValueError`, not `OSError`) so a non-UTF8/corrupt state file degrades to `invalid` instead of 500; added a regression test for that path.

## Notes
- The 20 "asyncio" test failures seen during saturation were a missing `pytest-asyncio` in the sandbox (pinned in `requirements-dev.txt`), not code.
- Out of L1 scope, flagged separately: connector stale-import bug `cannot import name 'TOTAL_VERIFIED_CAPSULES' from connector.tools.get_capsules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)