### PR TITLE
fix(vercel): align Node types with Node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@babel/preset-env": "^8.0.2",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
-        "@types/node": "^26.0.1",
+        "@types/node": "^22.20.0",
         "@types/ws": "^8.5.10",
         "audit-ci": "^7.1.0",
         "concurrently": "^10.0.3",
@@ -4535,12 +4535,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/qs": {
@@ -11407,9 +11407,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@babel/preset-env": "^8.0.2",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
-    "@types/node": "^26.0.1",
+    "@types/node": "^22.20.0",
     "@types/ws": "^8.5.10",
     "audit-ci": "^7.1.0",
     "concurrently": "^10.0.3",


### PR DESCRIPTION
## Summary

- Align `@types/node` with the pinned Vercel/runtime Node 22 engine.
- Update the package-lock entries for `@types/node` and its `undici-types` dependency.

## Context

Follow-up to the open PR #1184 review thread about `@types/node` being ahead of the Node 22 runtime. The latest observed Vercel failure was not caused by this mismatch: deployment `dpl_9fXoQNqHKRdcvf1ssPPHu4qVMtDt` failed during `npm ci` because `@babel/preset-env@8.0.2` required `@babel/core@^8.0.0` while the branch still had `@babel/core@7.29.7`. That split Babel bump was resolved separately by #1188, and the later production deployment on `ad23d5a` reached READY.

This PR keeps the runtime contract conservative by changing `@types/node` from the current 26.x line to the latest 22.x line.

## Validation

- `python3 -m json.tool package.json`
- `python3 -m json.tool package-lock.json`
- `jq` checks confirming `engines.node == "22.x"`, `@types/node == "^22.20.0"`, locked `@types/node == "22.20.0"`, and locked `undici-types == "6.21.0"`
- `git diff --cached --check`

Not run locally: `npm ci`, because this Codex shell has bundled `node` but no `npm` executable on PATH. GitHub/Vercel should validate the lockfile install on this PR.
