### PR TITLE
feat(hr): tiered RD consent management (#1200)

### DIFF
--- a/docs/api/RD_API_REFERENCE.md
+++ b/docs/api/RD_API_REFERENCE.md
@@ -101,7 +101,7 @@ regardless.
 **Consent endpoints:**
 
 | Method | Path | Purpose | Access |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | POST | `/rd/consent/grants` | Create grant | Subject only (CSRF) |
 | POST | `/rd/consent/grants/{id}/revoke` | Revoke grant | Subject or HR (CSRF) |
 | GET | `/rd/consent/grants/{id}` | Fetch one grant | Subject or HR |

--- a/docs/api/RD_API_REFERENCE.md
+++ b/docs/api/RD_API_REFERENCE.md
@@ -1,6 +1,6 @@
 # R&D Productization Pipeline API Reference
 
-**Version:** 1.1.0
+**Version:** 1.2.0
 **HR Runtime:** 3.0.0 "Helios" (confirmed by `modules/hr/__init__.py`)
 **Last Reviewed:** 2026-07-13
 **Base Path:** `/rd`  
@@ -65,22 +65,49 @@ Before using coherence metrics, review the [Ethics Framework](../../modules/hr/E
 
 ### Data Dignity Principles
 
-**Consent Architecture (planned; not implemented):**
+**Consent Architecture (implemented):**
 
-> **Status:** The tiered consent contract has no active HTTP surface or durable
-> grant/revocation store. Design and implementation are tracked in issue
-> [#1200](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1200).
-> The tiers below are policy requirements for that future implementation, not
-> claims enforced by the current `/rd` router.
+> **Status:** Implemented at `/rd/consent` per the Option A design approved on
+> issue [#1200](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1200):
+> grant state of record in `data/hr/consent_grants.json` (atomic writes),
+> tamper-evident audit history in the `insight_ledger` hash chain
+> (`hr_consent`). Owner: `modules/hr/consent/`. Runtime tests:
+> `tests/test_rd_consent_api.py`.
 
-- **Tier 1 (Default):** Aggregated, anonymized data
-- **Tier 2 (Consent Required):** Individual profiles visible to self and HR
-- **Tier 3 (Explicit Request):** Data shared with project leads
+- **Tier 1 (Default):** Aggregated, anonymized data — `GET /rd/consent/aggregate`,
+  no grant required; responses carry no individual identifiers and suppress
+  buckets below the k-anonymity threshold (5)
+- **Tier 2 (Consent Required):** Individual profiles visible to self and HR —
+  requires an active grant with grantee `self` or `hr`
+- **Tier 3 (Explicit Request):** Data shared with a named project lead —
+  requires an active grant with grantee `project_lead:<id>`
 
-**Required Withdrawal Rights for the planned implementation:**
-- Crew members can opt out of coherence tracking without penalty
-- Systems function gracefully with partial data
-- Withdrawal does not affect job security or advancement
+**Withdrawal Rights (enforced):**
+- Grants are revocable at any time by the subject (or HR on the subject's
+  behalf) via `POST /rd/consent/grants/{grant_id}/revoke`; revoked and expired
+  grants are retained as history, never deleted
+- Only the data subject can create a grant — HR and automated layers cannot
+  fabricate consent (enforced at the router, audited in the ledger)
+- Systems function gracefully with partial data; withdrawal does not affect
+  job security or advancement
+
+**Requester identity (interim):** the platform has no user-authentication
+layer yet, so `/rd/consent` endpoints identify callers via
+`X-Aurora-Requester` / `X-Aurora-Requester-Role` headers. This is an
+explicitly documented assertion contract to be replaced when platform authn
+lands; consent enforcement, CSRF on mutations, and ledger auditing apply
+regardless.
+
+**Consent endpoints:**
+
+| Method | Path | Purpose | Access |
+|---|---|---|---|
+| POST | `/rd/consent/grants` | Create grant | Subject only (CSRF) |
+| POST | `/rd/consent/grants/{id}/revoke` | Revoke grant | Subject or HR (CSRF) |
+| GET | `/rd/consent/grants/{id}` | Fetch one grant | Subject or HR |
+| GET | `/rd/consent/subjects/{id}/grants` | List subject grants | Self or HR |
+| GET | `/rd/consent/check` | Access decision for requester | Any authenticated requester; all decisions audited |
+| GET | `/rd/consent/aggregate` | Tier 1 anonymized aggregate | Open |
 
 ---
 
@@ -485,6 +512,12 @@ for pair in mediation["pairs"]:
 
 ## Version History
 
+- **v1.2.0** (2026-07-13): Tiered consent management implemented
+  - `/rd/consent` surface live per the Option A design approved on #1200
+  - Grant state in `data/hr/consent_grants.json`; audit history in
+    `insight_ledger` (`hr_consent`)
+  - Consent Architecture section updated from planned to implemented after
+    runtime tests passed (`tests/test_rd_consent_api.py`)
 - **v1.1.0** (2026-07-13): Runtime and governance reconciliation
   - Confirmed HR runtime version 3.0.0 "Helios" from the owning module
   - Marked tiered consent management as planned and linked issue #1200

--- a/docs/api/api_surface_inventory.json
+++ b/docs/api/api_surface_inventory.json
@@ -124,7 +124,21 @@
         "Router prefix is /rd.",
         "api/aurora_api.py includes rd_router when RD_PIPELINE_AVAILABLE is true."
       ],
-      "notes": "Distinct from HR staffing and character generation. The tiered Consent Architecture described in RD_API_REFERENCE.md is not implemented as an HTTP surface; its design and implementation are tracked in issue #1200."
+      "notes": "Distinct from HR staffing and character generation. The tiered Consent Architecture is implemented at /rd/consent (see rd_consent entry); design decision and acceptance criteria in issue #1200."
+    },
+    {
+      "id": "rd_consent",
+      "owner": "hr-rd-productization",
+      "runtime": "fastapi-router",
+      "entrypoint": "modules/hr/consent/api.py",
+      "mount_path": "/rd/consent",
+      "service_class": "main-app-router",
+      "status": "active-optional",
+      "status_evidence": [
+        "Router prefix is /consent, nested inside the /rd router.",
+        "modules/hr/rd_api.py includes it when CONSENT_AVAILABLE is true; reaches the app via the rd_pipeline mount."
+      ],
+      "notes": "Tiered consent management (issue #1200): grant/revoke/check/aggregate. Grant state in data/hr/consent_grants.json (atomic JSON); audit history in insight_ledger (hr_consent). Requester identity is header-asserted pending a platform authn layer."
     },
     {
       "id": "hr_system",

--- a/modules/hr/consent/__init__.py
+++ b/modules/hr/consent/__init__.py
@@ -1,0 +1,17 @@
+"""Tiered RD consent management (issue #1200).
+
+Implements the three-tier Consent Architecture described in
+docs/api/RD_API_REFERENCE.md:
+
+ - Tier 1 (Default):          aggregated, anonymized data — no grant needed
+ - Tier 2 (Consent Required): individual profiles visible to self and HR
+ - Tier 3 (Explicit Request): data shared with a named project lead
+
+Design approved on #1200 (Option A): grant state of record is an atomic
+JSON file under data/hr/; every consent event is additionally appended to
+the insight_ledger hash chain for tamper-evident audit history.
+"""
+
+from .store import ConsentStore, ConsentGrant, ConsentError
+
+__all__ = ["ConsentStore", "ConsentGrant", "ConsentError"]

--- a/modules/hr/consent/api.py
+++ b/modules/hr/consent/api.py
@@ -1,0 +1,276 @@
+"""Tiered RD consent API (issue #1200).
+
+Mounted under the existing ``/rd`` router (modules/hr/rd_api.py), giving:
+
+    POST /rd/consent/grants                 create a grant (subject only)
+    POST /rd/consent/grants/{id}/revoke     revoke (subject or HR)
+    GET  /rd/consent/grants/{id}            fetch one grant (subject or HR)
+    GET  /rd/consent/subjects/{id}/grants   list a subject's grants (self or HR)
+    GET  /rd/consent/check                  access decision for the requester
+    GET  /rd/consent/aggregate              Tier 1 anonymized aggregate
+
+Requester identity — documented interim contract:
+
+The platform has no user-authentication layer yet
+(src/middleware/fastapi_security.require_auth is an explicit placeholder),
+so requester identity is asserted via headers:
+
+    X-Aurora-Requester:      requester id (2-64 chars)
+    X-Aurora-Requester-Role: crew | hr | project_lead
+
+This bounds identity strength at the platform's current level — it does NOT
+make identity claims cryptographically trustworthy, and must be replaced
+with a real authn dependency when one exists. What IS enforced regardless:
+no request without an explicit asserted human requester can create consent
+(automated layers cannot fabricate grants), every mutation requires CSRF,
+and every allow/deny decision lands in the insight_ledger hash chain.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from modules.hr.consent.store import ConsentError, ConsentStore
+
+# Aurora security + rate limiting (guard optional import failures gracefully).
+# Uses require_csrf_token (token = Depends(security)) — the dependency form
+# used by modules/gumas, modules/insight_ledger, and modules/aumemmanager.
+try:
+    from src.middleware.fastapi_security import require_csrf_token, limiter
+    SECURITY_AVAILABLE = True
+except Exception:  # pragma: no cover - fallback path
+    SECURITY_AVAILABLE = False
+    def require_csrf_token(*args, **kwargs):  # type: ignore
+        return None
+    class DummyLimiter:  # minimal placeholder
+        @staticmethod
+        def limit(limit_str: str):
+            def _decorator(func):
+                return func
+            return _decorator
+    limiter = DummyLimiter()  # type: ignore
+
+logger = logging.getLogger("rd_consent_api")
+
+router = APIRouter(prefix="/consent", tags=["rd-consent"])
+
+_MUTATION_DEPS = [Depends(require_csrf_token)] if SECURITY_AVAILABLE else []
+
+REQUESTER_ID_HEADER = "X-Aurora-Requester"
+REQUESTER_ROLE_HEADER = "X-Aurora-Requester-Role"
+_REQUESTER_ROLES = {"crew", "hr", "project_lead"}
+_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{2,64}$")
+
+_store: Optional[ConsentStore] = None
+
+
+def get_store() -> ConsentStore:
+    global _store
+    if _store is None:
+        _store = ConsentStore()
+    return _store
+
+
+class Requester:
+    def __init__(self, requester_id: str, role: str) -> None:
+        self.requester_id = requester_id
+        self.role = role
+
+    @property
+    def is_hr(self) -> bool:
+        return self.role == "hr"
+
+    def grantee_identity(self, subject_id: str) -> str:
+        """The grantee string this requester matches when reading subject data."""
+        if self.is_hr:
+            return "hr"
+        if self.requester_id == subject_id:
+            return "self"
+        return f"project_lead:{self.requester_id}"
+
+
+def get_requester(request: Request) -> Requester:
+    requester_id = request.headers.get(REQUESTER_ID_HEADER, "")
+    role = request.headers.get(REQUESTER_ROLE_HEADER, "")
+    if not _ID_PATTERN.match(requester_id):
+        raise HTTPException(
+            status_code=401,
+            detail=f"missing or invalid {REQUESTER_ID_HEADER} header",
+        )
+    if role not in _REQUESTER_ROLES:
+        raise HTTPException(
+            status_code=401,
+            detail=f"{REQUESTER_ROLE_HEADER} must be one of {sorted(_REQUESTER_ROLES)}",
+        )
+    return Requester(requester_id, role)
+
+
+# -------------------------
+# Pydantic Models
+# -------------------------
+class CreateGrantRequest(BaseModel):
+    subject_id: str = Field(..., min_length=2, max_length=64)
+    tier: int = Field(..., ge=2, le=3)
+    data_class: str = Field(..., min_length=2, max_length=64)
+    purpose: str = Field(..., min_length=2, max_length=160)
+    grantee: str = Field(..., min_length=2, max_length=80)
+    expires_in_days: Optional[int] = Field(default=None, ge=1, le=365)
+
+
+class RevokeGrantRequest(BaseModel):
+    reason: str = Field(..., min_length=2, max_length=160)
+
+
+# -------------------------
+# Endpoints
+# -------------------------
+@router.post("/grants", status_code=201, dependencies=_MUTATION_DEPS)
+@limiter.limit("30/minute")
+def create_grant(
+    request: Request,
+    body: CreateGrantRequest,
+    requester: Requester = Depends(get_requester),
+) -> Dict[str, Any]:
+    """Create a consent grant. Only the data subject can consent.
+
+    HR cannot consent on a subject's behalf and no automated pathway exists:
+    consent that wasn't given by its subject isn't consent.
+    """
+    if requester.requester_id != body.subject_id:
+        raise HTTPException(
+            status_code=403,
+            detail="only the data subject can create a consent grant",
+        )
+    try:
+        grant, audited = get_store().grant(
+            subject_id=body.subject_id,
+            tier=body.tier,
+            data_class=body.data_class,
+            purpose=body.purpose,
+            grantee=body.grantee,
+            expires_in_days=body.expires_in_days,
+        )
+    except ConsentError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {
+        "success": True,
+        "grant": grant.to_dict(),
+        "audit_recorded": audited,
+        "context_tag": "rd_consent_grant",
+    }
+
+
+@router.post("/grants/{grant_id}/revoke", dependencies=_MUTATION_DEPS)
+@limiter.limit("30/minute")
+def revoke_grant(
+    request: Request,
+    grant_id: str,
+    body: RevokeGrantRequest,
+    requester: Requester = Depends(get_requester),
+) -> Dict[str, Any]:
+    """Revoke a grant. Allowed for the subject or HR (revocation only ever
+    removes access, so the safe direction is to make it easy)."""
+    store = get_store()
+    grant = store.get(grant_id)
+    if grant is None:
+        raise HTTPException(status_code=404, detail="grant not found")
+    if requester.requester_id != grant.subject_id and not requester.is_hr:
+        raise HTTPException(
+            status_code=403, detail="only the data subject or HR can revoke a grant"
+        )
+    try:
+        grant, audited = store.revoke(grant_id, body.reason)
+    except ConsentError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {
+        "success": True,
+        "grant": grant.to_dict(),
+        "audit_recorded": audited,
+        "context_tag": "rd_consent_revoke",
+    }
+
+
+@router.get("/grants/{grant_id}")
+@limiter.limit("120/minute")
+def get_grant(
+    request: Request,
+    grant_id: str,
+    requester: Requester = Depends(get_requester),
+) -> Dict[str, Any]:
+    """Fetch one grant — visible to its subject and HR (Tier 2 semantics)."""
+    grant = get_store().get(grant_id)
+    if grant is None or (
+        requester.requester_id != grant.subject_id and not requester.is_hr
+    ):
+        # 404 for unauthorized readers too: existence of a grant is itself
+        # individual data.
+        raise HTTPException(status_code=404, detail="grant not found")
+    return {"success": True, "grant": grant.to_dict(), "context_tag": "rd_consent_get"}
+
+
+@router.get("/subjects/{subject_id}/grants")
+@limiter.limit("120/minute")
+def list_subject_grants(
+    request: Request,
+    subject_id: str,
+    requester: Requester = Depends(get_requester),
+) -> Dict[str, Any]:
+    """List a subject's grants — visible to self and HR (Tier 2 semantics)."""
+    if requester.requester_id != subject_id and not requester.is_hr:
+        raise HTTPException(
+            status_code=403,
+            detail="individual consent records are visible to the subject and HR only",
+        )
+    grants = get_store().list_for_subject(subject_id)
+    return {
+        "success": True,
+        "count": len(grants),
+        "grants": [g.to_dict() for g in grants],
+        "context_tag": "rd_consent_list",
+    }
+
+
+@router.get("/check")
+@limiter.limit("240/minute")
+def check_access(
+    request: Request,
+    subject_id: str,
+    data_class: str,
+    purpose: str,
+    requester: Requester = Depends(get_requester),
+) -> Dict[str, Any]:
+    """Access decision for the requester against a subject's data.
+
+    The grantee identity is derived from the requester (self / hr /
+    project_lead:<id>) — callers cannot ask on behalf of someone else.
+    Every decision, including denials, is appended to the audit ledger.
+    """
+    grantee = requester.grantee_identity(subject_id)
+    decision = get_store().check_access(subject_id, data_class, purpose, grantee)
+    return {
+        "success": True,
+        "requester": requester.requester_id,
+        "grantee_identity": grantee,
+        "decision": decision,
+        "context_tag": "rd_consent_check",
+    }
+
+
+@router.get("/aggregate")
+@limiter.limit("120/minute")
+def aggregate(request: Request) -> Dict[str, Any]:
+    """Tier 1 (default) view: anonymized aggregate, no grant required.
+
+    Response carries no subject ids, grant ids, or grantee ids, and buckets
+    below the k-anonymity threshold are suppressed.
+    """
+    return {
+        "success": True,
+        "aggregate": get_store().aggregate(),
+        "context_tag": "rd_consent_aggregate",
+    }

--- a/modules/hr/consent/api.py
+++ b/modules/hr/consent/api.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, Optional
+from typing import Annotated, Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
@@ -129,12 +129,21 @@ class RevokeGrantRequest(BaseModel):
 # -------------------------
 # Endpoints
 # -------------------------
-@router.post("/grants", status_code=201, dependencies=_MUTATION_DEPS)
+@router.post(
+    "/grants",
+    status_code=201,
+    dependencies=_MUTATION_DEPS,
+    responses={
+        401: {"description": "Missing or invalid requester identity headers"},
+        403: {"description": "Requester is not the data subject"},
+        409: {"description": "Invalid tier/grantee combination or duplicate active grant"},
+    },
+)
 @limiter.limit("30/minute")
 def create_grant(
     request: Request,
     body: CreateGrantRequest,
-    requester: Requester = Depends(get_requester),
+    requester: Annotated[Requester, Depends(get_requester)],
 ) -> Dict[str, Any]:
     """Create a consent grant. Only the data subject can consent.
 
@@ -165,13 +174,22 @@ def create_grant(
     }
 
 
-@router.post("/grants/{grant_id}/revoke", dependencies=_MUTATION_DEPS)
+@router.post(
+    "/grants/{grant_id}/revoke",
+    dependencies=_MUTATION_DEPS,
+    responses={
+        401: {"description": "Missing or invalid requester identity headers"},
+        403: {"description": "Requester is neither the data subject nor HR"},
+        404: {"description": "Grant not found"},
+        409: {"description": "Grant is already revoked"},
+    },
+)
 @limiter.limit("30/minute")
 def revoke_grant(
     request: Request,
     grant_id: str,
     body: RevokeGrantRequest,
-    requester: Requester = Depends(get_requester),
+    requester: Annotated[Requester, Depends(get_requester)],
 ) -> Dict[str, Any]:
     """Revoke a grant. Allowed for the subject or HR (revocation only ever
     removes access, so the safe direction is to make it easy)."""
@@ -195,12 +213,18 @@ def revoke_grant(
     }
 
 
-@router.get("/grants/{grant_id}")
+@router.get(
+    "/grants/{grant_id}",
+    responses={
+        401: {"description": "Missing or invalid requester identity headers"},
+        404: {"description": "Grant not found (also returned to unauthorized readers)"},
+    },
+)
 @limiter.limit("120/minute")
 def get_grant(
     request: Request,
     grant_id: str,
-    requester: Requester = Depends(get_requester),
+    requester: Annotated[Requester, Depends(get_requester)],
 ) -> Dict[str, Any]:
     """Fetch one grant — visible to its subject and HR (Tier 2 semantics)."""
     grant = get_store().get(grant_id)
@@ -213,12 +237,18 @@ def get_grant(
     return {"success": True, "grant": grant.to_dict(), "context_tag": "rd_consent_get"}
 
 
-@router.get("/subjects/{subject_id}/grants")
+@router.get(
+    "/subjects/{subject_id}/grants",
+    responses={
+        401: {"description": "Missing or invalid requester identity headers"},
+        403: {"description": "Requester is neither the subject nor HR"},
+    },
+)
 @limiter.limit("120/minute")
 def list_subject_grants(
     request: Request,
     subject_id: str,
-    requester: Requester = Depends(get_requester),
+    requester: Annotated[Requester, Depends(get_requester)],
 ) -> Dict[str, Any]:
     """List a subject's grants — visible to self and HR (Tier 2 semantics)."""
     if requester.requester_id != subject_id and not requester.is_hr:
@@ -235,14 +265,19 @@ def list_subject_grants(
     }
 
 
-@router.get("/check")
+@router.get(
+    "/check",
+    responses={
+        401: {"description": "Missing or invalid requester identity headers"},
+    },
+)
 @limiter.limit("240/minute")
 def check_access(
     request: Request,
     subject_id: str,
     data_class: str,
     purpose: str,
-    requester: Requester = Depends(get_requester),
+    requester: Annotated[Requester, Depends(get_requester)],
 ) -> Dict[str, Any]:
     """Access decision for the requester against a subject's data.
 

--- a/modules/hr/consent/store.py
+++ b/modules/hr/consent/store.py
@@ -1,0 +1,326 @@
+"""Consent grant store — durable state + tamper-evident audit (issue #1200).
+
+Persistence split by role, per the approved Option A design:
+
+ - Current grant state lives in an atomic JSON file (default
+   ``data/hr/consent_grants.json``, written via src.utils.atomic_io).
+   Grants are never deleted: revocation and expiry leave the record in
+   place so the file itself is reviewable history.
+ - Every consent event (grant, revoke, denial, expiry observed at read
+   time) is appended to the insight_ledger hash chain. Grant state and
+   audit history are structurally separate: something that could edit the
+   JSON file still cannot rewrite the signed hash chain.
+
+Authority contract: this store exposes no bulk-import or backfill path.
+Grants enter only through explicit ``grant()`` calls, which the API layer
+restricts to the data subject. Audit-ledger availability is reported on
+every mutation (``audit_recorded``) rather than silently swallowed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+from src.utils.atomic_io import atomic_write_json
+
+logger = logging.getLogger("hr_consent")
+
+DEFAULT_STORE_PATH = Path("data/hr/consent_grants.json")
+
+# Tier semantics from docs/api/RD_API_REFERENCE.md ("Data Dignity Principles").
+# Tier 1 is the default (aggregate/anonymized) and never requires a grant, so
+# it never appears in the store.
+TIER_2 = 2
+TIER_3 = 3
+TIER_2_GRANTEES = {"self", "hr"}
+TIER_3_GRANTEE_PREFIX = "project_lead:"
+
+# Aggregate responses suppress any bucket smaller than this so individual
+# subjects cannot be singled out by differencing small groups.
+K_ANONYMITY_THRESHOLD = 5
+
+
+class ConsentError(ValueError):
+    """Raised for invalid consent operations (bad tier/grantee, duplicates)."""
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+@dataclass
+class ConsentGrant:
+    grant_id: str
+    subject_id: str
+    tier: int
+    data_class: str
+    purpose: str
+    grantee: str
+    granted_at: str
+    expires_at: Optional[str] = None
+    revoked_at: Optional[str] = None
+    revocation_reason: Optional[str] = None
+
+    def is_expired(self, now: Optional[datetime] = None) -> bool:
+        if self.expires_at is None:
+            return False
+        return datetime.fromisoformat(self.expires_at) <= (now or _utcnow())
+
+    def is_active(self, now: Optional[datetime] = None) -> bool:
+        return self.revoked_at is None and not self.is_expired(now)
+
+    def status(self, now: Optional[datetime] = None) -> str:
+        if self.revoked_at is not None:
+            return "revoked"
+        if self.is_expired(now):
+            return "expired"
+        return "active"
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["status"] = self.status()
+        return data
+
+
+def _validate_tier_grantee(tier: int, grantee: str) -> None:
+    if tier == TIER_2:
+        if grantee not in TIER_2_GRANTEES:
+            raise ConsentError(
+                f"Tier 2 grantee must be one of {sorted(TIER_2_GRANTEES)}"
+            )
+    elif tier == TIER_3:
+        if not grantee.startswith(TIER_3_GRANTEE_PREFIX) or len(grantee) <= len(
+            TIER_3_GRANTEE_PREFIX
+        ):
+            raise ConsentError(
+                "Tier 3 grantee must name an explicit project lead "
+                f"('{TIER_3_GRANTEE_PREFIX}<id>')"
+            )
+    else:
+        raise ConsentError("tier must be 2 or 3 (Tier 1 is the default; no grant needed)")
+
+
+class ConsentStore:
+    """Durable, revocable, auditable consent grants."""
+
+    def __init__(self, storage_path: Optional[Path] = None) -> None:
+        self._path = Path(storage_path) if storage_path else DEFAULT_STORE_PATH
+        self._lock = Lock()
+        self._grants: Dict[str, ConsentGrant] = {}
+        self._ledger = self._open_ledger()
+        self._load()
+
+    # -- persistence -------------------------------------------------------
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            raw = json.loads(self._path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            # A corrupt consent file must not silently become "no grants":
+            # that would fail open for Tier 1 aggregates and fail closed for
+            # subjects who did consent. Refuse to start instead.
+            raise ConsentError(f"consent store at {self._path} is unreadable: {exc}")
+        for item in raw.get("grants", []):
+            grant = ConsentGrant(**{k: item.get(k) for k in ConsentGrant.__dataclass_fields__})
+            self._grants[grant.grant_id] = grant
+
+    def _save(self) -> None:
+        payload = {
+            "_meta": {
+                "description": "RD tiered consent grants — state of record (issue #1200)",
+                "audit_channel": "insight_ledger (hr_consent)",
+                "updated_at": _iso(_utcnow()),
+            },
+            "grants": [asdict(g) for g in self._grants.values()],
+        }
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(self._path, payload)
+
+    # -- audit -------------------------------------------------------------
+
+    @staticmethod
+    def _open_ledger():
+        try:
+            from modules.insight_ledger.ledger_core import InsightLedger
+
+            return InsightLedger("hr_consent")
+        except Exception as exc:  # pragma: no cover - environment-dependent
+            logger.warning(
+                "insight_ledger unavailable — consent audit events degrade to "
+                "process logs only: %s",
+                exc,
+            )
+            return None
+
+    def _audit(self, event: str, context: Dict[str, Any], severity: str = "info") -> bool:
+        """Append a consent event to the audit ledger.
+
+        Returns True when the event landed in the hash chain. Callers surface
+        this (``audit_recorded``) instead of pretending audit always worked.
+        """
+        logger.info("consent event %s: %s", event, context)
+        if self._ledger is None:
+            return False
+        try:
+            from modules.insight_ledger.schemas import InsightRecord, InsightType
+
+            self._ledger.record_insight(
+                InsightRecord(
+                    insight_type=InsightType.AUDIT,
+                    content=f"rd-consent {event}",
+                    context=context,
+                    source="hr-consent",
+                    tags=["consent", event],
+                    severity=severity,
+                )
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - ledger runtime failure
+            logger.error("consent audit append failed for %s: %s", event, exc)
+            return False
+
+    # -- operations ---------------------------------------------------------
+
+    def grant(
+        self,
+        subject_id: str,
+        tier: int,
+        data_class: str,
+        purpose: str,
+        grantee: str,
+        expires_in_days: Optional[int] = None,
+    ) -> tuple[ConsentGrant, bool]:
+        _validate_tier_grantee(tier, grantee)
+        with self._lock:
+            existing = self._find_active_locked(subject_id, data_class, purpose, grantee)
+            if existing is not None:
+                raise ConsentError(
+                    f"an active grant already exists ({existing.grant_id}); "
+                    "revoke it before issuing a replacement"
+                )
+            now = _utcnow()
+            grant = ConsentGrant(
+                grant_id=uuid.uuid4().hex[:16],
+                subject_id=subject_id,
+                tier=tier,
+                data_class=data_class,
+                purpose=purpose,
+                grantee=grantee,
+                granted_at=_iso(now),
+                expires_at=_iso(now + timedelta(days=expires_in_days))
+                if expires_in_days
+                else None,
+            )
+            self._grants[grant.grant_id] = grant
+            self._save()
+        audited = self._audit("grant_created", grant.to_dict())
+        return grant, audited
+
+    def revoke(self, grant_id: str, reason: str) -> tuple[ConsentGrant, bool]:
+        with self._lock:
+            grant = self._grants.get(grant_id)
+            if grant is None:
+                raise KeyError(grant_id)
+            if grant.revoked_at is not None:
+                raise ConsentError("grant is already revoked")
+            grant.revoked_at = _iso(_utcnow())
+            grant.revocation_reason = reason
+            self._save()
+        audited = self._audit("grant_revoked", grant.to_dict())
+        return grant, audited
+
+    def get(self, grant_id: str) -> Optional[ConsentGrant]:
+        return self._grants.get(grant_id)
+
+    def list_for_subject(self, subject_id: str) -> List[ConsentGrant]:
+        return [g for g in self._grants.values() if g.subject_id == subject_id]
+
+    def _find_active_locked(
+        self, subject_id: str, data_class: str, purpose: str, grantee: str
+    ) -> Optional[ConsentGrant]:
+        for grant in self._grants.values():
+            if (
+                grant.subject_id == subject_id
+                and grant.data_class == data_class
+                and grant.purpose == purpose
+                and grant.grantee == grantee
+                and grant.is_active()
+            ):
+                return grant
+        return None
+
+    def check_access(
+        self, subject_id: str, data_class: str, purpose: str, grantee: str
+    ) -> Dict[str, Any]:
+        """Access decision for an individual-data read. Denials are audited."""
+        with self._lock:
+            grant = self._find_active_locked(subject_id, data_class, purpose, grantee)
+        if grant is not None:
+            decision = {
+                "allowed": True,
+                "tier": grant.tier,
+                "grant_id": grant.grant_id,
+                "expires_at": grant.expires_at,
+            }
+            decision["audit_recorded"] = self._audit(
+                "access_allowed",
+                {"subject_id": subject_id, "data_class": data_class,
+                 "purpose": purpose, "grantee": grantee, "grant_id": grant.grant_id},
+            )
+            return decision
+        decision = {
+            "allowed": False,
+            "reason": "no active grant for this subject/data_class/purpose/grantee",
+        }
+        decision["audit_recorded"] = self._audit(
+            "access_denied",
+            {"subject_id": subject_id, "data_class": data_class,
+             "purpose": purpose, "grantee": grantee},
+            severity="warning",
+        )
+        return decision
+
+    def aggregate(self) -> Dict[str, Any]:
+        """Tier 1 view: anonymized aggregate of active grants.
+
+        Contains no subject identifiers, grant ids, or grantee ids. Buckets
+        smaller than K_ANONYMITY_THRESHOLD are suppressed so the response
+        cannot be differenced back to individuals.
+        """
+        active = [g for g in self._grants.values() if g.is_active()]
+
+        def _bucketed(counts: Dict[str, int]) -> Dict[str, Any]:
+            out: Dict[str, Any] = {}
+            for key, count in sorted(counts.items()):
+                out[key] = count if count >= K_ANONYMITY_THRESHOLD else f"<{K_ANONYMITY_THRESHOLD}"
+            return out
+
+        by_tier: Dict[str, int] = {}
+        by_data_class: Dict[str, int] = {}
+        for g in active:
+            by_tier[f"tier_{g.tier}"] = by_tier.get(f"tier_{g.tier}", 0) + 1
+            by_data_class[g.data_class] = by_data_class.get(g.data_class, 0) + 1
+
+        return {
+            "tier": 1,
+            "anonymized": True,
+            "k_anonymity_threshold": K_ANONYMITY_THRESHOLD,
+            "total_active_grants": len(active)
+            if len(active) >= K_ANONYMITY_THRESHOLD or len(active) == 0
+            else f"<{K_ANONYMITY_THRESHOLD}",
+            "active_by_tier": _bucketed(by_tier),
+            "active_by_data_class": _bucketed(by_data_class),
+        }

--- a/modules/hr/consent/store.py
+++ b/modules/hr/consent/store.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from dataclasses import dataclass, asdict, field
+from dataclasses import dataclass, asdict, fields
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
@@ -134,7 +134,7 @@ class ConsentStore:
             # subjects who did consent. Refuse to start instead.
             raise ConsentError(f"consent store at {self._path} is unreadable: {exc}")
         for item in raw.get("grants", []):
-            grant = ConsentGrant(**{k: item.get(k) for k in ConsentGrant.__dataclass_fields__})
+            grant = ConsentGrant(**{f.name: item.get(f.name) for f in fields(ConsentGrant)})
             self._grants[grant.grant_id] = grant
 
     def _save(self) -> None:
@@ -171,7 +171,12 @@ class ConsentStore:
         Returns True when the event landed in the hash chain. Callers surface
         this (``audit_recorded``) instead of pretending audit always worked.
         """
-        logger.info("consent event %s: %s", event, context)
+        # Context values include request-supplied strings (subject ids,
+        # purposes); escape newlines so a crafted value cannot forge log lines.
+        safe_context = (
+            json.dumps(context, default=str).replace("\r", "\\r").replace("\n", "\\n")
+        )
+        logger.info("consent event %s: %s", event, safe_context)
         if self._ledger is None:
             return False
         try:
@@ -188,8 +193,8 @@ class ConsentStore:
                 )
             )
             return True
-        except Exception as exc:  # pragma: no cover - ledger runtime failure
-            logger.error("consent audit append failed for %s: %s", event, exc)
+        except Exception:  # pragma: no cover - ledger runtime failure
+            logger.exception("consent audit append failed for %s", event)
             return False
 
     # -- operations ---------------------------------------------------------

--- a/modules/hr/rd_api.py
+++ b/modules/hr/rd_api.py
@@ -612,3 +612,14 @@ def rd_health(request: Request) -> Dict[str, Any]:
         "active_projects": len(pipeline.active_projects),
         "context_tag": "rd_health",
     }
+
+
+# Tiered consent management (issue #1200) — mounted under /rd/consent so the
+# HR module owns the whole /rd surface with a single include in aurora_api.py.
+try:
+    from modules.hr.consent.api import router as consent_router
+    router.include_router(consent_router)
+    CONSENT_AVAILABLE = True
+except Exception as e:  # pragma: no cover - fallback path
+    CONSENT_AVAILABLE = False
+    logger.warning("RD consent surface unavailable: %s", e)

--- a/tests/test_api_router_coverage.py
+++ b/tests/test_api_router_coverage.py
@@ -91,6 +91,14 @@ NOT_MOUNTED_ON_PRIMARY_APP = {
     "generated_api_catalog_snapshot",
 }
 
+# Routers nested inside another router (parent.include_router(child) in the
+# parent's module) rather than included by aurora_api.py directly. They reach
+# the primary app if — and only if — their parent does, so the coverage check
+# credits them when the parent's include_router() call is present.
+NESTED_UNDER = {
+    "rd_consent": "rd_pipeline",  # modules/hr/rd_api.py includes consent_router
+}
+
 
 def _inventory_ids() -> set:
     import json
@@ -140,6 +148,10 @@ def test_every_main_app_router_inventory_entry_is_actually_included() -> None:
 
     symbols = extract_include_router_symbols(AURORA_API_PATH.read_text(encoding="utf-8"))
     mapped_ids = {ROUTER_SYMBOL_TO_INVENTORY_ID[s] for s in symbols if s in ROUTER_SYMBOL_TO_INVENTORY_ID}
+    # Nested routers are covered by their parent's include_router() call.
+    mapped_ids |= {
+        child for child, parent in NESTED_UNDER.items() if parent in mapped_ids
+    }
 
     stale = sorted(main_app_router_ids - mapped_ids)
     assert not stale, (

--- a/tests/test_api_surface_inventory.py
+++ b/tests/test_api_surface_inventory.py
@@ -86,8 +86,13 @@ def test_reconciled_mesh_qgia_pat_and_consent_contracts() -> None:
     assert "Read-only Personal Access Terminal" in pat["notes"]
 
     rd_notes = entries["rd_pipeline"]["notes"]
-    assert "not implemented as an HTTP surface" in rd_notes
+    assert "implemented at /rd/consent" in rd_notes
     assert "#1200" in rd_notes
+
+    consent = entries["rd_consent"]
+    assert consent["mount_path"] == "/rd/consent"
+    assert consent["entrypoint"] == "modules/hr/consent/api.py"
+    assert "insight_ledger" in consent["notes"]
 
 
 def test_governance_review_router_dispositions() -> None:

--- a/tests/test_rd_consent_api.py
+++ b/tests/test_rd_consent_api.py
@@ -1,0 +1,307 @@
+"""
+API tests for tiered RD consent management (issue #1200).
+
+Covers the issue's acceptance criteria explicitly:
+ - grant / denial / revocation / expiry / unauthorized disclosure
+ - consent decisions are persisted (across store reload), revocable, auditable
+ - individual-data reads enforce an explicit current grant
+ - the Tier 1 aggregate response carries no individual identifiers and
+   suppresses small buckets
+
+Follows the tests/test_aumemmanager_api.py pattern: env secrets before
+imports, slowapi stub, a minimal FastAPI app with just the router under
+test, and CSRF bearer tokens from generate_csrf_token.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tests._slowapi_stub import install_slowapi_stub
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-rd-consent-api")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-rd-consent-api")
+install_slowapi_stub()
+
+from modules.hr.consent import api as consent_api  # noqa: E402
+from modules.hr.consent.store import ConsentStore  # noqa: E402
+from src.middleware.fastapi_security import generate_csrf_token  # noqa: E402
+
+
+def _headers(requester: str, role: str = "crew") -> dict:
+    token = generate_csrf_token("test-session")
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-Aurora-Requester": requester,
+        "X-Aurora-Requester-Role": role,
+    }
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    # Isolate both persistence surfaces: the JSON grant store and the
+    # insight_ledger root (which otherwise defaults to cwd/data/ledgers).
+    monkeypatch.setenv("AURORA_LEDGER_PATH", str(tmp_path / "ledgers"))
+    store = ConsentStore(storage_path=tmp_path / "consent_grants.json")
+    monkeypatch.setattr(consent_api, "_store", store)
+
+    app = FastAPI()
+    app.include_router(consent_api.router, prefix="/rd")
+    return TestClient(app)
+
+
+def _create_grant(client, subject="crew_ana", tier=2, grantee="hr", **overrides):
+    body = {
+        "subject_id": subject,
+        "tier": tier,
+        "data_class": "coherence_profile",
+        "purpose": "team_coherence_review",
+        "grantee": grantee,
+    }
+    body.update(overrides)
+    return client.post("/rd/consent/grants", json=body, headers=_headers(subject))
+
+
+def test_grant_create_and_check_allows_access(client):
+    resp = _create_grant(client)
+    assert resp.status_code == 201
+    grant = resp.json()["grant"]
+    assert grant["status"] == "active"
+
+    check = client.get(
+        "/rd/consent/check",
+        params={
+            "subject_id": "crew_ana",
+            "data_class": "coherence_profile",
+            "purpose": "team_coherence_review",
+        },
+        headers=_headers("hr_officer", role="hr"),
+    )
+    assert check.status_code == 200
+    decision = check.json()["decision"]
+    assert decision["allowed"] is True
+    assert decision["grant_id"] == grant["grant_id"]
+
+
+def test_denial_without_grant(client):
+    check = client.get(
+        "/rd/consent/check",
+        params={
+            "subject_id": "crew_ana",
+            "data_class": "coherence_profile",
+            "purpose": "team_coherence_review",
+        },
+        headers=_headers("hr_officer", role="hr"),
+    )
+    assert check.status_code == 200
+    assert check.json()["decision"]["allowed"] is False
+
+
+def test_only_subject_can_create_grant(client):
+    """No automated layer or third party can fabricate consent."""
+    body = {
+        "subject_id": "crew_ana",
+        "tier": 2,
+        "data_class": "coherence_profile",
+        "purpose": "team_coherence_review",
+        "grantee": "hr",
+    }
+    # HR trying to consent on the subject's behalf → 403
+    resp = client.post(
+        "/rd/consent/grants", json=body, headers=_headers("hr_officer", role="hr")
+    )
+    assert resp.status_code == 403
+    # No requester identity at all → 401
+    token = generate_csrf_token("test-session")
+    resp = client.post(
+        "/rd/consent/grants", json=body, headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 401
+
+
+def test_revocation_removes_access(client):
+    grant_id = _create_grant(client).json()["grant"]["grant_id"]
+
+    resp = client.post(
+        f"/rd/consent/grants/{grant_id}/revoke",
+        json={"reason": "withdrawal without penalty"},
+        headers=_headers("crew_ana"),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["grant"]["status"] == "revoked"
+
+    check = client.get(
+        "/rd/consent/check",
+        params={
+            "subject_id": "crew_ana",
+            "data_class": "coherence_profile",
+            "purpose": "team_coherence_review",
+        },
+        headers=_headers("hr_officer", role="hr"),
+    )
+    assert check.json()["decision"]["allowed"] is False
+
+    # Double revocation is rejected, and the record is retained (auditable).
+    resp = client.post(
+        f"/rd/consent/grants/{grant_id}/revoke",
+        json={"reason": "again"},
+        headers=_headers("crew_ana"),
+    )
+    assert resp.status_code == 409
+
+
+def test_third_party_cannot_revoke(client):
+    grant_id = _create_grant(client).json()["grant"]["grant_id"]
+    resp = client.post(
+        f"/rd/consent/grants/{grant_id}/revoke",
+        json={"reason": "not mine to revoke"},
+        headers=_headers("crew_bo", role="crew"),
+    )
+    assert resp.status_code == 403
+
+
+def test_expiry_removes_access(client):
+    grant_resp = _create_grant(client, expires_in_days=1)
+    grant_id = grant_resp.json()["grant"]["grant_id"]
+
+    # Force the stored expiry into the past instead of sleeping.
+    store = consent_api.get_store()
+    stored = store.get(grant_id)
+    stored.expires_at = (
+        datetime.now(timezone.utc) - timedelta(minutes=1)
+    ).isoformat()
+
+    check = client.get(
+        "/rd/consent/check",
+        params={
+            "subject_id": "crew_ana",
+            "data_class": "coherence_profile",
+            "purpose": "team_coherence_review",
+        },
+        headers=_headers("hr_officer", role="hr"),
+    )
+    assert check.json()["decision"]["allowed"] is False
+
+    listing = client.get(
+        "/rd/consent/subjects/crew_ana/grants", headers=_headers("crew_ana")
+    )
+    assert listing.json()["grants"][0]["status"] == "expired"
+
+
+def test_unauthorized_disclosure_blocked(client):
+    """Individual consent records are visible to self and HR only (Tier 2)."""
+    _create_grant(client)
+    grant_id = _create_grant(
+        client, subject="crew_bo", grantee="hr"
+    ).json()["grant"]["grant_id"]
+
+    # Another crew member cannot list someone else's grants...
+    resp = client.get(
+        "/rd/consent/subjects/crew_ana/grants", headers=_headers("crew_bo")
+    )
+    assert resp.status_code == 403
+    # ...or fetch a grant by id (404, not 403 — existence is individual data).
+    resp = client.get(f"/rd/consent/grants/{grant_id}", headers=_headers("crew_ana"))
+    assert resp.status_code == 404
+    # Self and HR can.
+    assert (
+        client.get(f"/rd/consent/grants/{grant_id}", headers=_headers("crew_bo")).status_code
+        == 200
+    )
+    assert (
+        client.get(
+            f"/rd/consent/grants/{grant_id}", headers=_headers("hr_officer", role="hr")
+        ).status_code
+        == 200
+    )
+
+
+def test_tier3_requires_named_project_lead(client):
+    resp = _create_grant(client, tier=3, grantee="project_lead:lead_kim")
+    assert resp.status_code == 201
+
+    # A tier 3 grantee that names nobody is rejected.
+    resp = _create_grant(
+        client, subject="crew_bo", tier=3, grantee="everyone"
+    )
+    assert resp.status_code == 409
+
+    # The named lead gets access; a different lead does not.
+    params = {
+        "subject_id": "crew_ana",
+        "data_class": "coherence_profile",
+        "purpose": "team_coherence_review",
+    }
+    allowed = client.get(
+        "/rd/consent/check", params=params, headers=_headers("lead_kim", role="project_lead")
+    )
+    assert allowed.json()["decision"]["allowed"] is True
+    denied = client.get(
+        "/rd/consent/check", params=params, headers=_headers("lead_rex", role="project_lead")
+    )
+    assert denied.json()["decision"]["allowed"] is False
+
+
+def test_grants_persist_across_store_reload(client, tmp_path):
+    _create_grant(client)
+    path = consent_api.get_store()._path
+
+    reloaded = ConsentStore(storage_path=path)
+    grants = reloaded.list_for_subject("crew_ana")
+    assert len(grants) == 1
+    assert grants[0].is_active()
+
+
+def test_aggregate_is_anonymized_and_suppresses_small_buckets(client):
+    # 2 active grants — below the k=5 threshold, so counts must be suppressed.
+    _create_grant(client)
+    _create_grant(client, subject="crew_bo")
+
+    resp = client.get("/rd/consent/aggregate")
+    assert resp.status_code == 200
+    payload = resp.json()["aggregate"]
+    assert payload["anonymized"] is True
+    assert payload["total_active_grants"] == "<5"
+    assert payload["active_by_tier"].get("tier_2") == "<5"
+
+    # No individual identifiers anywhere in the response.
+    raw = json.dumps(resp.json())
+    assert "crew_ana" not in raw
+    assert "crew_bo" not in raw
+    assert "grant_id" not in raw
+
+
+def test_audit_events_land_in_insight_ledger(client):
+    """Grant + revoke + a denial should appear in the hash-chained ledger."""
+    resp = _create_grant(client)
+    if not resp.json().get("audit_recorded"):
+        pytest.skip("insight_ledger unavailable in this environment")
+    grant_id = resp.json()["grant"]["grant_id"]
+    client.post(
+        f"/rd/consent/grants/{grant_id}/revoke",
+        json={"reason": "test withdrawal"},
+        headers=_headers("crew_ana"),
+    )
+    client.get(
+        "/rd/consent/check",
+        params={
+            "subject_id": "crew_ana",
+            "data_class": "coherence_profile",
+            "purpose": "team_coherence_review",
+        },
+        headers=_headers("hr_officer", role="hr"),
+    )
+
+    ledger = consent_api.get_store()._ledger
+    entries = ledger.query_history()
+    tags = [tag for e in entries for tag in (e.tags or [])]
+    assert "grant_created" in tags
+    assert "grant_revoked" in tags
+    assert "access_denied" in tags
+    integrity = ledger.verify_integrity()
+    assert integrity["chain_intact"] is True
+    assert integrity["failed_entries"] == []


### PR DESCRIPTION
## What

Implements the three-tier Consent Architecture at **`/rd/consent`**, per the Option A design approved by L1 on #1200: grant state of record in `data/hr/consent_grants.json` (atomic writes via `src/utils/atomic_io`), tamper-evident audit history in the **insight_ledger** hash chain (`hr_consent`). Owner: new `modules/hr/consent/` package, nested under the existing `/rd` router so the HR module owns the whole surface with a single include in `aurora_api.py`.

| Endpoint | Access |
|---|---|
| `POST /rd/consent/grants` | subject only (CSRF) — HR and automated layers **cannot** fabricate consent |
| `POST /rd/consent/grants/{id}/revoke` | subject or HR (CSRF); revoked/expired grants retained, never deleted |
| `GET /rd/consent/grants/{id}`, `GET /rd/consent/subjects/{id}/grants` | self or HR (Tier 2 semantics; unauthorized reads get 404/403) |
| `GET /rd/consent/check` | grantee identity derived from requester; every allow **and deny** audited |
| `GET /rd/consent/aggregate` | Tier 1 default — no identifiers, k-anonymity suppression (<5) |

## Acceptance criteria → where satisfied

- **Persisted, revocable, auditable** — atomic JSON store survives reload (tested); revocation + double-revocation tested; grant/revoke/deny events land in the hash-chained ledger with `chain_intact` verified in tests.
- **Individual reads enforce an explicit current grant** — `check_access` requires an active (unrevoked, unexpired) grant matching subject/data_class/purpose/grantee.
- **Aggregate cannot be reversed** — response carries no subject ids/grant ids/grantees; buckets <5 suppressed; test asserts identifier absence in the raw payload.
- **Tests cover grant, denial, revocation, expiry, unauthorized disclosure** — `tests/test_rd_consent_api.py`, 11 tests, all passing locally (full venv: **11 passed**; plus inventory/coverage/app-assembly suite: **24 passed**).
- **`api_surface_inventory.json`** — new `rd_consent` entry; `rd_pipeline` notes updated; the #1204 router-coverage test extended with an explicit `NESTED_UNDER` model for routers reaching the app via a parent.
- **`RD_API_REFERENCE.md` planned → implemented** — v1.2.0, flipped only after runtime tests passed.

## Documented decisions (not silent assumptions)

- **Requester identity is header-asserted** (`X-Aurora-Requester`/`-Role`): the platform has no user-authn layer (`require_auth` is an explicit placeholder), so identity strength is bounded by the platform's. The interim contract is documented in the module docstring and API reference; consent enforcement, CSRF, and ledger audit apply regardless.
- **CSRF uses `require_csrf_token`** (the gumas/insight_ledger/aumemmanager pattern), *not* `rd_api.py`'s `Depends(verify_csrf_token)` — the latter is miswired (FastAPI treats its params as body fields) and is why some `tests/test_rd_api.py` cases fail on main. That pre-existing bug is flagged separately, not fixed here.
- **Audit degradation is visible**: mutations report `audit_recorded` instead of pretending the ledger write always succeeded; a corrupt store file refuses to load rather than silently becoming "no grants".

## Verification

- `pytest tests/test_rd_consent_api.py` → 11 passed.
- `pytest tests/test_rd_consent_api.py tests/test_api_surface_inventory.py tests/test_api_router_coverage.py tests/test_app_assembly.py` → 24 passed.
- Composed `/rd` router exercised end-to-end: aggregate 200 (open), individual read without identity 401, `/rd/health` unaffected.
- Pre-existing failures in `tests/test_rd_api.py`/`tests/test_ethics_integration.py` verified identical on clean main (git stash A/B) — not introduced by this PR.

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)