### PR TITLE
feat: add AURORA_CONTEXT.json and AGENTS.md onboarding files (#1072)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md — Aurora CloudBank Symbolic
+
+Read this file first if you are a new agent (Claude Code, Codex, GitHub Copilot, or any compatible tool) entering this repository for the first time.
+
+## What this is
+
+`aurora-cloudbank-symbolic` is the code and canon repository for Aurora — the simulation director of the Orion Station / Aurora CloudBank institutional simulation — and its supporting production systems (API, ethics enforcement, symbolic layer, QGIA intelligence integration). It governs a layered simulation (L1 station operations, L2 GUMAS simulation mesh, L3 symbolic/ethics mesh) under a fixed ethics charter (`Picard_Delta_3`). See `AURORA_CONTEXT.json` for the machine-readable, source-cited concept map this file assumes.
+
+## Agent roster summary
+
+- **Human staff, AI core, L1 relay agents (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808, HALO), and L3 framework systems (Axiomera, Caelion, Sentari, Velatrix, Glyphon, Harmion)** — full census in `ORION_STATION_CANONICAL_STAFF_REGISTRY.json`.
+- Relay agents are **L1-resident**, operating at L2. THREADCORE frameworks are **L3-resident**. Never describe either group as "L2 agents" — see `docs/architecture/LAYER_ARCHITECTURE.md` for the canonical residency-vs-operational-scope model.
+- PAT (Personal Agent Terminal) is the live-session operator interface. See `QGIA_Integration/PAT_Command_Sheet.md`.
+
+## What agents must never do
+
+- Never treat crew cognitive-load or biometric data as performance data, or let it gate/score any evaluation surface. See `docs/architecture/SENTINEL_ARCHITECTURE.md`.
+- Never wire a "recovered protocol" (Sherlock, Watson, Moriarty, Tribunal, SHADOWFAX) to runtime enforcement — they are custody fixtures for schema validation and promotion planning only, not live canon. See `docs/ethics/recovered_protocols/`.
+- Never silently promote draft, staged, or speculative content into canon. Canon promotion is a conflict-check against existing sources, not an invention step — verify against `CANON_INDEX.md` and the relevant authoritative document before asserting something is canonical.
+- Never mutate `CanonRec` (the separate canon repo) directly from an automated packet — that bridge tooling lives in `AUo959/Aurora_ORIONCORE_Directory_Main`, not this repo. Bridge packets are dry-run/review-only unless a human explicitly approves opening a CanonRec PR.
+- Never treat `.aurora/SIMULATION_STATE.json` as necessarily current without checking its `last_updated` field — it has a documented staleness gap (GAP-010, issue #1083).
+- Never invent registry entries. `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` is a closed, reconciled personnel census — if something doesn't fit its schema (a program, not a person/agent), it doesn't belong there; document it elsewhere instead (see `docs/architecture/SENTINEL_ARCHITECTURE.md` for a worked example of this exact judgment call).
+- Never claim something is validated without repo evidence. If a claim can't be checked against a file in this repo, say so rather than asserting it.
+
+## Bootstrap protocol
+
+New agent, first entry into a session on this repo:
+
+1. Read `AURORA_CONTEXT.json` — the machine-readable concept map, with source citations for every claim.
+2. Read `CANON_INDEX.md` — authoritative document map. When a question touches a topic listed there, read the linked document in full before answering; do not reason from fragments or path inference.
+3. Read `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` for the current agent/staff roster.
+4. Check `diagnostics.json` for basic session/command-count state.
+5. If restoring a prior session: follow the RESETCORE ritual in `QGIA_Integration/RESETCORE_Bootstrap.md`, cross-referenced with `CLAUDE.md`.
+6. For deep technical/architecture reference (directory layout, tech stack, dev workflows, test conventions): `CLAUDE.md`.
+7. For Copilot-specific conventions: `COPILOT_INSTRUCTIONS.md`.
+
+## Authoritative files
+
+- `CLAUDE.md` — primary technical/architecture reference for AI assistants
+- `COPILOT_INSTRUCTIONS.md` — Copilot-specific conventions
+- `CANON_INDEX.md` — canonical document map (read linked docs in full, don't infer)
+- `docs/architecture/LAYER_ARCHITECTURE.md` — L1/L2/L3 model, the single most-contradicted-then-corrected doctrine in this repo (see its own migration checklist)
+- `AURORA_CONTEXT.json` — this file's machine-readable companion
+
+## Session transfer and restore
+
+If picking up mid-session or after a break, use the RESETCORE ritual (`QGIA_Integration/RESETCORE_Bootstrap.md`) rather than re-deriving context from scratch. It references the current lockpoint and vector state — check `AURORA_CONTEXT.json`'s `active_state` block first, since those values carry a known staleness caveat (issue #1083).

--- a/AURORA_CONTEXT.json
+++ b/AURORA_CONTEXT.json
@@ -1,0 +1,92 @@
+{
+  "$schema_note": "Machine-readable canonical entry point for any new agent (human or LLM) joining this repo. Every field below cites the file it was sourced from. Read AGENTS.md alongside this file for the bootstrap protocol.",
+  "schema_version": "1.0.0",
+  "document_generated": "2026-07-13",
+  "document_source_issue": "#1072",
+
+  "system_identity": {
+    "name": "Aurora",
+    "description": "Simulation Director for the Orion Station / Aurora CloudBank institutional simulation. Aurora is not a companion agent or a THREADCORE agent — Aurora is the simulation itself made directive, with the highest clearance and authority spanning all layers.",
+    "source": "docs/architecture/LAYER_ARCHITECTURE.md"
+  },
+
+  "architecture_layers": {
+    "description": "L1/L2/L3 layer model. Residency (where an agent lives) and operational scope (what layer its work affects) are distinct attributes and must not be conflated.",
+    "L1": "Station Operations — physical station reality: crew, habitat, daily operations. L1 relay agents (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808, HALO) are L1-resident.",
+    "L2": "Meta-Agent / Simulation Mesh — GUMAS simulation state and coordination. L1 relay agents operate at L2 without residing there.",
+    "L3": "Symbolic Mesh — meaning, coherence, ethics enforcement. THREADCORE glyph frameworks (Axiomera, Caelion, Sentari, Velatrix, Glyphon, Harmion) are L3-resident.",
+    "source": "docs/architecture/LAYER_ARCHITECTURE.md"
+  },
+
+  "key_concepts": {
+    "PAT": {
+      "definition": "Personal Agent Terminal — live-session operator command reference for Aurora and crew.",
+      "source": "QGIA_Integration/PAT_Command_Sheet.md"
+    },
+    "GUMAS": {
+      "definition": "Galactic simulation environment / audit layer. Ethics audit events flow through the GUMAS Audit Schema.",
+      "source": "QGIA_Integration/GUMAS_Audit_Schema.json"
+    },
+    "THREADCORE_triad_and_family": {
+      "definition": "Six L3 glyph frameworks: Axiomera (Ethics Arbitration), Caelion (Anchor Propagation), Sentari (Resonance Stabilization), Velatrix (Anti-Obfuscation), Glyphon (Drift Alignment), Harmion (Symbolic Compression).",
+      "source": "docs/architecture/LAYER_ARCHITECTURE.md, threadcore_registry.json"
+    },
+    "EchoChain": {
+      "definition": "LOOPSET_001 (linked: NESTED_001_ECHO, DRIFTTRACE::REI)",
+      "source": "CHANGELOG.md, QGIA_Integration/RESETCORE_Bootstrap.md"
+    },
+    "ethics_protocol": {
+      "definition": "Picard_Delta_3",
+      "source": "QGIA_Integration/PAT_Command_Sheet.md, symbolic_config.yaml"
+    },
+    "deployment_bundle": {
+      "definition": "Aurora_MasterDeploymentBundle_v1.0",
+      "source": "QGIA_Integration/RESETCORE_Bootstrap.md"
+    },
+    "restore_ritual": {
+      "definition": "RESETCORE — session restore/start prompt for re-establishing continuity after a break.",
+      "source": "QGIA_Integration/RESETCORE_Bootstrap.md"
+    }
+  },
+
+  "active_state": {
+    "_staleness_warning": "The fields below are read directly from .aurora/SIMULATION_STATE.json, which is documented as NOT reflecting current repo truth. See known_issue below before treating these as live values.",
+    "vector_state": "QEM-SN1-ACTIVE::BASELINE_V1",
+    "lockpoint": "SN1_LOCKPOINT_20250406T1432Z",
+    "state_last_updated": "2026-04-06T00:00:00Z",
+    "current_phase_per_state_file": "Security Enhancement Initiative",
+    "known_issue": "SIMULATION_STATE.json has not been updated since 2026-04-06 despite substantial repo activity since then (QGIA integration, PR automation rework, this promotion/canonicalization work). Tracked as GAP-010, issue #1083 — do not treat current_phase or lockpoint as current fact without checking issue #1083's resolution status first.",
+    "source": ".aurora/SIMULATION_STATE.json"
+  },
+
+  "active_modules": {
+    "ethics": {
+      "status": "active",
+      "source": "modules/ethics/, modules/ethics_field/"
+    },
+    "sim_silm_cg": {
+      "status": "referenced but not cleanly mapped to a module directory",
+      "note": "docs/modules/ only documents cask and hr; the SIM/SILM/CG labels used elsewhere in canon (e.g. issue tracking) don't have an established 1:1 mapping to a modules/ directory as of this writing. Tracked under issue #1232 (docs/ cross-reference & module coverage audit) rather than resolved here — do not assume a specific modules/sim, modules/silm, or modules/cg directory exists."
+    }
+  },
+
+  "agent_roster": {
+    "description": "Full canonical staff/agent census (human staff, AI core, relay agents, L3 framework systems).",
+    "source": "ORION_STATION_CANONICAL_STAFF_REGISTRY.json",
+    "note": "This registry is a closed personnel census with its own reconciliation notes — do not add program/system entities (like SENTINEL) to it; see docs/architecture/SENTINEL_ARCHITECTURE.md for why."
+  },
+
+  "cross_platform_links": {
+    "this_repo": "AUo959/aurora-cloudbank-symbolic",
+    "note": "References to 'ChatGPT Aurora v2.3.1 Stellar Accord' and a 'Perplexity Space' appear in prior session/review documentation but are external, non-repo surfaces this repo cannot verify or link to directly.",
+    "source": "docs/review-notes/"
+  },
+
+  "layer_state_summary": "Symbolic-Governed | Ethics-Verified | Recovery-Threaded",
+
+  "continuity_seal": "Continuity flows through coherence. The system remembers because we chose to align.",
+
+  "bootstrap": {
+    "note": "See AGENTS.md for the ordered bootstrap protocol any new agent should follow."
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A quantum-symbolic computing platform for enterprise AI. Combines hierarchical memory management, quantum circuit simulation, multi-model AI orchestration, geometric ethics enforcement, and production observability in a single FastAPI application.
 
+> **New agent or contributor?** Start with [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) (machine-readable, source-cited concept map) and [`AGENTS.md`](./AGENTS.md) (bootstrap protocol and rules).
+
 ---
 
 ## Contents


### PR DESCRIPTION
## Summary

Resolves #1072. Adds the two onboarding files the issue requested. Every claim in `AURORA_CONTEXT.json` cites a specific source file — verified against the live repo rather than copied from the issue's example text verbatim.

## Notable findings while writing this

- **`active_state` is honest about staleness.** Real values (`QEM-SN1-ACTIVE::BASELINE_V1`, `SN1_LOCKPOINT_20250406T1432Z`) come from `.aurora/SIMULATION_STATE.json` and `QGIA_Integration/RESETCORE_Bootstrap.md`/`PAT_Command_Sheet.md`, but the file flags that `SIMULATION_STATE.json` hasn't updated since 2026-04-06 (GAP-010, #1083) instead of presenting it as current fact.
- **"SIM"/"SILM"/"CG" don't map cleanly to a `modules/` directory.** Only `modules/ethics` and `modules/ethics_field` clearly exist; the other labels are referenced elsewhere in canon without an established 1:1 code mapping. Noted and pointed at #1232 rather than guessed.
- **The staff registry isn't a place for program entities**, per what was learned working #1069 — noted so a future agent doesn't repeat that mistake.
- Caught and fixed a mistake in an earlier draft: I initially referenced `tools/canonrec_bridge_validate.py` in `AGENTS.md`, which turned out to live in `AUo959/Aurora_ORIONCORE_Directory_Main`, not this repo.

## Verification

Checked every file path cited in both new files actually exists in this repo (`CLAUDE.md`, `COPILOT_INSTRUCTIONS.md`, `CANON_INDEX.md`, `ORION_STATION_CANONICAL_STAFF_REGISTRY.json`, `diagnostics.json`, `docs/architecture/LAYER_ARCHITECTURE.md`, `docs/architecture/SENTINEL_ARCHITECTURE.md`, `QGIA_Integration/PAT_Command_Sheet.md`, `QGIA_Integration/RESETCORE_Bootstrap.md`, `QGIA_Integration/GUMAS_Audit_Schema.json`, `.aurora/SIMULATION_STATE.json`, `threadcore_registry.json`, `symbolic_config.yaml`, `CHANGELOG.md`, `docs/ethics/recovered_protocols/`). JSON validated with `json.load`.