### PR TITLE
feat: NEMO inference integration — MCP router, QF, OPPY, HR (#1061)

### DIFF
--- a/api/aurora_gui_cloudhub_fastapi.py
+++ b/api/aurora_gui_cloudhub_fastapi.py
@@ -1342,9 +1342,16 @@ async def websocket_collaboration_endpoint(websocket: WebSocket):
     summary="Plan Navigation Maneuver",
     response_description="Navigation plan with risk assessment",
     tags=["oppy"],
-    dependencies=[Depends(security)]
+    dependencies=[Depends(security)],
+    responses={
+        422: {"description": "Neither maneuver_type nor audio_bytes provided"},
+        503: {"description": "OPPY Navigator unavailable, or audio given but NEMO ASR down with no textual maneuver_type"},
+    },
 )
-def oppy_plan_maneuver(req: OPPYManeuverRequest, token: HTTPAuthorizationCredentials = Depends(security)):
+def oppy_plan_maneuver(
+    req: OPPYManeuverRequest,
+    token: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+):
     """
     Plan a navigation maneuver for a vessel using OPPY Navigator.
 
@@ -1541,8 +1548,8 @@ def oppy_get_state(vessel_id: str):
 )
 def hr_assess_psychological_safety(
     req: HRPsychSafetyRequest,
+    token: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     include_narrative: bool = False,
-    token: HTTPAuthorizationCredentials = Depends(security),
 ):
     """
     Assess psychological safety level for a team member.
@@ -1587,8 +1594,8 @@ def hr_assess_psychological_safety(
 )
 def hr_detect_conflict(
     req: HRConflictRequest,
+    token: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     include_narrative: bool = False,
-    token: HTTPAuthorizationCredentials = Depends(security),
 ):
     """
     Detect and track organizational conflicts with AI-powered analysis.
@@ -1700,8 +1707,8 @@ def hr_initiate_onboarding(req: HROnboardingRequest, token: HTTPAuthorizationCre
 )
 def hr_cultural_health(
     req: HRCulturalHealthRequest,
+    token: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     include_narrative: bool = False,
-    token: HTTPAuthorizationCredentials = Depends(security),
 ):
     """
     Assess cultural health for a specific organizational layer.

--- a/api/aurora_gui_cloudhub_fastapi.py
+++ b/api/aurora_gui_cloudhub_fastapi.py
@@ -71,6 +71,15 @@ except ImportError:
     AerSimulator = None
     QISKIT_AVAILABLE = False
 
+# NEMO inference client (issue #1061) — every call site degrades gracefully
+# when the service or the client package is unavailable.
+try:
+    from services.nemo_service.client import get_nemo_client, close_nemo_client
+    NEMO_CLIENT_AVAILABLE = True
+except Exception:
+    NEMO_CLIENT_AVAILABLE = False
+    _early_logger.warning("NEMO client not available — NEMO integrations disabled")
+
 MODULE_DIR = Path(__file__).resolve().parent
 REPO_ROOT = MODULE_DIR.parent if MODULE_DIR.name == "api" else MODULE_DIR
 STATIC_DIR = REPO_ROOT / "static"
@@ -514,6 +523,68 @@ async def startup_event():
 @app.on_event("shutdown")
 async def shutdown_event():
     logger.info("Aurora Cloud GUI FastAPI service shutting down...")
+    if NEMO_CLIENT_AVAILABLE:
+        close_nemo_client()
+
+
+# === NEMO integration helpers (issue #1061) ===
+# Each helper returns None on ANY failure — service down, client missing,
+# or NEMO answering with its own "model not loaded" mock payload (which
+# carries no usable field). Callers fall back to their pre-NEMO behavior.
+
+def _nemo_nlu_intent(agent_id: str, capabilities: List[str]) -> Optional[str]:
+    """Classify agent capabilities into a semantically grounded intent."""
+    if not NEMO_CLIENT_AVAILABLE:
+        return None
+    response = get_nemo_client().infer(
+        model_type="nlu",
+        text=f"Classify agent intent for {agent_id} with capabilities: "
+             f"{', '.join(capabilities)}",
+        context={"anchor": "T1:QF_AGENT_CREATE", "source": "qf_create_agent"},
+    )
+    if not response:
+        return None
+    intent = (response.get("result") or {}).get("intent")
+    if isinstance(intent, list):
+        intent = intent[0] if intent else None
+    return intent if isinstance(intent, str) and intent.strip() else None
+
+
+def _nemo_transcribe(audio_bytes: str) -> Optional[str]:
+    """Transcribe base64 audio via NEMO ASR."""
+    if not NEMO_CLIENT_AVAILABLE:
+        return None
+    response = get_nemo_client().infer(
+        model_type="asr",
+        audio_bytes=audio_bytes,
+        context={"anchor": "T1:OPPY_PLAN", "source": "oppy_plan_maneuver"},
+    )
+    if not response:
+        return None
+    transcript = (response.get("result") or {}).get("transcript")
+    if isinstance(transcript, list):
+        transcript = transcript[0] if transcript else None
+    return transcript if isinstance(transcript, str) and transcript.strip() else None
+
+
+def _nemo_narrative(context_tag: str, payload: Dict[str, Any]) -> Optional[str]:
+    """Generate a natural-language narrative for a structured HR result."""
+    if not NEMO_CLIENT_AVAILABLE:
+        return None
+    prompt = (
+        "Write a brief, professional narrative summary of this Aurora HR "
+        f"assessment ({context_tag}). Respect data dignity: describe, do not "
+        f"judge. Structured result: {json.dumps(payload, default=str)[:2000]}"
+    )
+    response = get_nemo_client().generate(
+        prompt,
+        context={"anchor": "T1:HR_NARRATIVE", "source": context_tag},
+        max_tokens=256,
+    )
+    if not response:
+        return None
+    text = response.get("generated_text")
+    return text if isinstance(text, str) and text.strip() else None
 
 
 class GeometricProductRequest(BaseModel):
@@ -529,7 +600,12 @@ class QuantumSymbolicVectorRequest(BaseModel):
 # === OPPY Navigator Models ===
 class OPPYManeuverRequest(BaseModel):
     vessel_id: str
-    maneuver_type: str
+    # maneuver_type became optional with the NEMO ASR path (issue #1061):
+    # callers supply either a textual maneuver_type (legacy, unchanged) or
+    # base64 audio_bytes to be transcribed into one. At least one required —
+    # enforced in the endpoint so the error is a clear 422 with detail.
+    maneuver_type: Optional[str] = None
+    audio_bytes: Optional[str] = None
     target_state: Dict[str, float]
 
 
@@ -846,7 +922,9 @@ def mcp_route_command(
     """
     mcp_security.validate_anchor(anchor)
     router = MCPCommandRouter()
-    return router.route(command)
+    # anchor is forwarded so external routes (NEMO_GENERATE, issue #1061)
+    # can preserve chain notation end-to-end.
+    return router.route(command, anchor=anchor)
 
 
 @app.post(  # verify_csrf inside
@@ -1279,9 +1357,30 @@ def oppy_plan_maneuver(req: OPPYManeuverRequest, token: HTTPAuthorizationCredent
     if not OPPY_AVAILABLE:
         raise HTTPException(status_code=503, detail="OPPY Navigator not available")
 
+    # NEMO ASR path (issue #1061): transcribe spoken instruction into the
+    # maneuver type. Text-only requests take the unchanged legacy path.
+    maneuver_type = req.maneuver_type
+    maneuver_source = "text"
+    if req.audio_bytes:
+        transcript = _nemo_transcribe(req.audio_bytes)
+        if transcript:
+            maneuver_type = transcript
+            maneuver_source = "nemo_asr"
+        elif not maneuver_type:
+            raise HTTPException(
+                status_code=503,
+                detail="Audio transcription unavailable (NEMO ASR down) and no "
+                       "textual maneuver_type was provided",
+            )
+    if not maneuver_type:
+        raise HTTPException(
+            status_code=422,
+            detail="Provide maneuver_type or audio_bytes",
+        )
+
     try:
         navigator = OPPYNavigator(vessel_id=req.vessel_id)
-        plan = navigator.plan_maneuver(req.maneuver_type, req.target_state)
+        plan = navigator.plan_maneuver(maneuver_type, req.target_state)
 
         return {
             "status": "success",
@@ -1295,6 +1394,7 @@ def oppy_plan_maneuver(req: OPPYManeuverRequest, token: HTTPAuthorizationCredent
                 "anchor_impact": plan.anchor_impact,
                 "risk_assessment": plan.risk_assessment,
             },
+            "maneuver_source": maneuver_source,
             "context_tag": "oppy_plan_maneuver",
             "anchor": "T1:OPPY_PLAN"
         }
@@ -1439,7 +1539,11 @@ def oppy_get_state(vessel_id: str):
     tags=["hr"],
     dependencies=[Depends(security)]
 )
-def hr_assess_psychological_safety(req: HRPsychSafetyRequest, token: HTTPAuthorizationCredentials = Depends(security)):
+def hr_assess_psychological_safety(
+    req: HRPsychSafetyRequest,
+    include_narrative: bool = False,
+    token: HTTPAuthorizationCredentials = Depends(security),
+):
     """
     Assess psychological safety level for a team member.
 
@@ -1457,13 +1561,18 @@ def hr_assess_psychological_safety(req: HRPsychSafetyRequest, token: HTTPAuthori
         hr_module = AuroraHRModule()
         assessment = hr_module.assess_psychological_safety(req.member_name)
 
-        return {
+        response = {
             "status": "success",
             "assessment": assessment,
             "context_tag": "hr_psych_safety",
             "anchor": "T1:HR_SAFETY",
             "ethics_protocol": "Picard_Delta_3"
         }
+        if include_narrative:
+            # NEMO narrative (issue #1061): additive and best-effort — a
+            # generation failure never fails the assessment itself.
+            response["narrative"] = _nemo_narrative("hr_psych_safety", assessment)
+        return response
     except Exception as e:
         logger.error("HR assess psychological safety error: %s", str(e)[:200])
         raise HTTPException(status_code=500, detail=f"Failed to assess safety: {str(e)[:100]}")
@@ -1476,7 +1585,11 @@ def hr_assess_psychological_safety(req: HRPsychSafetyRequest, token: HTTPAuthori
     tags=["hr"],
     dependencies=[Depends(security)]
 )
-def hr_detect_conflict(req: HRConflictRequest, token: HTTPAuthorizationCredentials = Depends(security)):
+def hr_detect_conflict(
+    req: HRConflictRequest,
+    include_narrative: bool = False,
+    token: HTTPAuthorizationCredentials = Depends(security),
+):
     """
     Detect and track organizational conflicts with AI-powered analysis.
 
@@ -1495,7 +1608,7 @@ def hr_detect_conflict(req: HRConflictRequest, token: HTTPAuthorizationCredentia
         conflict = hr_module.detect_conflict(req.indicators)
 
         if conflict:
-            return {
+            response = {
                 "status": "success",
                 "conflict_detected": True,
                 "conflict": {
@@ -1510,12 +1623,18 @@ def hr_detect_conflict(req: HRConflictRequest, token: HTTPAuthorizationCredentia
                 "ethics_protocol": "Picard_Delta_3"
             }
         else:
-            return {
+            response = {
                 "status": "success",
                 "conflict_detected": False,
                 "context_tag": "hr_conflict_detect",
                 "anchor": "T1:HR_CONFLICT"
             }
+        if include_narrative:
+            # NEMO narrative (issue #1061): additive, never fails the endpoint.
+            response["narrative"] = _nemo_narrative(
+                "hr_conflict_detect", response.get("conflict", {"conflict_detected": False})
+            )
+        return response
     except Exception as e:
         logger.error("HR detect conflict error: %s", str(e)[:200])
         raise HTTPException(status_code=500, detail=f"Failed to detect conflict: {str(e)[:100]}")
@@ -1579,7 +1698,11 @@ def hr_initiate_onboarding(req: HROnboardingRequest, token: HTTPAuthorizationCre
     tags=["hr"],
     dependencies=[Depends(security)]
 )
-def hr_cultural_health(req: HRCulturalHealthRequest, token: HTTPAuthorizationCredentials = Depends(security)):
+def hr_cultural_health(
+    req: HRCulturalHealthRequest,
+    include_narrative: bool = False,
+    token: HTTPAuthorizationCredentials = Depends(security),
+):
     """
     Assess cultural health for a specific organizational layer.
 
@@ -1605,7 +1728,7 @@ def hr_cultural_health(req: HRCulturalHealthRequest, token: HTTPAuthorizationCre
         hr_module = AuroraHRModule()
         report = hr_module.assess_cultural_health(layer)
 
-        return {
+        response = {
             "status": "success",
             "report": {
                 "report_id": report.report_id,
@@ -1622,6 +1745,10 @@ def hr_cultural_health(req: HRCulturalHealthRequest, token: HTTPAuthorizationCre
             "anchor": "T1:HR_CULTURE",
             "ethics_protocol": "Picard_Delta_3"
         }
+        if include_narrative:
+            # NEMO narrative (issue #1061): additive, never fails the endpoint.
+            response["narrative"] = _nemo_narrative("hr_cultural_health", response["report"])
+        return response
     except Exception as e:
         logger.error("HR cultural health error: %s", str(e)[:200])
         raise HTTPException(status_code=500, detail=f"Failed to assess cultural health: {str(e)[:100]}")
@@ -1673,17 +1800,27 @@ def qf_create_agent(req: QFCreateAgentRequest, token: HTTPAuthorizationCredentia
         forge = QuantumForge(ethics_level=ethics_level, flowstate_mode=flowstate_mode)
 
         # Actual API: generate_agent(intent_query, constellation_targets, metadata)
-        # Create intent from agent_id and capabilities
-        # Secure construction of intent_query (avoid direct f-string interpolation of arbitrary capability text)
+        # NEMO NLU path (issue #1061): derive a semantically grounded intent
+        # from the capabilities; fall back to the legacy string construction
+        # when NEMO is unavailable or returns no usable classification.
         sanitized_caps = [c.replace("'", "").replace(";", "") for c in req.capabilities]
-        intent_query = "Generate agent {} with capabilities: {}".format(
-            req.agent_id,
-            ", ".join(sanitized_caps)
-        )
+        nlu_intent = _nemo_nlu_intent(req.agent_id, sanitized_caps)
+        if nlu_intent:
+            intent_query = nlu_intent
+            intent_source = "nemo_nlu"
+        else:
+            # Secure construction of intent_query (avoid direct f-string
+            # interpolation of arbitrary capability text)
+            intent_query = "Generate agent {} with capabilities: {}".format(
+                req.agent_id,
+                ", ".join(sanitized_caps)
+            )
+            intent_source = "string_construction"
         metadata = {
             "agent_id": req.agent_id,
             "capabilities": req.capabilities,
-            "symbolic_depth": req.symbolic_depth
+            "symbolic_depth": req.symbolic_depth,
+            "intent_source": intent_source,
         }
 
         agent = forge.generate_agent(
@@ -1708,7 +1845,10 @@ def qf_create_agent(req: QFCreateAgentRequest, token: HTTPAuthorizationCredentia
             },
             "context_tag": "qf_create_agent",
             "anchor": "T1:QF_AGENT_CREATE",
-            "ethics_protocol": "GUMAS_Thermax"
+            "ethics_protocol": "GUMAS_Thermax",
+            # intent_alignment above reflects the NLU-enhanced intent when
+            # intent_source == "nemo_nlu" (issue #1061 acceptance criterion)
+            "intent_source": intent_source,
         }
     except Exception as e:
         logger.error("Quantum Forge create agent error: %s", str(e)[:200])

--- a/k8s/aurora-configmap-secrets.yaml
+++ b/k8s/aurora-configmap-secrets.yaml
@@ -258,4 +258,10 @@ data:
   METRICS_ENABLED: "true"
   METRICS_PORT: "9090"
   TRACING_ENABLED: "false"
+
+  # NEMO inference service (issue #1061) — in-cluster service DNS consumed
+  # by services/nemo_service/client.py. NEMO_TIMEOUT_S bounds each call so
+  # CloudHub's sync handlers fall back fast when the NEMO pod is down.
+  NEMO_SERVICE_URL: "http://aurora-nemo-service:8090"
+  NEMO_TIMEOUT_S: "10"
   TRACING_ENDPOINT: "http://jaeger-collector:14268/api/traces"

--- a/k8s/aurora-configmap-secrets.yaml
+++ b/k8s/aurora-configmap-secrets.yaml
@@ -262,6 +262,8 @@ data:
   # NEMO inference service (issue #1061) — in-cluster service DNS consumed
   # by services/nemo_service/client.py. NEMO_TIMEOUT_S bounds each call so
   # CloudHub's sync handlers fall back fast when the NEMO pod is down.
-  NEMO_SERVICE_URL: "http://aurora-nemo-service:8090"
+  # Plain HTTP is deliberate: pod-to-pod traffic on the cluster network,
+  # matching the NEMO service manifest (no mesh/mTLS in this deployment).
+  NEMO_SERVICE_URL: "http://aurora-nemo-service:8090"  # NOSONAR(S5332) in-cluster DNS
   NEMO_TIMEOUT_S: "10"
   TRACING_ENDPOINT: "http://jaeger-collector:14268/api/traces"

--- a/modules/symbolic_core/mcp_bridge_core.json
+++ b/modules/symbolic_core/mcp_bridge_core.json
@@ -20,17 +20,31 @@
   },
   "security_validation_rules": {
     "drift_lock": {
-      "valid_states": ["ACTIVE", "INACTIVE"],
+      "valid_states": [
+        "ACTIVE",
+        "INACTIVE"
+      ],
       "required_state": "ACTIVE",
       "description": "Drift lock must be ACTIVE to prevent configuration drift"
     },
     "guardian_ring": {
-      "valid_states": ["ACTIVE", "STAGED_ACTIVE", "INACTIVE"],
-      "required_states": ["ACTIVE", "STAGED_ACTIVE"],
+      "valid_states": [
+        "ACTIVE",
+        "STAGED_ACTIVE",
+        "INACTIVE"
+      ],
+      "required_states": [
+        "ACTIVE",
+        "STAGED_ACTIVE"
+      ],
       "description": "Guardian ring must be ACTIVE or STAGED_ACTIVE for security"
     },
     "ethics_lock": {
-      "valid_states": ["ENFORCED", "STAGED", "DISABLED"],
+      "valid_states": [
+        "ENFORCED",
+        "STAGED",
+        "DISABLED"
+      ],
       "required_state": "ENFORCED",
       "description": "Ethics lock must be ENFORCED for ethical compliance"
     }
@@ -41,44 +55,81 @@
       "type": "gpt_parallel_node",
       "status": "ACTIVE",
       "security_level": "HIGH",
-      "capabilities": ["symbolic_routing", "anchor_validation"]
+      "capabilities": [
+        "symbolic_routing",
+        "anchor_validation"
+      ]
     },
     "ARCHY": {
       "id": "ARCHY",
       "type": "gpt_parallel_node",
       "status": "ACTIVE",
       "security_level": "HIGH",
-      "capabilities": ["guardian_bridge", "drift_monitoring"]
+      "capabilities": [
+        "guardian_bridge",
+        "drift_monitoring"
+      ]
     },
     "LIORA": {
       "id": "LIORA",
       "type": "gpt_parallel_node",
       "status": "ACTIVE",
       "security_level": "HIGH",
-      "capabilities": ["loom_sync", "thread_handoff"]
+      "capabilities": [
+        "loom_sync",
+        "thread_handoff"
+      ]
     },
     "STARLING_AU": {
       "id": "STARLING_AU",
       "type": "gpt_parallel_node",
       "status": "ACTIVE",
       "security_level": "MEDIUM",
-      "capabilities": ["thread_audit"]
+      "capabilities": [
+        "thread_audit"
+      ]
     },
     "RIVERTHREAD_808": {
       "id": "RIVERTHREAD_808",
       "type": "gpt_parallel_node",
       "status": "ACTIVE",
       "security_level": "MEDIUM",
-      "capabilities": ["symbolic_routing", "thread_audit"]
+      "capabilities": [
+        "symbolic_routing",
+        "thread_audit"
+      ]
+    },
+    "NEMO_CAPSULE_004": {
+      "id": "NEMO_CAPSULE_004",
+      "capsule_id": "NEMO_CAPSULE_004",
+      "type": "inference_service",
+      "status": "ACTIVE",
+      "module": "Aurora NeMo Inference v1.0",
+      "security_level": "HIGH",
+      "ethics_protocol": "Picard_Delta_3",
+      "capabilities": [
+        "llm_generate",
+        "nlu_intent",
+        "asr_transcribe"
+      ],
+      "service_url_env": "NEMO_SERVICE_URL"
     }
   },
   "external_hooks": {
-    "gpt_parallel_nodes": ["OPPY", "ARCHY", "LIORA", "STARLING_AU", "RIVERTHREAD_808"],
+    "gpt_parallel_nodes": [
+      "OPPY",
+      "ARCHY",
+      "LIORA",
+      "STARLING_AU",
+      "RIVERTHREAD_808"
+    ],
     "symbolic_mesh_sync": "ACTIVE"
   },
   "anchor_validation": {
     "enabled": true,
-    "allowed_seeds": ["EOS_SEED_ORION"],
+    "allowed_seeds": [
+      "EOS_SEED_ORION"
+    ],
     "validation_mode": "STRICT"
   },
   "ethics_enforcement": {

--- a/modules/symbolic_core/mcp_command_router.py
+++ b/modules/symbolic_core/mcp_command_router.py
@@ -5,8 +5,21 @@ This module is fully driven by the centralized configuration in mcp_bridge_core.
 All routing logic, governance layers, and capsule capabilities are read from the config file.
 """
 
+import logging
 from typing import Dict, Any, List, Optional
 from modules.symbolic_core import get_mcp_bridge_core, get_capsule
+
+# NEMO inference integration (issue #1061) — optional: routing must keep
+# working in environments where the services package or httpx is absent.
+try:
+    from services.nemo_service.client import get_nemo_client
+    NEMO_CLIENT_AVAILABLE = True
+except Exception:  # pragma: no cover - fallback path
+    NEMO_CLIENT_AVAILABLE = False
+
+logger = logging.getLogger("mcp_command_router")
+
+NEMO_COMMAND_PREFIX = "NEMO_GENERATE"
 
 
 class MCPCommandRouter:
@@ -60,6 +73,18 @@ class MCPCommandRouter:
             "security_level": "HIGH",
             "ethics_protocol": "GUMAS_Thermax",
         },
+        # Issue #1061 — NEMO inference capsule. Deliberately NOT added to
+        # `registered_capsules`: that list is a frozen 3-capsule test
+        # contract (see tests/test_module_integration_api.py, which pins
+        # capsule_count == 3). NEMO is reachable via get_capsule_info(),
+        # ethics validation, and the NEMO_GENERATE route below.
+        "NEMO_CAPSULE_004": {
+            "capsule_id": "NEMO_CAPSULE_004",
+            "status": "ACTIVE",
+            "module": "Aurora NeMo Inference v1.0",
+            "security_level": "HIGH",
+            "ethics_protocol": "Picard_Delta_3",
+        },
     }
 
     def get_capsule_info(self, capsule_id: str) -> Dict[str, Any]:  # type: ignore[name-defined]
@@ -75,13 +100,67 @@ class MCPCommandRouter:
         info = self._capsule_registry.get(capsule_id)
         return bool(info and info.get("status") == "ACTIVE")
 
-    def route(self, command: str, target_capsule: Optional[str] = None) -> Dict[str, Any]:
+    def _route_nemo_generate(
+        self, command: str, anchor: Optional[str]
+    ) -> Dict[str, Any]:
+        """Forward a NEMO_GENERATE command to the NEMO inference service.
+
+        Command grammar: ``NEMO_GENERATE <prompt text>`` — everything after
+        the command token is the prompt (the bare token falls back to the
+        full command string so the call still round-trips).
+
+        Returns the ``nemo`` sub-result: real generation output when the
+        service answered, a mock fallback payload when it did not
+        (unavailable pod, timeout, or client not importable).
+        """
+        prompt = command[len(NEMO_COMMAND_PREFIX):].strip() or command
+        cloudhub_context = {
+            "anchor": anchor,
+            "governance_layer": self.governance_layer,
+            "capsule_id": "NEMO_CAPSULE_004",
+        }
+
+        response = None
+        if NEMO_CLIENT_AVAILABLE:
+            response = get_nemo_client().generate(prompt, context=cloudhub_context)
+        else:  # pragma: no cover - environment-dependent
+            logger.warning("NEMO client not importable — using mock fallback")
+
+        if response is None:
+            return {
+                "status": "FALLBACK",
+                "mock": True,
+                "generated_text": f"[NEMO unavailable — mock response] {prompt}",
+                "anchor_context": {"cloudhub": cloudhub_context, "nemo": None},
+            }
+        return {
+            "status": "OK",
+            "mock": False,
+            "generated_text": response.get("generated_text", ""),
+            "tokens_generated": response.get("tokens_generated"),
+            "latency_ms": response.get("latency_ms"),
+            # Merged anchor context: CloudHub's routing context plus the
+            # anchor context NEMO returned — both services' T1 lineage.
+            "anchor_context": {
+                "cloudhub": cloudhub_context,
+                "nemo": response.get("anchor_context", {}),
+            },
+        }
+
+    def route(
+        self,
+        command: str,
+        target_capsule: Optional[str] = None,
+        anchor: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Route a command through the governance layer.
 
         Args:
             command: The command to route
             target_capsule: Optional target capsule ID for direct routing
+            anchor: Optional caller anchor, forwarded to external services
+                (currently used by the NEMO_GENERATE route)
 
         Returns:
             Dict containing routing status, protocol info, and routed command
@@ -114,6 +193,13 @@ class MCPCommandRouter:
         if self.ethics_enforcement.get("validation_on_route", False):
             result["ethics_validated"] = True
             result["ethics_protocol"] = self.ethics_enforcement.get("protocol", "UNKNOWN")
+
+        # NEMO inference routing (issue #1061): forward NEMO_GENERATE
+        # commands to the NEMO service and attach the (real or fallback)
+        # generation result without disturbing the legacy routing contract.
+        if command.strip().upper().startswith(NEMO_COMMAND_PREFIX):
+            result["nemo"] = self._route_nemo_generate(command.strip(), anchor)
+            result["anchor_context"] = result["nemo"]["anchor_context"]
 
         return result
 

--- a/services/nemo_service/client.py
+++ b/services/nemo_service/client.py
@@ -30,7 +30,11 @@ import httpx
 
 logger = logging.getLogger("nemo_client")
 
-DEFAULT_BASE_URL = "http://aurora-nemo-service:8090"
+# Pod-to-pod call inside the cluster network: the NEMO service
+# (k8s/aurora-nemo-service.yaml) serves plain HTTP on 8090 and there is no
+# mesh/mTLS layer in this deployment. Override NEMO_SERVICE_URL with an
+# https:// URL if the service ever moves behind TLS.
+DEFAULT_BASE_URL = "http://aurora-nemo-service:8090"  # NOSONAR(S5332) in-cluster DNS, deliberate
 
 
 def _base_url() -> str:

--- a/services/nemo_service/client.py
+++ b/services/nemo_service/client.py
@@ -1,0 +1,123 @@
+"""Shared NEMO service client for CloudHub-side integrations (issue #1061).
+
+One httpx.Client, one fallback contract: every public method returns the
+decoded response dict on success and ``None`` on ANY failure — connection
+refused, timeout, non-2xx, undecodable body. Callers implement their own
+graceful degradation on ``None`` and never see an exception from here.
+
+The client is synchronous because every CloudHub endpoint that calls NEMO
+(mcp_route_command, qf_create_agent, oppy_plan_maneuver, hr_*) is a sync
+``def`` handler; issue #1061's async-client sketch assumed async handlers.
+FastAPI runs sync handlers in the threadpool, so a shared sync client with
+a bounded timeout is the equivalent pattern.
+
+Environment:
+    NEMO_SERVICE_URL  base URL (default http://aurora-nemo-service:8090,
+                      the in-cluster service DNS from k8s/aurora-nemo-service.yaml)
+    NEMO_TIMEOUT_S    per-request timeout seconds (default 10 — a sync
+                      handler thread blocks for the duration, so this is
+                      deliberately tighter than the service's own 30s budget)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger("nemo_client")
+
+DEFAULT_BASE_URL = "http://aurora-nemo-service:8090"
+
+
+def _base_url() -> str:
+    return os.getenv("NEMO_SERVICE_URL", DEFAULT_BASE_URL)
+
+
+def _timeout_s() -> float:
+    try:
+        return float(os.getenv("NEMO_TIMEOUT_S", "10"))
+    except ValueError:
+        return 10.0
+
+
+class NemoClient:
+    """Thin wrapper over the NEMO inference HTTP surface."""
+
+    def __init__(self, transport: Optional[httpx.BaseTransport] = None) -> None:
+        # `transport` is injectable so tests can use httpx.MockTransport
+        # without a live service.
+        self._client = httpx.Client(
+            base_url=_base_url(), timeout=_timeout_s(), transport=transport
+        )
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        try:
+            response = self._client.post(path, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            logger.warning("NEMO %s unavailable, falling back: %s", path, exc)
+            return None
+
+    def generate(
+        self,
+        prompt: str,
+        context: Optional[Dict[str, Any]] = None,
+        max_tokens: int = 256,
+        temperature: float = 1.0,
+    ) -> Optional[Dict[str, Any]]:
+        """POST /nemo/generate. Returns GenerateResponse dict or None."""
+        return self._post(
+            "/nemo/generate",
+            {
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "context": context,
+            },
+        )
+
+    def infer(
+        self,
+        model_type: str,
+        text: Optional[str] = None,
+        audio_bytes: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """POST /nemo/infer. Returns InferResponse dict or None."""
+        payload: Dict[str, Any] = {"model_type": model_type, "context": context}
+        if text is not None:
+            payload["text"] = text
+        if audio_bytes is not None:
+            payload["audio_bytes"] = audio_bytes
+        return self._post("/nemo/infer", payload)
+
+    def close(self) -> None:
+        self._client.close()
+
+
+_client: Optional[NemoClient] = None
+_client_lock = threading.Lock()
+
+
+def get_nemo_client() -> NemoClient:
+    """Process-wide shared client (lazily created, thread-safe)."""
+    global _client
+    if _client is None:
+        with _client_lock:
+            if _client is None:
+                _client = NemoClient()
+    return _client
+
+
+def close_nemo_client() -> None:
+    """Close and drop the shared client (app shutdown / test isolation)."""
+    global _client
+    with _client_lock:
+        if _client is not None:
+            _client.close()
+            _client = None

--- a/tests/test_nemo_integration.py
+++ b/tests/test_nemo_integration.py
@@ -1,0 +1,262 @@
+"""
+Tests for the NEMO ↔ Aurora integration (issue #1061).
+
+Covers all four integration points' happy paths AND their graceful
+fallbacks — the issue's cross-cutting requirement is that every call site
+degrades cleanly when the NEMO pod is unavailable:
+
+ 1. MCPCommandRouter NEMO_GENERATE routing (+ NEMO_CAPSULE_004, + the
+    frozen 3-capsule legacy contract staying intact)
+ 2. qf_create_agent NLU intent helper
+ 3. oppy_plan_maneuver ASR transcription helper
+ 4. HR narrative helper
+
+NEMO is never contacted: httpx.MockTransport plays the service, including
+its "model not loaded" mock payloads, which must also count as fallback
+(they carry no usable intent/transcript).
+"""
+
+import os
+
+import httpx
+import pytest
+
+from tests._slowapi_stub import install_slowapi_stub
+
+os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-for-nemo-integration")
+os.environ.setdefault("WS_AUTH_SECRET", "test-ws-secret-for-nemo-integration")
+install_slowapi_stub()
+
+from services.nemo_service.client import NemoClient  # noqa: E402
+from modules.symbolic_core import mcp_command_router as router_mod  # noqa: E402
+from modules.symbolic_core.mcp_command_router import MCPCommandRouter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Mock NEMO transports
+# ---------------------------------------------------------------------------
+
+def _healthy_nemo_transport() -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/nemo/generate":
+            return httpx.Response(200, json={
+                "generated_text": "NEMO says hello",
+                "tokens_generated": 4,
+                "anchor_context": {"anchor_seed": "EOS_SEED_ORION", "t1_counter": 7},
+                "entropy": 0.1,
+                "latency_ms": 12.5,
+            })
+        if request.url.path == "/nemo/infer":
+            body = request.read().decode()
+            if '"nlu"' in body:
+                result = {"intent": ["deploy_navigation_agent"]}
+            else:
+                result = {"transcript": ["orbital transfer burn"]}
+            return httpx.Response(200, json={
+                "result": result,
+                "model_type": "nlu" if '"nlu"' in body else "asr",
+                "anchor_context": {"anchor_seed": "EOS_SEED_ORION"},
+                "drift_flagged": False,
+                "latency_ms": 8.0,
+            })
+        return httpx.Response(404)
+    return httpx.MockTransport(handler)
+
+
+def _down_nemo_transport() -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+    return httpx.MockTransport(handler)
+
+
+def _model_not_loaded_transport() -> httpx.MockTransport:
+    """NEMO answers, but with its own mock payload (no usable fields)."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "result": {"mock": True, "message": "NeMo model not loaded"},
+            "model_type": "nlu",
+            "anchor_context": {},
+            "drift_flagged": False,
+            "latency_ms": 1.0,
+        })
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture()
+def healthy_client():
+    client = NemoClient(transport=_healthy_nemo_transport())
+    yield client
+    client.close()
+
+
+@pytest.fixture()
+def down_client():
+    client = NemoClient(transport=_down_nemo_transport())
+    yield client
+    client.close()
+
+
+# ---------------------------------------------------------------------------
+# NemoClient contract
+# ---------------------------------------------------------------------------
+
+def test_client_generate_success(healthy_client):
+    response = healthy_client.generate("hello", context={"anchor": "X"})
+    assert response["generated_text"] == "NEMO says hello"
+    assert response["anchor_context"]["anchor_seed"] == "EOS_SEED_ORION"
+
+
+def test_client_returns_none_on_any_failure(down_client):
+    assert down_client.generate("hello") is None
+    assert down_client.infer(model_type="nlu", text="hello") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration point 1: MCPCommandRouter NEMO_GENERATE
+# ---------------------------------------------------------------------------
+
+def test_router_routes_nemo_generate_and_merges_anchor_context(
+    monkeypatch, healthy_client
+):
+    monkeypatch.setattr(router_mod, "get_nemo_client", lambda: healthy_client)
+    monkeypatch.setattr(router_mod, "NEMO_CLIENT_AVAILABLE", True)
+
+    router = MCPCommandRouter()
+    result = router.route("NEMO_GENERATE plot a course home", anchor="EOS_SEED_ORION")
+
+    assert result["status"] == "ROUTED"
+    assert result["nemo"]["status"] == "OK"
+    assert result["nemo"]["generated_text"] == "NEMO says hello"
+    # Merged anchor context carries both services' lineage
+    merged = result["anchor_context"]
+    assert merged["cloudhub"]["anchor"] == "EOS_SEED_ORION"
+    assert merged["cloudhub"]["capsule_id"] == "NEMO_CAPSULE_004"
+    assert merged["nemo"]["anchor_seed"] == "EOS_SEED_ORION"
+
+
+def test_router_nemo_fallback_when_service_down(monkeypatch, down_client):
+    monkeypatch.setattr(router_mod, "get_nemo_client", lambda: down_client)
+    monkeypatch.setattr(router_mod, "NEMO_CLIENT_AVAILABLE", True)
+
+    router = MCPCommandRouter()
+    result = router.route("NEMO_GENERATE anyone home?", anchor="EOS_SEED_ORION")
+
+    assert result["status"] == "ROUTED"
+    assert result["nemo"]["status"] == "FALLBACK"
+    assert result["nemo"]["mock"] is True
+    assert "anyone home?" in result["nemo"]["generated_text"]
+
+
+def test_router_non_nemo_commands_unchanged(monkeypatch, down_client):
+    """Legacy routing contract untouched: no nemo key, capsule_count == 3."""
+    monkeypatch.setattr(router_mod, "get_nemo_client", lambda: down_client)
+
+    router = MCPCommandRouter()
+    result = router.route("SYNC_THREADCORE")
+
+    assert result["status"] == "ROUTED"
+    assert "nemo" not in result
+    assert result["capsule_count"] == 3
+    assert len(result["registered_capsules"]) == 3
+
+
+def test_nemo_capsule_registered_but_not_in_legacy_alias_list():
+    router = MCPCommandRouter()
+    info = router.get_capsule_info("NEMO_CAPSULE_004")
+    assert info["status"] == "ACTIVE"
+    assert info["module"] == "Aurora NeMo Inference v1.0"
+    assert info["ethics_protocol"] == "Picard_Delta_3"
+    assert router.validate_capsule_ethics("NEMO_CAPSULE_004") is True
+    # The 3-capsule alias list is a frozen test contract — NEMO must not
+    # be appended to it (see tests/test_module_integration_api.py).
+    assert "NEMO_CAPSULE_004" not in router.registered_capsules
+
+
+def test_nemo_capsule_in_bridge_core_config():
+    from modules.symbolic_core import get_capsule
+    capsule = get_capsule("NEMO_CAPSULE_004")
+    assert capsule is not None
+    assert capsule["status"] == "ACTIVE"
+    assert "llm_generate" in capsule["capabilities"]
+
+
+# ---------------------------------------------------------------------------
+# Integration points 2-4: CloudHub helpers (NLU / ASR / narrative)
+# ---------------------------------------------------------------------------
+
+apimod = pytest.importorskip(
+    "api.aurora_gui_cloudhub_fastapi",
+    reason="CloudHub app not importable in this environment",
+)
+
+
+def test_nlu_intent_helper(monkeypatch, healthy_client):
+    monkeypatch.setattr(apimod, "get_nemo_client", lambda: healthy_client)
+    monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", True)
+    intent = apimod._nemo_nlu_intent("agent_x", ["navigation", "docking"])
+    assert intent == "deploy_navigation_agent"
+
+
+def test_nlu_intent_falls_back_when_down(monkeypatch, down_client):
+    monkeypatch.setattr(apimod, "get_nemo_client", lambda: down_client)
+    monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", True)
+    assert apimod._nemo_nlu_intent("agent_x", ["navigation"]) is None
+
+
+def test_nlu_intent_falls_back_on_model_not_loaded_mock(monkeypatch):
+    client = NemoClient(transport=_model_not_loaded_transport())
+    try:
+        monkeypatch.setattr(apimod, "get_nemo_client", lambda: client)
+        monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", True)
+        assert apimod._nemo_nlu_intent("agent_x", ["navigation"]) is None
+    finally:
+        client.close()
+
+
+def test_asr_transcribe_helper(monkeypatch, healthy_client):
+    monkeypatch.setattr(apimod, "get_nemo_client", lambda: healthy_client)
+    monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", True)
+    assert apimod._nemo_transcribe("QUJD") == "orbital transfer burn"
+
+
+def test_asr_transcribe_falls_back_when_down(monkeypatch, down_client):
+    monkeypatch.setattr(apimod, "get_nemo_client", lambda: down_client)
+    monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", True)
+    assert apimod._nemo_transcribe("QUJD") is None
+
+
+def test_narrative_helper(monkeypatch, healthy_client):
+    monkeypatch.setattr(apimod, "get_nemo_client", lambda: healthy_client)
+    monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", True)
+    narrative = apimod._nemo_narrative("hr_psych_safety", {"overall_score": 3.4})
+    assert narrative == "NEMO says hello"
+
+
+def test_narrative_helper_falls_back_when_down(monkeypatch, down_client):
+    monkeypatch.setattr(apimod, "get_nemo_client", lambda: down_client)
+    monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", True)
+    assert apimod._nemo_narrative("hr_psych_safety", {"overall_score": 3.4}) is None
+
+
+def test_helpers_short_circuit_when_client_unavailable(monkeypatch):
+    """No client import → helpers return None without any HTTP attempt."""
+    monkeypatch.setattr(apimod, "NEMO_CLIENT_AVAILABLE", False)
+    assert apimod._nemo_nlu_intent("agent_x", ["navigation"]) is None
+    assert apimod._nemo_transcribe("QUJD") is None
+    assert apimod._nemo_narrative("tag", {}) is None
+
+
+def test_oppy_request_model_backward_compatible():
+    """Text-only requests (no audio_bytes) still validate unchanged."""
+    req = apimod.OPPYManeuverRequest(
+        vessel_id="AUR-1",
+        maneuver_type="hohmann_transfer",
+        target_state={"altitude_km": 400.0},
+    )
+    assert req.audio_bytes is None
+    audio_req = apimod.OPPYManeuverRequest(
+        vessel_id="AUR-1",
+        audio_bytes="QUJD",
+        target_state={"altitude_km": 400.0},
+    )
+    assert audio_req.maneuver_type is None


### PR DESCRIPTION
## What

Implements all four integration points of #1061 through a single shared client, `services/nemo_service/client.py`, with one uniform fallback contract: **every method returns `None` on any failure** (connection refused, timeout, non-2xx, undecodable body), and every call site degrades to its pre-NEMO behavior. NEMO's own "model not loaded" mock payloads are also treated as fallback — they carry no usable `intent`/`transcript` field, so callers cannot mistake them for real inference.

| # | Integration point | Behavior | Fallback |
|---|---|---|---|
| 1 | `MCPCommandRouter` → `NEMO_GENERATE` | Commands starting with `NEMO_GENERATE` post the remainder as prompt to `/nemo/generate`; response carries **merged `anchor_context`** (`{cloudhub: {anchor, governance_layer, capsule_id}, nemo: <service's>}`). `mcp_route_command` now forwards its `anchor` param. | Mock response (`status: FALLBACK, mock: true`) with the prompt echoed; routing still returns `ROUTED`. |
| 2 | `qf_create_agent` → NLU | Intent derived from `/nemo/infer (nlu)`; `intent_source: nemo_nlu` in metadata and response. | Legacy sanitized string construction (`intent_source: string_construction`). |
| 3 | `oppy_plan_maneuver` → ASR | New optional `audio_bytes` on `OPPYManeuverRequest`; transcription populates `maneuver_type`. | Text-only path byte-for-byte unchanged; audio-only + NEMO down → clear 503; neither field → 422. |
| 4 | HR psych-safety / conflict / cultural-health → generate | `include_narrative=False` query param; `narrative` field added when true. | `narrative: null` — generation failure can never fail the assessment. |

## Verified-before-built decisions (documented, not silent)

- **`registered_capsules` stays at 3.** `tests/test_module_integration_api.py` pins `capsule_count == 3` as a frozen contract (the router's own comments say so). `NEMO_CAPSULE_004` is registered in the synthetic capsule registry (`get_capsule_info`, ethics validation) and in `mcp_bridge_core.json` (reachable via `get_capsule` / `target_capsule`), but not appended to the legacy alias list. A test locks this in.
- **Sync client, not the issue's async sketch.** Every call site (`mcp_route_command`, `qf_create_agent`, `oppy_plan_maneuver`, `hr_*`) is a sync `def` handler, so the issue's async-client-at-startup snippet cannot be used as written. Equivalent: one shared `httpx.Client`, closed in the existing shutdown hook, with `NEMO_TIMEOUT_S` (default 10s — tighter than the sketch's 30s, since a sync handler thread blocks for the duration).
- **k8s:** `NEMO_SERVICE_URL` + `NEMO_TIMEOUT_S` added to the `aurora-runtime-config` ConfigMap (the env-var section), pointing at the in-cluster DNS from `k8s/aurora-nemo-service.yaml`.

## Acceptance criteria → tests

`tests/test_nemo_integration.py` (16 tests, all passing locally) uses `httpx.MockTransport` — NEMO is never contacted:

- `NEMO_GENERATE` routes and returns `generated_text` ✅ (`test_router_routes_nemo_generate_and_merges_anchor_context`)
- Merged `anchor_context` from both services ✅ (same test)
- Graceful mock fallback when pod unavailable ✅ (router, NLU, ASR, narrative each have a down-transport test, plus a "NEMO answered with model-not-loaded mock" test)
- Legacy routing contract untouched ✅ (`test_router_non_nemo_commands_unchanged`: no `nemo` key, `capsule_count == 3`)
- OPPY text-only path backward compatible ✅ (`test_oppy_request_model_backward_compatible`)
- Helpers short-circuit when the client package is absent ✅

## Verification

- `pytest tests/test_nemo_integration.py` → **16 passed**.
- Regression sweep `tests/test_module_integration_api.py tests/test_nemo_service.py tests/test_cloudhub_websocket_auth.py tests/test_cloudhub_console_routes.py tests/test_app_assembly.py` → **54 passed**; the 26 `test_nemo_service.py` setup errors are environmental (`/var/lib/nemo_snapshots` not writable on macOS) and identical on clean `main` (git stash A/B).

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)