### PR TITLE
Fix invalid codacy.yml workflow (missing on/jobs, top-level if: false)

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,6 +1,16 @@
 # Codacy Configuration
-
 # This file is used to configure the workflows for Codacy.
+# This workflow is disabled.
 
-# Disable this workflow by setting the following condition
-if: false
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  codacy:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disabled
+        run: echo 'Codacy workflow disabled'


### PR DESCRIPTION
`codacy.yml` had no `on:` trigger and no `jobs:` block — just a top-level `if: false`, which is not valid GitHub Actions syntax at any level. This caused every run to fail with 0 jobs scheduled (same class of bug fixed in #1229 for `deploy-pages.yml`).

This PR gives the file valid structure with `if: false` correctly placed on the job, so the workflow is properly disabled instead of failing on every push.