### PR TITLE
fix: GAP-010 — SIMULATION_STATE.json staleness (3-layer fix per #1083)

### DIFF
--- a/.aurora/ORION_STATION_CREW_MANIFEST.md
+++ b/.aurora/ORION_STATION_CREW_MANIFEST.md
@@ -1,0 +1,87 @@
+# Orion Station Crew Manifest
+
+Generated from `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` (registry version 1.0.0-reconstructed) as part of GAP-010 remediation (issue #1083).
+
+This file was 0 bytes prior to this generation — it is the human-readable crew manifest the canonical registry itself calls for, derived mechanically from that registry rather than hand-maintained separately, so the two cannot drift apart silently. Regenerate rather than hand-edit when the registry changes.
+
+---
+
+## Human Staff
+
+| ID | Name | Role | Division | Confidence |
+| --- | --- | --- | --- | --- |
+| CMD_001 | Alex Thorne | Commander, Orion Station | Command & Ethics | HIGH |
+| CMD_002 | Maya Shepard | Executive Officer | Command & Ethics | HIGH |
+| ETH_002 | Dr. Elira Noor | Lead Reflexivity Specialist | Command & Ethics | HIGH |
+| ETH_003 | Prof. Elena Sorensen | Cognitive Ethicist | Command & Ethics (Advisor) | HIGH |
+| HR_001 | Helena Vu | Cultural & HR Director | Command & Ethics | HIGH |
+| — | Varya Lin | Chief Science Officer | Legacy Core / seed staff | LEGACY_SEED |
+| — | Dr. Amira Sato | Chief Ethics Officer | Legacy Core / seed staff | LEGACY_SEED |
+| — | Julian Markov | Chief Security Officer | Legacy Core / seed staff | LEGACY_SEED |
+| — | Leena Porter | Bridge Operations Officer | Legacy Core / seed staff | LEGACY_SEED |
+| — | Jiro Tanaka | Chief Engineering Officer | Legacy Core / seed staff | LEGACY_SEED |
+| — | Dr. Ren Feldman | Chief Medical Officer | Legacy Core / seed staff | LEGACY_SEED |
+| OPS_002 | Raj Patel | Chief Engineer / Systems Engineer | Legacy Operational seed staff | LEGACY_SEED |
+| OPS_001 | Dr. Elena Vasquez | Flight Controller | Legacy Operational seed staff | LEGACY_SEED |
+| SYS_001 | Marcus Chen | Performance Optimization Engineer | Systems & Infrastructure | HIGH |
+| SYS_002 | Jessica Martinez | Backend Architect | Systems & Infrastructure | HIGH |
+| SYS_003 | Ryan Patel | Systems Integration Engineer | Systems & Infrastructure | HIGH |
+| SYS_004 | Ren Okada | Systems Portability Specialist | Systems & Infrastructure | HIGH |
+| SYS_005 | Dr. Kieran Zhao | Computational Optimization Lead | Systems & Infrastructure | HIGH |
+| SYS_006 | Ira Menon | Compiler Engineer | Systems & Infrastructure | HIGH |
+| SYS_007 | Vincent Kale | Layer Isolation Theorist | Systems & Infrastructure | HIGH |
+| SIM_001 | Dr. Amina Velin | Symbolic Systems Research Lead | Simulation & Cognitive Systems | HIGH |
+| SIM_002 | Tobias Qin | Code/Narrative Systems Engineer | Simulation & Cognitive Systems | HIGH |
+| SIM_003 | Emily Roberts | LLM-Simulation Bridge Developer | Simulation & Cognitive Systems | HIGH |
+| SIM_004 | Carmen Rivas | Simulation Binding Specialist | Simulation & Cognitive Systems | HIGH |
+| SIM_005 | Maren Koss | Cognitive Drift Mapper | Simulation & Cognitive Systems | HIGH |
+| UX_001 | Dante Kyros | UX Architect | Interface & Aesthetics | HIGH |
+| UX_002 | Naomi Vell | Narrative Framework Engineer | Interface & Aesthetics | HIGH |
+| UX_003 | Kai Drev | Interface Ecologist | Interface & Aesthetics | HIGH |
+| UX_004 | Haneul Park | Immersive Experience Theorist | Interface & Aesthetics | HIGH |
+| UX_005 | Juno Suresh | Symbolic Systems Artist | Interface & Aesthetics | HIGH |
+| UX_006 | Keira Halden | Lead Visual Concept Designer | Interface & Aesthetics | HIGH |
+| UX_007 | Rei Vatra | Atmospheric Painter & Color Theorist | Interface & Aesthetics | HIGH |
+| QA_001 | Olivia Nguyen | QA and Continuity Auditor | Operations & Quality Assurance | HIGH |
+| QA_002 | Samantha Lee | Logging & Observability Engineer | Operations & Quality Assurance | HIGH |
+| QA_003 | Tariq El-Sayegh | Speculative Systems Theorist | Operations & Quality Assurance | HIGH |
+
+## AI Core
+
+| ID | Name | Role | Division |
+| --- | --- | --- | --- |
+| AI_AURORA | Aurora (AU) | Station Intelligence Core | Command & Ethics (AI Core) |
+
+## L1 Relay Agents
+
+L1-resident, operating at L2 — see `docs/architecture/LAYER_ARCHITECTURE.md`. (Registry field name `l2_relay_agents` predates that residency correction; not renamed here — see the L2MetaAgentBridge rename follow-up task for the code-level rename.)
+
+| ID | Name | Role | Entity Type |
+| --- | --- | --- | --- |
+| L2_ARCHY | ARCHY | Architectural Coordination Relay | L2_RELAY |
+| L2_OPPY | OPPY | Operational Flight & Data Relay | L2_RELAY |
+| L2_LIORA | LIORA | Communications & Interface Relay | L2_RELAY |
+| L2_STARLING | STARLING_AU | Continuity & Reflection Dispatcher | L2_RELAY |
+| L2_RIVERTHREAD | RIVERTHREAD_808 | Logistics & Memory Relay | L2_RELAY |
+| L2_HALO | HALO | Drift Anchor & System Synchronization Relay | L2_RELAY |
+
+## L3 Framework Systems
+
+| ID | Name | Role | Entity Type |
+| --- | --- | --- | --- |
+| L3_AXIOMERA | Axiomera | Ethics Arbitration Framework | L3_FRAMEWORK |
+| L3_GLYPHON | Glyphon | Drift Alignment Framework | L3_FRAMEWORK |
+| L3_SENTARI | Sentari | Resonance Stabilization Framework | L3_FRAMEWORK |
+| L3_CAELION | Caelion | Anchor Propagation Framework | L3_FRAMEWORK |
+| L3_VELATRIX | Velatrix | Continuity & Anti-Obfuscation Framework | L3_FRAMEWORK |
+| L3_HARMION | Harmion | Symbolic Compression Framework | L3_FRAMEWORK |
+
+## Unresolved Entries
+
+Per the registry's own reconciliation notes — preserved here rather than silently dropped:
+
+- **UNRESOLVED_HUMAN_001** (HUMAN): Repo canon sources declare 36 human staff, but only 35 distinct human identities could be reconstructed from current machine-readable phase registers plus legacy seed references without inventing data. — status: `PENDING_RECONCILIATION`
+
+---
+
+**Totals:** 35 human staff + 1 AI core + 6 relay agents + 6 framework systems = 48 materialized entities. Registry's own declared count target is 49 (gap: 1, tracked in Unresolved Entries above).

--- a/.aurora/SIMULATION_STATE.json
+++ b/.aurora/SIMULATION_STATE.json
@@ -3,7 +3,7 @@
   "title": "Aurora CloudBank Orion Station - Canonical Simulation State",
   "description": "Complete quantum-symbolic station infrastructure with dark matter memory architecture. Simulation IS the system.",
   "version": "2.0.0-QUANTUM-CANONICAL",
-  "last_updated": "2026-04-06T00:00:00Z",
+  "last_updated": "2026-07-13T00:00:00Z",
   "simulation": {
     "name": "Aurora CloudBank Orion Station Operations",
     "status": "ACTIVE",
@@ -39,7 +39,7 @@
     }
   },
   "mission_state": {
-    "current_phase": "Security Enhancement Initiative",
+    "current_phase": "Ongoing Active Development (see continuity_events — no single-phase label has stayed accurate long enough to trust; Layer 2 freshness check exists specifically so this stops silently drifting)",
     "active_mission": null,
     "completed_missions": [
       {
@@ -82,10 +82,39 @@
         "commit": "fd62d3c5",
         "completion_date": "2026-04-06",
         "details": "Merged 7 open PRs, deleted 23 remote + 30 local stale branches, ran #321//. on clean main"
+      },
+      {
+        "id": "INTEG-1",
+        "name": "QGIA/Aurora Integration Bundle (Stage 1 + Stage 2)",
+        "status": "COMPLETE",
+        "efficiency": null,
+        "commit": "09506f1b",
+        "completion_date": "2026-06-20",
+        "details": "551-agent QGIA epistemic simulation, QSFE forecast engine, constellation-contracts manifests (QGIA-CORPUS, QGIA-SPINE), knowledge-indexes/. Retroactively recorded 2026-07-13 as part of GAP-010 remediation (#1083) — this is a backfilled record, not a live-tracked mission."
+      },
+      {
+        "id": "MAINT-1",
+        "name": "PR Automation Traceability Rework",
+        "status": "COMPLETE",
+        "efficiency": null,
+        "commit": "bd182c53",
+        "completion_date": "2026-05-XX",
+        "details": "Made Aurora PR automation traceable and quiet by default (#1078). Retroactively recorded 2026-07-13 as part of GAP-010 remediation (#1083) — this is a backfilled record, not a live-tracked mission."
       }
     ],
     "average_efficiency": 148,
-    "total_missions_completed": 5
+    "total_missions_completed": 5,
+    "mission_taxonomy": {
+      "description": "Mission ID prefixes. HIGH-* is reserved for the original feature-track missions (security/infra hardening). The four prefixes below (added 2026-07-13, GAP-010 remediation, issue #1083 Layer 3) exist so activity outside that track still generates a state record instead of falling through the update mechanism entirely.",
+      "prefixes": {
+        "HIGH": "Original feature-track missions (security/infra hardening). Do not reuse for the categories below.",
+        "MAINT": "Dependency and security maintenance — dependabot, manual patching.",
+        "INTEG": "Integration bundles and cross-system work (e.g. QGIA).",
+        "ARCH": "Architectural review, GAP registrations, doctrine/canon work.",
+        "OPS": "Operational housekeeping — branch cleanup, restore operations."
+      },
+      "note": "INTEG-1 and MAINT-1 below are the first entries under this taxonomy, backfilled retroactively as part of this same GAP-010 fix."
+    }
   },
   "system_status": {
     "csrf_coverage": 100,
@@ -93,7 +122,7 @@
     "logging_coverage": 75,
     "documentation_status": "CURRENT",
     "repository_state": "CLEAN",
-    "last_sync": "2026-04-06T00:00:00Z",
+    "last_sync": "2026-07-13T00:00:00Z",
     "branch_consolidation": {
       "completed": "2026-04-06T00:00:00Z",
       "remote_branches_deleted": 23,
@@ -111,7 +140,7 @@
     {
       "id": "ISSUE-001",
       "severity": "LOW",
-      "description": "Pydantic regex \u2192 pattern migration needed",
+      "description": "Pydantic regex → pattern migration needed",
       "impact": "Non-blocking, test compatibility only",
       "status": "DEFERRED"
     },
@@ -895,8 +924,8 @@
     "description": "Entire simulation advances probabilistically each cycle based on quantum state evolution",
     "cycle_frequency_hz": 0.1,
     "cycle_period_s": 10.0,
-    "current_cycle": 18472,
-    "cycles_since_initialization": 18472,
+    "current_cycle": 865192,
+    "cycles_since_initialization": 865192,
     "state_advancement": {
       "mechanism": "QUANTUM_PROBABILISTIC",
       "deterministic_components": [
@@ -1072,5 +1101,17 @@
     "dormant_systems": 43,
     "quantum_cycles_since_init": 18472,
     "memory_efficiency_percent": 98.7
-  }
+  },
+  "continuity_events": [
+    {
+      "event": "GAP-010: SIMULATION_STATE.json staleness",
+      "gap_start": "2026-04-06T00:00:00Z",
+      "gap_detected": "2026-06-21T20:28:00Z",
+      "gap_remediated": "2026-07-13T00:00:00Z",
+      "gap_duration_days": 98,
+      "description": "State file received zero updates for 98 days despite substantial repo activity (QGIA integration bundle, PR automation rework, GAP-007/008/009 registration, doc audits, PROJECT SENTINEL canonical promotion, and ~1700 commits). Root cause: the state file's only update pathways (manual mission close-out, #321//. sync chain) both require conscious invocation, and no mechanism existed to flag divergence from repo truth.",
+      "remediation": "See issue #1083 for the 3-layer fix: this backfill (Layer 1), .github/workflows/simulation-state-freshness.yml (Layer 2), and the MAINT-*/INTEG-*/ARCH-*/OPS-* mission taxonomy extension (Layer 3).",
+      "caveat": "This backfill is a best-effort summary of a 98-day, ~1700-commit gap, not an exhaustive mission log. Treat current_phase and completed_missions as directionally accurate, not a complete history."
+    }
+  ]
 }

--- a/.github/workflows/simulation-state-freshness.yml
+++ b/.github/workflows/simulation-state-freshness.yml
@@ -1,0 +1,32 @@
+name: Simulation State Freshness Check
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  check-state-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Check .aurora/SIMULATION_STATE.json freshness
+        run: |
+          set -euo pipefail
+          FILE=".aurora/SIMULATION_STATE.json"
+          LAST_COMMIT_TS=$(git log -1 --format=%ct -- "$FILE")
+          NOW_TS=$(date +%s)
+          DAYS_OLD=$(( (NOW_TS - LAST_COMMIT_TS) / 86400 ))
+          LAST_COMMIT_DATE=$(git log -1 --format=%ci -- "$FILE")
+
+          echo "Last commit touching $FILE: $LAST_COMMIT_DATE ($DAYS_OLD days ago)"
+
+          if [ "$DAYS_OLD" -gt 14 ]; then
+            echo "::error::$FILE is $DAYS_OLD days old — exceeds the 14-day freshness policy (GAP-010, issue #1083)."
+            exit 1
+          else
+            echo "::notice::$FILE is $DAYS_OLD days old — within the 14-day freshness policy."
+          fi


### PR DESCRIPTION
## Summary

Resolves #1083 (GAP-010). `.aurora/SIMULATION_STATE.json` had not been updated since 2026-04-06 — 98 days, ~1700 commits, zero autonomous update trigger or staleness detection.

## Layer 1 — immediate backfill

- `last_updated`, `system_status.last_sync` → 2026-07-13
- `quantum_cycle` advanced using the **actual** math: 0.1Hz = 8640 cycles/day, not the ~75,600/day figure in the issue's own text (which didn't match its own stated 0.1Hz rate). 18472 → 865192.
- Added `continuity_events` (new array) documenting the gap, root cause, and this remediation — with an explicit caveat that it's a best-effort summary of a 98-day/~1700-commit gap, not an exhaustive log.
- `mission_state.current_phase` updated, but deliberately doesn't pin a clean phase label — points at `continuity_events` and Layer 2 instead, since a static label is exactly what went stale last time.
- Backfilled `INTEG-1` (QGIA integration bundle) and `MAINT-1` (PR automation traceability rework) using the **new taxonomy** rather than `HIGH-10`/`HIGH-11` — `HIGH-10` is left free since #1085 separately proposed it for unrelated work that was never applied.
- `.aurora/ORION_STATION_CREW_MANIFEST.md` (was 0 bytes) generated mechanically from `ORION_STATION_CANONICAL_STAFF_REGISTRY.json` so the two can't silently drift apart again.

## Layer 2 — automated detection

`.github/workflows/simulation-state-freshness.yml`: fails (exit 1, visible red status) if the state file's last commit is >14 days old. This repo has **no branch protection**, so a failing check here can't block merges — it's purely the missing alert-on-drift signal, which was the actual root cause (Cause 2 in the issue: no staleness detection existed at all).

## Layer 3 — taxonomy

`mission_state.mission_taxonomy` documents `MAINT-*`/`INTEG-*`/`ARCH-*`/`OPS-*` prefixes for non-`HIGH-*`-track work, so activity like this fix itself generates a state record instead of having no category to go in.

## Verification

- `tests/test_l1_station_api.py` (the one test touching `.aurora/SIMULATION_STATE.json`, via a `tmp_path` copy) still passes.
- Both JSON files validate; the new workflow YAML validates.