### PR TITLE
aurora(queue): reconcile coordination spine and live queue

### DIFF
--- a/ops/work_queue/BRIDGE_FIELDS.md
+++ b/ops/work_queue/BRIDGE_FIELDS.md
@@ -1,6 +1,6 @@
 # Aurora Queue Bridge Fields
 
-**Status:** Draft field reference  
+**Status:** Active compatibility reference
 **Tracked in:** #1161  
 **Purpose:** Define non-breaking metadata that lets queue items coordinate with the ORIONCORE control-plane layer.
 
@@ -93,6 +93,8 @@ A safe migration order is:
 4. Update renderer to display a compact bridge section only when useful.
 5. Add read-only metrics collection.
 6. Add CI enforcement only after generated output is deterministic.
+
+Steps 1–3 and 5 are implemented. The legacy renderer intentionally ignores bridge fields, while the deterministic metrics report counts their adoption. Broader rendering or CI enforcement remains a separate compatibility decision.
 
 ---
 

--- a/ops/work_queue/COORDINATION_METRICS.md
+++ b/ops/work_queue/COORDINATION_METRICS.md
@@ -1,110 +1,39 @@
-# Aurora Dev Coordination Metrics
+<!-- !! GENERATED FILE — DO NOT EDIT BY HAND !!
+     Source of truth: ops/work_queue/queue.json
+     Regenerate:      python ops/work_queue/collect_coordination_metrics.py --markdown
+     Verify:          python ops/work_queue/collect_coordination_metrics.py --check -->
 
-**Status:** Metrics skeleton  
-**Tracked in:** #1161  
-**Depends on:** `ops/work_queue/CROSS_PLATFORM_COORDINATION.md`  
-**Purpose:** Measure whether the queue and coordination spine improve development flow.
+# Aurora Dev Coordination Metrics Report
 
----
+**Generated:** `2026-07-13T05:57:19Z`
+**Repo:** `AUo959/aurora-cloudbank-symbolic`
+**Queue:** `ops/work_queue/queue.json`
 
-## Measurement principle
+## Metrics
 
-The coordination spine is useful only if it reduces stale state, duplicate work, unsafe mutation, unclear handoffs, and review lag.
+| Metric | Value |
+|---|---:|
+| active_count | `19` |
+| completed_count | `8` |
+| status_counts | `{"needs-decision": 2, "open": 17}` |
+| bridge_field_counts | `{"claim_paths_set": 2, "claim_required": 2, "github_linkable": 13, "preferred_platform_set": 2, "review_class_set": 2}` |
+| queue_drift_count | _not measured_ |
+| generated_view_drift_count | `0` |
+| claim_conflict_count | _not measured_ |
+| duplicate_pr_avoidance_count | _not measured_ |
+| blocked_item_aging_count | _not measured_ |
+| review_debt_age_days_max | _not measured_ |
+| pr_cycle_time_days_median | _not measured_ |
+| handoff_success_count | _not measured_ |
+| ci_validation_success_rate | _not measured_ |
 
-This file defines the initial measurable signals. Future automation can render this file from queue, GitHub, control-plane handoff, and claim data.
+## Observations
 
----
+- Collector is read-only and local-file based.
+- GitHub issue/PR comparison requires an explicit --github-state export.
+- Control-plane session-state and claim metrics are placeholders until cross-repo input is explicitly provided.
 
-## Current metrics table
+## Blocked / not measured
 
-| Metric | Definition | Source surfaces | Desired trend | Current collection |
-|---|---|---|---|---|
-| Queue drift count | Queue entries whose status disagrees with live GitHub issue or PR state | `queue.json`, GitHub issues or PRs | Down to zero | Manual review |
-| Time-to-safe-next-action | Steps from session start to a claim-safe task recommendation | session log, queue, broker output | Down | Not yet automated |
-| Claim conflict count | Path conflicts detected before editing | control-plane claims | Visible and actionable | Not yet automated |
-| Duplicate PR avoidance | Existing branch or PR detected before new work begins | GitHub PRs and branches | Up initially, then stable | Manual review |
-| Blocked-item aging | Queue items blocked beyond threshold | `queue.json`, GitHub issue state | Down | Not yet automated |
-| Review debt age | Floor-touching changes awaiting review | control-plane review ledger or session state | Down | Not yet automated |
-| PR cycle time | Queue active to PR open to merged or closed | `queue.json`, GitHub PR timestamps | Down | Not yet automated |
-| Handoff success | Suspended task resumed without missing context | handoff state, PR or issue comments | Up | Manual review |
-| Generated-view drift | Whether generated queue views match `queue.json` | `sync_queue.py --check` | Zero | Queue Validation CI |
-| CI validation success | Coordination PRs passing required checks | GitHub Actions | Up | GitHub Actions |
-
----
-
-## Future machine-readable shape
-
-```json
-{
-  "schema_version": 1,
-  "generated_at": "YYYY-MM-DDTHH:MM:SSZ",
-  "repo": "AUo959/aurora-cloudbank-symbolic",
-  "queue_ref": "ops/work_queue/queue.json",
-  "control_plane_ref": "AUo959/Aurora_ORIONCORE_Directory_Main/catalog/session_state.json",
-  "metrics": {
-    "queue_drift_count": null,
-    "time_to_safe_next_action_steps": null,
-    "claim_conflict_count": null,
-    "duplicate_pr_avoidance_count": null,
-    "blocked_item_aging_count": null,
-    "review_debt_age_days_max": null,
-    "pr_cycle_time_days_median": null,
-    "handoff_success_count": null,
-    "generated_view_drift_count": null,
-    "ci_validation_success_rate": null
-  },
-  "observations": [],
-  "blocked": [
-    "Automated metrics collector not yet implemented.",
-    "Control-plane inputs must be passed explicitly."
-  ]
-}
-```
-
----
-
-## Minimum viable collector
-
-Suggested path:
-
-- `ops/work_queue/collect_coordination_metrics.py`
-
-Suggested inputs:
-
-- `ops/work_queue/queue.json`
-- generated queue views
-- GitHub issue or PR state for queue items with `github_issue` or `pr`
-- optional control-plane handoff export, passed explicitly as a path
-
-Suggested outputs:
-
-- `ops/work_queue/COORDINATION_METRICS.md`
-- optional JSON: `ops/work_queue/coordination_metrics.json`
-
----
-
-## Safety boundaries
-
-The metrics collector should remain read-only. It should report evidence and gaps; it should not change repo, queue, claim, GitHub, or runtime state.
-
----
-
-## Initial manual baseline
-
-Current known baseline from the June 24 queue audit:
-
-- Queue drift was observed: #1147, #1148, #1149, and #1150 remained active in queue state after closure or completion evidence.
-- Queue Validation exists and runs when `ops/work_queue/**` changes.
-- Coordination spine contract landed under #1161 via PR #1166.
-- Automated bridge fields and metrics collection are not yet implemented.
-
----
-
-## Next implementation step
-
-After PR #1160 and PR #1166 land:
-
-1. Add non-breaking bridge metadata to representative queue entries.
-2. Add a read-only metrics collector skeleton.
-3. Render this metrics file from collector output.
-4. Add CI check mode only after output is deterministic.
+- No direct GitHub API calls are made by this script.
+- No control-plane file is read unless future options explicitly pass a path.

--- a/ops/work_queue/CROSS_PLATFORM_COORDINATION.md
+++ b/ops/work_queue/CROSS_PLATFORM_COORDINATION.md
@@ -1,6 +1,6 @@
 # Aurora Dev Coordination Spine
 
-**Status:** Draft coordination contract  
+**Status:** Active coordination contract
 **Owner:** Aurora / ORIONCORE operators  
 **Tracked in:** #1161  
 **Applies to:** `AUo959/aurora-cloudbank-symbolic` work coordinated with the ORIONCORE control-plane repo
@@ -186,7 +186,7 @@ This system should aid development measurably. Initial metrics:
 | Generated-view drift | Whether views match `queue.json` | Zero |
 | CI validation success | Queue/coordination PRs passing required checks | Up |
 
-A future metrics script may render `ops/work_queue/COORDINATION_METRICS.md` or `reports/analysis/dev_coordination_metrics_latest.md`.
+`collect_coordination_metrics.py` renders `COORDINATION_METRICS.md` from local queue evidence and verifies the tracked artifact with `--check`. Live GitHub comparison remains explicit input through `--github-state`; the collector does not call GitHub or mutate either repository.
 
 ---
 
@@ -202,13 +202,14 @@ A future metrics script may render `ops/work_queue/COORDINATION_METRICS.md` or `
 
 ---
 
-## First implementation slice
+## Implementation status
 
-The first safe slice is documentation and compatibility only:
+The coordination spine is active at the compatibility layer:
 
-1. Add this coordination contract.
-2. Update `QUEUE_GUIDE.md` to point contributors at this session-start/session-close loop.
-3. Add bridge fields to queue entries in a later PR after PR #1160 lands and queue validation is green.
-4. Add metrics generation after bridge fields stabilize.
+1. This contract and `QUEUE_GUIDE.md` define the queue → broker → claim → PR → handoff loop.
+2. `queue_schema.json` accepts optional bridge metadata without changing legacy renderer semantics.
+3. Representative live queue entries carry claim, platform, review, and handoff metadata.
+4. `collect_coordination_metrics.py` provides read-only JSON/Markdown output and deterministic tracked-report verification.
+5. `sync_queue.py` derives projection timestamps from `queue.json` review metadata, so repeated rendering is byte-stable.
 
-This order avoids mixing stale-state cleanup, schema migration, broker integration, and metrics automation into one oversized change.
+The control-plane claim files, issue broker, and durable session state remain owned by the ORIONCORE root repository. This nested repository documents and consumes those surfaces; it does not duplicate or mutate them.

--- a/ops/work_queue/NEXT_UP.md
+++ b/ops/work_queue/NEXT_UP.md
@@ -5,7 +5,7 @@
 
 # Next Up — Aurora Work Queue
 
-_Generated: `2026-06-24T03:45:00Z` — edit `queue.json`, run `sync_queue.py`_
+_Generated: `2026-07-13T05:57:19Z` — edit `queue.json`, run `sync_queue.py`_
 
 ---
 
@@ -15,24 +15,23 @@ Items with `status: open` and all dependencies resolved.
 
 | Rank | ID | Title | Tags |
 |---|---|---|---|
-| 1 | #1126 | FastAPI lifespan migration (deprecation fix) | `runtime` `blocker` `deprecation` |
-| 2 | #1130 | CI green-path stabilization | `ci` `infrastructure` |
-| 3 | security/CVE-audit | CVE dependency audit (Sprint 311 follow-on) | `security` `audit` |
-| 4 | #1139 | docs/ethics — create top-level README and navigation index | `docs` `ethics` `navigation` |
-| 5 | #1140 | docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA | `docs` `architecture` `topology` |
-| 9 | #1137 | docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue | `ethics` `geometric` `implementation` |
-| 10 | #1138 | docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started | `ethics` `protocols` `custody` |
-| 11 | #1142 | docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue | `docs` `architecture` `drift-ledger` |
-| 12 | #1141 | docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined | `docs` `architecture` `QGIA` |
-| 13 | #1144 | docs/api — api_surface_inventory.json missing four surfaces | `docs` `api` `inventory` |
-| 14 | #1143 | docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology | `docs` `architecture` `scaling` |
-| 15 | #1145 | docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps | `docs` `api` `reference` |
-| 16 | #1146 | docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated | `docs` `api` `governance` |
-| 17 | #1135 | simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries | `simulation` `roster` `validation` |
-| 18 | #1136 | simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking | `simulation` `enhancement` `tracking` |
-| 19 | arch/layer-canonization | Layer architecture canonization (L1/L2/L3 enforcement in code) | `architecture` `canonical` `L1` `L2` `L3` |
-| 21 | ops/QGIA-doctrine-store | QGIA analytical framework — store in ops/analytical_frameworks/QGIA/ | `QGIA` `analytical-framework` `ops` `non-canonical` |
-| 22 | docs/api-reference | API reference documentation | `docs` `api` |
+| 1 | #1130 | SECURITY — pentest scope is stale against the current API surface | `security` `pentest` `api-surface` `blocking` |
+| 2 | security/CVE-audit | CVE dependency audit (Sprint 311 follow-on) | `security` `audit` |
+| 3 | #1139 | docs/ethics — create top-level README and navigation index | `docs` `ethics` `navigation` |
+| 4 | #1140 | docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA | `docs` `architecture` `topology` |
+| 5 | #1137 | docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue | `ethics` `geometric` `implementation` |
+| 6 | #1138 | docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started | `ethics` `protocols` `custody` |
+| 7 | #1142 | docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue | `docs` `architecture` `drift-ledger` |
+| 8 | #1141 | docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined | `docs` `architecture` `QGIA` |
+| 9 | #1144 | docs/api — api_surface_inventory.json missing four surfaces | `docs` `api` `inventory` |
+| 10 | #1143 | docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology | `docs` `architecture` `scaling` |
+| 11 | #1145 | docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps | `docs` `api` `reference` |
+| 12 | #1146 | docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated | `docs` `api` `governance` |
+| 13 | #1135 | simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries | `simulation` `roster` `validation` |
+| 14 | #1136 | simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking | `simulation` `enhancement` `tracking` |
+| 15 | arch/layer-canonization | Layer architecture canonization (L1/L2/L3 enforcement in code) | `architecture` `canonical` `L1` `L2` `L3` |
+| 17 | ops/QGIA-doctrine-store | QGIA analytical framework — store in ops/analytical_frameworks/QGIA/ | `QGIA` `analytical-framework` `ops` `non-canonical` |
+| 18 | docs/api-reference | API reference documentation | `docs` `api` |
 
 ---
 
@@ -50,5 +49,5 @@ Items gated on a human or governance decision. Agents skip these.
 
 | Rank | ID | Title |
 |---|---|---|
-| 20 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution |
-| 23 | feat/QGIA | QGIA integration hooks |
+| 16 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution |
+| 19 | feat/QGIA | QGIA integration hooks |

--- a/ops/work_queue/OPEN_GATES.md
+++ b/ops/work_queue/OPEN_GATES.md
@@ -5,7 +5,7 @@
 
 # Open Gates — Aurora Work Queue
 
-_Generated: `2026-06-24T03:45:00Z` — edit `queue.json`, run `sync_queue.py`_
+_Generated: `2026-07-13T05:57:19Z` — edit `queue.json`, run `sync_queue.py`_
 
 > Gates are items tagged `gate` or carrying `status: needs-decision`.
 > Nothing downstream can advance until the gate closes.
@@ -16,8 +16,8 @@ _Generated: `2026-06-24T03:45:00Z` — edit `queue.json`, run `sync_queue.py`_
 
 | Rank | ID | Title | Status |
 |---|---|---|---|
-| 20 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution | `needs-decision` |
-| 23 | feat/QGIA | QGIA integration hooks | `needs-decision` |
+| 16 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution | `needs-decision` |
+| 19 | feat/QGIA | QGIA integration hooks | `needs-decision` |
 
 ---
 

--- a/ops/work_queue/QUEUE.md
+++ b/ops/work_queue/QUEUE.md
@@ -5,10 +5,10 @@
 
 # Aurora Work Queue
 
-**Schema version:** `1.2.1`  
-**Last Aurora review:** `2026-06-24T03:45:00Z`  
-**Generated:** `2026-06-24T03:45:00Z`  
-**Items:** 23 active · 4 completed
+**Schema version:** `1.3.0`
+**Last Aurora review:** `2026-07-13T05:57:19Z`
+**Generated:** `2026-07-13T05:57:19Z`
+**Items:** 19 active · 8 completed
 
 > Aurora holds contextual authority over rank order.
 > Do not edit rank or `aurora_note` fields without an `aurora(queue):` commit.
@@ -18,39 +18,23 @@
 
 ## Active Queue
 
-### 1. 🟢 #1126 — FastAPI lifespan migration (deprecation fix)
+### 1. 🟢 #1130 — SECURITY — pentest scope is stale against the current API surface
 
 | Field | Value |
 |---|---|
 | **Status** | `open` |
 | **Owner** | _unassigned_ |
 | **Depends on** | — |
-| **Blocks** | #1130, docs/api-reference |
-| **Tags** | `runtime` `blocker` `deprecation` |
-
-**Aurora note:**
-
-> Critical runtime blocker. Resolves deprecation warning that affects all startup/shutdown hooks. Must land before any new feature PRs.
-
----
-
-### 2. 🟢 #1130 — CI green-path stabilization
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1126 |
 | **Blocks** | docs/api-reference |
-| **Tags** | `ci` `infrastructure` |
+| **Tags** | `security` `pentest` `api-surface` `blocking` |
 
 **Aurora note:**
 
-> CI cannot be trusted for gate-keeping until lifespan is resolved. Unblock #1126 first.
+> Live GitHub refresh on 2026-07-13 confirmed this pre-engagement security issue remains open. The former #1126 dependency is complete; remaining work includes the v2 scope, current API inventory alignment, QGIA/R&D disposition, and approval signatures.
 
 ---
 
-### 3. 🟢 security/CVE-audit — CVE dependency audit (Sprint 311 follow-on)
+### 2. 🟢 security/CVE-audit — CVE dependency audit (Sprint 311 follow-on)
 
 | Field | Value |
 |---|---|
@@ -66,7 +50,7 @@
 
 ---
 
-### 4. 🟢 #1139 — docs/ethics — create top-level README and navigation index
+### 3. 🟢 #1139 — docs/ethics — create top-level README and navigation index
 
 | Field | Value |
 |---|---|
@@ -82,7 +66,7 @@
 
 ---
 
-### 5. 🟢 #1140 — docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA
+### 4. 🟢 #1140 — docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA
 
 | Field | Value |
 |---|---|
@@ -98,55 +82,7 @@
 
 ---
 
-### 6. 🔵 #1151 — Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics
-
-| Field | Value |
-|---|---|
-| **Status** | `in-progress` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | #1152, #1153 |
-| **Tags** | `ethics` `protocols` `runtime` `design` |
-
-**Aurora note:**
-
-> Previously blocked by #1148–#1150; those prerequisite issues are now completed. PR #1157 is open and mergeable. Review first in the recovered-protocol chain. Documentation-only artifact — no runtime wiring.
-
----
-
-### 7. 🔵 #1152 — Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed
-
-| Field | Value |
-|---|---|
-| **Status** | `in-progress` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1151 |
-| **Blocks** | — |
-| **Tags** | `ethics` `protocols` `moriarty` `tests` |
-
-**Aurora note:**
-
-> Previously blocked by #1148–#1151. PR #1158 is open and mergeable, but review/merge should follow #1157 because the appeal and mapping assumptions depend on the runtime mapping design. No active L2-to-L1 behavior introduced.
-
----
-
-### 8. 🔵 #1153 — Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement
-
-| Field | Value |
-|---|---|
-| **Status** | `in-progress` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1151 |
-| **Blocks** | — |
-| **Tags** | `ethics` `protocols` `tribunal` `tests` |
-
-**Aurora note:**
-
-> Previously blocked by #1148–#1151. PR #1159 is open and mergeable, but Codacy reported two minor CodeStyle issues; review/merge should follow #1157 and preferably coordinate with #1158. No runtime enforcement wiring introduced.
-
----
-
-### 9. 🟢 #1137 — docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue
+### 5. 🟢 #1137 — docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue
 
 | Field | Value |
 |---|---|
@@ -162,7 +98,7 @@
 
 ---
 
-### 10. 🟢 #1138 — docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started
+### 6. 🟢 #1138 — docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started
 
 | Field | Value |
 |---|---|
@@ -178,7 +114,7 @@
 
 ---
 
-### 11. 🟢 #1142 — docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue
+### 7. 🟢 #1142 — docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue
 
 | Field | Value |
 |---|---|
@@ -194,7 +130,7 @@
 
 ---
 
-### 12. 🟢 #1141 — docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined
+### 8. 🟢 #1141 — docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined
 
 | Field | Value |
 |---|---|
@@ -210,7 +146,7 @@
 
 ---
 
-### 13. 🟢 #1144 — docs/api — api_surface_inventory.json missing four surfaces
+### 9. 🟢 #1144 — docs/api — api_surface_inventory.json missing four surfaces
 
 | Field | Value |
 |---|---|
@@ -226,7 +162,7 @@
 
 ---
 
-### 14. 🟢 #1143 — docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology
+### 10. 🟢 #1143 — docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology
 
 | Field | Value |
 |---|---|
@@ -242,7 +178,7 @@
 
 ---
 
-### 15. 🟢 #1145 — docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps
+### 11. 🟢 #1145 — docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps
 
 | Field | Value |
 |---|---|
@@ -258,7 +194,7 @@
 
 ---
 
-### 16. 🟢 #1146 — docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated
+### 12. 🟢 #1146 — docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated
 
 | Field | Value |
 |---|---|
@@ -274,7 +210,7 @@
 
 ---
 
-### 17. 🟢 #1135 — simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries
+### 13. 🟢 #1135 — simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries
 
 | Field | Value |
 |---|---|
@@ -290,7 +226,7 @@
 
 ---
 
-### 18. 🟢 #1136 — simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking
+### 14. 🟢 #1136 — simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking
 
 | Field | Value |
 |---|---|
@@ -306,7 +242,7 @@
 
 ---
 
-### 19. 🟢 arch/layer-canonization — Layer architecture canonization (L1/L2/L3 enforcement in code)
+### 15. 🟢 arch/layer-canonization — Layer architecture canonization (L1/L2/L3 enforcement in code)
 
 | Field | Value |
 |---|---|
@@ -322,7 +258,7 @@
 
 ---
 
-### 20. 🟡 sim/SENTINEL-phase0 — PROJECT SENTINEL — Phase 0: Ethics review board constitution
+### 16. 🟡 sim/SENTINEL-phase0 — PROJECT SENTINEL — Phase 0: Ethics review board constitution
 
 | Field | Value |
 |---|---|
@@ -338,7 +274,7 @@
 
 ---
 
-### 21. 🟢 ops/QGIA-doctrine-store — QGIA analytical framework — store in ops/analytical_frameworks/QGIA/
+### 17. 🟢 ops/QGIA-doctrine-store — QGIA analytical framework — store in ops/analytical_frameworks/QGIA/
 
 | Field | Value |
 |---|---|
@@ -354,13 +290,13 @@
 
 ---
 
-### 22. 🟢 docs/api-reference — API reference documentation
+### 18. 🟢 docs/api-reference — API reference documentation
 
 | Field | Value |
 |---|---|
 | **Status** | `open` |
 | **Owner** | _unassigned_ |
-| **Depends on** | #1126, #1130 |
+| **Depends on** | #1130 |
 | **Blocks** | — |
 | **Tags** | `docs` `api` |
 
@@ -370,7 +306,7 @@
 
 ---
 
-### 23. 🟡 feat/QGIA — QGIA integration hooks
+### 19. 🟡 feat/QGIA — QGIA integration hooks
 
 | Field | Value |
 |---|---|
@@ -390,7 +326,11 @@
 
 | ID | Title |
 |---|---|
+| #1126 | docs/specs/AUMEMMANAGER_PROMOTION_STARTER_SPEC.md — confirm promotion status and link to recovered_protocols/ |
 | #1147 | feat: Aurora-Aware Work Queue System (ops/work_queue/) |
 | #1148 | Protocol custody inventory — machine-readable manifest of recovered package/file hashes and blockers |
 | #1149 | Protocol JSON schemas — add schema files and validation tests for Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX |
 | #1150 | Protocol fixture intake — add sanitized canonical examples for Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX |
+| #1151 | Runtime mapping design — decide how protocol decisions map to EthicsEngine, ethics_gate, compliance monitor, and geometric ethics |
+| #1152 | Moriarty containment tests — test anomaly quarantine/review-only/rollback rules without enabling active L2-to-L1 behavior |
+| #1153 | Tribunal appeal tests — test dispute/appeal record requirements without runtime enforcement |

--- a/ops/work_queue/QUEUE_GUIDE.md
+++ b/ops/work_queue/QUEUE_GUIDE.md
@@ -1,8 +1,8 @@
 # Aurora Work Queue — Contributor Guide
 
-**Version:** 1.2.0  
+**Version:** 1.3.0
 **Owner:** Aurora (contextual authority) + Orion Station operators  
-**Last updated:** 2026-06-24  
+**Last updated:** 2026-07-13
 **Source of truth:** `ops/work_queue/queue.json`
 
 ---
@@ -203,4 +203,7 @@ When work pauses or crosses platforms, also update the durable control-plane han
 | `triage_rules.json` | Scoring weights and escalation triggers |
 | `QUEUE_GUIDE.md` | This file — workflow and field definitions |
 | `CROSS_PLATFORM_COORDINATION.md` | Queue/control-plane coordination contract |
+| `BRIDGE_FIELDS.md` | Optional queue-to-control-plane metadata reference |
+| `collect_coordination_metrics.py` | Read-only metrics collector and tracked-report verifier |
+| `COORDINATION_METRICS.md` | Generated local coordination metrics report |
 | `NEXT_UP.md` | Quick-start view for human contributors and agents |

--- a/ops/work_queue/README.md
+++ b/ops/work_queue/README.md
@@ -15,8 +15,12 @@ Tracked in: [#1147](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1
 | `triage_rules.json` | Scoring weights and escalation triggers | ✅ Yes (Aurora / queue steward) |
 | `gate_registry.json` | Named gate definitions | ✅ Yes (Aurora / queue steward) |
 | `QUEUE_GUIDE.md` | Onboarding — how Aurora, agents, and humans use the queue | ✅ Yes |
+| `CROSS_PLATFORM_COORDINATION.md` | Queue → broker/claim → GitHub → handoff contract | ✅ Yes |
+| `BRIDGE_FIELDS.md` | Optional queue-to-control-plane metadata reference | ✅ Yes |
 | `session_open_ritual.md` | Session-start checklist | ✅ Yes |
 | `sync_queue.py` | Renderer / CI drift-checker | ✅ Yes (ops contributor) |
+| `collect_coordination_metrics.py` | Read-only metrics collector / report checker | ✅ Yes (ops contributor) |
+| `COORDINATION_METRICS.md` | 🚫 **GENERATED — DO NOT EDIT** | ❌ No |
 | `QUEUE.md` | 🚫 **GENERATED — DO NOT EDIT** | ❌ No |
 | `NEXT_UP.md` | 🚫 **GENERATED — DO NOT EDIT** | ❌ No |
 | `OPEN_GATES.md` | 🚫 **GENERATED — DO NOT EDIT** | ❌ No |
@@ -25,7 +29,7 @@ Tracked in: [#1147](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1
 
 ## 🚫 Generated Files — Do Not Edit
 
-`QUEUE.md`, `NEXT_UP.md`, and `OPEN_GATES.md` are **rendered projections** of `queue.json`.
+`QUEUE.md`, `NEXT_UP.md`, `OPEN_GATES.md`, and `COORDINATION_METRICS.md` are **rendered projections** of `queue.json`.
 They are generated automatically and must not be edited by hand.
 
 **If you edit them directly:**
@@ -39,6 +43,13 @@ They are generated automatically and must not be edited by hand.
 python ops/work_queue/sync_queue.py
 git add ops/work_queue/QUEUE.md ops/work_queue/NEXT_UP.md ops/work_queue/OPEN_GATES.md
 git commit -m "aurora(queue): regenerate views"
+```
+
+Regenerate or verify the deterministic metrics report with:
+
+```bash
+python ops/work_queue/collect_coordination_metrics.py --markdown > ops/work_queue/COORDINATION_METRICS.md
+python ops/work_queue/collect_coordination_metrics.py --check
 ```
 
 ---
@@ -76,10 +87,10 @@ git push
 Queue authority events must use the `aurora(queue):` prefix:
 
 ```
-auroraqueue): re-rank #1140 above #1141 — topology contradiction is active blocker for QGIA
-auroraqueue): add Q-new-item — docs/archive audit gap identified
-auroraqueue): close #1148 — custody inventory complete, SHA verified
-auroraqueue): regenerate views
+aurora(queue): re-rank #1140 above #1141 — topology contradiction is active blocker for QGIA
+aurora(queue): add Q-new-item — docs/archive audit gap identified
+aurora(queue): close #1148 — custody inventory complete, SHA verified
+aurora(queue): regenerate views
 ```
 
 This prefix makes queue deltas machine-readable for changelog generation and CI summaries, and is the traceable event surface for Aurora’s contextual authority.

--- a/ops/work_queue/collect_coordination_metrics.py
+++ b/ops/work_queue/collect_coordination_metrics.py
@@ -29,17 +29,22 @@ import json
 import subprocess
 import sys
 from collections import Counter
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 HERE = Path(__file__).resolve().parent
 QUEUE_JSON = HERE / "queue.json"
 SYNC_QUEUE = HERE / "sync_queue.py"
+REPORT_MD = HERE / "COORDINATION_METRICS.md"
+GENERATED_BANNER = """<!-- !! GENERATED FILE — DO NOT EDIT BY HAND !!
+     Source of truth: ops/work_queue/queue.json
+     Regenerate:      python ops/work_queue/collect_coordination_metrics.py --markdown
+     Verify:          python ops/work_queue/collect_coordination_metrics.py --check -->"""
 
 
-def utc_now() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+def source_timestamp(data: dict[str, Any]) -> str:
+    """Return the queue review timestamp used for deterministic reports."""
+    return str(data.get("_meta", {}).get("last_aurora_review", "unknown"))
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -168,7 +173,7 @@ def collect(github_state_path: Path | None = None) -> dict[str, Any]:
 
     return {
         "schema_version": 1,
-        "generated_at": utc_now(),
+        "generated_at": source_timestamp(data),
         "repo": "AUo959/aurora-cloudbank-symbolic",
         "queue_ref": "ops/work_queue/queue.json",
         "control_plane_ref": "AUo959/Aurora_ORIONCORE_Directory_Main/catalog/session_state.json",
@@ -206,10 +211,12 @@ def collect(github_state_path: Path | None = None) -> dict[str, Any]:
 def render_markdown(payload: dict[str, Any]) -> str:
     metrics = payload["metrics"]
     lines = [
+        GENERATED_BANNER,
+        "",
         "# Aurora Dev Coordination Metrics Report",
         "",
-        f"**Generated:** `{payload['generated_at']}`  ",
-        f"**Repo:** `{payload['repo']}`  ",
+        f"**Generated:** `{payload['generated_at']}`",
+        f"**Repo:** `{payload['repo']}`",
         f"**Queue:** `{payload['queue_ref']}`",
         "",
         "## Metrics",
@@ -237,15 +244,31 @@ def render_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def check_report(payload: dict[str, Any]) -> bool:
+    """Return whether the tracked Markdown report matches deterministic output."""
+    if not REPORT_MD.exists():
+        print(f"MISSING: {REPORT_MD.relative_to(HERE.parent.parent)}")
+        return False
+    expected = render_markdown(payload)
+    if REPORT_MD.read_text(encoding="utf-8") != expected:
+        print(f"STALE:   {REPORT_MD.relative_to(HERE.parent.parent)}")
+        return False
+    print(f"OK:      {REPORT_MD.relative_to(HERE.parent.parent)}")
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--github-state", type=Path, help="Optional JSON export of issue/PR state for drift comparison.")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--json", action="store_true", help="Emit JSON metrics packet.")
     group.add_argument("--markdown", action="store_true", help="Emit Markdown report.")
+    group.add_argument("--check", action="store_true", help="Verify the tracked Markdown report without writing files.")
     args = parser.parse_args()
 
     payload = collect(args.github_state)
+    if args.check:
+        return 0 if check_report(payload) else 1
     if args.markdown:
         print(render_markdown(payload), end="")
     else:

--- a/ops/work_queue/queue.json
+++ b/ops/work_queue/queue.json
@@ -1,44 +1,45 @@
 {
   "_meta": {
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "Aurora-aware work queue. Machine-readable mirror of QUEUE.md. Aurora holds contextual authority. Do not edit rank order without Aurora annotation.",
-    "last_aurora_review": "2026-06-24T03:45:00Z",
+    "last_aurora_review": "2026-07-13T05:57:19Z",
     "schema": "https://github.com/AUo959/aurora-cloudbank-symbolic/blob/main/ops/work_queue/queue_schema.json"
   },
   "active": [
     {
       "rank": 1,
-      "id": "#1126",
-      "title": "FastAPI lifespan migration (deprecation fix)",
+      "id": "#1130",
+      "github_issue": 1130,
+      "title": "SECURITY — pentest scope is stale against the current API surface",
       "status": "open",
       "owner": null,
       "depends_on": [],
       "tags": [
-        "runtime",
-        "blocker",
-        "deprecation"
+        "security",
+        "pentest",
+        "api-surface",
+        "blocking"
       ],
-      "aurora_note": "Critical runtime blocker. Resolves deprecation warning that affects all startup/shutdown hooks. Must land before any new feature PRs.",
+      "preferred_platform": "either",
+      "claim_required": true,
+      "claim_paths": [
+        "docs/security",
+        "docs/api"
+      ],
+      "session_state_ref": null,
+      "review_class": "security-significant",
+      "handoff_surface": "catalog/session_state.json",
+      "coordination_notes": "Refresh the live issue and current API inventory before mutation; route scoped paths through the control-plane issue broker.",
+      "metrics_tags": [
+        "security",
+        "pentest",
+        "api"
+      ],
+      "aurora_note": "Live GitHub refresh on 2026-07-13 confirmed this pre-engagement security issue remains open. The former #1126 dependency is complete; remaining work includes the v2 scope, current API inventory alignment, QGIA/R&D disposition, and approval signatures.",
       "aurora_authority": true
     },
     {
       "rank": 2,
-      "id": "#1130",
-      "title": "CI green-path stabilization",
-      "status": "open",
-      "owner": null,
-      "depends_on": [
-        "#1126"
-      ],
-      "tags": [
-        "ci",
-        "infrastructure"
-      ],
-      "aurora_note": "CI cannot be trusted for gate-keeping until lifespan is resolved. Unblock #1126 first.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 3,
       "id": "security/CVE-audit",
       "title": "CVE dependency audit (Sprint 311 follow-on)",
       "status": "open",
@@ -52,8 +53,9 @@
       "aurora_authority": true
     },
     {
-      "rank": 4,
+      "rank": 3,
       "id": "#1139",
+      "github_issue": 1139,
       "title": "docs/ethics — create top-level README and navigation index",
       "status": "open",
       "owner": null,
@@ -63,11 +65,25 @@
         "ethics",
         "navigation"
       ],
+      "preferred_platform": "either",
+      "claim_required": true,
+      "claim_paths": [
+        "docs/ethics/README.md"
+      ],
+      "session_state_ref": null,
+      "review_class": "documentation-significant",
+      "handoff_surface": "catalog/session_state.json",
+      "coordination_notes": "Refresh the issue and check for an existing ethics navigation PR before creating a claimed worktree.",
+      "metrics_tags": [
+        "docs",
+        "ethics",
+        "navigation"
+      ],
       "aurora_note": "No blockers. Quick win. Ethics directory is not navigable by agents or contributors — no map to runtime surfaces, recovered protocols, or Picard_Delta_3. Unblocks all ethics cluster work that depends on directory orientation.",
       "aurora_authority": true
     },
     {
-      "rank": 5,
+      "rank": 4,
       "id": "#1140",
       "title": "docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA",
       "status": "open",
@@ -82,62 +98,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 6,
-      "id": "#1151",
-      "title": "Runtime mapping design — map protocol decisions to EthicsEngine, ethics_gate, compliance monitor, geometric ethics",
-      "status": "in-progress",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "ethics",
-        "protocols",
-        "runtime",
-        "design"
-      ],
-      "pr": 1157,
-      "aurora_note": "Previously blocked by #1148–#1150; those prerequisite issues are now completed. PR #1157 is open and mergeable. Review first in the recovered-protocol chain. Documentation-only artifact — no runtime wiring.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 7,
-      "id": "#1152",
-      "title": "Moriarty containment tests — anomaly quarantine/review-only/rollback without L2-to-L1 bleed",
-      "status": "in-progress",
-      "owner": null,
-      "depends_on": [
-        "#1151"
-      ],
-      "tags": [
-        "ethics",
-        "protocols",
-        "moriarty",
-        "tests"
-      ],
-      "pr": 1158,
-      "aurora_note": "Previously blocked by #1148–#1151. PR #1158 is open and mergeable, but review/merge should follow #1157 because the appeal and mapping assumptions depend on the runtime mapping design. No active L2-to-L1 behavior introduced.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 8,
-      "id": "#1153",
-      "title": "Tribunal appeal tests — dispute/appeal record requirements without runtime enforcement",
-      "status": "in-progress",
-      "owner": null,
-      "depends_on": [
-        "#1151"
-      ],
-      "tags": [
-        "ethics",
-        "protocols",
-        "tribunal",
-        "tests"
-      ],
-      "pr": 1159,
-      "aurora_note": "Previously blocked by #1148–#1151. PR #1159 is open and mergeable, but Codacy reported two minor CodeStyle issues; review/merge should follow #1157 and preferably coordinate with #1158. No runtime enforcement wiring introduced.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 9,
+      "rank": 5,
       "id": "#1137",
       "title": "docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue",
       "status": "open",
@@ -152,7 +113,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 10,
+      "rank": 6,
       "id": "#1138",
       "title": "docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started",
       "status": "open",
@@ -167,7 +128,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 11,
+      "rank": 7,
       "id": "#1142",
       "title": "docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue",
       "status": "open",
@@ -182,7 +143,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 12,
+      "rank": 8,
       "id": "#1141",
       "title": "docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined",
       "status": "open",
@@ -197,7 +158,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 13,
+      "rank": 9,
       "id": "#1144",
       "title": "docs/api — api_surface_inventory.json missing four surfaces",
       "status": "open",
@@ -215,7 +176,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 14,
+      "rank": 10,
       "id": "#1143",
       "title": "docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology",
       "status": "open",
@@ -230,7 +191,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 15,
+      "rank": 11,
       "id": "#1145",
       "title": "docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps",
       "status": "open",
@@ -247,7 +208,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 16,
+      "rank": 12,
       "id": "#1146",
       "title": "docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated",
       "status": "open",
@@ -266,7 +227,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 17,
+      "rank": 13,
       "id": "#1135",
       "title": "simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries",
       "status": "open",
@@ -281,7 +242,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 18,
+      "rank": 14,
       "id": "#1136",
       "title": "simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking",
       "status": "open",
@@ -296,7 +257,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 19,
+      "rank": 15,
       "id": "arch/layer-canonization",
       "title": "Layer architecture canonization (L1/L2/L3 enforcement in code)",
       "status": "open",
@@ -313,7 +274,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 20,
+      "rank": 16,
       "id": "sim/SENTINEL-phase0",
       "title": "PROJECT SENTINEL — Phase 0: Ethics review board constitution",
       "status": "needs-decision",
@@ -330,7 +291,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 21,
+      "rank": 17,
       "id": "ops/QGIA-doctrine-store",
       "title": "QGIA analytical framework — store in ops/analytical_frameworks/QGIA/",
       "status": "open",
@@ -346,13 +307,12 @@
       "aurora_authority": true
     },
     {
-      "rank": 22,
+      "rank": 18,
       "id": "docs/api-reference",
       "title": "API reference documentation",
       "status": "open",
       "owner": null,
       "depends_on": [
-        "#1126",
         "#1130"
       ],
       "tags": [
@@ -363,7 +323,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 23,
+      "rank": 19,
       "id": "feat/QGIA",
       "title": "QGIA integration hooks",
       "status": "needs-decision",
@@ -383,6 +343,13 @@
     }
   ],
   "completed": [
+    {
+      "id": "#1126",
+      "github_issue": 1126,
+      "title": "docs/specs/AUMEMMANAGER_PROMOTION_STARTER_SPEC.md — confirm promotion status and link to recovered_protocols/",
+      "closed": "2026-06-24",
+      "status": "done"
+    },
     {
       "id": "#1147",
       "title": "feat: Aurora-Aware Work Queue System (ops/work_queue/)",
@@ -406,6 +373,30 @@
       "title": "Protocol fixture intake — add sanitized canonical examples for Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX",
       "closed": "2026-06-24",
       "status": "done"
+    },
+    {
+      "id": "#1151",
+      "github_issue": 1151,
+      "title": "Runtime mapping design — decide how protocol decisions map to EthicsEngine, ethics_gate, compliance monitor, and geometric ethics",
+      "closed": "2026-07-13",
+      "status": "done",
+      "pr": 1157
+    },
+    {
+      "id": "#1152",
+      "github_issue": 1152,
+      "title": "Moriarty containment tests — test anomaly quarantine/review-only/rollback rules without enabling active L2-to-L1 behavior",
+      "closed": "2026-07-13",
+      "status": "done",
+      "pr": 1158
+    },
+    {
+      "id": "#1153",
+      "github_issue": 1153,
+      "title": "Tribunal appeal tests — test dispute/appeal record requirements without runtime enforcement",
+      "closed": "2026-07-13",
+      "status": "done",
+      "pr": 1159
     }
   ]
 }

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -18,10 +18,8 @@ Tracked in:        https://github.com/AUo959/aurora-cloudbank-symbolic/issues/11
 
 from __future__ import annotations
 
+import argparse
 import json
-import sys
-import textwrap
-from datetime import datetime, timezone
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -44,6 +42,7 @@ GENERATED_BANNER = (
 # ---------------------------------------------------------------------------
 # Load
 # ---------------------------------------------------------------------------
+
 
 def load_queue() -> dict:
     with QUEUE_JSON.open(encoding="utf-8") as f:
@@ -93,8 +92,9 @@ def _aurora_note(item: dict) -> str:
     return "\n".join(f"> {line}" if line.strip() else ">" for line in lines)
 
 
-def _ts() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+def _ts(data: dict) -> str:
+    """Use the source review timestamp so regenerated views are byte-stable."""
+    return str(data.get("_meta", {}).get("last_aurora_review", "unknown"))
 
 
 # ---------------------------------------------------------------------------
@@ -105,16 +105,16 @@ def render_queue_md(data: dict) -> str:
     meta = data.get("_meta", {})
     items = data.get("active", [])
     completed = data.get("completed", [])
-    ts = _ts()
+    ts = _ts(data)
 
     lines: list[str] = [
         GENERATED_BANNER,
         "",
         "# Aurora Work Queue",
         "",
-        f"**Schema version:** `{meta.get('version', 'unknown')}`  ",
-        f"**Last Aurora review:** `{meta.get('last_aurora_review', 'unknown')}`  ",
-        f"**Generated:** `{ts}`  ",
+        f"**Schema version:** `{meta.get('version', 'unknown')}`",
+        f"**Last Aurora review:** `{meta.get('last_aurora_review', 'unknown')}`",
+        f"**Generated:** `{ts}`",
         f"**Items:** {len(items)} active · {len(completed)} completed",
         "",
         "> Aurora holds contextual authority over rank order.",
@@ -142,8 +142,8 @@ def render_queue_md(data: dict) -> str:
         lines += [
             f"### {rank}. {emoji} {iid} — {title}",
             "",
-            f"| Field | Value |",
-            f"|---|---|",
+            "| Field | Value |",
+            "|---|---|",
             f"| **Status** | `{status}` |",
             f"| **Owner** | {owner} |",
             f"| **Depends on** | {deps_str} |",
@@ -166,7 +166,7 @@ def render_queue_md(data: dict) -> str:
             "|---|---|",
         ]
         for item in completed:
-            lines.append(f"| {item.get('id','?')} | {item.get('title','?')} |")
+            lines.append(f"| {item.get('id', '?')} | {item.get('title', '?')} |")
         lines.append("")
 
     return "\n".join(lines)
@@ -178,7 +178,7 @@ def render_queue_md(data: dict) -> str:
 
 def render_next_up_md(data: dict) -> str:
     items = data.get("active", [])
-    ts = _ts()
+    ts = _ts(data)
 
     open_items = [x for x in items if x.get("status") == "open"]
     blocked_items = [x for x in items if x.get("status") == "blocked"]
@@ -269,8 +269,7 @@ def render_next_up_md(data: dict) -> str:
 
 def render_open_gates_md(data: dict) -> str:
     items = data.get("active", [])
-    gate_data = data.get("gates", {})
-    ts = _ts()
+    ts = _ts(data)
 
     # Items that are themselves gate-holders: tagged 'gate' or status 'needs-decision'
     gates = [
@@ -307,7 +306,7 @@ def render_open_gates_md(data: dict) -> str:
         ]
         for g in gates:
             lines.append(
-                f"| {g['rank']} | {g['id']} | {g['title']} | `{g.get('status','?')}` |"
+                f"| {g['rank']} | {g['id']} | {g['title']} | `{g.get('status', '?')}` |"
             )
     else:
         lines.append("_No open gates. 🎉_")
@@ -365,6 +364,7 @@ def check_all(rendered: dict[Path, str]) -> bool:
             continue
         existing = path.read_text(encoding="utf-8")
         # Strip the timestamp line before comparing so clock-skew doesn't cause false positives.
+
         def strip_ts(text: str) -> str:
             return "\n".join(
                 line for line in text.splitlines()
@@ -382,14 +382,17 @@ def check_all(rendered: dict[Path, str]) -> bool:
 # Entry point
 # ---------------------------------------------------------------------------
 
-def main() -> None:
-    args = sys.argv[1:]
-    check_mode = "--check" in args
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--render", action="store_true", help="Render generated queue views in place (default).")
+    mode.add_argument("--check", action="store_true", help="Exit non-zero when a generated view is stale.")
+    args = parser.parse_args()
 
     data = load_queue()
     rendered = render_all(data)
 
-    if check_mode:
+    if args.check:
         print("Queue drift check...")
         ok = check_all(rendered)
         if not ok:
@@ -397,14 +400,15 @@ def main() -> None:
             print("ERROR: Generated queue views are out of sync with queue.json.")
             print("FIX:   python ops/work_queue/sync_queue.py")
             print("       Then commit the regenerated QUEUE.md, NEXT_UP.md, OPEN_GATES.md.")
-            sys.exit(1)
-        else:
-            print("All generated views are current.")
-    else:
-        print("Rendering queue views...")
-        write_all(rendered)
-        print("Done.")
+            return 1
+        print("All generated views are current.")
+        return 0
+
+    print("Rendering queue views...")
+    write_all(rendered)
+    print("Done.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- reconcile the Aurora work queue with live GitHub state, moving closed #1126 and #1151–#1153 to completed
- correct stale #1130 identity/dependency data and add bridge metadata to live #1130/#1139 entries
- make queue projections byte-stable from `last_aurora_review` and make `--help` non-mutating
- activate the coordination contract and add deterministic metrics report verification

## Validation

- `python3 ops/work_queue/sync_queue.py --check`
- `python3 ops/work_queue/collect_coordination_metrics.py --check`
- live-state metrics export: `queue_drift_count: 0`, `generated_view_drift_count: 0`
- `python -m pytest -q tests/test_work_queue_schema.py` (5 passed)
- configured pre-commit hooks (all passed)
- repeated queue renders produced identical SHA-1 hashes

## Scope / rollback

Coordination and queue surfaces only; no runtime or recovered-protocol promotion. Revert commit `c6a86571` to roll back.

Closes #1161