### PR TITLE
feat(sim): add scenario seed initializer adapter

### DIFF
--- a/simulation/scenario_seed_initializer.py
+++ b/simulation/scenario_seed_initializer.py
@@ -1,0 +1,201 @@
+"""Adapter for root L2 scenario seed uptake packets.
+
+This module consumes the root control-plane ``simulation_initializer`` payload
+shape and turns it into a validated CloudBank-side initialization object. It
+does not execute a simulation, promote canon, or convert observation categories
+into required outcomes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+REQUIRED_RUNTIME_FREEDOMS = frozenset(
+    {
+        "agent_policy_variation",
+        "knob_sweep_or_sensitivity_run",
+        "exogenous_pressure_variation",
+        "multi_outcome_branch_observation",
+        "post_run_narrative_rendering",
+    }
+)
+
+PROHIBITED_SEMANTIC_KEYS = frozenset(
+    {
+        "forced_winner",
+        "scripted_outcome",
+        "single_required_ending",
+        "required_ending",
+        "canonical_outcome",
+        "canon_fact_by_seed",
+        "runtime_mutation_by_seed",
+    }
+)
+
+
+class ScenarioSeedInitializationError(ValueError):
+    """Raised when an uptake packet cannot initialize a scenario seed."""
+
+
+@dataclass(frozen=True)
+class ScenarioSeedSimulationInitializer:
+    """Validated simulation initializer state derived from a root packet."""
+
+    source_card_id: str
+    seed: int
+    ticks: int
+    anchor_seed: str
+    roles: tuple[str, ...]
+    pressure_axes: tuple[str, ...]
+    knobs: dict[str, str]
+    runtime_freedoms: tuple[str, ...]
+    expected_end_state_handling: str
+
+    def to_initial_state(self) -> dict[str, Any]:
+        """Return the narrow runtime initialization shape."""
+
+        return {
+            "source_card_id": self.source_card_id,
+            "seed": self.seed,
+            "ticks": self.ticks,
+            "anchor_seed": self.anchor_seed,
+            "initial_condition_vector": {
+                "roles": list(self.roles),
+                "pressure": list(self.pressure_axes),
+                "knobs": dict(self.knobs),
+            },
+            "runtime_freedoms": list(self.runtime_freedoms),
+            "expected_end_state_handling": self.expected_end_state_handling,
+        }
+
+
+def initialize_from_uptake_packet(packet: Mapping[str, Any]) -> ScenarioSeedSimulationInitializer:
+    """Build a CloudBank initializer from a root uptake packet.
+
+    ``packet`` may be the whole uptake packet or the nested
+    ``consumer_payloads.simulation_initializer`` object. Whole packets must
+    preserve the root boundary assertions that prohibit nested writes and direct
+    canon promotion.
+    """
+
+    source_card_id = _source_card_id(packet)
+    simulation_payload = _simulation_payload(packet)
+    _assert_boundary(packet)
+    _reject_prohibited_keys(simulation_payload)
+
+    vector = _mapping(simulation_payload.get("initial_condition_vector"), "initial_condition_vector")
+    roles = _string_tuple(vector.get("roles"), "initial_condition_vector.roles", minimum=4)
+    pressure = _string_tuple(vector.get("pressure"), "initial_condition_vector.pressure", minimum=2)
+    knobs = _string_mapping(vector.get("knobs"), "initial_condition_vector.knobs", minimum=5)
+    runtime_freedoms = _string_tuple(
+        simulation_payload.get("runtime_freedoms"),
+        "runtime_freedoms",
+        minimum=len(REQUIRED_RUNTIME_FREEDOMS),
+    )
+
+    missing_freedoms = REQUIRED_RUNTIME_FREEDOMS.difference(runtime_freedoms)
+    if missing_freedoms:
+        raise ScenarioSeedInitializationError(
+            "runtime_freedoms missing required freedom(s): " + ", ".join(sorted(missing_freedoms))
+        )
+
+    expected_handling = _string(simulation_payload.get("expected_end_state_handling"), "expected_end_state_handling")
+    if "observation categories" not in expected_handling:
+        raise ScenarioSeedInitializationError(
+            "expected_end_state_handling must preserve observation-category semantics"
+        )
+
+    return ScenarioSeedSimulationInitializer(
+        source_card_id=source_card_id,
+        seed=_positive_int(simulation_payload.get("seed"), "seed"),
+        ticks=_positive_int(simulation_payload.get("ticks"), "ticks"),
+        anchor_seed=_string(simulation_payload.get("anchor_seed"), "anchor_seed"),
+        roles=roles,
+        pressure_axes=pressure,
+        knobs=knobs,
+        runtime_freedoms=runtime_freedoms,
+        expected_end_state_handling=expected_handling,
+    )
+
+
+def _source_card_id(packet: Mapping[str, Any]) -> str:
+    value = packet.get("source_card_id")
+    if isinstance(value, str) and value:
+        return value
+    return _string(packet.get("source_card_id", "unknown"), "source_card_id")
+
+
+def _simulation_payload(packet: Mapping[str, Any]) -> Mapping[str, Any]:
+    consumer_payloads = packet.get("consumer_payloads")
+    if isinstance(consumer_payloads, Mapping):
+        return _mapping(consumer_payloads.get("simulation_initializer"), "consumer_payloads.simulation_initializer")
+    return packet
+
+
+def _assert_boundary(packet: Mapping[str, Any]) -> None:
+    boundary = packet.get("boundary_assertions")
+    if boundary is None:
+        return
+    boundary_map = _mapping(boundary, "boundary_assertions")
+    if boundary_map.get("writes_nested_repos") is not False:
+        raise ScenarioSeedInitializationError("packet must not authorize nested repo writes")
+    if boundary_map.get("canonrec_promotion") != "not_authorized_by_this_packet":
+        raise ScenarioSeedInitializationError("packet must not authorize CanonRec promotion")
+
+
+def _reject_prohibited_keys(value: Any) -> None:
+    keys = _iter_keys(value)
+    prohibited = PROHIBITED_SEMANTIC_KEYS.intersection(keys)
+    if prohibited:
+        raise ScenarioSeedInitializationError(
+            "simulation_initializer contains prohibited semantic key(s): " + ", ".join(sorted(prohibited))
+        )
+
+
+def _iter_keys(value: Any) -> set[str]:
+    keys: set[str] = set()
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            keys.add(str(key))
+            keys.update(_iter_keys(item))
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            keys.update(_iter_keys(item))
+    return keys
+
+
+def _mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ScenarioSeedInitializationError(f"{field} must be an object")
+    return value
+
+
+def _string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ScenarioSeedInitializationError(f"{field} must be a non-empty string")
+    return value
+
+
+def _positive_int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ScenarioSeedInitializationError(f"{field} must be a positive integer")
+    return value
+
+
+def _string_tuple(value: Any, field: str, minimum: int) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ScenarioSeedInitializationError(f"{field} must be a list of strings")
+    result = tuple(_string(item, field) for item in value)
+    if len(result) < minimum:
+        raise ScenarioSeedInitializationError(f"{field} must contain at least {minimum} item(s)")
+    return result
+
+
+def _string_mapping(value: Any, field: str, minimum: int) -> dict[str, str]:
+    mapping = _mapping(value, field)
+    result = {_string(key, field): _string(item, field) for key, item in mapping.items()}
+    if len(result) < minimum:
+        raise ScenarioSeedInitializationError(f"{field} must contain at least {minimum} item(s)")
+    return result

--- a/tests/test_scenario_seed_initializer.py
+++ b/tests/test_scenario_seed_initializer.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+
+from simulation.scenario_seed_initializer import (
+    ScenarioSeedInitializationError,
+    initialize_from_uptake_packet,
+)
+
+
+def sample_packet() -> dict:
+    return {
+        "source_card_id": "SCN-0903",
+        "consumer_payloads": {
+            "simulation_initializer": {
+                "seed": 903,
+                "ticks": 4,
+                "anchor_seed": "EOS_SEED_ORION",
+                "initial_condition_vector": {
+                    "roles": [
+                        "Veteran Trainer",
+                        "Civil Authority",
+                        "Credential Institution",
+                        "Proxy Actor",
+                    ],
+                    "pressure": ["clock", "legitimacy", "escalation"],
+                    "knobs": {
+                        "Dominant solver": "truth | diplomacy | containment | reform",
+                        "Institution strength": "strong enforcement vs hollow legitimacy",
+                        "Mobility": "localized incident -> multi-region mobilization",
+                        "Norm enforcement": "high taboo -> low panic",
+                        "Power distribution": "state vs league vs sponsors vs insurgents",
+                    },
+                },
+                "runtime_freedoms": [
+                    "agent_policy_variation",
+                    "knob_sweep_or_sensitivity_run",
+                    "exogenous_pressure_variation",
+                    "multi_outcome_branch_observation",
+                    "post_run_narrative_rendering",
+                ],
+                "expected_end_state_handling": (
+                    "expected_end_states are observation categories and fixture-coverage labels only; "
+                    "they must not be converted into required runtime endings."
+                ),
+            }
+        },
+        "boundary_assertions": {
+            "root_control_plane_only": True,
+            "writes_nested_repos": False,
+            "cloudbank_runtime_wiring": "not_authorized_by_this_packet",
+            "canonrec_promotion": "not_authorized_by_this_packet",
+        },
+    }
+
+
+def test_initialize_from_root_uptake_packet_preserves_open_outcome_contract():
+    initializer = initialize_from_uptake_packet(sample_packet())
+
+    assert initializer.source_card_id == "SCN-0903"
+    assert initializer.seed == 903
+    assert initializer.ticks == 4
+    assert initializer.anchor_seed == "EOS_SEED_ORION"
+    assert "multi_outcome_branch_observation" in initializer.runtime_freedoms
+
+    initial_state = initializer.to_initial_state()
+    assert initial_state["initial_condition_vector"]["roles"][0] == "Veteran Trainer"
+    assert "expected_end_states" not in initial_state
+    assert "required runtime endings" in initial_state["expected_end_state_handling"]
+
+
+def test_initialize_from_direct_simulation_payload_is_supported():
+    payload = sample_packet()["consumer_payloads"]["simulation_initializer"]
+
+    initializer = initialize_from_uptake_packet(payload)
+
+    assert initializer.source_card_id == "unknown"
+    assert initializer.to_initial_state()["seed"] == 903
+
+
+def test_rejects_nested_write_or_canon_promotion_authorization():
+    packet = sample_packet()
+    packet["boundary_assertions"]["writes_nested_repos"] = True
+
+    with pytest.raises(ScenarioSeedInitializationError, match="nested repo writes"):
+        initialize_from_uptake_packet(packet)
+
+    packet = sample_packet()
+    packet["boundary_assertions"]["canonrec_promotion"] = "authorized"
+
+    with pytest.raises(ScenarioSeedInitializationError, match="CanonRec promotion"):
+        initialize_from_uptake_packet(packet)
+
+
+def test_rejects_scripted_outcome_semantics():
+    packet = sample_packet()
+    packet["consumer_payloads"]["simulation_initializer"]["scripted_outcome"] = "Civil authority wins"
+
+    with pytest.raises(ScenarioSeedInitializationError, match="scripted_outcome"):
+        initialize_from_uptake_packet(packet)
+
+
+def test_rejects_low_emergence_capacity_payloads():
+    packet = sample_packet()
+    packet["consumer_payloads"]["simulation_initializer"]["initial_condition_vector"]["roles"] = ["one"]
+
+    with pytest.raises(ScenarioSeedInitializationError, match="roles"):
+        initialize_from_uptake_packet(packet)

--- a/tests/test_scenario_seed_initializer.py
+++ b/tests/test_scenario_seed_initializer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import pytest
+from collections.abc import Callable
 
 from simulation.scenario_seed_initializer import (
     ScenarioSeedInitializationError,
@@ -54,6 +54,19 @@ def sample_packet() -> dict:
     }
 
 
+def assert_raises_message(
+    exc_type: type[Exception],
+    message_fragment: str,
+    action: Callable[[], object],
+) -> None:
+    try:
+        action()
+    except exc_type as exc:
+        assert message_fragment in str(exc)
+        return
+    raise AssertionError(f"Expected {exc_type.__name__} containing {message_fragment!r}")
+
+
 def test_initialize_from_root_uptake_packet_preserves_open_outcome_contract():
     initializer = initialize_from_uptake_packet(sample_packet())
 
@@ -82,27 +95,39 @@ def test_rejects_nested_write_or_canon_promotion_authorization():
     packet = sample_packet()
     packet["boundary_assertions"]["writes_nested_repos"] = True
 
-    with pytest.raises(ScenarioSeedInitializationError, match="nested repo writes"):
-        initialize_from_uptake_packet(packet)
+    assert_raises_message(
+        ScenarioSeedInitializationError,
+        "nested repo writes",
+        lambda: initialize_from_uptake_packet(packet),
+    )
 
     packet = sample_packet()
     packet["boundary_assertions"]["canonrec_promotion"] = "authorized"
 
-    with pytest.raises(ScenarioSeedInitializationError, match="CanonRec promotion"):
-        initialize_from_uptake_packet(packet)
+    assert_raises_message(
+        ScenarioSeedInitializationError,
+        "CanonRec promotion",
+        lambda: initialize_from_uptake_packet(packet),
+    )
 
 
 def test_rejects_scripted_outcome_semantics():
     packet = sample_packet()
     packet["consumer_payloads"]["simulation_initializer"]["scripted_outcome"] = "Civil authority wins"
 
-    with pytest.raises(ScenarioSeedInitializationError, match="scripted_outcome"):
-        initialize_from_uptake_packet(packet)
+    assert_raises_message(
+        ScenarioSeedInitializationError,
+        "scripted_outcome",
+        lambda: initialize_from_uptake_packet(packet),
+    )
 
 
 def test_rejects_low_emergence_capacity_payloads():
     packet = sample_packet()
     packet["consumer_payloads"]["simulation_initializer"]["initial_condition_vector"]["roles"] = ["one"]
 
-    with pytest.raises(ScenarioSeedInitializationError, match="roles"):
-        initialize_from_uptake_packet(packet)
+    assert_raises_message(
+        ScenarioSeedInitializationError,
+        "roles",
+        lambda: initialize_from_uptake_packet(packet),
+    )

--- a/tests/test_scenario_seed_initializer.py
+++ b/tests/test_scenario_seed_initializer.py
@@ -59,6 +59,8 @@ def assert_raises_message(
     message_fragment: str,
     action: Callable[[], object],
 ) -> None:
+    """Assert that an action raises an expected exception message fragment."""
+
     try:
         action()
     except exc_type as exc:

--- a/tests/test_scenario_seed_initializer.py
+++ b/tests/test_scenario_seed_initializer.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from unittest import TestCase
 
 from simulation.scenario_seed_initializer import (
     ScenarioSeedInitializationError,
     initialize_from_uptake_packet,
 )
+
+CHECK = TestCase()
 
 
 def sample_packet() -> dict:
@@ -64,7 +67,7 @@ def assert_raises_message(
     try:
         action()
     except exc_type as exc:
-        assert message_fragment in str(exc)
+        CHECK.assertIn(message_fragment, str(exc))
         return
     raise AssertionError(f"Expected {exc_type.__name__} containing {message_fragment!r}")
 
@@ -72,16 +75,22 @@ def assert_raises_message(
 def test_initialize_from_root_uptake_packet_preserves_open_outcome_contract():
     initializer = initialize_from_uptake_packet(sample_packet())
 
-    assert initializer.source_card_id == "SCN-0903"
-    assert initializer.seed == 903
-    assert initializer.ticks == 4
-    assert initializer.anchor_seed == "EOS_SEED_ORION"
-    assert "multi_outcome_branch_observation" in initializer.runtime_freedoms
+    CHECK.assertEqual(initializer.source_card_id, "SCN-0903")
+    CHECK.assertEqual(initializer.seed, 903)
+    CHECK.assertEqual(initializer.ticks, 4)
+    CHECK.assertEqual(initializer.anchor_seed, "EOS_SEED_ORION")
+    CHECK.assertIn("multi_outcome_branch_observation", initializer.runtime_freedoms)
 
     initial_state = initializer.to_initial_state()
-    assert initial_state["initial_condition_vector"]["roles"][0] == "Veteran Trainer"
-    assert "expected_end_states" not in initial_state
-    assert "required runtime endings" in initial_state["expected_end_state_handling"]
+    CHECK.assertEqual(
+        initial_state["initial_condition_vector"]["roles"][0],
+        "Veteran Trainer",
+    )
+    CHECK.assertNotIn("expected_end_states", initial_state)
+    CHECK.assertIn(
+        "required runtime endings",
+        initial_state["expected_end_state_handling"],
+    )
 
 
 def test_initialize_from_direct_simulation_payload_is_supported():
@@ -89,8 +98,8 @@ def test_initialize_from_direct_simulation_payload_is_supported():
 
     initializer = initialize_from_uptake_packet(payload)
 
-    assert initializer.source_card_id == "unknown"
-    assert initializer.to_initial_state()["seed"] == 903
+    CHECK.assertEqual(initializer.source_card_id, "unknown")
+    CHECK.assertEqual(initializer.to_initial_state()["seed"], 903)
 
 
 def test_rejects_nested_write_or_canon_promotion_authorization():


### PR DESCRIPTION
## Summary

- Adds a CloudBank scenario seed initializer adapter for root L2 uptake packets.
- Preserves the boundary that scenario seeds are initial conditions and pressure fields, not scripted outcomes or canon facts.
- Rejects packets that imply nested repo writes, direct CanonRec promotion, or required runtime endings.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/cloudbank-l2-scenario-pycache python3 -m pytest tests/test_scenario_seed_initializer.py -q`
- `PYTHONPYCACHEPREFIX=/private/tmp/cloudbank-l2-scenario-pycache python3 -m py_compile simulation/scenario_seed_initializer.py tests/test_scenario_seed_initializer.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/aurora-root-pycache python3 tools/l2_scenario_seed_uptake.py --ids SCN-0903 --summary`
- Root `build_report(..., ["SCN-0903"])` into CloudBank `initialize_from_uptake_packet(...)`: `{"status": "pass", "seed": 903, "source_card_id": "SCN-0903", "roles": 6, "pressure_axes": 3, "knob_axes": 7}`

## Migration Note

The old `/private/tmp/cloudbank-l2-scenario-adapter` worktree still pointed its Git metadata at the inert iCloud checkout. This PR was refreshed from a new `/private/tmp/cloudbank-l2-scenario-adapter-dev` worktree whose Git common dir is under `/Users/travisstreets/dev/Aurora_ORIONCORE_Directory_Main/...`.

Original local adapter commit `1eedd38f` was rebased onto current `origin/main` `464de5b6` as `0122c101`. Adapter file contents are unchanged from the old branch; only the base changed.
