### PR TITLE
feat: promote PROJECT SENTINEL to canonical architecture (#1069)

### DIFF
--- a/constellation-contracts/manifests/sentinel-coordinator.manifest.json
+++ b/constellation-contracts/manifests/sentinel-coordinator.manifest.json
@@ -1,0 +1,52 @@
+{
+  "constellation_version": "1.0.0-alpha",
+  "node": {
+    "designation": "SENTINEL-COORDINATOR",
+    "symbolic_tag": "s.tag::sentinel.coordinator",
+    "repo": "aurora-cloudbank-symbolic",
+    "role": "spoke",
+    "stack": ["python", "fastapi"],
+    "description": "PROJECT SENTINEL coordinator — aggregates Stream 1 (crew cognitive load), Stream 2 (AI self-audit), and Stream 3 (ethics overlay) into one named entity for constellation health/status reporting."
+  },
+  "upstream": [
+    "s.tag::constellation.prime"
+  ],
+  "downstream": [],
+  "governance": {
+    "charter": "Picard_Delta_3",
+    "l3_modules": ["Axiomera", "Velatrix", "Glyphon", "Caelion", "Harmion"],
+    "primary_audit_authority": "Axiomera",
+    "primary_audit_authority_note": "Axiomera (Ethics Arbitration Framework, L3_AXIOMERA) is the named L3 audit authority for SENTINEL events. threadcore_registry.json's schema is a payload/version registry, not an event-routing table, so this assignment is recorded here and in docs/architecture/SENTINEL_ARCHITECTURE.md rather than there.",
+    "ethics_protocol": true
+  },
+  "streams": {
+    "stream_1_crew_cognitive_load": {
+      "status": "stub_unwired",
+      "anchor": null,
+      "source": "src/sensors/crew_load/"
+    },
+    "stream_2_ai_self_audit": {
+      "status": "operational",
+      "anchor": "T1-SENTINEL-001",
+      "source": "src/sensors/observatory/symbolic/ethical_signal.py"
+    },
+    "stream_3_ethics_overlay": {
+      "status": "operational",
+      "anchor": "T1-SENTINEL-001",
+      "source": "ethics/, symbolic_config.yaml"
+    }
+  },
+  "contracts": {
+    "published": ["sentinel-status"],
+    "consumed": ["constellation-event", "constellation-health"]
+  },
+  "health": {
+    "last_sync": null,
+    "status": "initializing"
+  },
+  "meta": {
+    "created": "2026-07-13T00:00:00-04:00",
+    "created_by": "Claude Code",
+    "proposal_ref": "issue #1069 — PROJECT SENTINEL canonical promotion"
+  }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,7 +107,6 @@ Cross-namespace bridges: L2 relay agents (HALO, STARLING, LIORA, OPPY, ARCHY, RI
 **Priority:** Medium | **Owner:** Medical division (Dr. Vasquez)
 Wire a real HRV/cortisol-proxy data source to `src/sensors/crew_load/`, and define Stream 1's own consent/opt-out hook. See `docs/architecture/SENTINEL_ARCHITECTURE.md` — Remaining Work.
 
-
 ### WS-001 — QUANTUM_FORGE Alignment Review
 **Priority:** Medium | **Gap:** GAP-005  
 Cross-reference `docs/QUANTUM_FORGE_V3_COMPLETE_GUIDE.md` vs `01_QUANTUM_FORGE_AxiomManifest.md`. Note: QGIA_ARCHITECTURE.md Section 8 names 10 computational modules (Lanchester, QSFE, EDM, ABCP, RPRN, TCA, etc.) not in the axiom manifest — these are complementary layers, not conflicts.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,9 +90,23 @@ Cross-namespace bridges: L2 relay agents (HALO, STARLING, LIORA, OPPY, ARCHY, RI
 - Created `docs/REVIEW_PROTOCOL.md` as standalone review standard for all agents and contributors
 - Full incident record: `docs/review-notes/2026-06-22_general-review-and-gap-010.md`
 
+### PROJECT SENTINEL Canonical Promotion ✅
+*Completed: 2026-07-13 (issue #1069)*
+
+- Promoted SENTINEL from NON-CANONICAL R&D proposal to canonical architecture — Streams 2 (AI self-audit) and 3 (ethics overlay) were already operational in code
+- Created `docs/architecture/SENTINEL_ARCHITECTURE.md` as the canonical technical reference
+- Registered `SENTINEL-COORDINATOR` in `constellation-contracts/manifests/sentinel-coordinator.manifest.json`, with Axiomera as named L3 audit authority
+- Added Stream 1 (crew cognitive load) stub sensors at `src/sensors/crew_load/` and a stub status endpoint at `/sentinel/crew-load/status` — not wired to a real biometric provider yet
+- Full detail, including two schema mismatches found (staff registry and ThreadCore payload registry don't fit a program entity like SENTINEL): `docs/architecture/SENTINEL_ARCHITECTURE.md`
+
 ---
 
 ## Open Work Streams
+
+### WS-011 — SENTINEL Stream 1 Biometric Provider
+**Priority:** Medium | **Owner:** Medical division (Dr. Vasquez)
+Wire a real HRV/cortisol-proxy data source to `src/sensors/crew_load/`, and define Stream 1's own consent/opt-out hook. See `docs/architecture/SENTINEL_ARCHITECTURE.md` — Remaining Work.
+
 
 ### WS-001 — QUANTUM_FORGE Alignment Review
 **Priority:** Medium | **Gap:** GAP-005  

--- a/docs/architecture/SENTINEL_ARCHITECTURE.md
+++ b/docs/architecture/SENTINEL_ARCHITECTURE.md
@@ -12,7 +12,7 @@
 ## Streams
 
 | Stream | Description | Status | Implementation |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | 1 — Crew Cognitive Load Monitoring | HRV/cortisol-proxy biometric signals, aggregated and anonymized by default | **Stub — not wired** | `src/sensors/crew_load/` |
 | 2 — AI Self-Audit | Reasoning-drift detection, entropy measurement, sentinel-risk mapping | **Operational** | `services/nemo_service/symbolic_bridge.py`, `src/sensors/observatory/symbolic/ethical_signal.py`, `src/sensors/constants.py` |
 | 3 — Ethics Overlay | Picard_Delta_3 charter enforcement, GUMAS ethics audit log, consent hooks | **Operational** | `ethics/`, `symbolic_config.yaml` |
@@ -45,7 +45,7 @@ Per the original proposal's routing (CC: Dr. Amira Sato — Ethics & Governance;
 Per the original 2026-04-09 proposal, cross-checked against `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` (canonical titles used below where they differ from the proposal's informal phrasing):
 
 | Name | Canonical role | Registry ID |
-|---|---|---|
+| --- | --- | --- |
 | Alex Thorne | Commander, Orion Station | CMD_001 |
 | Maya Shepard | Executive Officer | CMD_002 |
 | Dr. Elira Noor | Lead Reflexivity Specialist | ETH_002 |

--- a/docs/architecture/SENTINEL_ARCHITECTURE.md
+++ b/docs/architecture/SENTINEL_ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# PROJECT SENTINEL — Canonical Architecture
+
+**Status:** CANONICAL ARCHITECTURE — v1.0
+**Supersedes:** `simulation/RD_PROPOSAL_SENTINEL.md` (NON-CANONICAL R&D Proposal, submitted 2026-04-09) as the authoritative status reference. The R&D document remains the historical record of the original proposal and rationale.
+**Promoted:** 2026-07-13 (issue #1069)
+**Anchors:** `T1-SENTINEL-001` (ethics/self-audit streams), `T1-RSD-002` (monitoring dashboard, `modules/resilience_sentinel/`)
+
+## Summary
+
+*Situational Ethics & Neural-Telemetry Integration for Networked Exploratory Leadership* (SENTINEL) is a three-stream crew-wellness and AI-integrity program. Two of its three streams are already operational in code; this document promotes the system's documentation status to match that reality and formally records what remains.
+
+## Streams
+
+| Stream | Description | Status | Implementation |
+|---|---|---|---|
+| 1 — Crew Cognitive Load Monitoring | HRV/cortisol-proxy biometric signals, aggregated and anonymized by default | **Stub — not wired** | `src/sensors/crew_load/` |
+| 2 — AI Self-Audit | Reasoning-drift detection, entropy measurement, sentinel-risk mapping | **Operational** | `services/nemo_service/symbolic_bridge.py`, `src/sensors/observatory/symbolic/ethical_signal.py`, `src/sensors/constants.py` |
+| 3 — Ethics Overlay | Picard_Delta_3 charter enforcement, GUMAS ethics audit log, consent hooks | **Operational** | `ethics/`, `symbolic_config.yaml` |
+
+Stream 1+2 monitoring surfaces are additionally exposed via the Resilience Sentinel Dashboard (`modules/resilience_sentinel/`, anchor `T1-RSD-002`, 16+ live endpoints at `/sentinel/*`, now including the Stream 1 status stub at `/sentinel/crew-load/status`).
+
+## Layer boundary (hard constraint)
+
+**Crew cognitive-load data is never performance data.** Stream 1 exists to support crew wellbeing and safety, not evaluation. This constraint is structural, not a policy note to be revisited per-deployment:
+
+- Stream 1 sensors (`src/sensors/crew_load/`) emit aggregated/anonymized values by default.
+- No Stream 1 metric may be joined, correlated, or reported against any individual's performance record, review, or evaluation surface.
+- `/sentinel/crew-load/status` currently reports registration state only (no live readings) — it cannot leak individual biometric data because no provider is wired yet. Any future provider wiring must preserve the aggregation-by-default posture before this endpoint returns live values.
+- Opt-out: crew members may decline Stream 1 monitoring; declining must not affect standing, assignment, or evaluation. The original proposal cites a consent-hook file (`ethics_subroutine_v2.1.json`) for this — that file does not exist anywhere in the current repo. Stream 3's consent handling runs through the live `ethics/` stack instead; Stream 1 has no consent hook of its own yet since it has no live data path to opt out of. Flagged as an open follow-up, not asserted as done.
+
+## Ethics review record
+
+Per the original proposal's routing (CC: Dr. Amira Sato — Ethics & Governance; CC: Axiomera — L3 Ethics Arbitration), Stream 3's live ethics-audit path already runs through the existing `EthicsEngine`/`GeometricEthics` stack under the Picard_Delta_3 charter. No separate SENTINEL-specific ethics board was convened as a distinct body — review occurred as part of standard system-design ethics gating. This document records that as the formal review basis for canonical promotion; it does not retroactively invent a board that did not meet.
+
+## Governance registration
+
+**Coordinator entity:** `SENTINEL-COORDINATOR`, registered in `constellation-contracts/manifests/sentinel-coordinator.manifest.json`, governed under Picard_Delta_3 alongside the other constellation spokes.
+
+**L3 audit authority:** **Axiomera** (Ethics Arbitration Framework, `L3_AXIOMERA`) is the named L3 audit authority for SENTINEL events. This is recorded in the coordinator manifest's `governance.primary_audit_authority` field.
+
+*Registration note:* the original acceptance criteria for this promotion (issue #1069) asked for entries in `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` and `threadcore_registry.json`. Neither file's actual schema fits a program/system entity like SENTINEL — the staff registry is a closed personnel census (36 human + 1 AI core + 6 relay + 6 framework = 49 tracked entities, with its own reconciliation notes warning against inventing entries), and `threadcore_registry.json` is a ThreadCore *payload*-version registry, not an event-routing table. Rather than force a mismatched entry into either, SENTINEL's governance registration lives here and in the constellation manifest, which is schema-appropriate for a system/program entity.
+
+## Sponsoring staff
+
+Per the original 2026-04-09 proposal, cross-checked against `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` (canonical titles used below where they differ from the proposal's informal phrasing):
+
+| Name | Canonical role | Registry ID |
+|---|---|---|
+| Alex Thorne | Commander, Orion Station | CMD_001 |
+| Maya Shepard | Executive Officer | CMD_002 |
+| Dr. Elira Noor | Lead Reflexivity Specialist | ETH_002 |
+| Prof. Elena Sorensen | Cognitive Ethicist (Advisor) | ETH_003 |
+| Dr. Amira Sato | Chief Ethics Officer (Legacy Core) | — |
+| Lt. Julian Markov | Chief Security Officer (Legacy Core) | — |
+| Jiro Tanaka | Chief Engineering Officer (Legacy Core) | — |
+| Varya Lin | Chief Science Officer (Legacy Core) | — |
+| Helena Vu | Cultural & HR Director | HR_001 |
+| Dr. Ren Feldman | Chief Medical Officer (Legacy Core) | — |
+| Leena Porter | Bridge Operations Officer (Legacy Core) | — |
+
+## Remaining work
+
+- Wire a real biometric provider to `src/sensors/crew_load/` (Medical division / Dr. Vasquez) — Stream 1 stays a stub until then.
+- Define Stream 1's own consent/opt-out hook (Stream 3's exists; Stream 1's does not, since there is no live data path yet to opt out of).
+- `docs/api/api_surface_inventory.json` should list `/sentinel/crew-load/status` once the broader API surface inventory work (#1204) covers this router.

--- a/modules/resilience_sentinel/api.py
+++ b/modules/resilience_sentinel/api.py
@@ -15,6 +15,8 @@ from pydantic import BaseModel, Field
 
 from src.middleware.fastapi_security import require_csrf_token, verify_ws_token
 
+from src.sensors.crew_load import CognitiveLoadMonitor, MicrobiomeProxySensor
+
 from .alert_manager import AlertSeverity
 from .monitoring_engine import MonitoringEngine
 
@@ -145,6 +147,33 @@ async def get_health():
         checks=[HealthCheckResponse(**check) for check in report["checks"]],
         alerts=report["alerts"],
     )
+
+
+@router.get("/crew-load/status")
+async def get_crew_load_status():
+    """
+    PROJECT SENTINEL Stream 1 — crew cognitive-load monitoring status.
+
+    Stub endpoint. No biometric provider is wired yet (see
+    src/sensors/crew_load/). Returns each sensor's registration state, not
+    live readings, so callers can distinguish "not yet implemented" from
+    "no data right now." See docs/architecture/SENTINEL_ARCHITECTURE.md for
+    the layer-boundary constraint this stream operates under (crew load
+    data must never be reported as, or feed, performance data).
+    """
+    sensors = {
+        "cognitive_load": CognitiveLoadMonitor(),
+        "microbiome_proxy": MicrobiomeProxySensor(),
+    }
+    return {
+        "stream": "SENTINEL_STREAM_1",
+        "wired": False,
+        "sensors": {
+            name: {"sensor_id": s.sensor_id, "layer": s.layer.value, "provider_wired": False}
+            for name, s in sensors.items()
+        },
+        "note": "Stub endpoint — no biometric provider wired.",
+    }
 
 
 @router.get("/metrics", response_model=Dict[str, Any])

--- a/simulation/RD_PROPOSAL_SENTINEL.md
+++ b/simulation/RD_PROPOSAL_SENTINEL.md
@@ -1,8 +1,8 @@
 # PROJECT SENTINEL
 ## R&D Submission — Orion Station (ORH-07)
 
-**Document Class:** NON-CANONICAL CONTEXT — R&D Proposal  
-**Status:** Submitted for R&D Review  
+**Document Class:** HISTORICAL RECORD — Original R&D Proposal (superseded as the status reference by `docs/architecture/SENTINEL_ARCHITECTURE.md`, promoted to CANONICAL ARCHITECTURE v1.0 on 2026-07-13, issue #1069)
+**Status:** Promoted to canonical — see `docs/architecture/SENTINEL_ARCHITECTURE.md` for current stream status
 **Submitted By:** Senior Staff, Orion Station — Joint Proposal  
 **Submission Date:** 2026-04-09  
 **Session Reference:** Senior Staff All-Hands, Station Day [current]  

--- a/src/sensors/crew_load/__init__.py
+++ b/src/sensors/crew_load/__init__.py
@@ -1,0 +1,16 @@
+"""PROJECT SENTINEL Stream 1 — crew cognitive-load sensors (stubs, unwired).
+
+See docs/architecture/SENTINEL_ARCHITECTURE.md for scope and the
+layer-boundary constraint: crew load data != performance data.
+"""
+
+from src.sensors.crew_load.biometric_stream import BiometricStreamSource, NullBiometricStream
+from src.sensors.crew_load.cognitive_load_monitor import CognitiveLoadMonitor
+from src.sensors.crew_load.microbiome_proxy import MicrobiomeProxySensor
+
+__all__ = [
+    "BiometricStreamSource",
+    "NullBiometricStream",
+    "CognitiveLoadMonitor",
+    "MicrobiomeProxySensor",
+]

--- a/src/sensors/crew_load/biometric_stream.py
+++ b/src/sensors/crew_load/biometric_stream.py
@@ -1,0 +1,44 @@
+"""PROJECT SENTINEL Stream 1 — async biometric data ingestion interface (stub).
+
+Defines the ingestion boundary between a future real-time biometric feed
+(Dr. Vasquez / Medical division) and ``CognitiveLoadMonitor``'s provider
+callable. No transport (websocket, MQTT, device SDK, etc.) is implemented —
+this stub only fixes the shape so the real feed can be wired later without
+changing the sensor side.
+
+Layer-boundary constraint (see SENTINEL_ARCHITECTURE.md): implementations
+must emit aggregated/anonymized values by default. Individual-level
+biometric identity must never be attached to a value that flows into a
+performance-evaluation surface.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class BiometricStreamSource(ABC):
+    """Abstract async source of aggregated crew biometric signals.
+
+    A concrete implementation (not part of this stub) would poll or
+    subscribe to the real Medical-division feed and normalize readings
+    into the metric names ``CognitiveLoadMonitor`` expects
+    (``hrv_rmssd_ms``, ``cortisol_proxy_index``, ``aggregate_load_score``).
+    """
+
+    @abstractmethod
+    async def read_latest(self) -> Dict[str, float]:
+        """Return the latest aggregated metric snapshot.
+
+        Must return an empty dict rather than raise when no data is
+        available yet — sensors fall back to each metric's default.
+        """
+        raise NotImplementedError
+
+
+class NullBiometricStream(BiometricStreamSource):
+    """No-op stream used until a real feed is wired. Always empty."""
+
+    async def read_latest(self) -> Dict[str, float]:
+        return {}

--- a/src/sensors/crew_load/cognitive_load_monitor.py
+++ b/src/sensors/crew_load/cognitive_load_monitor.py
@@ -1,0 +1,39 @@
+"""PROJECT SENTINEL Stream 1 — cognitive load monitor (stub, not wired).
+
+Tracks HRV (heart-rate variability) and cortisol-proxy signal streams as an
+aggregated, anonymized-by-default cognitive load indicator (see
+``docs/architecture/SENTINEL_ARCHITECTURE.md`` for the layer-boundary
+constraint: crew load data must never be conflated with, or reported as,
+performance data).
+
+No provider is wired yet — Dr. Vasquez / Medical division owns the real
+biometric feed integration (T1-SENTINEL-001, Stream 1). This stub exists so
+``modules/resilience_sentinel`` can register the sensor shape ahead of that
+integration.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("hrv_rmssd_ms", MetricUnit.COUNT,
+               lambda v: v < 20, "HRV RMSSD below 20ms — elevated load"),
+    MetricSpec("cortisol_proxy_index", MetricUnit.RATIO,
+               lambda v: v > 0.8, "cortisol-proxy index above 0.8 — elevated load"),
+    MetricSpec("aggregate_load_score", MetricUnit.RATIO,
+               lambda v: v > 0.75, "aggregate cognitive load score above 0.75", default=0.0),
+]
+
+
+class CognitiveLoadMonitor(ProviderSensor):
+    """Stub sensor for crew cognitive-load signals. No provider wired."""
+
+    budget_key = "internal_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("crew_load.cognitive", Layer.L1, "cognitive_load",
+                         METRICS, provider)

--- a/src/sensors/crew_load/microbiome_proxy.py
+++ b/src/sensors/crew_load/microbiome_proxy.py
@@ -1,0 +1,33 @@
+"""PROJECT SENTINEL Stream 1 — microbiome-correlated cognitive proxy (stub).
+
+Placeholder for Dr. Ren Feldman's longitudinal microbiome-correlated
+cognitive state research. No dataset, model, or provider exists yet; this
+stub only reserves the metric name and unit so future integration doesn't
+require touching ``CognitiveLoadMonitor`` or its callers.
+
+Layer-boundary constraint (see SENTINEL_ARCHITECTURE.md): this signal is
+research-stage and must not gate, score, or otherwise feed any
+performance-evaluation surface.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from src.sensors.core.reading_types import Layer, MetricUnit
+from src.sensors.core.sensor_base import MetricSpec, ProviderSensor
+
+METRICS = [
+    MetricSpec("microbiome_cognitive_proxy_index", MetricUnit.RATIO,
+               default=0.0),  # no alert threshold — research-stage, advisory only
+]
+
+
+class MicrobiomeProxySensor(ProviderSensor):
+    """Stub sensor reserving the microbiome-cognitive-proxy metric shape."""
+
+    budget_key = "internal_sensor"
+
+    def __init__(self, provider: Optional[Callable[[], Dict[str, float]]] = None):
+        super().__init__("crew_load.microbiome_proxy", Layer.L1, "cognitive_load",
+                         METRICS, provider)


### PR DESCRIPTION
## Summary

Resolves #1069. Streams 2 (AI self-audit) and 3 (ethics overlay) were already operational in code; this formalizes that and adds Stream 1 (crew cognitive load) as unwired stubs.

- **`docs/architecture/SENTINEL_ARCHITECTURE.md`** (new) — canonical technical reference. Documents the hard layer-boundary constraint (crew load data ≠ performance data), the ethics review basis for promotion, and sponsoring-staff titles reconciled against `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` (Elira Noor is "Lead Reflexivity Specialist" not "Ethics Officer"; Varya Lin is "Chief Science Officer" not "Systems Architect" — the original proposal's informal titles didn't match the registry).
- **`simulation/RD_PROPOSAL_SENTINEL.md`** — header updated from NON-CANONICAL R&D proposal to historical record, pointing to the new canonical doc.
- **`constellation-contracts/manifests/sentinel-coordinator.manifest.json`** (new) — registers the SENTINEL-COORDINATOR node, Axiomera as named L3 audit authority.
- **`src/sensors/crew_load/`** (new) — three stub sensors (`cognitive_load_monitor`, `biometric_stream`, `microbiome_proxy`) following the existing `ProviderSensor` convention from `src/sensors/internal/`. No provider wired — shape only, for a future real biometric feed.
- **`modules/resilience_sentinel/api.py`** — adds `GET /sentinel/crew-load/status`, a stub reporting sensor registration state (not live readings).
- **`docs/ROADMAP.md`** — completed-milestone entry + WS-011 tracking remaining Stream 1 provider-wiring work.

## Two acceptance criteria deliberately not forced in

- `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` is a closed personnel census (49 tracked entities) with its own reconciliation notes warning against inventing entries — SENTINEL is a program, not a person/agent identity, so it doesn't belong there.
- `threadcore_registry.json` is a ThreadCore payload-version registry, not an event-routing/audit-authority table — Axiomera's audit-authority assignment lives in the constellation manifest and `SENTINEL_ARCHITECTURE.md` instead.

## Also flagged as a gap, not fabricated

`ethics_subroutine_v2.1.json` — referenced by both the original proposal and issue #1069 for consent-hook wiring — does not exist anywhere in the current repo. Documented as an open item rather than invented.

## Verification

- All 49 existing tests in `tests/test_resilience_sentinel*.py` pass against the modified `api.py`.
- The three new sensor stubs import and instantiate correctly against the real `ProviderSensor` base class (`src/sensors/core/sensor_base.py`).
- The new manifest JSON parses correctly.