### PR TITLE
fix(hr): restore CSRF enforcement on R&D pipeline API mutating endpoints

### DIFF
--- a/data/hr/rd_projects_seed.json
+++ b/data/hr/rd_projects_seed.json
@@ -1,0 +1,37 @@
+{
+  "description": "Initial R&D productization pipeline seed projects (Phase 1 - see modules/hr/RD_DIVISION_QUANTUM_EXPANSION.md)",
+  "projects": [
+    {
+      "project_id": "rdp-vsa-encoding",
+      "name": "VSA Personality Encoding Algorithm",
+      "project_type": "algorithm",
+      "lead_researcher": "kai_chen",
+      "team_members": ["priya_sharma", "tobias_qin"],
+      "key_technologies": ["vsa", "quantum-algorithms", "python"]
+    },
+    {
+      "project_id": "rdp-cask-ml",
+      "name": "CASK ML Model Architecture",
+      "project_type": "framework",
+      "lead_researcher": "priya_sharma",
+      "team_members": ["kai_chen"],
+      "key_technologies": ["machine-learning", "cask", "python"]
+    },
+    {
+      "project_id": "rdp-pipeline-api",
+      "name": "Productization Pipeline API",
+      "project_type": "microservice",
+      "lead_researcher": "marcus_webb",
+      "team_members": ["tobias_qin"],
+      "key_technologies": ["fastapi", "python"]
+    },
+    {
+      "project_id": "rdp-nli-tracking",
+      "name": "NLI Pipeline Tracking Integration",
+      "project_type": "module",
+      "lead_researcher": "tobias_qin",
+      "team_members": ["marcus_webb"],
+      "key_technologies": ["nli", "symbolic-linguistics", "python"]
+    }
+  ]
+}

--- a/modules/hr/rd_api.py
+++ b/modules/hr/rd_api.py
@@ -44,15 +44,12 @@ from modules.hr.rd_productization import (
 
 # Aurora security + rate limiting (guard optional import failures gracefully)
 try:
-    from src.middleware.fastapi_security import security, verify_csrf_token, limiter
+    from src.middleware.fastapi_security import require_csrf_token, limiter
     SECURITY_AVAILABLE = True
 except Exception:  # pragma: no cover - fallback path
     SECURITY_AVAILABLE = False
-    class DummySec:  # minimal placeholder
-        pass
-    security = DummySec()  # type: ignore
-    def verify_csrf_token(*args, **kwargs):  # type: ignore
-        return True
+    def require_csrf_token() -> None:  # type: ignore
+        return None
     class DummyLimiter:  # minimal placeholder
         @staticmethod
         def limit(limit_str: str):
@@ -255,7 +252,7 @@ def list_projects(request: Request) -> Dict[str, Any]:
     }
 
 
-@router.post("/projects", dependencies=[Depends(security), Depends(verify_csrf_token)] if SECURITY_AVAILABLE else [])
+@router.post("/projects", dependencies=[Depends(require_csrf_token)] if SECURITY_AVAILABLE else [])
 @limiter.limit("30/minute")
 def create_project(request: Request, body: CreateProjectRequest) -> Dict[str, Any]:
     """Create new R&D project with DLP tracking."""
@@ -280,7 +277,7 @@ def create_project(request: Request, body: CreateProjectRequest) -> Dict[str, An
 
 @router.post(
     "/projects/{project_id}/advance",
-    dependencies=[Depends(security), Depends(verify_csrf_token)] if SECURITY_AVAILABLE else []
+    dependencies=[Depends(require_csrf_token)] if SECURITY_AVAILABLE else []
 )
 @limiter.limit("30/minute")
 def advance_stage(request: Request, project_id: str, body: AdvanceStageRequest) -> Dict[str, Any]:
@@ -299,7 +296,7 @@ def advance_stage(request: Request, project_id: str, body: AdvanceStageRequest) 
 
 @router.post(
     "/projects/{project_id}/readiness",
-    dependencies=[Depends(security), Depends(verify_csrf_token)] if SECURITY_AVAILABLE else []
+    dependencies=[Depends(require_csrf_token)] if SECURITY_AVAILABLE else []
 )
 @limiter.limit("45/minute")
 def update_readiness(request: Request, project_id: str, body: ReadinessRequest) -> Dict[str, Any]:
@@ -356,7 +353,7 @@ def update_readiness(request: Request, project_id: str, body: ReadinessRequest) 
 
 @router.post(
     "/projects/{project_id}/coherence",
-    dependencies=[Depends(security), Depends(verify_csrf_token)] if SECURITY_AVAILABLE else []
+    dependencies=[Depends(require_csrf_token)] if SECURITY_AVAILABLE else []
 )
 @limiter.limit("45/minute")
 def update_coherence(request: Request, project_id: str, body: CoherenceRequest):

--- a/scripts/generate_api_catalog.py
+++ b/scripts/generate_api_catalog.py
@@ -21,29 +21,38 @@ from pathlib import Path
 # Assemble the app with process-local generation fixtures. These values exist
 # only for this process, are never serialized, and avoid reading operator
 # credentials while preserving security/monitoring routes in the OpenAPI tree.
-for env_name in (
-    "CSRF_SECRET_KEY",
-    "WS_AUTH_SECRET",
-    "JWT_SECRET_KEY",
-    "MONITORING_SIGNING_KEY",
+# Skipped when the core secrets are already configured (e.g. under pytest,
+# where conftest.py provides session-wide values): overwriting CSRF_SECRET_KEY
+# at import time desyncs tokens minted via fastapi_security's module constant
+# from the secret GlobalCsrfMiddleware binds at the app's first request,
+# breaking every token-authenticated endpoint test collected after this module.
+if not all(
+    os.environ.get(name)
+    for name in ("CSRF_SECRET_KEY", "WS_AUTH_SECRET", "JWT_SECRET_KEY")
 ):
-    os.environ[env_name] = secrets.token_hex(32)
+    for env_name in (
+        "CSRF_SECRET_KEY",
+        "WS_AUTH_SECRET",
+        "JWT_SECRET_KEY",
+        "MONITORING_SIGNING_KEY",
+    ):
+        os.environ[env_name] = secrets.token_hex(32)
 
-os.environ["AURORA_ENV"] = "test"
-os.environ["AURORA_ALLOW_DEV_AUTH_FIXTURE"] = "true"
-for role in ("ADMIN", "OPERATOR", "OBSERVER"):
-    os.environ[f"AURORA_DEV_{role}_PASSWORD"] = secrets.token_urlsafe(32)
+    os.environ["AURORA_ENV"] = "test"
+    os.environ["AURORA_ALLOW_DEV_AUTH_FIXTURE"] = "true"
+    for role in ("ADMIN", "OPERATOR", "OBSERVER"):
+        os.environ[f"AURORA_DEV_{role}_PASSWORD"] = secrets.token_urlsafe(32)
 
-for credential_name in (
-    "ANTHROPIC_API_KEY",
-    "GEMINI_API_KEY",
-    "GOOGLE_API_KEY",
-    "OPENAI_ADMIN_KEY",
-    "OPENAI_API_KEY",
-):
-    os.environ.pop(credential_name, None)
-os.environ.pop("AURORA_AUTH_USERS_FILE", None)
-os.environ.pop("AURORA_AUTH_USERS_JSON", None)
+    for credential_name in (
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_ADMIN_KEY",
+        "OPENAI_API_KEY",
+    ):
+        os.environ.pop(credential_name, None)
+    os.environ.pop("AURORA_AUTH_USERS_FILE", None)
+    os.environ.pop("AURORA_AUTH_USERS_JSON", None)
 
 # Add project root to path
 project_root = Path(__file__).parent.parent

--- a/tests/test_ethics_integration.py
+++ b/tests/test_ethics_integration.py
@@ -6,23 +6,16 @@ Validates that inquiry-first patterns are properly implemented.
 from fastapi.testclient import TestClient
 
 from api.aurora_api import app
-from modules.hr.rd_api import security, verify_csrf_token
-
-
-def override_security():
-    """Mock security dependency."""
-    return {"sub": "test_user"}
-
-
-def override_csrf():
-    """Mock CSRF verification."""
-    return True
-
-
-app.dependency_overrides[security] = override_security
-app.dependency_overrides[verify_csrf_token] = override_csrf
+from src.middleware.fastapi_security import generate_csrf_token
 
 client = TestClient(app)
+
+
+def _auth_headers() -> dict:
+    # GlobalCsrfMiddleware checks X-CSRF-Token on unsafe methods; the
+    # require_csrf_token route dependency reads the bearer credentials.
+    token = generate_csrf_token("ethics-test-session")
+    return {"Authorization": f"Bearer {token}", "X-CSRF-Token": token}
 
 
 def test_full_coherence_has_ethics_context():
@@ -61,23 +54,23 @@ def test_mediation_has_inquiry_prompts():
 def test_readiness_has_inquiry_prompts():
     """Verify readiness endpoint includes contextual questions."""
     # Create test project first
-    client.post("/rd/projects", json={"body": {
+    client.post("/rd/projects", json={
         "project_id": "ethics-test-001",
         "name": "Ethics Test Project",
         "project_type": "module",
         "lead_researcher": "test_lead",
         "team_members": [],
         "key_technologies": []
-    }})
-    
+    }, headers=_auth_headers())
+
     # Update readiness
-    response = client.post("/rd/projects/ethics-test-001/readiness", json={"body": {
+    response = client.post("/rd/projects/ethics-test-001/readiness", json={
         "code_quality": 0.9,
         "documentation": 0.85,
         "test_coverage": 0.88,
         "performance": 0.82,
         "security": 0.91
-    }})
+    }, headers=_auth_headers())
     
     assert response.status_code == 200
     data = response.json()
@@ -90,22 +83,22 @@ def test_readiness_has_inquiry_prompts():
 def test_coherence_has_ethics_guidance():
     """Verify team coherence includes interpretive guidance."""
     # Create test project first
-    client.post("/rd/projects", json={"body": {
+    client.post("/rd/projects", json={
         "project_id": "ethics-test-002",
         "name": "Ethics Test Project 2",
         "project_type": "tool",
         "lead_researcher": "test_lead",
         "team_members": ["member_a", "member_b"],
         "key_technologies": []
-    }})
-    
+    }, headers=_auth_headers())
+
     # Update coherence
-    response = client.post("/rd/projects/ethics-test-002/coherence", json={"body": {
+    response = client.post("/rd/projects/ethics-test-002/coherence", json={
         "team_vectors": {
             "member_a": [0.5, 0.5, 0.5],
             "member_b": [0.52, 0.48, 0.51]
         }
-    }})
+    }, headers=_auth_headers())
     
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_rd_api.py
+++ b/tests/test_rd_api.py
@@ -1,45 +1,16 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from api.aurora_api import app
+from src.middleware.fastapi_security import generate_csrf_token
 
-# Mock security dependencies for testing
-from src.middleware.fastapi_security import security, verify_csrf_token
-
-
-def override_security():
-    """Mock security dependency - always allow access in tests."""
-    return {"sub": "test_user"}
-
-
-def override_csrf():
-    """Mock CSRF verification - always pass in tests."""
-    return True
-
-
-@pytest.fixture(autouse=True)
-def setup_security_overrides():
-    """Set up security overrides for each test and clean up after."""
-    # Set overrides before each test
-    app.dependency_overrides[security] = override_security
-    app.dependency_overrides[verify_csrf_token] = override_csrf
-    yield
-    # Clean up after each test (though they need to stay for this module)
-
-
-# Create client after overrides are set
-@pytest.fixture
-def rd_client():
-    """Provide a test client with security overrides."""
-    app.dependency_overrides[security] = override_security
-    app.dependency_overrides[verify_csrf_token] = override_csrf
-    return TestClient(app)
-
-
-# For backward compatibility with existing tests
 client = TestClient(app)
-app.dependency_overrides[security] = override_security
-app.dependency_overrides[verify_csrf_token] = override_csrf
+
+
+def _auth_headers() -> dict:
+    # GlobalCsrfMiddleware checks X-CSRF-Token on unsafe methods; the
+    # require_csrf_token route dependency reads the bearer credentials.
+    token = generate_csrf_token("rd-api-test-session")
+    return {"Authorization": f"Bearer {token}", "X-CSRF-Token": token}
 
 
 def test_rd_health():
@@ -68,12 +39,12 @@ def test_create_and_advance_project():
         "team_members": ["alpha", "beta"],
         "key_technologies": ["python"],
     }
-    # Creation - FastAPI embeds body when Request parameter present
-    r_create = client.post("/rd/projects", json={"body": payload})
+    r_create = client.post("/rd/projects", json=payload, headers=_auth_headers())
     assert r_create.status_code == 200, r_create.text
     r_adv = client.post(
         "/rd/projects/rdp-test-api/advance",
-        json={"body": {"new_stage": "proof_of_concept", "milestone": "Initial POC"}},
+        json={"new_stage": "proof_of_concept", "milestone": "Initial POC"},
+        headers=_auth_headers(),
     )
     assert r_adv.status_code == 200, r_adv.text
     data = r_adv.json()
@@ -81,45 +52,63 @@ def test_create_and_advance_project():
 
 
 def test_update_readiness_and_coherence():
-    # Ensure project exists - embedded body format
+    # Ensure project exists
     client.post(
         "/rd/projects",
-        json={"body": {
+        json={
             "project_id": "rdp-readiness",
             "name": "Readiness Project",
             "project_type": "module",
             "lead_researcher": "lead_x",
             "team_members": ["member_a", "member_b"],
             "key_technologies": ["fastapi"],
-        }},
+        },
+        headers=_auth_headers(),
     )
     r_ready = client.post(
         "/rd/projects/rdp-readiness/readiness",
-        json={"body": {
+        json={
             "code_quality": 0.9,
             "documentation": 0.8,
             "test_coverage": 0.85,
             "performance": 0.75,
             "security": 0.88,
-        }},
+        },
+        headers=_auth_headers(),
     )
-    assert r_ready.status_code == 200
+    assert r_ready.status_code == 200, r_ready.text
     readiness_score = r_ready.json()["production_readiness"]
     assert 0.0 <= readiness_score <= 1.0
 
     r_coh = client.post(
         "/rd/projects/rdp-readiness/coherence",
-        json={"body": {
+        json={
             "team_vectors": {
                 "lead_x": [0.2, 0.3, 0.5],
                 "member_a": [0.21, 0.29, 0.52],
                 "member_b": [0.19, 0.31, 0.49],
             }
-        }},
+        },
+        headers=_auth_headers(),
     )
-    assert r_coh.status_code == 200
+    assert r_coh.status_code == 200, r_coh.text
     coherence = r_coh.json()["team_coherence"]
     assert 0.0 <= coherence <= 1.0
+
+
+def test_mutating_endpoint_requires_csrf_token():
+    r = client.post(
+        "/rd/projects",
+        json={
+            "project_id": "rdp-no-token",
+            "name": "No Token Project",
+            "project_type": "tool",
+            "lead_researcher": "lead_y",
+            "team_members": [],
+            "key_technologies": [],
+        },
+    )
+    assert r.status_code == 403
 
 
 def test_pipeline_report():


### PR DESCRIPTION
## Problem

`modules/hr/rd_api.py` guarded its POST endpoints with `dependencies=[Depends(security), Depends(verify_csrf_token)]`. `verify_csrf_token(token, session_id)` has no `Depends(security)` default on its parameters, so FastAPI treated them as request-body fields: every POST under `/rd` returned **422 demanding phantom `token`/`body` fields**, and the tests had to wrap payloads in `{"body": ...}` to compensate. `tests/test_rd_api.py` (`test_list_seed_projects`, `test_create_and_advance_project`, `test_update_readiness_and_coherence`) and two `tests/test_ethics_integration.py` tests fail on `main`.

## Fix

- **`modules/hr/rd_api.py`** — use the repo-standard `Depends(require_csrf_token)` on all four mutating endpoints (same pattern as `modules/gumas/api/routes.py`, `modules/insight_ledger/api.py`, `modules/aumemmanager/api_integration.py`). The `SECURITY_AVAILABLE` fallback is kept as a no-arg stub.
- **`data/hr/rd_projects_seed.json`** (new, force-added past the `data/` ignore like `l1_roster_vsa.json`) — the seed file referenced by the module docstring never existed, so `test_list_seed_projects` asserted `count >= 1` against an empty pipeline. Seeds the 4 Phase-1 projects from `RD_DIVISION_QUANTUM_EXPANSION.md`.
- **`tests/test_rd_api.py`, `tests/test_ethics_integration.py`** — switched to the canonical `generate_csrf_token` header pattern (`Authorization: Bearer` + `X-CSRF-Token`, as in `test_gumas_api.py`) instead of dependency overrides, unwrapped the `{"body": ...}` payloads, and added a 403 regression test for tokenless mutation.
- **`scripts/generate_api_catalog.py`** — importing it under pytest (via `tests/test_generate_api_catalog.py`) overwrote `CSRF_SECRET_KEY` & friends with random values at collection time. Tokens are minted from the secret `fastapi_security` binds at import, while `GlobalCsrfMiddleware` reads the env lazily at the app's first request, so the overwrite 403'd every token-authenticated endpoint test collected after it. The generation fixtures are now skipped when the core secrets are already configured. This also fixes pre-existing full-run failures in `test_gumas_api` (2), `test_quantum_simulator` (1), and `test_conftest_env_isolation` (1).

## Verification

- `pytest tests/test_rd_api.py tests/test_ethics_integration.py tests/test_generate_api_catalog.py tests/test_rd_productization.py tests/test_rd_full_coherence.py` → **18 passed**.
- Broad filtered sweep (`-k "rd or router or aurora_api or openapi or coverage or csrf or security"`, 539 selected): **15 failures on main → 9 on this branch**, and the remaining 9 (redis-dependent synergy dashboards, `test_playground_auth`, `test_aumemmanager_api` slowapi issue, `test_insight_ledger_security` path test) all reproduce on `main` unchanged — no new failures.
- `flake8 --select=E9,F63,F7,F82` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)