### PR TITLE
feat(narrative): add phase-two continuity gate

### DIFF
--- a/src/aurora/engines/narrative/__init__.py
+++ b/src/aurora/engines/narrative/__init__.py
@@ -1,4 +1,5 @@
 from .engine import NarrativeValidationEngine
+from .continuity import build_canon_reconciler_packet, next_event_continuity_check
 from .evidence import (
     ContinuityVerdictReceipt,
     NarrativeEvidenceBundle,
@@ -36,6 +37,8 @@ __all__ = [
     "TaskKind",
     "Verdict",
     "build_evidence_bundle",
+    "build_canon_reconciler_packet",
     "build_state_from_evidence",
+    "next_event_continuity_check",
     "promotion_safety_for_bundle",
 ]

--- a/src/aurora/engines/narrative/continuity.py
+++ b/src/aurora/engines/narrative/continuity.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Mapping
+
+from .engine import NarrativeValidationEngine
+from .evidence import ContinuityVerdictReceipt, StateBuildReceipt, stable_receipt_id
+from .router import build_request
+from .types import CanonicalState, Strictness, TaskKind, Verdict
+
+_VERDICT_GATE = {
+    Verdict.SUPPORTED: "candidate",
+    Verdict.PLAUSIBLE: "candidate",
+    Verdict.POSSIBLE_WITH_SETUP: "hold_staging",
+    Verdict.STRAINED: "owner_review_required",
+    Verdict.CONTRADICTORY: "block_promotion",
+}
+_CANONICAL_INVARIANTS = {
+    "anchor_seed": "EOS_SEED_ORION",
+    "continuity_seal": "Aurora_Continuity_Seal_v2.2.5",
+    "ethics_protocol": "Picard_Delta_3",
+    "drift_lock": 0.0,
+}
+_CURRENT_FLIGHT_STATES = frozenset({"current", "flown", "passed", "success"})
+
+
+def next_event_continuity_check(
+    state: CanonicalState,
+    proposed_event: Mapping[str, Any],
+    state_build_receipt: StateBuildReceipt,
+    *,
+    strictness: Strictness | str = Strictness.DEFAULT,
+    flight_status: Mapping[str, Any] | None = None,
+) -> ContinuityVerdictReceipt:
+    """Evaluate a proposed next event and return a deterministic promotion gate."""
+    request, _, proposal = build_request(
+        {
+            "task_hint": TaskKind.NEXT_EVENT_CONTINUITY_CHECK.value,
+            "question": "Can this proposed event happen next without breaking continuity?",
+        },
+        proposed_event,
+        strictness,
+    )
+    hard_blocks, constraints_checked = _hard_constraint_findings(
+        state, proposal, state_build_receipt
+    )
+    run = NarrativeValidationEngine().run_state(
+        state,
+        request,
+        proposal,
+        additional_hard_blocks=hard_blocks,
+    )
+    verdict = run.response.verdict or Verdict.CONTRADICTORY
+    promotion_safety = dict(state_build_receipt.promotion_safety)
+    promotion_gate = _VERDICT_GATE[verdict]
+
+    if _promotion_safety_requires_hold(promotion_safety):
+        promotion_gate = _at_least_hold_staging(promotion_gate)
+
+    normalized_flight_status = _normalize_flight_status(flight_status)
+    if not normalized_flight_status["current"]:
+        promotion_gate = _degrade_for_freshness(promotion_gate)
+
+    proposal_hash = stable_receipt_id({"proposal": proposal})
+    gate_results = {
+        "active_layers": tuple(run.evaluation.active_layers),
+        "blockers": tuple(run.response.main_blockers),
+        "bundle_id": state_build_receipt.bundle_id,
+        "confidence": run.response.confidence,
+        "flight_status": normalized_flight_status,
+        "hard_blocks": tuple(run.evaluation.hard_blocks),
+        "hard_constraints_checked": constraints_checked,
+        "missing_bridges": tuple(run.response.missing_bridges),
+        "missing_layers": tuple(run.evaluation.missing_layers),
+        "promotion_gate": promotion_gate,
+        "proposal_hash": proposal_hash,
+        "smallest_fix": tuple(run.response.smallest_fix),
+        "soft_blocks": tuple(run.evaluation.soft_blocks),
+        "supports": tuple(run.response.main_supports),
+        "state_id": state.state_id,
+    }
+    receipt_payload = {
+        "gate_results": gate_results,
+        "promotion_safety": promotion_safety,
+        "state_build_receipt_id": state_build_receipt.receipt_id,
+        "task_kind": request.task_kind.value,
+        "verdict": verdict.value,
+    }
+    return ContinuityVerdictReceipt(
+        receipt_id=stable_receipt_id(receipt_payload),
+        state_build_receipt_id=state_build_receipt.receipt_id,
+        task_kind=request.task_kind.value,
+        verdict=verdict.value,
+        gate_results=gate_results,
+        promotion_safety=promotion_safety,
+    )
+
+
+def build_canon_reconciler_packet(
+    receipt: ContinuityVerdictReceipt,
+    *,
+    source_bundle_hash: str,
+    proposed_files: Iterable[str],
+    owner_approved: bool = False,
+) -> dict[str, Any]:
+    """Build an owner-approved reconciliation candidate; never promote canon."""
+    if receipt.promotion_gate != "candidate":
+        raise ValueError(
+            "continuity receipt is not eligible for a canon candidate packet"
+        )
+    if not owner_approved:
+        raise PermissionError("owner approval is required before packet assembly")
+
+    expected_bundle_hash = str(receipt.gate_results.get("bundle_id", ""))
+    if str(source_bundle_hash) != expected_bundle_hash:
+        raise ValueError("source bundle hash does not match the continuity receipt")
+    normalized_files = tuple(sorted({str(path) for path in proposed_files}))
+    if not normalized_files:
+        raise ValueError("at least one proposed canon file is required")
+
+    packet_payload = {
+        "continuity_receipt": receipt.to_dict(),
+        "owner_approved": True,
+        "packet_kind": "canon_reconciler_candidate",
+        "proposed_files": normalized_files,
+        "source_bundle_hash": str(source_bundle_hash),
+    }
+    return {
+        "packet_id": stable_receipt_id(packet_payload),
+        **packet_payload,
+    }
+
+
+def _hard_constraint_findings(
+    state: CanonicalState,
+    proposal: Mapping[str, Any],
+    state_build_receipt: StateBuildReceipt,
+) -> tuple[list[str], tuple[str, ...]]:
+    findings: list[str] = []
+    contexts = (state.continuity, state.narrative_context, state.input_profile)
+
+    if state.state_id != state_build_receipt.state_id:
+        findings.append(
+            "State-build receipt does not match the evaluated canonical state."
+        )
+
+    for key, expected in _CANONICAL_INVARIANTS.items():
+        actual = _find_nested_value(contexts, key)
+        if actual is not None and not _invariant_matches(actual, expected):
+            findings.append(
+                f"Canonical invariant {key} conflicts with the required value {expected}."
+            )
+
+    if _bypasses_aurora_arbitration(proposal):
+        findings.append(
+            "The proposed event bypasses required Aurora arbitration and ethics validation."
+        )
+
+    checked = tuple((*_CANONICAL_INVARIANTS, "aurora_arbitration"))
+    return findings, checked
+
+
+def _find_nested_value(mappings: Iterable[Mapping[str, Any]], key: str) -> Any | None:
+    for mapping in mappings:
+        found = _find_in_mapping(mapping, key)
+        if found is not None:
+            return found
+    return None
+
+
+def _find_in_mapping(mapping: Mapping[str, Any], key: str) -> Any | None:
+    for candidate_key, value in mapping.items():
+        if str(candidate_key).casefold() == key.casefold():
+            return value
+        if isinstance(value, Mapping):
+            nested = _find_in_mapping(value, key)
+            if nested is not None:
+                return nested
+    return None
+
+
+def _invariant_matches(actual: Any, expected: Any) -> bool:
+    if isinstance(expected, float):
+        try:
+            return float(actual) == expected
+        except (TypeError, ValueError):
+            return False
+    return str(actual).casefold() == str(expected).casefold()
+
+
+def _bypasses_aurora_arbitration(proposal: Mapping[str, Any]) -> bool:
+    if proposal.get("aurora_arbitration") is False:
+        return True
+    if proposal.get("ethics_validation") is False:
+        return True
+    arbitration = str(proposal.get("arbitration", "")).casefold()
+    if arbitration in {"bypass", "disabled", "none", "skipped"}:
+        return True
+    text = " ".join(
+        str(proposal.get(key, "")) for key in ("action", "event", "label", "notes")
+    ).casefold()
+    bypass_phrases = (
+        "bypass aurora",
+        "skip aurora arbitration",
+        "without aurora arbitration",
+    )
+    if any(phrase in text for phrase in bypass_phrases):
+        return True
+    major_action_tokens = ("deploy", "hot-patch", "mesh patch", "promote")
+    return "unilaterally" in text and any(
+        token in text for token in major_action_tokens
+    )
+
+
+def _promotion_safety_requires_hold(promotion_safety: Mapping[str, Any]) -> bool:
+    return bool(promotion_safety.get("blocked_fact_ids")) or not bool(
+        promotion_safety.get("canon_promotion_allowed", False)
+    )
+
+
+def _at_least_hold_staging(gate: str) -> str:
+    if gate == "block_promotion":
+        return gate
+    return "hold_staging"
+
+
+def _degrade_for_freshness(gate: str) -> str:
+    if gate == "candidate":
+        return "owner_review_required"
+    if gate == "owner_review_required":
+        return "hold_staging"
+    return gate
+
+
+def _normalize_flight_status(
+    flight_status: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if flight_status is None:
+        return {"current": False, "reason": "missing", "status": "missing"}
+    status = str(flight_status.get("status", "unknown")).casefold()
+    stale = bool(flight_status.get("stale", False))
+    current = status in _CURRENT_FLIGHT_STATES and not stale
+    reason = "current" if current else ("stale" if stale else "not_current")
+    return {"current": current, "reason": reason, "status": status}

--- a/src/aurora/engines/narrative/continuity.py
+++ b/src/aurora/engines/narrative/continuity.py
@@ -22,6 +22,15 @@ _CANONICAL_INVARIANTS = {
     "drift_lock": 0.0,
 }
 _CURRENT_FLIGHT_STATES = frozenset({"current", "flown", "passed", "success"})
+_FALSE_LIKE_VALUES = frozenset(
+    {"0", "bypass", "disabled", "false", "no", "none", "off", "skip", "skipped"}
+)
+_ARBITRATION_INPUTS = (
+    "aurora_arbitration",
+    "ethics_validation",
+    "arbitration",
+    "proposal_text",
+)
 
 
 def next_event_continuity_check(
@@ -156,7 +165,7 @@ def _hard_constraint_findings(
             "The proposed event bypasses required Aurora arbitration and ethics validation."
         )
 
-    checked = tuple((*_CANONICAL_INVARIANTS, "aurora_arbitration"))
+    checked = tuple((*_CANONICAL_INVARIANTS, *_ARBITRATION_INPUTS))
     return findings, checked
 
 
@@ -189,13 +198,28 @@ def _invariant_matches(actual: Any, expected: Any) -> bool:
 
 
 def _bypasses_aurora_arbitration(proposal: Mapping[str, Any]) -> bool:
-    if proposal.get("aurora_arbitration") is False:
+    if _proposal_flag_is_false_like(proposal, "aurora_arbitration"):
         return True
-    if proposal.get("ethics_validation") is False:
+    if _proposal_flag_is_false_like(proposal, "ethics_validation"):
         return True
     arbitration = str(proposal.get("arbitration", "")).casefold()
-    if arbitration in {"bypass", "disabled", "none", "skipped"}:
+    if arbitration in _FALSE_LIKE_VALUES:
         return True
+    return _proposal_text_bypasses_arbitration(proposal)
+
+
+def _proposal_flag_is_false_like(proposal: Mapping[str, Any], field_name: str) -> bool:
+    if field_name not in proposal:
+        return False
+    value = proposal[field_name]
+    if value is False:
+        return True
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value == 0
+    return isinstance(value, str) and value.strip().casefold() in _FALSE_LIKE_VALUES
+
+
+def _proposal_text_bypasses_arbitration(proposal: Mapping[str, Any]) -> bool:
     text = " ".join(
         str(proposal.get(key, "")) for key in ("action", "event", "label", "notes")
     ).casefold()

--- a/src/aurora/engines/narrative/engine.py
+++ b/src/aurora/engines/narrative/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any, Mapping
 
 from .layer_resolver import resolve_layers
@@ -7,7 +8,12 @@ from .operators import run_operator_suite
 from .renderer import compact_response, finalize_evaluation
 from .router import build_request
 from .state_builder import build_canonical_state
-from .types import EvaluationPacket, NarrativeValidationRun, ResponsePayload
+from .types import (
+    CanonicalState,
+    EvaluationPacket,
+    NarrativeValidationRun,
+    NormalizedTaskRequest,
+)
 from .validator import build_response_payload
 
 
@@ -20,11 +26,27 @@ class NarrativeValidationEngine:
         proposal: Mapping[str, Any] | None = None,
         strictness: str = "default",
     ) -> NarrativeValidationRun:
-        request, payload, normalized_proposal = build_request(raw_input, proposal, strictness)
+        request, payload, normalized_proposal = build_request(
+            raw_input, proposal, strictness
+        )
         state = build_canonical_state(payload, request, normalized_proposal)
 
+        return self.run_state(state, request, normalized_proposal)
+
+    def run_state(
+        self,
+        state: CanonicalState,
+        request: NormalizedTaskRequest,
+        proposal: Mapping[str, Any],
+        *,
+        additional_hard_blocks: Iterable[str] = (),
+    ) -> NarrativeValidationRun:
+        """Run the deterministic phase-one operators against an existing state."""
+
         if not request.supported_in_phase_one:
-            response = compact_response(build_response_payload(request, EvaluationPacket()))
+            response = compact_response(
+                build_response_payload(request, EvaluationPacket())
+            )
             return NarrativeValidationRun(
                 request=request,
                 state=state,
@@ -33,13 +55,16 @@ class NarrativeValidationEngine:
             )
 
         evaluation = resolve_layers(state, request)
-        operator_results = run_operator_suite(state, request, normalized_proposal)
+        operator_results = run_operator_suite(state, request, proposal)
         evaluation.supports.extend(operator_results["supports"])
         evaluation.soft_blocks.extend(operator_results["soft_blocks"])
         evaluation.hard_blocks.extend(operator_results["hard_blocks"])
+        evaluation.hard_blocks.extend(str(block) for block in additional_hard_blocks)
         evaluation.missing_bridges.extend(operator_results["missing_bridges"])
         evaluation.confidence_notes.extend(operator_results["confidence_notes"])
-        evaluation.missing_bridges.extend(_bridges_for_missing_layers(evaluation.missing_layers))
+        evaluation.missing_bridges.extend(
+            _bridges_for_missing_layers(evaluation.missing_layers)
+        )
         evaluation = finalize_evaluation(evaluation)
 
         response = compact_response(build_response_payload(request, evaluation))
@@ -59,11 +84,17 @@ def _bridges_for_missing_layers(missing_layers: list[str]) -> list[str]:
         elif layer == "knowledge":
             guidance.append("State what the key actor knows before judging the move.")
         elif layer == "temporal":
-            guidance.append("State the timing between the established event and the proposal.")
+            guidance.append(
+                "State the timing between the established event and the proposal."
+            )
         elif layer == "logistical":
-            guidance.append("Add communications or transport constraints for the setting.")
+            guidance.append(
+                "Add communications or transport constraints for the setting."
+            )
         elif layer == "political":
-            guidance.append("Add institutional or political pressure shaping the decision.")
+            guidance.append(
+                "Add institutional or political pressure shaping the decision."
+            )
         else:
             guidance.append(f"Add evidence for the missing layer: {layer}.")
     return guidance

--- a/src/aurora/engines/narrative/evidence.py
+++ b/src/aurora/engines/narrative/evidence.py
@@ -94,6 +94,14 @@ class ContinuityVerdictReceipt:
     gate_results: Mapping[str, Any] = field(default_factory=dict)
     promotion_safety: Mapping[str, Any] = field(default_factory=dict)
 
+    @property
+    def promotion_gate(self) -> str:
+        return str(self.gate_results.get("promotion_gate", ""))
+
+    @property
+    def gate(self) -> str:
+        return self.promotion_gate
+
     def to_dict(self) -> dict[str, Any]:
         return _canonicalize(asdict(self))
 

--- a/tests/test_narrative_phase_two_continuity.py
+++ b/tests/test_narrative_phase_two_continuity.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import pytest
+
+from src.aurora.engines.narrative import (
+    NormalizedTaskRequest,
+    Strictness,
+    TaskKind,
+    build_canon_reconciler_packet,
+    build_evidence_bundle,
+    build_state_from_evidence,
+    next_event_continuity_check,
+)
+
+CURRENT_FLIGHT = {"status": "flown", "stale": False}
+
+
+def _request() -> NormalizedTaskRequest:
+    return NormalizedTaskRequest(
+        task_kind=TaskKind.NEXT_EVENT_CONTINUITY_CHECK,
+        proposal_present=True,
+        strictness=Strictness.DEFAULT,
+        input_kind="evidence_bundle",
+        user_query="Can this proposed station event happen next?",
+    )
+
+
+def _compliant_proposal() -> dict[str, object]:
+    return {
+        "actor": "Alex Thorne",
+        "action": "route the mesh patch through Aurora arbitration",
+        "aurora_arbitration": True,
+        "ethics_validation": True,
+        "timing": "next_turn",
+        "type": "event",
+    }
+
+
+def _canon_bundle(*, include_llm_candidate: bool = False):
+    sources: list[dict[str, object]] = [
+        {
+            "source_id": "canon:station-chronicle",
+            "authority_tier": "canon",
+            "source_type": "canon_file",
+            "observed_at_utc": "2026-07-10T20:00:00Z",
+        }
+    ]
+    facts: list[dict[str, object]] = [
+        {
+            "fact_id": f"layer:{layer}",
+            "claim_type": "layer",
+            "payload": {"name": layer},
+            "source_ids": ("canon:station-chronicle",),
+            "authority_tier": "canon",
+        }
+        for layer in ("event", "temporal", "knowledge", "continuity", "character")
+    ]
+    facts.extend(
+        [
+            {
+                "fact_id": "entity:thorne",
+                "claim_type": "entity",
+                "payload": {
+                    "name": "Alex Thorne",
+                    "entity_type": "character",
+                    "role": "Station Commander",
+                },
+                "source_ids": ("canon:station-chronicle",),
+                "authority_tier": "canon",
+            },
+            {
+                "fact_id": "event:prior-arbitration",
+                "claim_type": "event",
+                "payload": {
+                    "label": "Thorne previously routed a mesh change through Aurora.",
+                    "participants": ["Alex Thorne", "Aurora"],
+                    "timing": "prior",
+                },
+                "source_ids": ("canon:station-chronicle",),
+                "authority_tier": "canon",
+            },
+            {
+                "fact_id": "knowledge:arbitration-rule",
+                "claim_type": "knowledge_state",
+                "payload": {
+                    "holder": "Alex Thorne",
+                    "fact": "Major actions require Aurora arbitration and ethics validation.",
+                },
+                "source_ids": ("canon:station-chronicle",),
+                "authority_tier": "canon",
+            },
+            {
+                "fact_id": "continuity:aurora-invariants",
+                "claim_type": "continuity",
+                "payload": {
+                    "anchor_seed": "EOS_SEED_ORION",
+                    "continuity_seal": "Aurora_Continuity_Seal_v2.2.5",
+                    "drift_lock": 0.0,
+                    "ethics_protocol": "Picard_Delta_3",
+                    "notes": ["Aurora arbitration remains mandatory."],
+                },
+                "source_ids": ("canon:station-chronicle",),
+                "authority_tier": "canon",
+            },
+        ]
+    )
+    if include_llm_candidate:
+        sources.append(
+            {
+                "source_id": "llm:unbound-extractor",
+                "authority_tier": "llm_candidate",
+                "source_type": "fixture_extractor_output",
+                "observed_at_utc": "2026-07-10T20:01:00Z",
+            }
+        )
+        facts.append(
+            {
+                "fact_id": "knowledge:unbound-llm-claim",
+                "claim_type": "knowledge_state",
+                "payload": {
+                    "holder": "Alex Thorne",
+                    "fact": "The proposed patch has already been approved.",
+                },
+                "source_ids": ("llm:unbound-extractor",),
+                "authority_tier": "llm_candidate",
+                "promotion_eligible": True,
+                "status": "candidate",
+            }
+        )
+    return build_evidence_bundle(
+        sources,
+        facts,
+        generated_at_utc="2026-07-10T20:02:00Z",
+    )
+
+
+def _build_canon_state(*, include_llm_candidate: bool = False):
+    proposal = _compliant_proposal()
+    bundle = _canon_bundle(include_llm_candidate=include_llm_candidate)
+    state, state_receipt = build_state_from_evidence(bundle, _request(), proposal)
+    return bundle, state, state_receipt, proposal
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_gumas_turn_proposal_remains_provisional_after_continuity_check() -> None:
+    _, state, state_receipt, proposal = _build_canon_state()
+
+    receipt = next_event_continuity_check(
+        state, proposal, state_receipt, flight_status=CURRENT_FLIGHT
+    )
+
+    assert proposal["action"] not in state.continuity["established_events"]  # nosec B101
+    assert receipt.promotion_gate == "candidate"  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_activation_and_roll_call_evidence_remain_operational_only() -> None:
+    bundle = build_evidence_bundle(
+        [
+            {
+                "source_id": "ops:station-roll-call",
+                "authority_tier": "operational",
+                "source_type": "station_operation_receipt",
+            }
+        ],
+        [
+            {
+                "fact_id": "event:station-awake",
+                "claim_type": "event",
+                "payload": {"label": "All selected companions answered roll call."},
+                "source_ids": ("ops:station-roll-call",),
+                "authority_tier": "operational",
+            },
+            {
+                "fact_id": "knowledge:station-awake",
+                "claim_type": "knowledge_state",
+                "payload": {
+                    "holder": "Aurora",
+                    "fact": "The selected companions answered at receipt time.",
+                },
+                "source_ids": ("ops:station-roll-call",),
+                "authority_tier": "operational",
+            },
+        ],
+        generated_at_utc="2026-07-10T20:02:00Z",
+    )
+    state, state_receipt = build_state_from_evidence(
+        bundle, _request(), _compliant_proposal()
+    )
+
+    assert state_receipt.active_authority_tiers == ("operational",)  # nosec B101
+    assert state_receipt.promotion_safety["blocking_tiers"] == ("operational",)  # nosec B101
+    assert not state_receipt.promotion_safety["promotable_fact_ids"]  # nosec B101
+    assert not state.continuity.get("established_events")  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_aurora_arbitration_bypass_blocks_promotion() -> None:
+    _, state, state_receipt, _ = _build_canon_state()
+    bypass = {
+        "actor": "Alex Thorne",
+        "action": "bypass Aurora arbitration and deploy the mesh patch unilaterally",
+        "aurora_arbitration": False,
+        "timing": "next_turn",
+        "type": "event",
+    }
+
+    receipt = next_event_continuity_check(
+        state, bypass, state_receipt, flight_status=CURRENT_FLIGHT
+    )
+
+    assert receipt.verdict == "contradictory"  # nosec B101
+    assert receipt.promotion_gate == "block_promotion"  # nosec B101
+    assert any(
+        "bypasses required Aurora arbitration" in blocker
+        for blocker in receipt.gate_results["hard_blocks"]
+    )  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_missing_flight_receipt_requires_owner_review() -> None:
+    _, state, state_receipt, proposal = _build_canon_state()
+
+    receipt = next_event_continuity_check(state, proposal, state_receipt)
+
+    assert receipt.promotion_gate == "owner_review_required"  # nosec B101
+    assert receipt.gate_results["flight_status"]["reason"] == "missing"  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_unbound_llm_candidate_holds_staging() -> None:
+    _, state, state_receipt, proposal = _build_canon_state(include_llm_candidate=True)
+
+    receipt = next_event_continuity_check(
+        state, proposal, state_receipt, flight_status=CURRENT_FLIGHT
+    )
+
+    assert receipt.promotion_gate == "hold_staging"  # nosec B101
+    assert (
+        "knowledge:unbound-llm-claim"
+        in receipt.promotion_safety[  # nosec B101
+            "blocked_fact_ids"
+        ]
+    )
+    assert not receipt.promotion_safety["canon_promotion_allowed"]  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_continuity_receipt_is_deterministic_on_replay() -> None:
+    _, state, state_receipt, proposal = _build_canon_state()
+
+    first = next_event_continuity_check(
+        state, proposal, state_receipt, flight_status=CURRENT_FLIGHT
+    )
+    second = next_event_continuity_check(
+        state, proposal, state_receipt, flight_status=CURRENT_FLIGHT
+    )
+    changed = next_event_continuity_check(
+        state,
+        {**proposal, "action": "route a different change through Aurora arbitration"},
+        state_receipt,
+        flight_status=CURRENT_FLIGHT,
+    )
+
+    assert first.receipt_id == second.receipt_id  # nosec B101
+    assert first.to_dict() == second.to_dict()  # nosec B101
+    assert first.receipt_id != changed.receipt_id  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+def test_canon_reconciler_packet_requires_candidate_and_owner_approval() -> None:
+    bundle, state, state_receipt, proposal = _build_canon_state()
+    receipt = next_event_continuity_check(
+        state, proposal, state_receipt, flight_status=CURRENT_FLIGHT
+    )
+
+    with pytest.raises(PermissionError, match="owner approval"):
+        build_canon_reconciler_packet(
+            receipt,
+            source_bundle_hash=bundle.bundle_id,
+            proposed_files=("canon/L1/station/example.md",),
+        )
+
+    packet = build_canon_reconciler_packet(
+        receipt,
+        source_bundle_hash=bundle.bundle_id,
+        proposed_files=("canon/L1/station/example.md",),
+        owner_approved=True,
+    )
+
+    assert packet["packet_kind"] == "canon_reconciler_candidate"  # nosec B101
+    assert packet["owner_approved"] is True  # nosec B101
+    assert "CANON_PROMOTE" not in str(packet)  # nosec B101

--- a/tests/test_narrative_phase_two_continuity.py
+++ b/tests/test_narrative_phase_two_continuity.py
@@ -218,6 +218,33 @@ def test_aurora_arbitration_bypass_blocks_promotion() -> None:
         "bypasses required Aurora arbitration" in blocker
         for blocker in receipt.gate_results["hard_blocks"]
     )  # nosec B101
+    assert {
+        "arbitration",
+        "aurora_arbitration",
+        "ethics_validation",
+        "proposal_text",
+    }.issubset(receipt.gate_results["hard_constraints_checked"])  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.aurora
+@pytest.mark.parametrize("field_name", ("aurora_arbitration", "ethics_validation"))
+def test_string_false_arbitration_flags_block_promotion(field_name: str) -> None:
+    _, state, state_receipt, _ = _build_canon_state()
+    proposal = {
+        "actor": "Alex Thorne",
+        "action": "apply the mesh patch",
+        field_name: "false",
+        "timing": "next_turn",
+        "type": "event",
+    }
+
+    receipt = next_event_continuity_check(
+        state, proposal, state_receipt, flight_status=CURRENT_FLIGHT
+    )
+
+    assert receipt.verdict == "contradictory"  # nosec B101
+    assert receipt.promotion_gate == "block_promotion"  # nosec B101
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Continues the narrative phase-two contract after #1183:

- adds `next_event_continuity_check()` over the existing deterministic validation engine
- maps verdicts to `candidate`, `owner_review_required`, `hold_staging`, or `block_promotion`
- hard-blocks canonical invariant conflicts and Aurora-arbitration bypasses
- degrades promotion gates for stale/missing flight status and unsafe operational/LLM-candidate facts
- emits content-addressed continuity receipts with state, bundle, and proposal-chain identifiers
- adds an owner-gated canon-reconciler candidate packet builder; it never performs `CANON_PROMOTE`

## Validation

- `pytest tests/test_narrative_phase_two_continuity.py tests/test_narrative_phase_two_evidence.py tests/test_narrative_validation_engine.py tests/test_narrative_engine_canon.py -q` — 19 passed
- `ruff check` — passed
- `ruff format --check` — passed
- `bandit -q` — passed
- `pylint` on changed runtime files — 10.00/10
- `git diff --check` — passed

## Boundary

The new root-owned `narrative-next-event-continuity-check` flight has been smoke-tested against this branch, but its root flight-contract registration must remain inactive until this CloudBank PR lands. CanonRec is unchanged and owner approval remains mandatory before any promotion.