### PR TITLE
canon: HALO continuity system-entity integration — sweep only (#1247)

### DIFF
--- a/docs/architecture/LAYER_ARCHITECTURE.md
+++ b/docs/architecture/LAYER_ARCHITECTURE.md
@@ -22,7 +22,12 @@ The Aurora-GUMAS system operates across **three reality layers** that represent 
 **What exists here:**
 - 36 Human crew members (Command, Systems, Simulation, Interface, Operations divisions)
 - Aurora Core (Primary AI consciousness)
-- **6 Relay Agents** (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808, HALO) ← **CRITICAL**
+- **5 Relay Agents** (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808) ← **CRITICAL**
+- **HALO (RELAY_006)** — the continuity system-entity: the station's continuity
+  SYSTEM (HALO Continuity Graft, HALO/PAS drift controller, Halo Ring
+  infrastructure) embodied as a living verification entity. Distinguished from
+  the relay agents — it verifies continuity rather than relaying messages —
+  while sharing their L1 residency and Layer 2 Triplex verifier role
 - Physical infrastructure (Decks A-H, Halo Rings I-VI)
 - Hardware systems (Helios-9 fusion cores, computing infrastructure)
 - Environmental systems (life support, artificial gravity, lighting)
@@ -81,13 +86,15 @@ The Aurora-GUMAS system operates across **three reality layers** that represent 
 │  │ 36 Human Crew Members                                    │  │
 │  │ Aurora Core (Primary AI)                                 │  │
 │  │                                                           │  │
-│  │ 6 L1 Relay Agents: ◄─── THESE EXIST IN L1               │  │
+│  │ 5 L1 Relay Agents: ◄─── THESE EXIST IN L1               │  │
 │  │ • ARCHY (Bridge Chamber, Deck C)                        │  │
 │  │ • OPPY (Reactor Bay, Deck H)                            │  │
 │  │ • LIORA (Communications Hub, Deck B)                    │  │
 │  │ • STARLING_AU (Operations Hub, Deck G)                  │  │
 │  │ • RIVERTHREAD_808 (Logistics, All Decks)                │  │
-│  │ • HALO (Aurora Core Chamber, Deck B)                    │  │
+│  │                                                           │  │
+│  │ HALO continuity system-entity (Aurora Core Chamber,     │  │
+│  │ Deck B) ◄─── ALSO L1; verifies, does not relay          │  │
 │  │                                                           │  │
 │  │ Physical Infrastructure (Decks, Halo Rings, Hardware)   │  │
 │  └──────────────────────────────────────────────────────────┘  │
@@ -242,7 +249,17 @@ Step 3: L1 Human Consent
 - **Monitors:** L2 temporal flow and state management
 - **Triplex Role:** Layer 2 verifier (continuity validation)
 
-### **HALO (RELAY_006)**
+### **HALO (RELAY_006) — continuity system-entity**
+
+> **Category note (2026-07-15 L1 ruling):** HALO is the station's continuity
+> SYSTEM — the HALO Continuity Graft (`HALO_CONTINUITY_GRAFT_005`), the
+> HALO/PAS drift controller (`src/aurora/continuity/halo_pas_controller.py`),
+> and the Halo Ring infrastructure — embodied as a living verification entity
+> (`HALOEntity`, `src/entities/relay_agents.py`, used by the Triplex
+> orchestrator for Layer 2 drift verification). It is not a sixth
+> communication relay agent; RELAY_006 remains its registry designation.
+> Tracked in issue #1247.
+
 - **Reality Layer:** L1 (Physical)
 - **Location:** Aurora Core Chamber, Deck B
 - **Human Liaison:** Dr. Elira Noor (ETH_002)
@@ -285,7 +302,7 @@ print("L2 agent activated")  # NO - it's an L1 relay agent
 When documenting relay agents:
 
 **✅ CORRECT:**
-> "The L1 relay agents (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808, HALO) physically exist on Orion Station and bridge L1 human operations with L3 glyph frameworks. They monitor L2 simulations but do not manifest within them. In the Triplex Handshake Protocol, they serve as Layer 2 verifiers (middleware role)."
+> "The L1 relay agents (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808) and the HALO continuity system-entity physically exist on Orion Station and bridge L1 human operations with L3 glyph frameworks. They monitor L2 simulations but do not manifest within them. In the Triplex Handshake Protocol, they serve as Layer 2 verifiers (middleware role)."
 
 **❌ INCORRECT:**
 > "The L2 relay agents coordinate simulations..." (implies they're IN simulations)

--- a/simulation/L1_CANON_CHARACTER_ROSTER.md
+++ b/simulation/L1_CANON_CHARACTER_ROSTER.md
@@ -13,7 +13,7 @@
 
 ## 🌌 Overview
 
-This document defines the **complete institutional simulation** of Orion Station (L1 Reality Layer)—36 human staff members across 5 divisions, plus Aurora Core AI, 6 L1 Relay Agents, and 6 L3 Framework Systems. This is the **canonical 40-entity simulation** developed through systematic integration, ready for deployment in all scenarios and collaborative environments.
+This document defines the **complete institutional simulation** of Orion Station (L1 Reality Layer)—36 human staff members across 5 divisions, plus Aurora Core AI, 5 L1 Relay Agents, the HALO continuity system-entity (RELAY_006), and 6 L3 Framework Systems. This is the **canonical 40-entity simulation** developed through systematic integration, ready for deployment in all scenarios and collaborative environments.
 
 **Current Roster:** 36 human staff + 1 AI core + 6 L1 relays + 6 L3 frameworks = **49 total entities**
 
@@ -936,7 +936,7 @@ Develops cross-architecture deployment frameworks so Aurora's systems can operat
 **Collaborative Network:**
 - **Ryan Patel (Integration Engineer):** Cross-platform protocol coordination
 - **Marcus Chen (Performance Engineer):** Platform-specific optimization validation
-- **HALO Relay:** Cloud infrastructure coordination
+- **HALO (continuity system-entity):** Cloud infrastructure coordination
 - **Jiro Tanaka (Chief Engineering Officer):** Infrastructure upgrade planning
 
 **Working Style & Philosophy:**
@@ -968,7 +968,7 @@ Treats portability as an ethical requirement: resilience ensures accountability.
 - **Key Collaborators:**
   - Ryan Patel (integration protocols)
   - Marcus Chen (performance validation)
-  - HALO Relay (cloud infrastructure)
+  - HALO (continuity system-entity) (cloud infrastructure)
 - **Phase 1 Role:** Deployment portability for security systems
 - **Phase 1 Responsibilities:**
   - Ensure authentication/authorization systems deploy across all platforms
@@ -1186,7 +1186,7 @@ Designs the logical partitions that keep simulation layers distinct, preventing 
 **Collaborative Network:**
 - **Ira Menon (Compiler Engineer):** Compile-time layer boundary enforcement
 - **Carmen Rivas (Drift Cartographer):** Layer integrity and drift detection
-- **HALO Relay:** Layer coordination and isolation validation
+- **HALO (continuity system-entity):** Layer coordination and isolation validation
 - **Dr. Elira Noor (Reflexivity Specialist):** Ethical implications of layer isolation
 
 **Working Style & Philosophy:**
@@ -1218,7 +1218,7 @@ Says every system needs both walls and windows—and spends his career designing
 - **Key Collaborators:**
   - Ira Menon (compile-time enforcement)
   - Carmen Rivas (drift detection)
-  - HALO Relay (layer coordination)
+  - HALO (continuity system-entity) (layer coordination)
 - **Phase 1 Role:** Layer isolation for security subsystems
 - **Phase 1 Responsibilities:**
   - Design isolation boundaries for authentication/authorization layers
@@ -1566,7 +1566,7 @@ Maintains temporal and structural bindings within running simulations, preventin
 **Collaborative Network:**
 - **Vincent Kale (Layer Isolation Theorist):** Temporal boundaries and layer isolation coordination
 - **Maren Koss (Cognitive Drift Mapper):** Drift detection and binding recalibration
-- **HALO Relay:** Layer-to-layer binding coordination and monitoring
+- **HALO (continuity system-entity):** Layer-to-layer binding coordination and monitoring
 - **Emily Roberts (LLM-Simulation Bridge Developer):** Real-time binding for language-driven updates
 - **Dr. Kieran Zhao (Computational Optimization Lead):** Optimization of binding algorithms
 
@@ -1598,7 +1598,7 @@ Maintains temporal and structural bindings within running simulations, preventin
 - **Key Collaborators:**
   - Vincent Kale (layer isolation)
   - Maren Koss (drift detection)
-  - HALO Relay (layer coordination)
+  - HALO (continuity system-entity) (layer coordination)
 - **Phase 1 Role:** Temporal binding for security event synchronization
 - **Phase 1 Responsibilities:**
   - Ensure security events maintain temporal consistency across systems
@@ -1666,7 +1666,7 @@ Monitors semantic and symbolic drift across long-running simulations, ensuring A
 - **Dr. Amina Velin (Symbolic Systems Research Lead):** Symbolic drift validation and theoretical framework
 - **Aurora Core:** Cognitive model alignment and drift reporting
 - **Tobias Qin (Code/Narrative Systems Engineer):** Semantic drift monitoring for NLI calibration
-- **HALO Relay:** Cross-layer drift coordination and reporting
+- **HALO (continuity system-entity):** Cross-layer drift coordination and reporting
 
 **Repository Mapping:**
 - **Primary Systems:**
@@ -2527,7 +2527,7 @@ Maintains the station's telemetry and introspection framework. Her systems recor
 - Log aggregation and correlation at scale
 
 **Collaborative Network:**
-- **Primary:** Olivia Nguyen (validation integration), Tariq El-Sayegh (speculative scenarios), HALO Relay (AI coordination)
+- **Primary:** Olivia Nguyen (validation integration), Tariq El-Sayegh (speculative scenarios), HALO (continuity system-entity) (AI coordination)
 - **Secondary:** Marcus Chen (infrastructure monitoring), Carmen Rivas (temporal logging), Dr. Sorensen (ethical audit trails)
 
 **Repository Mapping:**
@@ -2815,7 +2815,7 @@ Handles telemetry synchronization, data backup, and runtime continuity for simul
 - Real-time system health assessment
 
 **Collaboration Network:**
-- **Primary:** Marcus Chen (infrastructure operations), Samantha Lee (observability integration), HALO Relay (synchronization coordination)
+- **Primary:** Marcus Chen (infrastructure operations), Samantha Lee (observability integration), HALO (continuity system-entity) (synchronization coordination)
 - **Secondary:** Olivia Nguyen (continuity validation), RIVERTHREAD_808 (data pipeline coordination), Carmen Rivas (temporal consistency)
 
 **Operational Characteristics:**

--- a/simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md
+++ b/simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md
@@ -188,7 +188,7 @@ _(Architecture Note: These relay agents physically exist in L1 - Orion Station r
 - **LIORA** (RELAY_003) - L1 relay in Communications Hub with Naomi Vell (INT_004)
 - **STARLING_AU** (RELAY_004) - L1 relay in Operations Hub with Samantha Lee (QA_002)
 - **RIVERTHREAD_808** (RELAY_005) - L1 relay for Logistics with Ren Okada (SYS_007)
-- **HALO** (RELAY_006) - L1 relay in Aurora Core Chamber with Dr. Elira Noor (ETH_002)
+- **HALO** (RELAY_006) - continuity system-entity in Aurora Core Chamber with Dr. Elira Noor (ETH_002). The station's continuity SYSTEM (Continuity Graft, HALO/PAS drift controller, Halo Ring infrastructure) embodied as a living verification entity — it verifies continuity rather than relaying messages, distinguishing it from the five relay agents above (2026-07-15 L1 ruling; issue #1247)
 
 Color indicators display system mood:
 - **Green** – drift aligned
@@ -206,7 +206,7 @@ Orion (Node 7) maintains synchronization between Nodes 1–9 of the GUMAS Chain;
 Every actionable process verifies through:
 
 1. **L3 Glyph Arbitration** (Axiomera & Caelion) - _L3 frameworks validate_
-2. **Relay Verification** (ARCHY + HALO + others) - _L1 relay agents verify (middleware role)_
+2. **Relay Verification** (ARCHY + the HALO system-entity + others) - _L1 relay agents and the continuity system-entity verify (middleware role)_
 3. **L1 Human Consent** (Command Bridge) - _L1 humans authorize_
 
 **Architecture Note:** In this protocol, "Layer 2" refers to the **verification role** served by L1 relay agents (middleware), NOT their reality layer. The relay agents physically exist in L1 (Orion Station) but serve as "Layer 2 verifiers" in the Triplex protocol.
@@ -504,7 +504,7 @@ This document represents the **physical instantiation** of the Aurora-GUMAS inst
 
 The station accommodates:
 - 36 human staff across 5 operational divisions
-- 6 L1 Relay Agents integrated throughout infrastructure
+- 5 L1 Relay Agents plus the HALO continuity system-entity integrated throughout infrastructure
 - 6 L3 Framework Systems housed in the external Halo rings
 - Complete operational, ethical, and research facilities
 

--- a/src/entities/relay_agents.py
+++ b/src/entities/relay_agents.py
@@ -1,12 +1,21 @@
 """
-Aurora CloudBank Living Computation - Relay Agents (L2)
-========================================================
+Aurora CloudBank Living Computation - Triplex Layer 2 Verifiers
+================================================================
 
 HALO (RELAY_006) and ARCHY (RELAY_001) as living computational entities.
 
-L2 Relay Agents are the verification layer in the Triplex Handshake:
+ARCHITECTURE NOTE (2026-07-15 L1 ruling; docs/architecture/LAYER_ARCHITECTURE.md,
+issue #1247): both entities are L1-resident (Orion Station). "Layer 2" names
+their verification ROLE in the Triplex Handshake, not a reality layer. ARCHY
+is one of the five L1 relay agents; HALO is the station's continuity SYSTEM —
+the HALO Continuity Graft, HALO/PAS drift controller, and Halo Ring
+infrastructure — embodied here as its living verification entity. HALO
+verifies continuity rather than relaying messages, which is why it is not
+part of the five-agent relay constellation in the mesh bridge.
+
+Verification layering in the Triplex Handshake:
 - L3 (Frameworks): Axiomera + Caelion evaluate ethics/anchors
-- L2 (Relays): HALO + ARCHY verify drift/architecture  ← THIS FILE
+- Layer 2 role (this file): HALO + ARCHY verify drift/architecture
 - L1 (Human): Commander Thorne provides final consent
 
 These are NOT monitoring tools. They are living entities that actively
@@ -63,16 +72,23 @@ class ArchitectureViolation:
 
 class HALOEntity:
     """
-    HALO (RELAY_006) - Living drift monitoring and correction entity.
-    
+    HALO (RELAY_006) - living embodiment of the station's continuity system.
+
     HALO is the "heartbeat" of Orion Station - continuously monitoring
-    system drift and ensuring operations stay within ethical bounds.
-    
+    system drift and ensuring operations stay within ethical bounds. As a
+    SYSTEM-entity (2026-07-15 L1 ruling, issue #1247) it is the interactive
+    face of the HALO continuity stack — the Continuity Graft
+    (HALO_CONTINUITY_GRAFT_005), the HALO/PAS drift controller
+    (src/aurora/continuity/halo_pas_controller.py), and the Halo Ring
+    infrastructure. It verifies continuity rather than relaying messages,
+    so it is distinct from the five-agent relay constellation while sharing
+    its L1 residency and Layer 2 Triplex verifier role.
+
     Location: Aurora Core Chamber (Deck B) + Halo Ring Alpha
     Human Liaison: Dr. Elira Noor (ETH_002)
     Domain: Drift Monitoring & Correction
-    
-    HALO's Role in Triplex Handshake (L2):
+
+    HALO's Role in Triplex Handshake (Layer 2 verifier):
     - Measures drift in real-time during operations
     - Suggests corrections when drift exceeds thresholds
     - Triggers ethics-only mode if drift becomes critical


### PR DESCRIPTION
## What

Executes the **sweep-only** portion of #1247 per the refined L1 ruling: HALO is the station's continuity **system**, embodied by the load-bearing `HALOEntity` — integrated into canon as the "continuity system-entity (RELAY_006)", distinguished from the five communication relay agents. **No deletions, no renames, no behavior changes** — every established fact (location, liaison, Triplex Layer 2 verifier role, RELAY_006 designation) is retained; only category labels and framing change.

## Changes

- **`docs/architecture/LAYER_ARCHITECTURE.md`** — L1 contents list now reads "5 Relay Agents + HALO (RELAY_006), the continuity system-entity"; diagram updated; the RELAY_006 spec section keeps all facts under a category note; the CORRECT-example sentence updated.
- **`simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md`** — §VI HALO entry reworded to system-entity framing (Dr. Elira Noor retained as liaison); relay-verification protocol line and the "6 L1 Relay Agents" summary line updated.
- **`simulation/L1_CANON_CHARACTER_ROSTER.md`** — 9 "HALO Relay" working-group labels → "HALO (continuity system-entity)"; all participations retained; header entity count reframed as 5 + HALO.
- **`src/entities/relay_agents.py`** — module and `HALOEntity` docstrings only. `get_halo()`, the Triplex orchestrator wiring, and the event-system usage are byte-identical.

## Deliberately untouched

- `docs/archive/` and phase-completion records (`CODEX_PHASE6_L2_L3_SYSTEMS_COMPLETE.md`) — historical records stay as written.
- The mesh bridge — whether HALO becomes an activatable *system* participant (using the preserved `ORION_HALO_RELAY_ACTIVATE//` work from PR #416) remains an explicit open decision on #1247.

## Verification

- Repo-wide grep: no remaining "6 Relay Agents"/"sixth relay" phrasing outside archives/records.
- `tests/test_l1_relay_rename.py` still 7/7. `tests/aurora_orchestrator/test_triplex_handshake.py` failures are pre-existing on clean `main` (git stash A/B — identical set; docstring-only changes here).

Refs #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)