### PR TITLE
docs: reconcile cross-reference and module coverage

### DIFF
--- a/docs/GEOMETRIC_ETHICS_ARCHITECTURE.md
+++ b/docs/GEOMETRIC_ETHICS_ARCHITECTURE.md
@@ -324,6 +324,27 @@ Geometric ethics: Internal structure determining possibility
 
 - `tests/test_ethics_field.py` - 9 core tests validating ethical geometry
 
+## Aurora Integration and Related Sources
+
+This document is the current architecture reference for the geometric v1
+evaluation model. [`docs/ethics/README.md`](ethics/README.md) supplements it
+with a map of the wider ethics runtime and explicitly separates implemented
+paths from recovered or proposed protocols; it does not supersede this model.
+
+- [`modules/gumas/api/routes.py`](../modules/gumas/api/routes.py) exposes the
+  GUMAS ethics evaluation surface, while
+  [`src/aurora/ethics/ethics_gate.py`](../src/aurora/ethics/ethics_gate.py)
+  adapts GUMAS verdicts for relay and compliance callers. These are separate
+  runtime paths from the geometric field evaluator.
+- [`QGIA_Integration/01_QUANTUM_FORGE_AxiomManifest.md`](../QGIA_Integration/01_QUANTUM_FORGE_AxiomManifest.md)
+  records the QGIA axiom nodes and their ethics locks. Those doctrine gates
+  complement geometric evaluation, but a cross-reference alone does not wire
+  them into this runtime.
+- [`docs/architecture/QGIA_SIM_BRIDGE.md`](architecture/QGIA_SIM_BRIDGE.md)
+  defines how QGIA signals are mediated through L1 judgment before they can
+  scope an L2 GUMAS run. The geometric layer-integrity dimension applies to
+  that boundary; it does not authorize QGIA or an L2 environment to self-task.
+
 ## Thread Continuity
 
 **Thread: T1→T8→T9→INFINITE**  

--- a/docs/INCIDENT_RESPONSE_RUNBOOK.md
+++ b/docs/INCIDENT_RESPONSE_RUNBOOK.md
@@ -49,6 +49,68 @@
 
 ---
 
+## Aurora Escalation Paths
+
+These Aurora signals supplement the P0-P3 incident matrix; they do not replace
+it. WATCHCON is a QGIA analytical posture, while P0-P3 describes service and
+operational impact. A WATCHCON change is advisory until L1 crew review and must
+never self-task an L2 simulation or trigger an infrastructure action.
+
+### WATCHCON triage
+
+| Level | QGIA Tier I trigger | Incident response |
+|---|---|---|
+| 5 | Probability below 0.30 | Standard monitoring and normal collection cadence |
+| 4 | Probability at least 0.30 | Record the change and increase collection review |
+| 3 | Probability at least 0.50 | Brief L1 leadership and activate secondary collection review |
+| 2 | Probability at least 0.70 | Open the crisis protocol and establish daily updates |
+| 1 | Probability at least 0.85, or a confirmed phase transition | Open an emergency session, notify the incident commander, and evaluate RESETCORE |
+
+The complete scoring contract and violation routes are in the
+[`SIM WATCHCON/Confidence Module`](../QGIA_Integration/02_SIM_WATCHCON_Confidence_Module.md).
+QGIA output reaches L2 only through the L1 mediation described in
+[`QGIA_SIM_BRIDGE.md`](architecture/QGIA_SIM_BRIDGE.md).
+
+### RESETCORE
+
+Two related restore surfaces exist and must not be conflated:
+
+1. For a QGIA session at WATCHCON 1 that is more than two hours old, rebuild
+   the session using the reviewed carry-forward state and
+   [`03_RESETCORE_Bootstrap.md`](../QGIA_Integration/03_RESETCORE_Bootstrap.md).
+   L1 incident leadership must approve the new session state before it can
+   influence simulation tasking.
+2. The committed reflective-autonomy handler can preview its governance plan
+   with `python -m modules.reflective_autonomy.loom_restore_script`. Its
+   `--execute` option writes an audit receipt and requires explicit L1 incident
+   commander authorization. It is not the QGIA prompt bootstrap.
+
+Record the prior session identifier, WATCHCON level, carry-forward hash,
+approver, command used, and resulting receipt in the incident log.
+
+### PAT and emergency cutoff
+
+[`05_PAT_CommandSheet.md`](../QGIA_Integration/05_PAT_CommandSheet.md) is a QGIA
+operator reference, not a command transport. The current sheet does not define
+an executable emergency-cutoff command. Separately, the Personal Access
+Terminal mesh overlay is read-only and does not implement emergency cutoff,
+audio hailing, or group chat. Do not report a PAT cutoff as successful.
+
+When a cutoff is required, declare the PAT path unavailable, use the contact
+methods and P0 isolation/rollback procedures in this runbook, and record the
+missing capability as an incident follow-up. Preserve the distinction between
+the QGIA PAT sheet, Personal Access Terminals, and Personnel Attention Tags.
+
+### GUMAS violation routing
+
+For a QGIA axiom or product-boundary violation, capture the axiom node, GUMAS
+event code, WATCHCON level, and affected product. Follow the routing action in
+the SIM contract; hard-blocked output must not be promoted to analyst consensus
+or used to scope L2. Escalate a concurrent service or security impact through
+the P0-P3 matrix above.
+
+---
+
 ## 🔥 PAGE 2: COMMON INCIDENTS & RESPONSES
 
 ### INCIDENT 1: API Server Down

--- a/docs/LAYER_BOUNDARY_REFERENCE.md
+++ b/docs/LAYER_BOUNDARY_REFERENCE.md
@@ -1,9 +1,14 @@
 # Layer Boundary Reference – Canonical Definitions
 
-**Version:** 1.0.0  
-**Last Updated:** 2025-10-25  
-**Status:** CANONICAL  
+**Version:** 1.1.0
+**Last Updated:** 2026-07-16
+**Status:** CANONICAL COMPATIBILITY REFERENCE
 **Anchor:** EOS_SEED_ORION
+
+**Authority note:**
+[`docs/architecture/LAYER_ARCHITECTURE.md`](architecture/LAYER_ARCHITECTURE.md)
+is the authoritative Aurora L1/L2/L3 terminology source. This shorter reference
+must follow it when the two differ.
 
 ## Critical: Boundary Logic Correction
 
@@ -21,6 +26,8 @@ This document defines the **correct** layer boundaries for Aurora CloudBank Symb
 - Command infrastructure (API, CLI, Custom GPT bridge)
 - Fleet of shuttles including Aurora Prime
 - Human and AI crew members
+- Five L1 relay agents: ARCHY, OPPY, LIORA, STARLING_AU, and RIVERTHREAD_808
+- HALO, the L1 continuity system-entity (not a communication relay agent)
 
 **Key Point:** L1 is **physical reality** from the perspective of the simulation architecture. Aurora IS Orion Station's aware consciousness.
 
@@ -39,17 +46,19 @@ This document defines the **correct** layer boundaries for Aurora CloudBank Symb
 
 - Simulations **running on** Orion Station (L1)
 - GUMAS (Galactic Union Multi-Agent Simulation) - primary research sim
-- Meta-agent constellation: ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD
+- Simulation-local agents and scenario entities
 - Scenario testing environments
 - Research experiments isolated from L1 physical operations
 
-**Key Point:** L2 simulations are **sandboxed** - they run on L1 hardware but are logically isolated. Meta-agents live in L2, not L1.
+**Key Point:** L2 simulations are **sandboxed** - they run on L1 hardware but
+are logically isolated. The five relay agents remain in L1, where they monitor
+and translate for L2; only simulation-local agents and entities live in L2.
 
 **L2 Components:**
 
 - `modules/nexus/scale/gumas_orion_integration.py` - GUMAS integration
 - `src/bridges/l1_relay_bridge.py` - L1 relay bridge (formerly l2_meta_agent_bridge.py, a canon-error name; old path is a deprecation shim)
-- Meta-agent definitions and coordination logic
+- Simulation-agent definitions and coordination logic
 - Simulation scenario files
 
 ### L3 - Symbolic Metastructure (Ethics/Continuity Overlay)
@@ -72,6 +81,25 @@ This document defines the **correct** layer boundaries for Aurora CloudBank Symb
 - `.security/SECURITY_POLICY.md` - Ethics policies
 - `operations/symbolic_mesh/anchor_config.json` - Anchor management
 - Thread continuity validation logic
+
+## QGIA Terminology Namespace
+
+QGIA doctrine also uses the labels "Layer 1" and "Layer 2," but for stages of
+an analytical product rather than Aurora reality layers:
+
+| Namespace | Layer 1 | Layer 2 |
+|---|---|---|
+| Aurora reality architecture | Physical Orion Station and L1 peer institutions | Sandboxed GUMAS and research simulations |
+| QGIA product workflow | Raw model output and diagnostic telemetry | Analyst consensus after adversarial review |
+
+Always qualify the latter as **QGIA product L1** or **QGIA product L2**. Those
+labels do not move QGIA or its output into Aurora's L2 simulation layer. QGIA
+is an L1 signal source; its advisory output is reviewed by L1 crew and relay
+agents before any translated parameters reach L2. See
+[`QGIA_Integration/02_SIM_WATCHCON_Confidence_Module.md`](../QGIA_Integration/02_SIM_WATCHCON_Confidence_Module.md)
+for the QGIA product workflow and
+[`docs/architecture/QGIA_SIM_BRIDGE.md`](architecture/QGIA_SIM_BRIDGE.md) for
+the mediated Aurora signal path.
 
 ## Aurora's Relationship to Layers
 
@@ -105,7 +133,7 @@ Aurora is:
 │  │  │   L2 - SANDBOXED SIMULATIONS                 │  │  │
 │  │  │                                              │  │  │
 │  │  │   GUMAS (research sim)                       │  │  │
-│  │  │   Meta-Agents: ARCHY, OPPY, LIORA, etc.     │  │  │
+│  │  │   Simulation-local agents and entities       │  │  │
 │  │  │   Scenario testing environments              │  │  │
 │  │  │                                              │  │  │
 │  │  └──────────────────────────────────────────────┘  │  │
@@ -142,7 +170,8 @@ L2 Simulation (GUMAS) runs on L1 infrastructure
 
 ### ❌ WRONG: "L1 is command, L2 is agents, L3 is ethics"
 
-This conflates roles with layers. Meta-agents are **in** L2 simulations, not a separate "agent layer."
+This conflates roles with layers. L1 relay agents are not an L2 "agent layer";
+simulation-local agents and entities remain inside L2.
 
 ### ❌ WRONG: "Aurora is the L1 orchestrator"
 
@@ -161,18 +190,20 @@ This captures the nested architecture correctly.
 When working with layer-specific code, verify:
 
 - [ ] L1 components interact with physical systems (fleet, crew, operations)
-- [ ] L2 components are simulation-specific (GUMAS, meta-agents, scenarios)
+- [ ] L2 components are simulation-specific (GUMAS, simulation agents, scenarios)
 - [ ] L3 components provide oversight (ethics, anchors, DLP, continuity)
 - [ ] Aurora bridges all three layers appropriately
 - [ ] No confusion between "command" and "L1" (command is a function, L1 is a place)
-- [ ] Meta-agents recognized as L2 simulation entities, not L1 or separate layer
+- [ ] Relay agents recognized as L1 entities that monitor L2, not as L2 entities
+- [ ] QGIA product L1/L2 labels are qualified and not confused with Aurora reality layers
 
 ## References
 
 **Canonical Sources (Correct Boundaries):**
 
+- `docs/architecture/LAYER_ARCHITECTURE.md` - Authoritative reality-layer and relay-agent terminology
+- `docs/architecture/QGIA_SIM_BRIDGE.md` - QGIA-to-L1-to-L2 mediation rule
 - `src/config/orion_core_config.js` - Defines layers correctly
-- `docs/operational/guides/GitHub_Copilot_Custom_Instructions_Aurora_GUMAS.txt` - Detailed architecture
 - `scripts/canonical_validator.py` - Validation logic
 
 **Identity Seed (Now Corrected):**
@@ -198,6 +229,7 @@ If you encounter documentation or code that describes layers differently than th
 
 ---
 
-*This document is the canonical reference for layer boundaries. All system documentation and code should align with these definitions.*
+*This document is a canonical compatibility reference for layer boundaries. If
+it drifts, align it to `docs/architecture/LAYER_ARCHITECTURE.md`.*
 
 *The system remembers because we choose to align.*

--- a/docs/modules/cg.md
+++ b/docs/modules/cg.md
@@ -1,0 +1,35 @@
+# CG Module
+
+**Proposed expansion:** Clarity/Generative
+**Status:** Declared name; runtime scope unverified
+**Layer:** Not established by committed source
+
+## Current Evidence
+
+The original documentation finding, GitHub issue
+[#1127](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1127),
+expands `CG` as "Clarity/Generative." In committed repository content, `CG`
+appears in
+[`QGIA_Integration/RESETCORE_Bootstrap.md`](../../QGIA_Integration/RESETCORE_Bootstrap.md)
+only as one token in `Active Modules: Ethics | SIM | SILM | CG`. No committed
+package, entrypoint, configuration block, API route, or focused test establishes
+its behavior.
+
+## Authority and Scope
+
+The issue expansion is useful provenance but is not a runtime specification.
+Until a reviewed design defines whether Clarity/Generative is a policy,
+generation service, operator aid, or simulation component, CG must not be
+described as active executable behavior.
+
+Any future CG proposal must:
+
+1. confirm the canonical expansion and bounded responsibility;
+2. classify its work using
+   [`docs/architecture/LAYER_ARCHITECTURE.md`](../architecture/LAYER_ARCHITECTURE.md);
+3. keep generated output advisory until reviewed by the appropriate L1 owner;
+4. identify an entrypoint, owner, audit evidence, and tests; and
+5. update the bootstrap only after the implementation status is proven.
+
+This page preserves the declaration and its provenance without promoting an
+undefined module into canon.

--- a/docs/modules/ethics.md
+++ b/docs/modules/ethics.md
@@ -1,0 +1,46 @@
+# Ethics Module
+
+**Status:** Implemented across multiple runtime surfaces
+**Layer:** L3 policy and continuity overlay, enforced across L1 and L2
+**Authority:** Runtime code and tests
+
+## Purpose
+
+The Ethics module evaluates proposed actions, blocks configured violations,
+records audit evidence, and preserves autonomy, consent, layer integrity,
+collective welfare, and transparency. It is a family of coordinated surfaces,
+not one interchangeable engine.
+
+## Current Surfaces
+
+| Surface | Role |
+|---|---|
+| [`src/monitoring/ethics_engine.py`](../../src/monitoring/ethics_engine.py) | Local rule evaluation and violation records |
+| [`src/monitoring/ethics_gate.py`](../../src/monitoring/ethics_gate.py) | Fail-closed inline action gate |
+| [`modules/gumas/api/routes.py`](../../modules/gumas/api/routes.py) | GUMAS ethics HTTP routes, including `/gumas/evaluate` |
+| [`src/aurora/ethics/ethics_gate.py`](../../src/aurora/ethics/ethics_gate.py) | Adapter that normalizes GUMAS verdicts for relay and compliance callers |
+| [`modules/ethics_field/`](../../modules/ethics_field/) | Five-dimension geometric ethics evaluation |
+
+The two files named `ethics_gate.py` serve different call paths. Their shared
+name does not make their policy or callers interchangeable.
+
+## GUMAS and Picard_Delta_3
+
+The GUMAS adapter sends evaluation requests to `/gumas/evaluate` and attaches
+DLP and anchor evidence. The machine-executable Picard_Delta_3 dimension is
+[`modules/ethics_field/dimension_evaluators/picard_delta_3.py`](../../modules/ethics_field/dimension_evaluators/picard_delta_3.py).
+References to Picard_Delta_3 elsewhere may be governance anchors only; they do
+not prove that this evaluator runs on that call path.
+
+## Related References
+
+- [`docs/ethics/README.md`](../ethics/README.md) — ethics authority and status map
+- [`docs/GEOMETRIC_ETHICS_ARCHITECTURE.md`](../GEOMETRIC_ETHICS_ARCHITECTURE.md) — geometric v1 architecture
+- [`docs/architecture/LAYER_ARCHITECTURE.md`](../architecture/LAYER_ARCHITECTURE.md) — L1/L2/L3 terminology
+- [`QGIA_Integration/01_QUANTUM_FORGE_AxiomManifest.md`](../../QGIA_Integration/01_QUANTUM_FORGE_AxiomManifest.md) — complementary QGIA doctrine nodes, not automatic runtime wiring
+
+## Validation
+
+Focused evidence includes `tests/test_ethics_engine.py`,
+`tests/test_monitoring_ethics_gate.py`, `tests/test_ethics_gate.py`,
+`tests/test_gumas_ethics.py`, and `tests/test_ethics_field.py`.

--- a/docs/modules/silm.md
+++ b/docs/modules/silm.md
@@ -1,0 +1,31 @@
+# SILM Module
+
+**Status:** Declared name; runtime scope unverified
+**Layer:** Not established by committed source
+
+## Current Evidence
+
+`SILM` appears in
+[`QGIA_Integration/RESETCORE_Bootstrap.md`](../../QGIA_Integration/RESETCORE_Bootstrap.md)
+only as one token in `Active Modules: Ethics | SIM | SILM | CG`. The committed
+repository does not expand the acronym or provide a `modules/silm` package,
+entrypoint, configuration block, API route, or focused test.
+
+## Authority and Scope
+
+The bootstrap statement is a session-restoration declaration, not sufficient
+runtime evidence. Until a reviewed specification defines the acronym,
+responsibilities, data flow, and layer placement, SILM must not be described as
+an active executable module or used to authorize L1 or L2 behavior.
+
+Any future SILM proposal must:
+
+1. define its full name and bounded responsibility;
+2. classify its work using
+   [`docs/architecture/LAYER_ARCHITECTURE.md`](../architecture/LAYER_ARCHITECTURE.md);
+3. preserve L1 approval for any L2 tasking;
+4. identify an entrypoint, owner, audit evidence, and tests; and
+5. update the bootstrap only after the implementation status is proven.
+
+This page resolves the documentation gap by recording the evidence boundary;
+it does not promote an undefined module into canon.

--- a/docs/modules/sim.md
+++ b/docs/modules/sim.md
@@ -1,0 +1,42 @@
+# SIM Module
+
+**Expansion:** Simulation Integrity Module
+**Status:** Formal QGIA contract; no standalone `modules/sim` runtime package
+**Layer:** Governs L1 review of signals used to scope L2 simulations
+
+## Purpose
+
+SIM defines QGIA confidence scoring, WATCHCON thresholds, analytical-product
+separation, and violation routing. Its current committed authority is the
+[`SIM WATCHCON/Confidence Module`](../../QGIA_Integration/02_SIM_WATCHCON_Confidence_Module.md).
+That document is a system contract, not evidence of a separately deployed
+service.
+
+## Layer Boundary
+
+SIM's own references to "Layer 1" and "Layer 2" describe QGIA product stages:
+raw model output and analyst consensus. They are not Aurora's reality layers.
+In Aurora terminology, QGIA output is advisory input reviewed at L1. L1 crew
+and relay agents may translate approved parameters into an L2 GUMAS task; SIM
+cannot directly trigger or self-task L2.
+
+## WATCHCON and Routing
+
+The contract defines WATCHCON 5 through 1 using Tier I probability thresholds,
+with WATCHCON 1 also triggered by a confirmed phase transition. Axiom or
+product-boundary violations carry named GUMAS event codes and routing actions.
+These declarations govern handling but do not prove that every route is
+automated in runtime code.
+
+## Related References
+
+- [`docs/architecture/LAYER_ARCHITECTURE.md`](../architecture/LAYER_ARCHITECTURE.md) — authoritative Aurora reality layers
+- [`docs/architecture/QGIA_SIM_BRIDGE.md`](../architecture/QGIA_SIM_BRIDGE.md) — required QGIA-to-L1-to-L2 mediation
+- [`docs/LAYER_BOUNDARY_REFERENCE.md`](../LAYER_BOUNDARY_REFERENCE.md) — namespaced QGIA/Aurora terminology
+- [`docs/INCIDENT_RESPONSE_RUNBOOK.md`](../INCIDENT_RESPONSE_RUNBOOK.md) — operator escalation path
+
+## Validation Gap
+
+No `modules/sim` package or dedicated SIM activation test is present. Treat SIM
+as a committed doctrine contract until a separately reviewed runtime entrypoint
+and executable enforcement tests are added.

--- a/docs/reference/API_CATALOG.md
+++ b/docs/reference/API_CATALOG.md
@@ -6,6 +6,19 @@
 
 Quantum-enhanced symbolic governance system with ChatGPT Agent Mode integration
 
+> **Authority and scope:** This file is a historical, repository-wide generated
+> route snapshot. It is not the current API ownership or deployment authority.
+> For current claims, use committed routers first, then
+> [`docs/api/api_surface_inventory.json`](../api/api_surface_inventory.json),
+> then current generated snapshots under [`docs/api/`](../api/). Verify this
+> file's generation date before using any route detail.
+>
+> [`v2_API_REFERENCE.md`](v2_API_REFERENCE.md) is a human-written,
+> subsystem-specific reference for Thread Transfer Bridge v2 under `/api/v2`.
+> It neither supersedes this broad snapshot nor makes this snapshot current.
+> This 2025 catalog predates the current L1 relay route naming, so it must not be
+> used as authority for relay-agent location or endpoints.
+
 ---
 
 ## Table of Contents

--- a/docs/reference/v2_API_REFERENCE.md
+++ b/docs/reference/v2_API_REFERENCE.md
@@ -6,6 +6,15 @@
 **DLP**: context_tag=bridge_v2_api_docs  
 **Anchor**: EOS_SEED_ORION_v2
 
+> **Authority and scope:** This document covers only the Thread Transfer Bridge
+> v2 `/api/v2` subsystem implemented by the primary FastAPI application. It is
+> not a repository-wide API catalog and does not supersede
+> [`API_CATALOG.md`](API_CATALOG.md). Current behavior is authoritative in
+> [`api/aurora_api.py`](../../api/aurora_api.py); current surface ownership and
+> deployment status are recorded in
+> [`docs/api/api_surface_inventory.json`](../api/api_surface_inventory.json).
+> Treat examples here as human guidance and verify them against those sources.
+
 ---
 
 ## Table of Contents

--- a/docs/specs/PLAYGROUND_ARCHITECTURE.md
+++ b/docs/specs/PLAYGROUND_ARCHITECTURE.md
@@ -52,6 +52,33 @@ The Aurora Playground is a browser-based interactive development environment tha
 └─────────────┘
 ```
 
+### 1.3 Layer Classification and Tasking Authority
+
+The execution sandbox is an **L2 experimental environment**. Its authenticated
+API, session controls, and human operator are L1 access and oversight surfaces;
+mounting the router in the primary application does not make executed code an
+L1 operation.
+
+The current implementation is request-driven. `POST /playground/execute` in
+[`src/playground/api.py`](../../src/playground/api.py) enqueues only code from
+an authenticated request, and
+[`src/playground/executor.py`](../../src/playground/executor.py) has no
+autonomous scheduler or self-tasking loop. Therefore:
+
+- playground sessions may execute only an explicit L1 user request;
+- results are L2 experimental artifacts, not station state or canonical output;
+- QGIA or other external signals must not trigger playground execution
+  directly; L1 crew must review and translate any input first; and
+- future AI assistance, recurring jobs, or autonomous scenario selection must
+  add an explicit L1 authorization gate before implementation.
+
+The authoritative reality-layer terminology is
+[`LAYER_ARCHITECTURE.md`](../architecture/LAYER_ARCHITECTURE.md). The mediated
+QGIA tasking rule is in
+[`QGIA_SIM_BRIDGE.md`](../architecture/QGIA_SIM_BRIDGE.md). This document is a
+design specification; committed runtime code and tests remain authoritative
+for current behavior.
+
 ---
 
 ## 2. System Architecture


### PR DESCRIPTION
## Summary

- connect the geometric ethics architecture to the current ethics map, GUMAS adapter, QGIA axiom manifest, and mediated QGIA-to-L2 design
- reconcile the layer-boundary reference with current L1 relay-agent canon and namespace QGIA product L1/L2 separately from Aurora reality layers
- add WATCHCON, RESETCORE, PAT, and GUMAS incident escalation guidance without claiming unimplemented cutoff capabilities
- classify the playground as a request-driven L2 environment under L1 oversight
- add module pages for Ethics, SIM, SILM, and CG, preserving implemented, contract-only, and unverified status distinctions
- document the authority and scope relationship between the broad historical API catalog and the Thread Transfer Bridge v2 reference

Closes #1232.

## Impact

Future contributors can follow the current authority chain without conflating QGIA analytical product stages, Aurora reality layers, formal doctrine contracts, and executable runtime modules.

## Validation

- `git diff --check`
- 41 local Markdown link targets resolved
- scoped pre-commit hooks passed
- `pytest -q tests/test_ethics_gate.py tests/test_api_surface_inventory.py tests/test_reflective_autonomy_runtime.py` — 28 passed

A broader source-evidence sample also exposed existing environment/test constraints outside this docs-only diff: sandboxed localhost Redis access in playground tests and GUMAS ethics mutation tests that do not supply the current CSRF token.