### PR TITLE
docs(api): reconcile mesh, QGIA, and PAT surfaces

### DIFF
--- a/docs/api/api_surface_inventory.json
+++ b/docs/api/api_surface_inventory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "last_reviewed": "2026-05-26",
+  "last_reviewed": "2026-07-13",
   "governance_decision": "primary-fastapi-with-declared-standalone-services",
   "status_values": [
     "active",
@@ -83,6 +83,21 @@
       "notes": "Current prefix is /simulate; older /quantum claims are legacy unless reintroduced."
     },
     {
+      "id": "qgia_forecast",
+      "owner": "qgia-forecast",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/qgia/api.py",
+      "mount_path": "/qgia",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /qgia.",
+        "api/aurora_api.py includes the router through a guarded import.",
+        "tests/test_qgia_api.py validates forecast, population, trust-network, and health routes."
+      ],
+      "notes": "Forecast-engine API backed by process-local engine and result state. This is not the generic L1 inter-node exchange transport described in QGIA_L1_NODE_REGISTRATION.md; that transport remains tracked in issue #1141."
+    },
+    {
       "id": "rd_pipeline",
       "owner": "hr-rd-productization",
       "runtime": "fastapi-router",
@@ -94,7 +109,7 @@
         "Router prefix is /rd.",
         "api/aurora_api.py includes rd_router when RD_PIPELINE_AVAILABLE is true."
       ],
-      "notes": "Distinct from HR staffing and character generation."
+      "notes": "Distinct from HR staffing and character generation. The tiered Consent Architecture described in RD_API_REFERENCE.md is not implemented as an HTTP surface; its design and implementation are tracked in issue #1200."
     },
     {
       "id": "hr_system",
@@ -339,14 +354,29 @@
       "owner": "mesh-runtime",
       "runtime": "fastapi-standalone",
       "entrypoint": "src/servers/l2_integration_server.py",
-      "mount_path": "/api/mesh, /api/bridge, /ws/mesh",
+      "mount_path": "/api/mesh, /api/mesh/agents, /api/mesh/agents/{agent_id}, /api/mesh/agents/{agent_id}/activate, /api/bridge, /ws/mesh",
       "service_class": "standalone-service",
       "status": "active-standalone",
       "status_evidence": [
         "create_app() defines /api/mesh/status, /api/mesh/messages, /api/mesh/channels/{channel_id}/history, /api/mesh/events, bridge compatibility routes, and /ws/mesh.",
-        "tests/test_mesh_router_v1.py validates the API and UI contract."
+        "create_app() defines GET /api/mesh/agents, GET /api/mesh/agents/{agent_id}, and POST /api/mesh/agents/{agent_id}/activate.",
+        "tests/test_mesh_router_v1.py validates the mesh-agent API and UI contract."
       ],
       "notes": "Canonical Mesh Runtime V1 surface."
+    },
+    {
+      "id": "pat_terminal_overlay",
+      "owner": "mesh-runtime",
+      "runtime": "fastapi-standalone-route-group",
+      "entrypoint": "src/servers/l2_integration_server.py",
+      "mount_path": "/api/mesh/terminals, /api/mesh/terminals/{terminal_id}",
+      "service_class": "standalone-service-route-group",
+      "status": "active-standalone",
+      "status_evidence": [
+        "create_app() defines read-only terminal list and terminal lookup routes.",
+        "tests/test_mesh_runtime_api_surface.py validates PAT overlay lookup and Personal Access Terminal versus Personnel Attention Tag disambiguation."
+      ],
+      "notes": "Read-only Personal Access Terminal compatibility overlay. It does not implement availability state, audio hailing, group chat, emergency cutoff, or memory preview; those Space configuration capabilities are not active API claims."
     },
     {
       "id": "api_bridge_server",

--- a/tests/test_api_surface_inventory.py
+++ b/tests/test_api_surface_inventory.py
@@ -51,6 +51,30 @@ def test_required_api_surface_entries_are_present() -> None:
         "drift_metrics",
         "gumas_ethics",
         "mesh_runtime_v1",
+        "pat_terminal_overlay",
+        "qgia_forecast",
         "mesh_api_js",
         "enhanced_api_bridge",
     } <= ids
+
+
+def test_reconciled_mesh_qgia_pat_and_consent_contracts() -> None:
+    inventory = json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+    entries = {entry["id"]: entry for entry in inventory["entries"]}
+
+    mesh_mounts = entries["mesh_runtime_v1"]["mount_path"]
+    assert "/api/mesh/agents" in mesh_mounts
+    assert "/api/mesh/agents/{agent_id}" in mesh_mounts
+    assert "/api/mesh/agents/{agent_id}/activate" in mesh_mounts
+
+    assert entries["qgia_forecast"]["mount_path"] == "/qgia"
+    assert "not the generic L1 inter-node exchange transport" in entries["qgia_forecast"]["notes"]
+
+    pat = entries["pat_terminal_overlay"]
+    assert pat["status"] == "active-standalone"
+    assert "/api/mesh/terminals" in pat["mount_path"]
+    assert "Read-only Personal Access Terminal" in pat["notes"]
+
+    rd_notes = entries["rd_pipeline"]["notes"]
+    assert "not implemented as an HTTP surface" in rd_notes
+    assert "#1200" in rd_notes


### PR DESCRIPTION
## Summary

- record the canonical mesh-agent routes explicitly in `mesh_runtime_v1`
- inventory the active `/qgia` forecast router while distinguishing it from the still-unimplemented L1 inter-node transport tracked in #1141
- inventory the implemented read-only Personal Access Terminal overlay without promoting unsupported Space capabilities
- record that RD tiered consent management has no active HTTP surface and is now tracked in #1200
- add regression assertions for the reconciled contracts

## Validation

- `python -m pytest -q tests/test_api_surface_inventory.py` (3 passed)
- `python -m pytest -q tests/test_mesh_router_v1.py tests/test_mesh_runtime_api_surface.py tests/test_qgia_api.py` (23 passed)
- pre-commit hooks for both changed files
- `git diff --check`

## Risk and rollback

Inventory and regression-test change only; no runtime routes are changed. Revert commit `edf55408` to roll back.

Closes #1144