### PR TITLE
docs: record instance bridge runtime role

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -158,7 +158,7 @@ Systems that operate autonomously without direct user interaction.
 |--------|----------|-------|----------------|
 | **CASK** | `modules/cask/` | Backend service, no API endpoints | Add `/cask/*` routes (medium priority) |
 | **GUMAS** | `modules/gumas/` | Core engine exists, no API | Add `/gumas/*` ethics endpoints (high priority) |
-| **Instance Bridge** | `modules/instance_bridge/` | No tests/imports found | Investigate or deprecate |
+| **Instance Bridge** | `modules/instance_bridge/` | Standalone localhost WebSocket relay; no API, mesh, or thread-transfer importers; 11 focused tests | Retain as an active standalone tool |
 | **Flight Control** | `modules/flight_control/` | 3 JS infrastructure tests | Adequate or needs expansion? |
 
 ---


### PR DESCRIPTION
## Summary

- correct the stale module inventory entry for `instance_bridge`
- record its current role as a standalone localhost WebSocket relay
- record that no API, mesh, or thread-transfer surface imports it
- retain the existing focused 11-test coverage as the verified contract

## Why

Issue #1024 was implemented on `main`, but `modules/README.md` still reported that no tests or import evidence existed. That stale row made the runtime ownership decision look unresolved.

## Impact

Documentation now matches the tested implementation. No runtime behavior changes.

## Validation

- `pytest -q tests/test_instance_bridge.py` — 11 passed
- scoped pre-commit hooks for `modules/README.md` — passed
- `git diff --check` — passed

Fixes #1024