### PR TITLE
aurora(queue): reconcile closed GitHub issues

### DIFF
--- a/ops/work_queue/COORDINATION_METRICS.md
+++ b/ops/work_queue/COORDINATION_METRICS.md
@@ -5,7 +5,7 @@
 
 # Aurora Dev Coordination Metrics Report
 
-**Generated:** `2026-07-13T05:57:19Z`
+**Generated:** `2026-07-16T00:36:36Z`
 **Repo:** `AUo959/aurora-cloudbank-symbolic`
 **Queue:** `ops/work_queue/queue.json`
 
@@ -13,10 +13,10 @@
 
 | Metric | Value |
 |---|---:|
-| active_count | `19` |
-| completed_count | `8` |
-| status_counts | `{"needs-decision": 2, "open": 17}` |
-| bridge_field_counts | `{"claim_paths_set": 2, "claim_required": 2, "github_linkable": 13, "preferred_platform_set": 2, "review_class_set": 2}` |
+| active_count | `6` |
+| completed_count | `21` |
+| status_counts | `{"needs-decision": 2, "open": 4}` |
+| bridge_field_counts | `{}` |
 | queue_drift_count | _not measured_ |
 | generated_view_drift_count | `0` |
 | claim_conflict_count | _not measured_ |

--- a/ops/work_queue/NEXT_UP.md
+++ b/ops/work_queue/NEXT_UP.md
@@ -5,7 +5,7 @@
 
 # Next Up — Aurora Work Queue
 
-_Generated: `2026-07-13T05:57:19Z` — edit `queue.json`, run `sync_queue.py`_
+_Generated: `2026-07-16T00:36:36Z` — edit `queue.json`, run `sync_queue.py`_
 
 ---
 
@@ -15,23 +15,10 @@ Items with `status: open` and all dependencies resolved.
 
 | Rank | ID | Title | Tags |
 |---|---|---|---|
-| 1 | #1130 | SECURITY — pentest scope is stale against the current API surface | `security` `pentest` `api-surface` `blocking` |
-| 2 | security/CVE-audit | CVE dependency audit (Sprint 311 follow-on) | `security` `audit` |
-| 3 | #1139 | docs/ethics — create top-level README and navigation index | `docs` `ethics` `navigation` |
-| 4 | #1140 | docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA | `docs` `architecture` `topology` |
-| 5 | #1137 | docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue | `ethics` `geometric` `implementation` |
-| 6 | #1138 | docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started | `ethics` `protocols` `custody` |
-| 7 | #1142 | docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue | `docs` `architecture` `drift-ledger` |
-| 8 | #1141 | docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined | `docs` `architecture` `QGIA` |
-| 9 | #1144 | docs/api — api_surface_inventory.json missing four surfaces | `docs` `api` `inventory` |
-| 10 | #1143 | docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology | `docs` `architecture` `scaling` |
-| 11 | #1145 | docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps | `docs` `api` `reference` |
-| 12 | #1146 | docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated | `docs` `api` `governance` |
-| 13 | #1135 | simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries | `simulation` `roster` `validation` |
-| 14 | #1136 | simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking | `simulation` `enhancement` `tracking` |
-| 15 | arch/layer-canonization | Layer architecture canonization (L1/L2/L3 enforcement in code) | `architecture` `canonical` `L1` `L2` `L3` |
-| 17 | ops/QGIA-doctrine-store | QGIA analytical framework — store in ops/analytical_frameworks/QGIA/ | `QGIA` `analytical-framework` `ops` `non-canonical` |
-| 18 | docs/api-reference | API reference documentation | `docs` `api` |
+| 1 | security/CVE-audit | CVE dependency audit (Sprint 311 follow-on) | `security` `audit` |
+| 2 | arch/layer-canonization | Layer architecture canonization (L1/L2/L3 enforcement in code) | `architecture` `canonical` `L1` `L2` `L3` |
+| 4 | ops/QGIA-doctrine-store | QGIA analytical framework — store in ops/analytical_frameworks/QGIA/ | `QGIA` `analytical-framework` `ops` `non-canonical` |
+| 5 | docs/api-reference | API reference documentation | `docs` `api` |
 
 ---
 
@@ -49,5 +36,5 @@ Items gated on a human or governance decision. Agents skip these.
 
 | Rank | ID | Title |
 |---|---|---|
-| 16 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution |
-| 19 | feat/QGIA | QGIA integration hooks |
+| 3 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution |
+| 6 | feat/QGIA | QGIA integration hooks |

--- a/ops/work_queue/OPEN_GATES.md
+++ b/ops/work_queue/OPEN_GATES.md
@@ -5,7 +5,7 @@
 
 # Open Gates — Aurora Work Queue
 
-_Generated: `2026-07-13T05:57:19Z` — edit `queue.json`, run `sync_queue.py`_
+_Generated: `2026-07-16T00:36:36Z` — edit `queue.json`, run `sync_queue.py`_
 
 > Gates are items tagged `gate` or carrying `status: needs-decision`.
 > Nothing downstream can advance until the gate closes.
@@ -16,8 +16,8 @@ _Generated: `2026-07-13T05:57:19Z` — edit `queue.json`, run `sync_queue.py`_
 
 | Rank | ID | Title | Status |
 |---|---|---|---|
-| 16 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution | `needs-decision` |
-| 19 | feat/QGIA | QGIA integration hooks | `needs-decision` |
+| 3 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution | `needs-decision` |
+| 6 | feat/QGIA | QGIA integration hooks | `needs-decision` |
 
 ---
 

--- a/ops/work_queue/QUEUE.md
+++ b/ops/work_queue/QUEUE.md
@@ -6,9 +6,9 @@
 # Aurora Work Queue
 
 **Schema version:** `1.3.0`
-**Last Aurora review:** `2026-07-13T05:57:19Z`
-**Generated:** `2026-07-13T05:57:19Z`
-**Items:** 19 active · 8 completed
+**Last Aurora review:** `2026-07-16T00:36:36Z`
+**Generated:** `2026-07-16T00:36:36Z`
+**Items:** 6 active · 21 completed
 
 > Aurora holds contextual authority over rank order.
 > Do not edit rank or `aurora_note` fields without an `aurora(queue):` commit.
@@ -18,23 +18,7 @@
 
 ## Active Queue
 
-### 1. 🟢 #1130 — SECURITY — pentest scope is stale against the current API surface
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | docs/api-reference |
-| **Tags** | `security` `pentest` `api-surface` `blocking` |
-
-**Aurora note:**
-
-> Live GitHub refresh on 2026-07-13 confirmed this pre-engagement security issue remains open. The former #1126 dependency is complete; remaining work includes the v2 scope, current API inventory alignment, QGIA/R&D disposition, and approval signatures.
-
----
-
-### 2. 🟢 security/CVE-audit — CVE dependency audit (Sprint 311 follow-on)
+### 1. 🟢 security/CVE-audit — CVE dependency audit (Sprint 311 follow-on)
 
 | Field | Value |
 |---|---|
@@ -50,199 +34,7 @@
 
 ---
 
-### 3. 🟢 #1139 — docs/ethics — create top-level README and navigation index
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | — |
-| **Tags** | `docs` `ethics` `navigation` |
-
-**Aurora note:**
-
-> No blockers. Quick win. Ethics directory is not navigable by agents or contributors — no map to runtime surfaces, recovered protocols, or Picard_Delta_3. Unblocks all ethics cluster work that depends on directory orientation.
-
----
-
-### 4. 🟢 #1140 — docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | #1144 |
-| **Tags** | `docs` `architecture` `topology` |
-
-**Aurora note:**
-
-> No blockers. Single doc edit — mesh/agents routes are canonical per PR #1011 but the topology doc still marks them as drift. Two documents are actively contradictory. Any agent loading the topology doc gets wrong information. Fix before any QGIA or mesh work proceeds.
-
----
-
-### 5. 🟢 #1137 — docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | — |
-| **Tags** | `ethics` `geometric` `implementation` |
-
-**Aurora note:**
-
-> No blockers. Evaluation concluded v2 provides genuine signal for cases 3.4 and 3.5. Implementation work (FieldCurvatureV2, advisory wiring, get_formation_statistics additions) has never been tracked. Create follow-up implementation issue and confirm test file exists.
-
----
-
-### 6. 🟢 #1138 — docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | — |
-| **Tags** | `ethics` `protocols` `custody` |
-
-**Aurora note:**
-
-> Partially superseded by completed #1148, #1149, and #1150: custody fixture, schema, and sanitized fixture scaffolding now exist. Remaining live work is true custody verification: source/internal SHA resolution, verified_at/verified_by fields, and SHADOWFAX standalone bundle disposition.
-
----
-
-### 7. 🟢 #1142 — docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | #1146 |
-| **Tags** | `docs` `architecture` `drift-ledger` |
-
-**Aurora note:**
-
-> Two unresolved items: mesh_api.js disposition decision and generate_api_catalog.py output path drift. The catalog generator defect directly blocks API snapshot currency. Fix output path before any API doc work proceeds. Unblocks #1146.
-
----
-
-### 8. 🟢 #1141 — docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | #1144 |
-| **Tags** | `docs` `architecture` `QGIA` |
-
-**Aurora note:**
-
-> qgia_agent_registry_full.json has been pending commit for 102 days. No runtime router surface defined for the inter-node exchange protocol. Blocks #1144 (inventory missing surfaces). Resolve before QGIA integration work proceeds.
-
----
-
-### 9. 🟢 #1144 — docs/api — api_surface_inventory.json missing four surfaces
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1140, #1141 |
-| **Blocks** | #1145, #1146 |
-| **Tags** | `docs` `api` `inventory` |
-
-**Aurora note:**
-
-> Blocked by #1140 (topology contradiction) and #1141 (QGIA router undefined). Four missing surfaces: /api/mesh/agents, /api/qgia, PAT routes, Consent Architecture v3.1. Inventory is the source-of-truth anchor for the entire docs/api cluster.
-
----
-
-### 10. 🟢 #1143 — docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | — |
-| **Tags** | `docs` `architecture` `scaling` |
-
-**Aurora note:**
-
-> Standalone. No blockers. scaling_plan.md has no last_reviewed date, no version marker, and no stated relationship to the QGIA node, GUMAS 9-node L2 network, or current two-node L1 topology. May be materially stale.
-
----
-
-### 11. 🟢 #1145 — docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1144 |
-| **Blocks** | #1146 |
-| **Tags** | `docs` `api` `reference` |
-
-**Aurora note:**
-
-> Blocked by #1144 (inventory must be current before reference doc is updated). Three gaps: Consent Architecture v3.1 status unknown, HR module version header stale, no token budget cross-reference for compute-intensive endpoints.
-
----
-
-### 12. 🟢 #1146 — docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | #1142, #1144, #1145 |
-| **Blocks** | — |
-| **Tags** | `docs` `api` `governance` |
-
-**Aurora note:**
-
-> Governance self-audit. Closes last in the docs/api cluster after #1142, #1144, and #1145 are resolved. Three violations: snapshot currency not self-enforcing, test_api_surface_inventory.py is schema-only not coverage, review cadence conditions met but review not triggered.
-
----
-
-### 13. 🟢 #1135 — simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | — |
-| **Tags** | `simulation` `roster` `validation` |
-
-**Aurora note:**
-
-> No blockers. Three overlapping roster documents with no stated reconciliation or authoritative source. 165 KB is not a maintainable document size. OPPY and STARLING_AU entries need cross-check across registries before QGIA integration work.
-
----
-
-### 14. 🟢 #1136 — simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking
-
-| Field | Value |
-|---|---|
-| **Status** | `open` |
-| **Owner** | _unassigned_ |
-| **Depends on** | — |
-| **Blocks** | — |
-| **Tags** | `simulation` `enhancement` `tracking` |
-
-**Aurora note:**
-
-> No blockers. 38 KB proposal with no acceptance status, no issue linkage, and no reference from CANON_INDEX.md. Risk of agents implementing rejected or superseded proposals. Needs per-enhancement status recorded.
-
----
-
-### 15. 🟢 arch/layer-canonization — Layer architecture canonization (L1/L2/L3 enforcement in code)
+### 2. 🟢 arch/layer-canonization — Layer architecture canonization (L1/L2/L3 enforcement in code)
 
 | Field | Value |
 |---|---|
@@ -258,7 +50,7 @@
 
 ---
 
-### 16. 🟡 sim/SENTINEL-phase0 — PROJECT SENTINEL — Phase 0: Ethics review board constitution
+### 3. 🟡 sim/SENTINEL-phase0 — PROJECT SENTINEL — Phase 0: Ethics review board constitution
 
 | Field | Value |
 |---|---|
@@ -274,7 +66,7 @@
 
 ---
 
-### 17. 🟢 ops/QGIA-doctrine-store — QGIA analytical framework — store in ops/analytical_frameworks/QGIA/
+### 4. 🟢 ops/QGIA-doctrine-store — QGIA analytical framework — store in ops/analytical_frameworks/QGIA/
 
 | Field | Value |
 |---|---|
@@ -290,23 +82,23 @@
 
 ---
 
-### 18. 🟢 docs/api-reference — API reference documentation
+### 5. 🟢 docs/api-reference — API reference documentation
 
 | Field | Value |
 |---|---|
 | **Status** | `open` |
 | **Owner** | _unassigned_ |
-| **Depends on** | #1130 |
+| **Depends on** | — |
 | **Blocks** | — |
 | **Tags** | `docs` `api` |
 
 **Aurora note:**
 
-> Do not write API docs against a moving target. Wait for CI green. Superseded in priority by the specific docs/api audit issues (#1144, #1145, #1146) which address the same surface with more precision.
+> The specific docs/API audit issues #1144, #1145, and #1146 and pentest scope issue #1130 are complete. Refresh the live API inventory before starting so documentation targets current main.
 
 ---
 
-### 19. 🟡 feat/QGIA — QGIA integration hooks
+### 6. 🟡 feat/QGIA — QGIA integration hooks
 
 | Field | Value |
 |---|---|
@@ -334,3 +126,16 @@
 | #1151 | Runtime mapping design — decide how protocol decisions map to EthicsEngine, ethics_gate, compliance monitor, and geometric ethics |
 | #1152 | Moriarty containment tests — test anomaly quarantine/review-only/rollback rules without enabling active L2-to-L1 behavior |
 | #1153 | Tribunal appeal tests — test dispute/appeal record requirements without runtime enforcement |
+| #1130 | SECURITY — pentest scope is stale against the current API surface |
+| #1139 | docs/ethics — create top-level README and navigation index |
+| #1140 | docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA |
+| #1137 | docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue |
+| #1138 | docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started |
+| #1142 | docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue |
+| #1141 | docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined |
+| #1144 | docs/api — api_surface_inventory.json missing four surfaces |
+| #1143 | docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology |
+| #1145 | docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps |
+| #1146 | docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated |
+| #1135 | simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries |
+| #1136 | simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking |

--- a/ops/work_queue/queue.json
+++ b/ops/work_queue/queue.json
@@ -2,44 +2,12 @@
   "_meta": {
     "version": "1.3.0",
     "description": "Aurora-aware work queue. Machine-readable mirror of QUEUE.md. Aurora holds contextual authority. Do not edit rank order without Aurora annotation.",
-    "last_aurora_review": "2026-07-13T05:57:19Z",
+    "last_aurora_review": "2026-07-16T00:36:36Z",
     "schema": "https://github.com/AUo959/aurora-cloudbank-symbolic/blob/main/ops/work_queue/queue_schema.json"
   },
   "active": [
     {
       "rank": 1,
-      "id": "#1130",
-      "github_issue": 1130,
-      "title": "SECURITY — pentest scope is stale against the current API surface",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "security",
-        "pentest",
-        "api-surface",
-        "blocking"
-      ],
-      "preferred_platform": "either",
-      "claim_required": true,
-      "claim_paths": [
-        "docs/security",
-        "docs/api"
-      ],
-      "session_state_ref": null,
-      "review_class": "security-significant",
-      "handoff_surface": "catalog/session_state.json",
-      "coordination_notes": "Refresh the live issue and current API inventory before mutation; route scoped paths through the control-plane issue broker.",
-      "metrics_tags": [
-        "security",
-        "pentest",
-        "api"
-      ],
-      "aurora_note": "Live GitHub refresh on 2026-07-13 confirmed this pre-engagement security issue remains open. The former #1126 dependency is complete; remaining work includes the v2 scope, current API inventory alignment, QGIA/R&D disposition, and approval signatures.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 2,
       "id": "security/CVE-audit",
       "title": "CVE dependency audit (Sprint 311 follow-on)",
       "status": "open",
@@ -53,211 +21,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 3,
-      "id": "#1139",
-      "github_issue": 1139,
-      "title": "docs/ethics — create top-level README and navigation index",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "docs",
-        "ethics",
-        "navigation"
-      ],
-      "preferred_platform": "either",
-      "claim_required": true,
-      "claim_paths": [
-        "docs/ethics/README.md"
-      ],
-      "session_state_ref": null,
-      "review_class": "documentation-significant",
-      "handoff_surface": "catalog/session_state.json",
-      "coordination_notes": "Refresh the issue and check for an existing ethics navigation PR before creating a claimed worktree.",
-      "metrics_tags": [
-        "docs",
-        "ethics",
-        "navigation"
-      ],
-      "aurora_note": "No blockers. Quick win. Ethics directory is not navigable by agents or contributors — no map to runtime surfaces, recovered protocols, or Picard_Delta_3. Unblocks all ethics cluster work that depends on directory orientation.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 4,
-      "id": "#1140",
-      "title": "docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "docs",
-        "architecture",
-        "topology"
-      ],
-      "aurora_note": "No blockers. Single doc edit — mesh/agents routes are canonical per PR #1011 but the topology doc still marks them as drift. Two documents are actively contradictory. Any agent loading the topology doc gets wrong information. Fix before any QGIA or mesh work proceeds.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 5,
-      "id": "#1137",
-      "title": "docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "ethics",
-        "geometric",
-        "implementation"
-      ],
-      "aurora_note": "No blockers. Evaluation concluded v2 provides genuine signal for cases 3.4 and 3.5. Implementation work (FieldCurvatureV2, advisory wiring, get_formation_statistics additions) has never been tracked. Create follow-up implementation issue and confirm test file exists.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 6,
-      "id": "#1138",
-      "title": "docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "ethics",
-        "protocols",
-        "custody"
-      ],
-      "aurora_note": "Partially superseded by completed #1148, #1149, and #1150: custody fixture, schema, and sanitized fixture scaffolding now exist. Remaining live work is true custody verification: source/internal SHA resolution, verified_at/verified_by fields, and SHADOWFAX standalone bundle disposition.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 7,
-      "id": "#1142",
-      "title": "docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "docs",
-        "architecture",
-        "drift-ledger"
-      ],
-      "aurora_note": "Two unresolved items: mesh_api.js disposition decision and generate_api_catalog.py output path drift. The catalog generator defect directly blocks API snapshot currency. Fix output path before any API doc work proceeds. Unblocks #1146.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 8,
-      "id": "#1141",
-      "title": "docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "docs",
-        "architecture",
-        "QGIA"
-      ],
-      "aurora_note": "qgia_agent_registry_full.json has been pending commit for 102 days. No runtime router surface defined for the inter-node exchange protocol. Blocks #1144 (inventory missing surfaces). Resolve before QGIA integration work proceeds.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 9,
-      "id": "#1144",
-      "title": "docs/api — api_surface_inventory.json missing four surfaces",
-      "status": "open",
-      "owner": null,
-      "depends_on": [
-        "#1140",
-        "#1141"
-      ],
-      "tags": [
-        "docs",
-        "api",
-        "inventory"
-      ],
-      "aurora_note": "Blocked by #1140 (topology contradiction) and #1141 (QGIA router undefined). Four missing surfaces: /api/mesh/agents, /api/qgia, PAT routes, Consent Architecture v3.1. Inventory is the source-of-truth anchor for the entire docs/api cluster.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 10,
-      "id": "#1143",
-      "title": "docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "docs",
-        "architecture",
-        "scaling"
-      ],
-      "aurora_note": "Standalone. No blockers. scaling_plan.md has no last_reviewed date, no version marker, and no stated relationship to the QGIA node, GUMAS 9-node L2 network, or current two-node L1 topology. May be materially stale.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 11,
-      "id": "#1145",
-      "title": "docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps",
-      "status": "open",
-      "owner": null,
-      "depends_on": [
-        "#1144"
-      ],
-      "tags": [
-        "docs",
-        "api",
-        "reference"
-      ],
-      "aurora_note": "Blocked by #1144 (inventory must be current before reference doc is updated). Three gaps: Consent Architecture v3.1 status unknown, HR module version header stale, no token budget cross-reference for compute-intensive endpoints.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 12,
-      "id": "#1146",
-      "title": "docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated",
-      "status": "open",
-      "owner": null,
-      "depends_on": [
-        "#1142",
-        "#1144",
-        "#1145"
-      ],
-      "tags": [
-        "docs",
-        "api",
-        "governance"
-      ],
-      "aurora_note": "Governance self-audit. Closes last in the docs/api cluster after #1142, #1144, and #1145 are resolved. Three violations: snapshot currency not self-enforcing, test_api_surface_inventory.py is schema-only not coverage, review cadence conditions met but review not triggered.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 13,
-      "id": "#1135",
-      "title": "simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "simulation",
-        "roster",
-        "validation"
-      ],
-      "aurora_note": "No blockers. Three overlapping roster documents with no stated reconciliation or authoritative source. 165 KB is not a maintainable document size. OPPY and STARLING_AU entries need cross-check across registries before QGIA integration work.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 14,
-      "id": "#1136",
-      "title": "simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking",
-      "status": "open",
-      "owner": null,
-      "depends_on": [],
-      "tags": [
-        "simulation",
-        "enhancement",
-        "tracking"
-      ],
-      "aurora_note": "No blockers. 38 KB proposal with no acceptance status, no issue linkage, and no reference from CANON_INDEX.md. Risk of agents implementing rejected or superseded proposals. Needs per-enhancement status recorded.",
-      "aurora_authority": true
-    },
-    {
-      "rank": 15,
+      "rank": 2,
       "id": "arch/layer-canonization",
       "title": "Layer architecture canonization (L1/L2/L3 enforcement in code)",
       "status": "open",
@@ -274,7 +38,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 16,
+      "rank": 3,
       "id": "sim/SENTINEL-phase0",
       "title": "PROJECT SENTINEL — Phase 0: Ethics review board constitution",
       "status": "needs-decision",
@@ -291,7 +55,7 @@
       "aurora_authority": true
     },
     {
-      "rank": 17,
+      "rank": 4,
       "id": "ops/QGIA-doctrine-store",
       "title": "QGIA analytical framework — store in ops/analytical_frameworks/QGIA/",
       "status": "open",
@@ -307,23 +71,21 @@
       "aurora_authority": true
     },
     {
-      "rank": 18,
+      "rank": 5,
       "id": "docs/api-reference",
       "title": "API reference documentation",
       "status": "open",
       "owner": null,
-      "depends_on": [
-        "#1130"
-      ],
+      "depends_on": [],
       "tags": [
         "docs",
         "api"
       ],
-      "aurora_note": "Do not write API docs against a moving target. Wait for CI green. Superseded in priority by the specific docs/api audit issues (#1144, #1145, #1146) which address the same surface with more precision.",
+      "aurora_note": "The specific docs/API audit issues #1144, #1145, and #1146 and pentest scope issue #1130 are complete. Refresh the live API inventory before starting so documentation targets current main.",
       "aurora_authority": true
     },
     {
-      "rank": 19,
+      "rank": 6,
       "id": "feat/QGIA",
       "title": "QGIA integration hooks",
       "status": "needs-decision",
@@ -397,6 +159,97 @@
       "closed": "2026-07-13",
       "status": "done",
       "pr": 1159
+    },
+    {
+      "id": "#1130",
+      "github_issue": 1130,
+      "title": "SECURITY — pentest scope is stale against the current API surface",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1139",
+      "github_issue": 1139,
+      "title": "docs/ethics — create top-level README and navigation index",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1140",
+      "github_issue": 1140,
+      "title": "docs/architecture — fix RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md contradiction re: mesh/agents routes and QGIA",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1137",
+      "github_issue": 1137,
+      "title": "docs/ethics — geometric curvature v2 supplemental warning layer has no follow-up implementation issue",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1138",
+      "github_issue": 1138,
+      "title": "docs/ethics/recovered_protocols — all five custody records PENDING; custody inventory work not started",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1142",
+      "github_issue": 1142,
+      "title": "docs/architecture — RUNTIME_PATH_DRIFT_LEDGER.md: two unresolved items with no tracking issue",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1141",
+      "github_issue": 1141,
+      "title": "docs/architecture — QGIA_L1_NODE_REGISTRATION.md: agent registry pending 102 days, no exchange router defined",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1144",
+      "github_issue": 1144,
+      "title": "docs/api — api_surface_inventory.json missing four surfaces",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1143",
+      "github_issue": 1143,
+      "title": "docs/architecture — scaling_plan.md has no issue coverage and no relationship to current runtime topology",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1145",
+      "github_issue": 1145,
+      "title": "docs/api — RD_API_REFERENCE.md version 1.0.0 (2025-11-12, 7 months stale); three gaps",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1146",
+      "github_issue": 1146,
+      "title": "docs/api — API_CATALOG_GOVERNANCE.md: three governance rules currently violated",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1135",
+      "github_issue": 1135,
+      "title": "simulation/ — L1_CANON_CHARACTER_ROSTER.md (165 KB) has no validation against QGIA or Orion registries",
+      "closed": "2026-07-13",
+      "status": "done"
+    },
+    {
+      "id": "#1136",
+      "github_issue": 1136,
+      "title": "simulation/ — ORION_STATION_ENHANCEMENT_PROPOSAL.md (38 KB) has no implementation tracking",
+      "closed": "2026-07-13",
+      "status": "done"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- move 13 GitHub-backed queue entries that closed on 2026-07-13 from `active` to `completed`
- preserve the relative order of the six remaining repo-native items and normalize their ranks
- clear the completed #1130 dependency from `docs/api-reference`
- regenerate `QUEUE.md`, `NEXT_UP.md`, `OPEN_GATES.md`, and coordination metrics from the canonical queue

## Why

The generated `NEXT_UP.md` still presented #1130, #1135–#1146, and #1139 as ready work even though live GitHub state confirms all 13 issues are closed. This created a false work-selection surface.

## Impact

The queue now reports 6 active and 21 completed items. It does not ingest or rank the repository’s other open issues; that remains future roadmap work under #1131.

## Validation

- `pytest -q tests/test_work_queue_schema.py` — 5 passed
- `python3 ops/work_queue/sync_queue.py --check` — all generated views current
- `python3 ops/work_queue/collect_coordination_metrics.py --check` — current
- scoped pre-commit hooks for the five changed queue files — passed
- `git diff --check` — passed

Refs #1131