### PR TITLE
ci(queue): blocking schema validation in queue-validation.yml (#1131)

### DIFF
--- a/.github/workflows/queue-validation.yml
+++ b/.github/workflows/queue-validation.yml
@@ -5,6 +5,9 @@
 # Also available as a manual workflow_dispatch for on-demand audits.
 #
 # What it checks:
+#   - queue.json validates against queue_schema.json
+#     (blocking here; the same tests run non-blocking in the full-suite pass
+#     of Aurora CI (Minimal) — see tests/test_work_queue_schema.py).
 #   - QUEUE.md, NEXT_UP.md, and OPEN_GATES.md are in sync with queue.json.
 #
 # If drift is detected the job fails with a clear remediation message.
@@ -43,12 +46,12 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      # jsonschema is used by sync_queue.py for schema validation (optional dep).
-      # Install it gracefully so the check still runs if it is not yet needed.
+      # jsonschema + pytest are required by the schema-validation step below.
+      # sync_queue.py itself has no third-party dependencies.
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install jsonschema || true
+          pip install jsonschema pytest
 
       - name: Validate queue.json exists and is valid JSON
         run: |
@@ -63,6 +66,20 @@ jobs:
               print(f"ERROR: {path} is not valid JSON: {e}")
               sys.exit(1)
           EOF
+
+      # Blocking schema validation, scoped to the only PRs that can break it
+      # (this workflow triggers on ops/work_queue/** paths). Elsewhere the same
+      # tests run in Aurora CI (Minimal)'s full-suite pass, which is
+      # informational only (continue-on-error) — without this step a schema
+      # violation could merge with green checks. Closes the "Queue validation
+      # CI" roadmap item of issue #1131.
+      # --noconftest: tests/conftest.py imports fastapi at collection time,
+      # which would drag the full requirements.txt install into this job.
+      # test_work_queue_schema.py needs only stdlib + jsonschema and no
+      # conftest fixtures, so it runs standalone.
+      - name: Validate queue.json against queue_schema.json
+        run: |
+          pytest --noconftest tests/test_work_queue_schema.py -q --no-header
 
       - name: Check generated views are in sync with queue.json
         id: drift_check


### PR DESCRIPTION
## What

Adds a blocking step to `.github/workflows/queue-validation.yml` that runs `pytest --noconftest tests/test_work_queue_schema.py`, closing the **"Queue validation CI"** roadmap checkbox of #1131.

## Why this shape

Verification-first findings that drove the design:

- `tests/test_work_queue_schema.py` **already exists** and fully validates `queue.json` against `queue_schema.json` (plus negative cases). No new validator was written — this PR just changes *where it's enforced*.
- On PRs, that test only runs in Aurora CI (Minimal)'s **full-suite pass, which is `continue-on-error`** (the blocking "critical tests" step is filtered to `@pytest.mark.critical/smoke`). So a schema-violating `queue.json` could merge with all checks green.
- `queue-validation.yml` is path-scoped to `ops/work_queue/**` — exactly the set of PRs that can introduce a violation — and it previously checked only JSON parseability and view drift. Its comment claiming `sync_queue.py` does schema validation was inaccurate (`sync_queue.py` has no schema/jsonschema references); fixed.
- `--noconftest` because `tests/conftest.py` imports `fastapi` at collection, which would force a full `requirements.txt` install into this 5-minute-timeout job; the schema test file needs only stdlib + `jsonschema` and no conftest fixtures.
- `pip install jsonschema` lost its `|| true` — it's now a hard dependency of a blocking step.

## Verification

- Workflow YAML validated with `yaml.safe_load`.
- `pytest --noconftest tests/test_work_queue_schema.py` in a clean venv with only `jsonschema` + `pytest`: **5 passed in 0.08s**.
- Current `ops/work_queue/queue.json` validates against the schema with 0 errors, so this cannot break existing PRs.
- The workflow file itself is in the trigger paths, so the new step self-tests on this PR.

Refs #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)