### PR TITLE
Fix invalid top-level if: false in deploy-pages.yml

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,5 @@
 # This workflow is disabled
 
-# Disable the workflow
-if: false
-
 on:
   push:
     branches:
@@ -10,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Moves the `if: false` condition from the workflow root (invalid GitHub Actions syntax, causing every push to produce an instant `failure` with 0 jobs scheduled) into the `deploy` job, which is the correct location to disable a job while keeping the workflow file syntactically valid.

Confirmed via the Actions API that recent runs of this workflow (e.g. run 29255183030) return `total_count: 0` jobs with conclusion `failure`, matching GitHub's own diagnostic: "This run likely failed because of a workflow file issue."