### PR TITLE
docs(api): complete catalog governance self-audit

### DIFF
--- a/docs/api/API_CATALOG_GOVERNANCE.md
+++ b/docs/api/API_CATALOG_GOVERNANCE.md
@@ -1,7 +1,7 @@
 # API Catalog Governance
 
 **Status:** Active governance decision
-**Last reviewed:** 2026-05-26
+**Last reviewed:** 2026-07-13
 **Inventory:** `docs/api/api_surface_inventory.json`
 
 ## Decision
@@ -72,8 +72,25 @@ Each inventory entry must include:
   route authority by the Python mesh runtime unless a deployment surface later
   mounts it explicitly.
 - `docs/api/API_CATALOG.json` and `docs/api/api_schema.json` are generated
-  snapshots. Use them for route detail only after confirming their generated
-  timestamp is current.
+  snapshots. `API_CATALOG.json` records `generated_at` and `source_commit`;
+  `api_schema.json` records the same values as `x-generated-at` and
+  `x-source-commit`. Use them for route detail only after completing the
+  currency check below.
+
+## Snapshot Currency Check
+
+The generated metadata identifies the runtime commit that was assembled, not
+the commit that later stored the generated files. Verify all of the following:
+
+1. The timestamp and source commit agree across both generated JSON files.
+2. The source commit exists and is an ancestor of the checkout being reviewed.
+3. No route-bearing files under `api/`, `modules/`, or `src/` changed after the
+   source commit. If they did, inspect the changes and regenerate when any HTTP
+   or WebSocket surface changed.
+
+The catalog's `total_routes` is the number of OpenAPI paths. The `routes` array
+contains one record per supported HTTP operation, so its length can be larger.
+Neither count proves inventory ownership coverage.
 
 ## Update Workflow
 
@@ -82,9 +99,28 @@ Each inventory entry must include:
    evidence.
 3. Update `docs/architecture/RUNTIME_PATH_DRIFT_LEDGER.md` if older docs,
    commands, or routes now conflict.
-4. Regenerate OpenAPI/catalog snapshots only when route-level detail changed and
-   the generator output path is understood.
-5. Run `python3 -m pytest -q tests/test_api_surface_inventory.py`.
+4. Regenerate OpenAPI/catalog snapshots when route-level detail changed with
+   `python3 scripts/generate_api_catalog.py`. The default output is the tracked
+   `docs/api/` directory, independent of caller working directory.
+5. Run `python3 -m pytest -q tests/test_api_surface_inventory.py` for inventory
+   schema, required-field, and named regression checks. This is a structural
+   test, not a complete comparison with live router registrations. Automated
+   router-coverage validation is tracked in issue #1204.
+
+## 2026-07-13 Review Receipt
+
+- Issues #1142, #1144, and #1145 were resolved before this review.
+- The catalog and schema snapshots were regenerated with matching timestamps
+  and source commit metadata.
+- Mesh-agent routes, the QGIA forecast router, the read-only PAT terminal
+  overlay, and the unimplemented RD consent contract were reconciled in #1144;
+  consent implementation remains explicitly tracked in #1200.
+- A manual comparison of `api/aurora_api.py` router registrations with the
+  inventory found and added four omitted active routers: L1 Station, Sensor
+  Array, Checkpoint Vault, and CASK.
+- The existing inventory test was confirmed to be structural rather than a
+  completeness proof. Issue #1204 tracks a deterministic router-coverage
+  validator; until it lands, every review must include the manual comparison.
 
 ## Review Cadence
 

--- a/docs/api/api_surface_inventory.json
+++ b/docs/api/api_surface_inventory.json
@@ -308,6 +308,20 @@
       "notes": "Crew collaboration endpoint currently lives in the main API file."
     },
     {
+      "id": "l1_station",
+      "owner": "l1-station",
+      "runtime": "fastapi-router",
+      "entrypoint": "src/api/l1_station_api.py",
+      "mount_path": "/api/aurora",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /api/aurora.",
+        "api/aurora_api.py imports src.api.l1_station_api and includes the router."
+      ],
+      "notes": "L1 station health and simulation-state surface."
+    },
+    {
       "id": "l2_meta_agents",
       "owner": "l2-agents",
       "runtime": "fastapi-router",
@@ -336,6 +350,34 @@
       "notes": "Drift metrics and Prometheus exporter surface."
     },
     {
+      "id": "sensor_array",
+      "owner": "sensor-array",
+      "runtime": "fastapi-router-factory",
+      "entrypoint": "src/sensors/api/routes.py",
+      "mount_path": "/api/sensors",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "build_router() constructs the observation router.",
+        "api/aurora_api.py creates a SensorArrayFacade and includes the router with prefix /api/sensors."
+      ],
+      "notes": "GET-only internal, external, observatory, fusion, and health observation surface."
+    },
+    {
+      "id": "checkpoint_vault",
+      "owner": "checkpoint-vault",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/checkpoint_vault/api.py",
+      "mount_path": "/checkpoint",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /checkpoint.",
+        "api/aurora_api.py imports modules.checkpoint_vault.api and includes the router."
+      ],
+      "notes": "Ethical checkpoint creation, lookup, rollback, and agent-history surface."
+    },
+    {
       "id": "playground",
       "owner": "developer-experience",
       "runtime": "fastapi-router",
@@ -348,6 +390,20 @@
         "api/aurora_api.py imports src.playground and includes playground_router."
       ],
       "notes": "Interactive execution, share, health, metrics, and WebSocket surface."
+    },
+    {
+      "id": "cask",
+      "owner": "cask",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/cask/api.py",
+      "mount_path": "/api/cask",
+      "service_class": "main-app-router",
+      "status": "active",
+      "status_evidence": [
+        "Router prefix is /api/cask.",
+        "api/aurora_api.py imports modules.cask.api and includes the router."
+      ],
+      "notes": "Read-only CASK technical specification, comparison, risk, and topology surface."
     },
     {
       "id": "mesh_runtime_v1",

--- a/tests/test_api_surface_inventory.py
+++ b/tests/test_api_surface_inventory.py
@@ -1,3 +1,9 @@
+"""Structural checks for the governed API inventory.
+
+These tests validate schema and named regression contracts. They do not prove
+complete coverage of routers mounted by the live applications; see issue #1204.
+"""
+
 import json
 from pathlib import Path
 
@@ -50,6 +56,10 @@ def test_required_api_surface_entries_are_present() -> None:
         "monitoring_dashboard",
         "drift_metrics",
         "gumas_ethics",
+        "l1_station",
+        "sensor_array",
+        "checkpoint_vault",
+        "cask",
         "mesh_runtime_v1",
         "pat_terminal_overlay",
         "qgia_forecast",
@@ -78,3 +88,17 @@ def test_reconciled_mesh_qgia_pat_and_consent_contracts() -> None:
     rd_notes = entries["rd_pipeline"]["notes"]
     assert "not implemented as an HTTP surface" in rd_notes
     assert "#1200" in rd_notes
+
+
+def test_governance_review_router_dispositions() -> None:
+    inventory = json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+    entries = {entry["id"]: entry for entry in inventory["entries"]}
+
+    assert entries["l1_station"]["mount_path"] == "/api/aurora"
+    assert entries["sensor_array"]["mount_path"] == "/api/sensors"
+    assert entries["checkpoint_vault"]["mount_path"] == "/checkpoint"
+    assert entries["cask"]["mount_path"] == "/api/cask"
+
+    for entry_id in ("l1_station", "sensor_array", "checkpoint_vault", "cask"):
+        assert entries[entry_id]["status"] == "active"
+        assert entries[entry_id]["service_class"] == "main-app-router"


### PR DESCRIPTION
## Summary

- complete the API catalog governance self-audit after #1142, #1144, and #1145
- define a programmatic snapshot-currency check using matching timestamp/source-commit metadata
- clarify that `tests/test_api_surface_inventory.py` is structural, not a live-router completeness proof
- add the four active main-app routers found missing during the manual review: L1 Station, Sensor Array, Checkpoint Vault, and CASK
- record the 2026-07-13 review receipt and link the deterministic coverage follow-up in #1204

## Evidence

- `API_CATALOG.json` and `api_schema.json` have matching generated timestamps and source commits
- the recorded source commit exists, is an ancestor of this branch, and no `api/`, `modules/`, or `src/` route-bearing files changed after it
- manual `api/aurora_api.py` `include_router(...)` review reconciled all committed mounted routers against the inventory; direct routes in the main module remain owned by `primary_fastapi_app`

## Validation

- `python -m pytest -q tests/test_api_surface_inventory.py tests/test_generate_api_catalog.py` — 7 passed
- pre-commit on the three changed files — all hooks passed
- `git diff --check` — passed

Fixes #1146