### PR TITLE
docs(architecture): reconcile scaling topology

### DIFF
--- a/docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md
+++ b/docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md
@@ -60,6 +60,11 @@ dependency degrades that module rather than disabling the full app.
 The API governance registry for these surfaces lives at
 `docs/api/api_surface_inventory.json`.
 
+Deployment replica, state-externalization, capacity, and regional-failover
+claims are governed separately by [`scaling_plan.md`](./scaling_plan.md). A
+route being active here is not evidence that it is safe for multi-worker,
+multi-pod, or multi-region writes.
+
 ## Mesh and Bridge Authority
 
 The implemented Python mesh runtime V1 surface currently confirmed by

--- a/docs/architecture/SYSTEM_ARCHITECTURE_DIAGRAM.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE_DIAGRAM.md
@@ -1,8 +1,17 @@
 # Aurora CloudBank Symbolic - System Architecture Diagram
 
-**Version:** 1.0.0  
-**Date:** November 13, 2025  
-**Purpose:** Visual map of all systems and their integration points
+**Version:** 1.0.1
+**Snapshot date:** November 13, 2025
+**Authority note updated:** July 13, 2026
+**Status:** Historical system snapshot; several wiring claims below are stale
+**Purpose:** Visual map of systems and their integration points at the recorded date
+
+> **Current authority:** Use
+> [`RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md`](./RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md)
+> for live router and service ownership, and
+> [`scaling_plan.md`](./scaling_plan.md) for replica, state, capacity, and
+> multi-region readiness. This diagram does not currently model the QGIA L1-B
+> forecast surface or prove deployment-scale readiness.
 
 ---
 

--- a/docs/architecture/scaling_plan.md
+++ b/docs/architecture/scaling_plan.md
@@ -1,7 +1,8 @@
 # Aurora CloudBank Scaling Plan
 
 **Status:** Architecture plan
-**Last reviewed:** 2026-06-02
+**Version:** 1.1.0
+**Last reviewed:** 2026-07-13
 **Scope:** Horizontal and multi-region scaling for the CloudBank API and adjacent runtime services
 
 This plan extends the current single-worker safety posture into a staged path
@@ -26,6 +27,29 @@ ordering, and failover controls.
 | Insight Ledger | `modules/insight_ledger/api.py` keeps a module-level ledger instance; `api/aurora_api.py` initializes `./data/insight_ledger`. | Ledger writes need a single-writer service, durable append log, or transactional backend before concurrent pods write to it. |
 | Auth and logout | `src/security/auth_routes.py` documents logout as client-side; `docs/RBAC_SECURITY_SUMMARY.md` lists database-backed users and Redis token blacklist as future work. | Users, refresh state, revocation, and session tracking need shared storage before HA auth claims. |
 | Mesh and audit records | `src/mesh/runtime.py` uses SQLite and JSONL transcripts; monitoring/audit components write JSONL files. | Event and audit surfaces need shared databases, object storage, or log pipelines before cross-pod and cross-region operation. |
+| QGIA forecast API | `modules/qgia/api.py` mounts at `/qgia`, creates one process-local `QGIAForecastEngine`, and stores forecast results in the module-level `_forecast_store` dictionary. | Health and population reads can be replicated, but forecast creation/retrieval needs shared durable storage, idempotency, and backpressure before multi-pod scale. |
+
+## Network and Simulation Topology Scope
+
+Three different uses of "node" must remain separate in scaling decisions:
+
+| Topology | Evidence | Scaling interpretation |
+| --- | --- | --- |
+| CloudBank service replicas | Kubernetes and application deployment surfaces in this repo | This plan governs their state, traffic, failover, and capacity. |
+| L1 peer network | `QGIA_L1_NODE_REGISTRATION.md` defines Orion Station L1-A and QGIA L1-B | Institutional/network authority; not a declaration that either node is a deployable replica of the other. |
+| L2 GUMAS chain | `LAYER_ARCHITECTURE.md` and `simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md` describe a nine-node simulation network | Simulation topology; it does not substitute for CloudBank pod, database, or region capacity evidence. |
+
+The `/qgia` router is a current forecast-engine surface, not a verified generic
+inter-node exchange transport. The six-step exchange protocol remains a
+separate design concern under issue #1141. QGIA-to-L2 tasking must remain
+mediated through L1 crew and relay judgment as defined by
+`QGIA_SIM_BRIDGE.md`; scaling must not introduce autonomous QGIA-to-L2 writes.
+
+The QGIA registration document's `500TB` daily throughput is an institutional
+design claim. No load test, deployment manifest, queue, storage pipeline, or
+capacity model in this repo verifies CloudBank can ingest that volume. Do not
+use that number for sizing or readiness claims until an explicit transport and
+measured capacity envelope exist.
 
 ## Target Architecture
 
@@ -64,6 +88,7 @@ state services:
 | P1 | Insight Ledger | Introduce a ledger storage interface with single-writer, transaction, or durable-log guarantees. | Concurrent API pods without corrupting audit history. |
 | P1 | AuMemManager | Replace module-level in-memory production storage with a backend interface and durable/vector store. | Consistent memory reads and writes across pods. |
 | P1 | Mesh/event state | Move mesh events and transcripts from local SQLite/JSONL to an event bus and durable sink. | Cross-pod communication and replay. |
+| P1 | QGIA forecast state | Replace `_forecast_store` with a durable repository and add idempotent forecast submission, queueing, and bounded retention. | Consistent `/qgia/forecast` create/list/get behavior across pods. |
 | P2 | Monitoring and audit logs | Route JSONL-style audit events through centralized logging or append-only object storage. | Region-level compliance records and recovery. |
 | P2 | Uploads, snapshots, and model artifacts | Replace pod-local file assumptions with object storage or managed PVC policy. | Rollouts and pod rescheduling without data loss. |
 | P2 | NeMo/GPU inference | Add a queue, GPU node-pool sizing, and backpressure policy. | Independent GPU worker scale without overloading scarce devices. |
@@ -181,6 +206,10 @@ Exit criteria:
    evidence requirements.
 12. Define NeMo/GPU inference scaling around a queue, node-pool capacity, and
    backpressure rather than generic pod HPA.
+13. Externalize QGIA forecast results and define an idempotent queued execution
+    model before scaling `/qgia` beyond one process.
+14. Define and load-test the approved L1 inter-node transport before assigning
+    any capacity or latency guarantee to cross-node exchange.
 
 ## Operator Rules
 
@@ -193,3 +222,11 @@ Exit criteria:
 - Prefer active-passive regional failover before active-active.
 - Update deployment docs whenever a phase graduates so operator-facing claims
   match current repo evidence.
+
+## Architecture References
+
+- [`RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md`](./RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md) — current router, mesh, and L1 peer-node authority.
+- [`SYSTEM_ARCHITECTURE_DIAGRAM.md`](./SYSTEM_ARCHITECTURE_DIAGRAM.md) — broad historical system map; verify live mounts against the runtime-topology document.
+- [`LAYER_ARCHITECTURE.md`](./LAYER_ARCHITECTURE.md) — authoritative L1/L2/L3 definitions, including the nine-node GUMAS design.
+- [`QGIA_L1_NODE_REGISTRATION.md`](./QGIA_L1_NODE_REGISTRATION.md) — L1-A/L1-B institutional network definition.
+- [`QGIA_SIM_BRIDGE.md`](./QGIA_SIM_BRIDGE.md) — required L1 mediation between QGIA signals and L2 simulation tasking.


### PR DESCRIPTION
## Summary

- distinguish CloudBank service replicas from the Orion/QGIA L1 peer network and the nine-node L2 simulation topology
- document the current process-local QGIA forecast store and the state guarantees required before multi-worker or multi-region scaling
- mark the broad system diagram as a historical snapshot and cross-link the current runtime and scaling authorities
- preserve L1-mediated QGIA-to-L2 tasking and keep the unimplemented generic inter-node transport tracked separately in #1141

## Validation

- `python -m pytest -q tests/test_qgia_api.py tests/test_api_surface_inventory.py` (14 passed)
- pre-commit hooks for all three changed documents
- `git diff --check`

## Risk and rollback

Documentation-only reconciliation. Revert commit `09aef951` to roll back.

Closes #1143