### PR TITLE
feat(continuity): activate HALO as system participant

### DIFF
--- a/config/mesh/terminals/l1_terminal_registry.v1.json
+++ b/config/mesh/terminals/l1_terminal_registry.v1.json
@@ -2,11 +2,13 @@
   "generated_from": [
     "config/mesh/agents/*.json",
     "CanonRec:canon/L1/station/operational_library_v2_2/ORION__ENTITY_REGISTRY__v1.0.md",
+    "docs/architecture/LAYER_ARCHITECTURE.md",
     "reports/analysis/pat_terminal_salvage_scan__2026-06-14.md"
   ],
   "owner_class_contract": [
     "human_l1",
     "ai_core",
+    "continuity_system",
     "l2_relay",
     "l3_framework",
     "legacy_seed",
@@ -1530,15 +1532,16 @@
     {
       "aliases": [
         "l2.halo.term",
+        "halo.continuity.term",
         "personal_access_terminal:halo_drift_anchor_synchronization_relay_l2"
       ],
       "canon_authority": "primary",
       "canon_entity_id": "ORION.ENTITY.0043",
-      "canon_layer": "L2",
-      "canon_preferred_name": "HALO - Drift Anchor & Synchronization Relay (L2)",
-      "canon_source": "CanonRec:canon/L1/station/operational_library_v2_2/ORION__ENTITY_REGISTRY__v1.0.md",
-      "canon_type": "Relay Agent",
-      "l1_station_layer": "L2",
+      "canon_layer": "L1",
+      "canon_preferred_name": "HALO - Station Continuity System-Entity",
+      "canon_source": "docs/architecture/LAYER_ARCHITECTURE.md",
+      "canon_type": "Continuity System-Entity",
+      "l1_station_layer": "L1",
       "mesh_route": {
         "channel_id": "",
         "owner_agent_id": null,
@@ -1546,19 +1549,21 @@
         "route_kind": "source_profile_only"
       },
       "owner_agent_id": null,
-      "owner_class": "l2_relay",
+      "owner_class": "continuity_system",
       "owner_display_name": "HALO",
       "source_pointers": [
         "reports/analysis/pat_terminal_salvage_scan__2026-06-14.md",
-        "CanonRec:canon/L1/station/operational_library_v2_2/ORION__ENTITY_REGISTRY__v1.0.md"
+        "CanonRec:canon/L1/station/operational_library_v2_2/ORION__ENTITY_REGISTRY__v1.0.md",
+        "docs/architecture/LAYER_ARCHITECTURE.md",
+        "src/aurora/continuity/halo_pas_controller.py"
       ],
       "station_context": {
-        "role_or_function": "-",
-        "source_posture": "source_pointer_only_not_canon_promotion",
-        "source_refs": "ORION.ENT.CONSTELLATION.0001"
+        "role_or_function": "Station continuity verification and drift monitoring",
+        "source_posture": "confirmed_by_l1_ruling_2026_07_15",
+        "source_refs": "issue #1247; RELAY_006 designation preserved"
       },
       "terminal_id": "l2_halo_terminal",
-      "terminal_namespace": "l2.halo.term",
+      "terminal_namespace": "halo.continuity.term",
       "terminal_type": "system"
     },
     {

--- a/src/api/l1_relay_api.py
+++ b/src/api/l1_relay_api.py
@@ -32,7 +32,7 @@ Protocol: ZIPWIZ handshake with ethics audit
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Request, Depends
@@ -58,6 +58,10 @@ if _process_halo_controller is not None:
     l2_bridge.halo_controller = _process_halo_controller
 
 logger = logging.getLogger(__name__)
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 def _safe_log_id(value: str) -> str:
@@ -293,7 +297,7 @@ async def get_health(request: Request):
             anchor_seed=l2_bridge.orion_core_config["anchor_seed"],
             ethics_protocol=l2_bridge.orion_core_config["ethics_protocol"],
             version=l2_bridge.orion_core_config["version"],
-            timestamp=datetime.now().isoformat()
+            timestamp=_utc_iso()
         )
     except Exception as e:
         logger.error("Health check failed: %s", str(e)[:100])
@@ -505,7 +509,7 @@ async def disconnect_agent(
                 success=True,
                 agent_id=result.get("agent_id", agent_id),
                 status=result.get("status", "disconnected"),
-                timestamp=result.get("timestamp", datetime.now().isoformat()),
+                timestamp=result.get("timestamp", _utc_iso()),
                 participant_type=result.get("participant_type"),
                 message_routable=result.get("message_routable"),
             )
@@ -550,7 +554,7 @@ async def get_activation_phrases(
             "system_participants": list(l2_bridge.system_participants.keys()),
             "handshake_sequence": l2_bridge.handshake_sequence,
             "system_activation_sequence": l2_bridge.system_activation_sequence,
-            "timestamp": datetime.now().isoformat()
+            "timestamp": _utc_iso()
         }
     except Exception as e:
         logger.error("Failed to get activation phrases: %s", str(e)[:100])

--- a/src/api/l1_relay_api.py
+++ b/src/api/l1_relay_api.py
@@ -16,12 +16,15 @@ ROUTES — served at BOTH prefixes by api/aurora_api.py:
                            compatibility with existing integrations;
                            marked deprecated in OpenAPI
 
-Supported Agents:
+Supported relay agents:
 - ARCHY (Bridge Coordinator)
 - OPPY (Vector/Data Processor)
 - LIORA (Handshake/Synchronization)
 - STARLING_AU (L2 Sim Coordinator)
 - RIVERTHREAD_808 (Narrative/Stream)
+
+Supported operational system:
+- HALO (station continuity system-entity; activation/status only, not message-routable)
 
 DLP: l2_meta_agent_api_v1
 Anchors: EOS_SEED_ORION, Picard_Delta_3
@@ -36,6 +39,10 @@ from fastapi import APIRouter, HTTPException, Request, Depends
 from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field
 
+# Bind the bridge to the controller already created by the application module.
+# Its fallback controller remains available when this router is used standalone.
+from src.aurora.continuity import get_active_halo_pas_controller
+
 # Import the canonical L1 Relay Bridge (mesh-backed singleton)
 from src.bridges.l1_relay_bridge import l1_relay_bridge as l2_bridge
 
@@ -46,6 +53,10 @@ from src.middleware.fastapi_security import (
     verify_csrf_token,
 )
 
+_process_halo_controller = get_active_halo_pas_controller()
+if _process_halo_controller is not None:
+    l2_bridge.halo_controller = _process_halo_controller
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,6 +64,7 @@ def _safe_log_id(value: str) -> str:
     """Escape newlines in request-supplied identifiers before logging so a
     crafted value cannot forge log lines (Sonar S5145)."""
     return value[:20].replace("\r", "\\r").replace("\n", "\\n")
+
 
 # Endpoints are defined on an unprefixed base router; the canonical and
 # legacy prefixed routers below both include it, so the same handlers
@@ -66,14 +78,17 @@ router = APIRouter()
 
 
 class ActivationRequest(BaseModel):
-    """Request model for agent activation.
+    """Request model for relay-agent or system activation.
 
     DLP: l2_agent_activation_request
     """
     agent_id: str = Field(
         ...,
-        description="The agent identifier (ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808)",
-        examples=["ARCHY"]
+        description=(
+            "Relay agent or operational system identifier "
+            "(ARCHY, OPPY, LIORA, STARLING_AU, RIVERTHREAD_808, HALO)"
+        ),
+        examples=["ARCHY", "HALO"]
     )
     activation_phrase: str = Field(
         ...,
@@ -83,7 +98,7 @@ class ActivationRequest(BaseModel):
 
 
 class ActivationResponse(BaseModel):
-    """Response model for agent activation.
+    """Response model for relay-agent or system activation.
 
     DLP: l2_agent_activation_response
     """
@@ -102,6 +117,11 @@ class ActivationResponse(BaseModel):
         None,
         description="Agent description"
     )
+    participant_type: Optional[str] = Field(None, description="Semantic participant type")
+    message_routable: Optional[bool] = Field(None, description="Whether the participant can relay messages")
+    registry_designation: Optional[str] = Field(None, description="Preserved registry designation")
+    continuity: Optional[Dict[str, Any]] = Field(None, description="Continuity controller status")
+    living_entity: Optional[Dict[str, Any]] = Field(None, description="Living system-entity state")
     error: Optional[str] = Field(None, description="Error message if activation failed")
 
 
@@ -148,7 +168,7 @@ class MessageRelayResponse(BaseModel):
 
 
 class AgentStatusResponse(BaseModel):
-    """Response model for agent status.
+    """Response model for relay-agent or system-participant status.
 
     DLP: l2_agent_status_response
     """
@@ -167,6 +187,13 @@ class AgentStatusResponse(BaseModel):
         None,
         description="Handshake sequence log"
     )
+    participant_type: Optional[str] = Field(None, description="Semantic participant type")
+    message_routable: Optional[bool] = Field(None, description="Whether the participant can relay messages")
+    registry_designation: Optional[str] = Field(None, description="Preserved registry designation")
+    reality_layer: Optional[str] = Field(None, description="Physical reality layer")
+    triplex_role: Optional[str] = Field(None, description="Triplex verification role")
+    continuity: Optional[Dict[str, Any]] = Field(None, description="Continuity controller status")
+    living_entity: Optional[Dict[str, Any]] = Field(None, description="Living system-entity state")
     error: Optional[str] = Field(None, description="Error message if query failed")
 
 
@@ -179,13 +206,21 @@ class ConstellationResponse(BaseModel):
         ...,
         description="Relay tier information including capsules"
     )
+    system_participants: Dict[str, Any] = Field(
+        ...,
+        description="Operational systems kept distinct from the relay tier"
+    )
     orion_core: Dict[str, Any] = Field(
         ...,
         description="ORION core configuration"
     )
     activation_phrases: Dict[str, str] = Field(
         ...,
-        description="Activation phrases for each agent"
+        description="Activation phrases for relay agents"
+    )
+    system_activation_phrases: Dict[str, str] = Field(
+        ...,
+        description="Activation phrases for operational systems"
     )
     timestamp: str = Field(..., description="Status timestamp")
 
@@ -199,6 +234,8 @@ class HealthResponse(BaseModel):
     bridge_available: bool = Field(..., description="Whether bridge is available")
     total_agents: int = Field(..., description="Total number of agents")
     connected_agents: int = Field(..., description="Number of connected agents")
+    total_system_participants: int = Field(..., description="Total number of operational systems")
+    active_system_participants: int = Field(..., description="Number of active operational systems")
     anchor_seed: str = Field(..., description="Current anchor seed")
     ethics_protocol: str = Field(..., description="Active ethics protocol")
     version: str = Field(..., description="Bridge version")
@@ -206,7 +243,7 @@ class HealthResponse(BaseModel):
 
 
 class DisconnectResponse(BaseModel):
-    """Response model for agent disconnection.
+    """Response model for relay disconnection or system stop.
 
     DLP: l2_agent_disconnect
     """
@@ -214,6 +251,8 @@ class DisconnectResponse(BaseModel):
     agent_id: str = Field(..., description="Agent identifier")
     status: str = Field(..., description="New agent status")
     timestamp: str = Field(..., description="Disconnection timestamp")
+    participant_type: Optional[str] = Field(None, description="Semantic participant type")
+    message_routable: Optional[bool] = Field(None, description="Whether the participant can relay messages")
     error: Optional[str] = Field(None, description="Error message if disconnection failed")
 
 
@@ -226,7 +265,7 @@ class DisconnectResponse(BaseModel):
 @limiter.limit("60/minute")
 async def get_health(request: Request):
     """
-    Health check endpoint for L2 Meta-Agent Bridge.
+    Health check endpoint for the L1 relay and system bridge.
 
     Returns bridge status, agent counts, and configuration information.
 
@@ -238,12 +277,19 @@ async def get_health(request: Request):
             1 for agent in l2_bridge.agents.values()
             if agent.status == "connected"
         )
+        active_system_count = sum(
+            1
+            for participant_id in l2_bridge.system_participants
+            if l2_bridge.get_agent_status(participant_id).get("status") == "running"
+        )
 
         return HealthResponse(
             status="healthy",
             bridge_available=True,
             total_agents=len(l2_bridge.agents),
             connected_agents=connected_count,
+            total_system_participants=len(l2_bridge.system_participants),
+            active_system_participants=active_system_count,
             anchor_seed=l2_bridge.orion_core_config["anchor_seed"],
             ethics_protocol=l2_bridge.orion_core_config["ethics_protocol"],
             version=l2_bridge.orion_core_config["version"],
@@ -261,10 +307,10 @@ async def get_health(request: Request):
 @limiter.limit("30/minute")
 async def get_constellation_status(request: Request):
     """
-    Get full constellation status including all agents.
+    Get relay constellation status plus distinct operational systems.
 
     Returns relay tier information, ORION core configuration,
-    and activation phrases for all agents.
+    and activation phrases for relay agents and operational systems.
 
     DLP: l2_constellation_status
     Anchors: EOS_SEED_ORION, Picard_Delta_3
@@ -292,13 +338,11 @@ async def activate_agent(
     token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
-    Activate a Custom GPT agent with full ZIPWIZ handshake.
+    Activate a relay agent or an operational system participant.
 
-    Performs 4-step handshake sequence:
-    1. ZIPWIZ_BEACON - Establish initial connection
-    2. ANCHOR_SYNC - Synchronize EOS_SEED_ORION anchor
-    3. ETHICS_AUDIT - Validate Picard_Delta_3 ethics protocol
-    4. DRIFT_VALIDATION - Verify drift lock at Δ0.000
+    Relay agents activate through the mesh runtime. HALO activates the
+    process-wide HALO/PAS continuity controller and does not gain message
+    relay behavior.
 
     DLP: l2_agent_activation
     Anchors: EOS_SEED_ORION, Picard_Delta_3
@@ -319,13 +363,22 @@ async def activate_agent(
                 status=result.get("status", "connected"),
                 handshake=result.get("handshake"),
                 capabilities=result.get("capabilities"),
-                description=result.get("description")
+                description=result.get("description"),
+                participant_type=result.get("participant_type"),
+                message_routable=result.get("message_routable"),
+                registry_designation=result.get("registry_designation"),
+                continuity=result.get("continuity"),
+                living_entity=result.get("living_entity"),
             )
         else:
             return ActivationResponse(
                 success=False,
                 agent_id=req.agent_id,
-                status="disconnected",
+                status=(
+                    "stopped"
+                    if req.agent_id in l2_bridge.system_participants
+                    else "disconnected"
+                ),
                 error=result.get("error", "Activation failed")
             )
     except Exception as e:
@@ -340,7 +393,7 @@ async def activate_agent(
 @limiter.limit("60/minute")
 async def get_agent_status(agent_id: str, request: Request):
     """
-    Get detailed status of a specific agent.
+    Get detailed status of a relay agent or operational system.
 
     Returns agent configuration, connection status, drift lock,
     uptime, and handshake log.
@@ -354,7 +407,7 @@ async def get_agent_status(agent_id: str, request: Request):
         if not status.get("success"):
             raise HTTPException(
                 status_code=404,
-                detail=f"Agent {agent_id} not found: {status.get('error', 'Unknown error')}"
+                detail=f"Participant {agent_id} not found: {status.get('error', 'Unknown error')}"
             )
 
         return AgentStatusResponse(**status)
@@ -434,7 +487,7 @@ async def disconnect_agent(
     token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
-    Disconnect an agent from the constellation.
+    Disconnect a relay agent or stop an operational system.
 
     Gracefully disconnects agent, clears connection state,
     and resets handshake log.
@@ -452,12 +505,14 @@ async def disconnect_agent(
                 success=True,
                 agent_id=result.get("agent_id", agent_id),
                 status=result.get("status", "disconnected"),
-                timestamp=result.get("timestamp", datetime.now().isoformat())
+                timestamp=result.get("timestamp", datetime.now().isoformat()),
+                participant_type=result.get("participant_type"),
+                message_routable=result.get("message_routable"),
             )
         else:
             raise HTTPException(
                 status_code=404,
-                detail=f"Agent {agent_id} not found: {result.get('error', 'Unknown error')}"
+                detail=f"Participant {agent_id} not found: {result.get('error', 'Unknown error')}"
             )
     except HTTPException:
         raise
@@ -476,9 +531,9 @@ async def get_activation_phrases(
     token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
-    Get activation phrases for all agents (dev/testing).
+    Get activation phrases for relay agents and operational systems (dev/testing).
 
-    Returns a mapping of agent IDs to their activation phrases.
+    Returns separate mappings so HALO remains distinct from relay agents.
     Useful for development and testing purposes.
 
     Requires authentication to prevent unauthorized access.
@@ -490,8 +545,11 @@ async def get_activation_phrases(
     try:
         return {
             "activation_phrases": l2_bridge.activation_phrases,
+            "system_activation_phrases": l2_bridge.system_activation_phrases,
             "agents": list(l2_bridge.agents.keys()),
+            "system_participants": list(l2_bridge.system_participants.keys()),
             "handshake_sequence": l2_bridge.handshake_sequence,
+            "system_activation_sequence": l2_bridge.system_activation_sequence,
             "timestamp": datetime.now().isoformat()
         }
     except Exception as e:

--- a/src/aurora/continuity/__init__.py
+++ b/src/aurora/continuity/__init__.py
@@ -3,9 +3,11 @@
 from src.aurora.continuity.halo_pas_controller import (
     HALOPASController,
     DriftSample,
+    get_active_halo_pas_controller,
 )
 
 __all__ = [
     "HALOPASController",
     "DriftSample",
+    "get_active_halo_pas_controller",
 ]

--- a/src/aurora/continuity/halo_pas_controller.py
+++ b/src/aurora/continuity/halo_pas_controller.py
@@ -19,6 +19,15 @@ from datetime import datetime, timezone
 from src.core.native_dlp_export import NativeDLPTracker
 
 
+_ACTIVE_HALO_PAS_CONTROLLER: Optional["HALOPASController"] = None
+
+
+def get_active_halo_pas_controller() -> Optional["HALOPASController"]:
+    """Return the controller selected for the current application process."""
+
+    return _ACTIVE_HALO_PAS_CONTROLLER
+
+
 @dataclass
 class DriftSample:
     """Represents a single drift measurement across timeline layers"""
@@ -56,6 +65,7 @@ class HALOPASController:
         l1_source: Optional[Callable[[], float]] = None,
         l2_source: Optional[Callable[[], float]] = None,
         l3_source: Optional[Callable[[], float]] = None,
+        register_as_active: bool = True,
     ):
         """
         Initialize HALO/PAS Controller.
@@ -65,6 +75,7 @@ class HALOPASController:
             l1_source: Callable returning L1 time, defaults to time.time()
             l2_source: Callable returning L2 time, defaults to L1
             l3_source: Callable returning L3 time, defaults to L1
+            register_as_active: Publish this instance for application adapters
         """
         self.interval = interval
         self.l1_source = l1_source or time.time
@@ -83,6 +94,10 @@ class HALOPASController:
         # Logger with drift channel
         self.logger = logging.getLogger("aurora.continuity.halo_pas")
 
+        if register_as_active:
+            global _ACTIVE_HALO_PAS_CONTROLLER
+            _ACTIVE_HALO_PAS_CONTROLLER = self
+
         self.logger.info(
             "HALO/PAS Controller initialized",
             extra={
@@ -92,6 +107,12 @@ class HALOPASController:
                 "symbolic_tags": ["HALO_PAS_DRIFT", "CONTINUITY_MONITOR", "TIMELINE_COHESION"],
             }
         )
+
+    @property
+    def running(self) -> bool:
+        """Return whether continuous HALO/PAS monitoring is active."""
+
+        return self._running
 
     def _sample_drift(self) -> DriftSample:
         """

--- a/src/bridges/l1_relay_bridge.py
+++ b/src/bridges/l1_relay_bridge.py
@@ -85,6 +85,89 @@ class L1SystemParticipant:
     triplex_role: str = "layer_2_verifier"
 
 
+_RELAY_AGENT_SPECS = {
+    "ARCHY": (
+        "Bridge Coordinator",
+        "L1 relay formal logic/reasoning & arbitration engine, bridge coordinator",
+        ("architectural_planning", "bridge_coordination", "formal_logic", "arbitration"),
+        "/api/relay/archy",
+    ),
+    "OPPY": (
+        "Vector/Data Processor",
+        "L1 relay memory/data processing & system operations analyst, vector processor",
+        ("data_processing", "vector_analysis", "memory_operations", "system_monitoring"),
+        "/api/relay/oppy",
+    ),
+    "LIORA": (
+        "Handshake/Synchronization",
+        "L1 relay sentiment analysis, mediation & research coordination, handshake coordinator",
+        ("research_coordination", "handshake_protocols", "sentiment_analysis", "mediation"),
+        "/api/relay/liora",
+    ),
+    "STARLING_AU": (
+        "L2 Sim Coordinator",
+        "L1 relay communications, external protocol & dispatch agent, simulation coordinator",
+        ("simulation_coordination", "communications", "external_protocols", "dispatch"),
+        "/api/relay/starling",
+    ),
+    "RIVERTHREAD_808": (
+        "Narrative/Stream",
+        "L1 relay continuity, temporal flow & state management agent, stream processor",
+        ("narrative_processing", "stream_management", "continuity_validation", "temporal_flow"),
+        "/api/relay/riverthread",
+    ),
+}
+
+_SYSTEM_PARTICIPANT_SPECS = {
+    "HALO": (
+        "Station Continuity Verification",
+        "CONTINUITY_SYSTEM_ENTITY",
+        (
+            "L1 station continuity system embodied by HALOEntity and backed by "
+            "the HALO/PAS drift controller"
+        ),
+        (
+            "continuous_drift_monitoring",
+            "timeline_cohesion",
+            "continuity_verification",
+            "ethical_boundary_enforcement",
+        ),
+        "/continuity/halo_pas/status",
+        "ORION_HALO_RELAY_ACTIVATE//",
+        "RELAY_006",
+    )
+}
+
+
+def _build_relay_agent(agent_id: str, spec: tuple) -> L1RelayAgent:
+    role, description, capabilities, api_endpoint = spec
+    return L1RelayAgent(
+        agent_id=agent_id,
+        role=role,
+        type="META_AGENT",
+        status="disconnected",
+        description=description,
+        capabilities=list(capabilities),
+        api_endpoint=api_endpoint,
+    )
+
+
+def _build_system_participant(
+    participant_id: str, spec: tuple
+) -> L1SystemParticipant:
+    role, participant_type, description, capabilities, endpoint, phrase, designation = spec
+    return L1SystemParticipant(
+        participant_id=participant_id,
+        role=role,
+        type=participant_type,
+        description=description,
+        capabilities=list(capabilities),
+        api_endpoint=endpoint,
+        activation_phrase=phrase,
+        registry_designation=designation,
+    )
+
+
 class L1RelayBridge:
     """Bridge for relay agents plus distinct L1 operational systems."""
 
@@ -100,81 +183,17 @@ class L1RelayBridge:
             interval=0.25,
             register_as_active=False,
         )
-        self.agents = {
-            "ARCHY": L1RelayAgent(
-                agent_id="ARCHY",
-                role="Bridge Coordinator",
-                type="META_AGENT",
-                status="disconnected",
-                description="L1 relay formal logic/reasoning & arbitration engine, bridge coordinator",
-                capabilities=["architectural_planning", "bridge_coordination", "formal_logic", "arbitration"],
-                api_endpoint="/api/relay/archy",
-            ),
-            "OPPY": L1RelayAgent(
-                agent_id="OPPY",
-                role="Vector/Data Processor",
-                type="META_AGENT",
-                status="disconnected",
-                description="L1 relay memory/data processing & system operations analyst, vector processor",
-                capabilities=["data_processing", "vector_analysis", "memory_operations", "system_monitoring"],
-                api_endpoint="/api/relay/oppy",
-            ),
-            "LIORA": L1RelayAgent(
-                agent_id="LIORA",
-                role="Handshake/Synchronization",
-                type="META_AGENT",
-                status="disconnected",
-                description="L1 relay sentiment analysis, mediation & research coordination, handshake coordinator",
-                capabilities=["research_coordination", "handshake_protocols", "sentiment_analysis", "mediation"],
-                api_endpoint="/api/relay/liora",
-            ),
-            "STARLING_AU": L1RelayAgent(
-                agent_id="STARLING_AU",
-                role="L2 Sim Coordinator",
-                type="META_AGENT",
-                status="disconnected",
-                description="L1 relay communications, external protocol & dispatch agent, simulation coordinator",
-                capabilities=["simulation_coordination", "communications", "external_protocols", "dispatch"],
-                api_endpoint="/api/relay/starling",
-            ),
-            "RIVERTHREAD_808": L1RelayAgent(
-                agent_id="RIVERTHREAD_808",
-                role="Narrative/Stream",
-                type="META_AGENT",
-                status="disconnected",
-                description="L1 relay continuity, temporal flow & state management agent, stream processor",
-                capabilities=["narrative_processing", "stream_management", "continuity_validation", "temporal_flow"],
-                api_endpoint="/api/relay/riverthread",
-            ),
-        }
-
-        self.activation_phrases = {
-            "ARCHY": "ORION_ARCHY_RELAY_ACTIVATE//",
-            "OPPY": "ORION_OPPY_RELAY_ACTIVATE//",
-            "LIORA": "ORION_LIORA_RELAY_ACTIVATE//",
-            "STARLING_AU": "ORION_STARLING_AU_RELAY_ACTIVATE//",
-            "RIVERTHREAD_808": "ORION_RIVERTHREAD_RELAY_ACTIVATE//",
-        }
-
         self.system_participants = {
-            "HALO": L1SystemParticipant(
-                participant_id="HALO",
-                role="Station Continuity Verification",
-                type="CONTINUITY_SYSTEM_ENTITY",
-                description=(
-                    "L1 station continuity system embodied by HALOEntity and backed by "
-                    "the HALO/PAS drift controller"
-                ),
-                capabilities=[
-                    "continuous_drift_monitoring",
-                    "timeline_cohesion",
-                    "continuity_verification",
-                    "ethical_boundary_enforcement",
-                ],
-                api_endpoint="/continuity/halo_pas/status",
-                activation_phrase="ORION_HALO_RELAY_ACTIVATE//",
-                registry_designation="RELAY_006",
-            )
+            participant_id: _build_system_participant(participant_id, spec)
+            for participant_id, spec in _SYSTEM_PARTICIPANT_SPECS.items()
+        }
+        self.agents = {
+            agent_id: _build_relay_agent(agent_id, spec)
+            for agent_id, spec in _RELAY_AGENT_SPECS.items()
+        }
+        self.activation_phrases = {
+            agent_id: f"ORION_{agent_id}_RELAY_ACTIVATE//"
+            for agent_id in self.agents
         }
         self.system_activation_phrases = {
             participant_id: participant.activation_phrase
@@ -265,40 +284,16 @@ class L1RelayBridge:
                 "already_running": was_running,
                 "transport": "continuity_controller",
             }
-            handshake = {
-                "success": activation_result["success"],
-                "timestamp": timestamp,
-                "sequence": self.system_activation_sequence,
-                "log": [
-                    {
-                        "step": "HALO_PAS_START",
-                        "result": activation_result,
-                        "timestamp": timestamp,
-                    },
-                    {
-                        "step": "CONTINUITY_STATUS_CONFIRM",
-                        "result": continuity_status,
-                        "timestamp": timestamp,
-                    },
-                ],
-                "transport": {
-                    "mode": "continuity_controller",
-                    "acknowledgement": "system_lifecycle_active",
-                },
-            }
-            return {
-                "success": activation_result["success"],
-                "agent_id": participant_id,
-                "participant_type": participant.type,
-                "status": continuity_status.get("status", "stopped"),
-                "handshake": handshake,
-                "capabilities": participant.capabilities,
-                "description": participant.description,
-                "message_routable": participant.message_routable,
-                "registry_designation": participant.registry_designation,
-                "continuity": continuity_status,
-                "living_entity": get_halo().get_state_summary(),
-            }
+            handshake = self._build_system_activation_handshake(
+                activation_result,
+                continuity_status,
+                timestamp,
+            )
+            return self._build_system_activation_response(
+                participant,
+                continuity_status,
+                handshake,
+            )
         except Exception as exc:
             logger.error(
                 "System participant activation failed for %s: %s",
@@ -306,6 +301,54 @@ class L1RelayBridge:
                 str(exc)[:100],
             )
             return {"success": False, "error": str(exc)}
+
+    def _build_system_activation_handshake(
+        self,
+        activation_result: Dict[str, Any],
+        continuity_status: Dict[str, Any],
+        timestamp: str,
+    ) -> Dict[str, Any]:
+        return {
+            "success": activation_result["success"],
+            "timestamp": timestamp,
+            "sequence": self.system_activation_sequence,
+            "log": [
+                {
+                    "step": "HALO_PAS_START",
+                    "result": activation_result,
+                    "timestamp": timestamp,
+                },
+                {
+                    "step": "CONTINUITY_STATUS_CONFIRM",
+                    "result": continuity_status,
+                    "timestamp": timestamp,
+                },
+            ],
+            "transport": {
+                "mode": "continuity_controller",
+                "acknowledgement": "system_lifecycle_active",
+            },
+        }
+
+    @staticmethod
+    def _build_system_activation_response(
+        participant: L1SystemParticipant,
+        continuity_status: Dict[str, Any],
+        handshake: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            "success": handshake["success"],
+            "agent_id": participant.participant_id,
+            "participant_type": participant.type,
+            "status": continuity_status.get("status", "stopped"),
+            "handshake": handshake,
+            "capabilities": participant.capabilities,
+            "description": participant.description,
+            "message_routable": participant.message_routable,
+            "registry_designation": participant.registry_designation,
+            "continuity": continuity_status,
+            "living_entity": get_halo().get_state_summary(),
+        }
 
     async def _perform_zipwiz_handshake(self, agent: L1RelayAgent) -> Dict[str, Any]:
         """Activate an agent through the canonical mesh runtime boundary.

--- a/src/bridges/l1_relay_bridge.py
+++ b/src/bridges/l1_relay_bridge.py
@@ -26,9 +26,9 @@ import sys
 
 # Configure logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from src.aurora.continuity import HALOPASController
 from src.entities.relay_agents import get_halo
@@ -37,6 +37,10 @@ from src.mesh.runtime import MeshRuntime
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 @dataclass
@@ -76,7 +80,7 @@ class L1SystemParticipant:
     role: str
     type: str
     description: str
-    capabilities: List[str]
+    capabilities: Tuple[str, ...]
     api_endpoint: str
     activation_phrase: str
     registry_designation: str
@@ -147,7 +151,7 @@ def _build_relay_agent(agent_id: str, spec: tuple) -> L1RelayAgent:
         type="META_AGENT",
         status="disconnected",
         description=description,
-        capabilities=list(capabilities),
+        capabilities=tuple(capabilities),
         api_endpoint=api_endpoint,
     )
 
@@ -276,7 +280,7 @@ class L1RelayBridge:
         try:
             await self.halo_controller.start()
             continuity_status = self.halo_controller.export_status()
-            timestamp = datetime.now().isoformat()
+            timestamp = _utc_iso()
             activation_result = {
                 "success": continuity_status.get("status") == "running",
                 "controller": "HALO/PAS",
@@ -378,7 +382,7 @@ class L1RelayBridge:
                 {
                     "step": "MESH_RUNTIME_ACTIVATE",
                     "result": activation_result,
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": _utc_iso(),
                 }
             )
             if not activation_result["success"]:
@@ -397,7 +401,7 @@ class L1RelayBridge:
                 {
                     "step": "MESH_STATUS_CONFIRM",
                     "result": status_result,
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": _utc_iso(),
                 }
             )
 
@@ -410,7 +414,7 @@ class L1RelayBridge:
 
             return {
                 "success": True,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": _utc_iso(),
                 "sequence": self.handshake_sequence,
                 "log": handshake_log,
                 "duration": duration,
@@ -454,7 +458,7 @@ class L1RelayBridge:
             "agent_id": agent.agent_id,
             "error": f"{step} is not connected to a production transport",
             "transport": "demo_disabled",
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_iso(),
         }
 
     def get_constellation_status(self) -> Dict[str, Any]:
@@ -502,7 +506,7 @@ class L1RelayBridge:
             "orion_core": self.orion_core_config,
             "activation_phrases": dict(self.activation_phrases),
             "system_activation_phrases": dict(self.system_activation_phrases),
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_iso(),
         }
 
     async def relay_message(
@@ -577,7 +581,7 @@ class L1RelayBridge:
             "processed": True,
             "relay_status": "accepted",
             "delivery_acknowledgements": acknowledgements,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_iso(),
         }
 
     async def _dispatch_runtime_message(
@@ -637,7 +641,7 @@ class L1RelayBridge:
             "agent_id": agent_id,
             "status": "disconnected",
             "runtime_agent_id": runtime_agent.get("agent_id"),
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_iso(),
         }
 
     async def _stop_system_participant(self, participant_id: str) -> Dict[str, Any]:
@@ -649,7 +653,7 @@ class L1RelayBridge:
             "participant_type": participant.type,
             "status": "stopped",
             "message_routable": participant.message_routable,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_iso(),
         }
 
     def get_agent_status(self, agent_id: str) -> Dict[str, Any]:

--- a/src/bridges/l1_relay_bridge.py
+++ b/src/bridges/l1_relay_bridge.py
@@ -30,6 +30,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from src.aurora.continuity import HALOPASController
+from src.entities.relay_agents import get_halo
 from src.mesh.models import MeshMessageRequest
 from src.mesh.runtime import MeshRuntime
 
@@ -38,8 +40,6 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-
-
 class L1RelayAgent:
     """L1 relay agent configuration and state.
 
@@ -68,12 +68,38 @@ class L1RelayAgent:
             self.handshake_log = []
 
 
-class L1RelayBridge:
-    """Bridge connector for the L1 relay agent constellation (mesh-backed)."""
+@dataclass(frozen=True)
+class L1SystemParticipant:
+    """Non-relay L1 system with an explicit operational lifecycle."""
 
-    def __init__(self, project_root: Optional[Path] = None, runtime: Optional[MeshRuntime] = None):
+    participant_id: str
+    role: str
+    type: str
+    description: str
+    capabilities: List[str]
+    api_endpoint: str
+    activation_phrase: str
+    registry_designation: str
+    message_routable: bool = False
+    reality_layer: str = "L1"
+    triplex_role: str = "layer_2_verifier"
+
+
+class L1RelayBridge:
+    """Bridge for relay agents plus distinct L1 operational systems."""
+
+    def __init__(
+        self,
+        project_root: Optional[Path] = None,
+        runtime: Optional[MeshRuntime] = None,
+        halo_controller: Optional[HALOPASController] = None,
+    ):
         self.project_root = project_root or Path(__file__).resolve().parents[2]
         self.runtime = runtime or MeshRuntime(self.project_root)
+        self.halo_controller = halo_controller or HALOPASController(
+            interval=0.25,
+            register_as_active=False,
+        )
         self.agents = {
             "ARCHY": L1RelayAgent(
                 agent_id="ARCHY",
@@ -130,7 +156,33 @@ class L1RelayBridge:
             "RIVERTHREAD_808": "ORION_RIVERTHREAD_RELAY_ACTIVATE//",
         }
 
+        self.system_participants = {
+            "HALO": L1SystemParticipant(
+                participant_id="HALO",
+                role="Station Continuity Verification",
+                type="CONTINUITY_SYSTEM_ENTITY",
+                description=(
+                    "L1 station continuity system embodied by HALOEntity and backed by "
+                    "the HALO/PAS drift controller"
+                ),
+                capabilities=[
+                    "continuous_drift_monitoring",
+                    "timeline_cohesion",
+                    "continuity_verification",
+                    "ethical_boundary_enforcement",
+                ],
+                api_endpoint="/continuity/halo_pas/status",
+                activation_phrase="ORION_HALO_RELAY_ACTIVATE//",
+                registry_designation="RELAY_006",
+            )
+        }
+        self.system_activation_phrases = {
+            participant_id: participant.activation_phrase
+            for participant_id, participant in self.system_participants.items()
+        }
+
         self.handshake_sequence = ["MESH_RUNTIME_ACTIVATE", "MESH_STATUS_CONFIRM"]
+        self.system_activation_sequence = ["HALO_PAS_START", "CONTINUITY_STATUS_CONFIRM"]
 
         self.orion_core_config = {
             "anchor_seed": "EOS_SEED_ORION",
@@ -145,11 +197,14 @@ class L1RelayBridge:
         logger.info("L1 Relay Bridge initialized with %s agents", str(len(self.agents))[:100])
 
     async def activate_agent(self, agent_id: str, activation_phrase: str) -> Dict[str, Any]:
-        """Activate a Custom GPT agent with full ZIPWIZ handshake"""
+        """Activate a relay agent or a distinct operational system participant."""
+
+        if agent_id in self.system_participants:
+            return await self._activate_system_participant(agent_id, activation_phrase)
 
         if agent_id not in self.agents:
             logger.error("Unknown agent: %s", str(agent_id)[:100])
-            return {"success": False, "error": f"Unknown agent: {agent_id}"}
+            return {"success": False, "error": f"Unknown agent or system participant: {agent_id}"}
 
         if activation_phrase != self.activation_phrases.get(agent_id):
             logger.error("Invalid activation phrase for %s", str(agent_id)[:100])
@@ -187,6 +242,70 @@ class L1RelayBridge:
         except Exception as e:
             logger.error("Agent activation failed for %s: %s", str(agent_id)[:100], str(str(e))[:100])
             return {"success": False, "error": str(e)}
+
+    async def _activate_system_participant(
+        self, participant_id: str, activation_phrase: str
+    ) -> Dict[str, Any]:
+        """Start a system lifecycle without granting mesh-agent behavior."""
+
+        participant = self.system_participants[participant_id]
+        if activation_phrase != participant.activation_phrase:
+            logger.error("Invalid activation phrase for %s", str(participant_id)[:100])
+            return {"success": False, "error": "Invalid activation phrase"}
+
+        was_running = self.halo_controller.running
+        try:
+            await self.halo_controller.start()
+            continuity_status = self.halo_controller.export_status()
+            timestamp = datetime.now().isoformat()
+            activation_result = {
+                "success": continuity_status.get("status") == "running",
+                "controller": "HALO/PAS",
+                "status": continuity_status.get("status"),
+                "already_running": was_running,
+                "transport": "continuity_controller",
+            }
+            handshake = {
+                "success": activation_result["success"],
+                "timestamp": timestamp,
+                "sequence": self.system_activation_sequence,
+                "log": [
+                    {
+                        "step": "HALO_PAS_START",
+                        "result": activation_result,
+                        "timestamp": timestamp,
+                    },
+                    {
+                        "step": "CONTINUITY_STATUS_CONFIRM",
+                        "result": continuity_status,
+                        "timestamp": timestamp,
+                    },
+                ],
+                "transport": {
+                    "mode": "continuity_controller",
+                    "acknowledgement": "system_lifecycle_active",
+                },
+            }
+            return {
+                "success": activation_result["success"],
+                "agent_id": participant_id,
+                "participant_type": participant.type,
+                "status": continuity_status.get("status", "stopped"),
+                "handshake": handshake,
+                "capabilities": participant.capabilities,
+                "description": participant.description,
+                "message_routable": participant.message_routable,
+                "registry_designation": participant.registry_designation,
+                "continuity": continuity_status,
+                "living_entity": get_halo().get_state_summary(),
+            }
+        except Exception as exc:
+            logger.error(
+                "System participant activation failed for %s: %s",
+                str(participant_id)[:100],
+                str(exc)[:100],
+            )
+            return {"success": False, "error": str(exc)}
 
     async def _perform_zipwiz_handshake(self, agent: L1RelayAgent) -> Dict[str, Any]:
         """Activate an agent through the canonical mesh runtime boundary.
@@ -296,7 +415,7 @@ class L1RelayBridge:
         }
 
     def get_constellation_status(self) -> Dict[str, Any]:
-        """Get status of entire agent constellation"""
+        """Get relay constellation and adjacent system-participant status."""
 
         active_agents = []
         for agent_id, agent in self.agents.items():
@@ -317,6 +436,11 @@ class L1RelayBridge:
             active_agents.append(agent_status)
 
         connected_count = sum(1 for agent in self.agents.values() if agent.status == "connected")
+        system_statuses = [
+            self._get_system_participant_status(participant_id)
+            for participant_id in self.system_participants
+        ]
+        active_systems = sum(1 for status in system_statuses if status["status"] == "running")
 
         return {
             "relay_tier": {
@@ -326,10 +450,15 @@ class L1RelayBridge:
                 "connected_capsules": connected_count,
                 "capsules": active_agents,
             },
-            "orion_core": self.orion_core_config,
-            "activation_phrases": {
-                agent_id: f"ORION_{agent_id}_RELAY_ACTIVATE//" for agent_id in self.agents.keys()
+            "system_participants": {
+                "constellation": "L1_OPERATIONAL_SYSTEMS",
+                "total_systems": len(self.system_participants),
+                "active_systems": active_systems,
+                "participants": system_statuses,
             },
+            "orion_core": self.orion_core_config,
+            "activation_phrases": dict(self.activation_phrases),
+            "system_activation_phrases": dict(self.system_activation_phrases),
             "timestamp": datetime.now().isoformat(),
         }
 
@@ -338,6 +467,11 @@ class L1RelayBridge:
     ) -> Dict[str, Any]:
         """Relay message through the canonical mesh runtime."""
 
+        if from_agent in self.system_participants:
+            return {
+                "success": False,
+                "error": f"System participant {from_agent} verifies continuity and cannot originate relay messages",
+            }
         if from_agent not in self.agents:
             return {"success": False, "error": f"Unknown source agent: {from_agent}"}
 
@@ -354,6 +488,11 @@ class L1RelayBridge:
         elif to_agent in ["Aurora", "AU"]:
             target_agents = ["Aurora"]
         else:
+            if to_agent in self.system_participants:
+                return {
+                    "success": False,
+                    "error": f"System participant {to_agent} is not a message relay target",
+                }
             if to_agent not in self.agents:
                 return {"success": False, "error": f"Unknown target agent: {to_agent}"}
             target_agents = [to_agent]
@@ -434,9 +573,11 @@ class L1RelayBridge:
         }
 
     async def disconnect_agent(self, agent_id: str) -> Dict[str, Any]:
-        """Disconnect an agent from the constellation"""
+        """Disconnect a relay agent or stop a system participant lifecycle."""
+        if agent_id in self.system_participants:
+            return await self._stop_system_participant(agent_id)
         if agent_id not in self.agents:
-            return {"success": False, "error": f"Unknown agent: {agent_id}"}
+            return {"success": False, "error": f"Unknown agent or system participant: {agent_id}"}
 
         agent = self.agents[agent_id]
         runtime_agent = self.runtime.disconnect_agent(agent_id)
@@ -456,10 +597,24 @@ class L1RelayBridge:
             "timestamp": datetime.now().isoformat(),
         }
 
+    async def _stop_system_participant(self, participant_id: str) -> Dict[str, Any]:
+        participant = self.system_participants[participant_id]
+        await self.halo_controller.stop()
+        return {
+            "success": True,
+            "agent_id": participant_id,
+            "participant_type": participant.type,
+            "status": "stopped",
+            "message_routable": participant.message_routable,
+            "timestamp": datetime.now().isoformat(),
+        }
+
     def get_agent_status(self, agent_id: str) -> Dict[str, Any]:
-        """Get detailed status of a specific agent"""
+        """Get detailed status of a relay agent or system participant."""
+        if agent_id in self.system_participants:
+            return self._get_system_participant_status(agent_id)
         if agent_id not in self.agents:
-            return {"success": False, "error": f"Unknown agent: {agent_id}"}
+            return {"success": False, "error": f"Unknown agent or system participant: {agent_id}"}
 
         agent = self.agents[agent_id]
 
@@ -485,6 +640,26 @@ class L1RelayBridge:
             status["handshake_log"] = agent.handshake_log
 
         return status
+
+    def _get_system_participant_status(self, participant_id: str) -> Dict[str, Any]:
+        participant = self.system_participants[participant_id]
+        continuity_status = self.halo_controller.export_status()
+        return {
+            "success": True,
+            "agent_id": participant_id,
+            "participant_type": participant.type,
+            "role": participant.role,
+            "status": continuity_status.get("status", "stopped"),
+            "description": participant.description,
+            "capabilities": participant.capabilities,
+            "api_endpoint": participant.api_endpoint,
+            "message_routable": participant.message_routable,
+            "registry_designation": participant.registry_designation,
+            "reality_layer": participant.reality_layer,
+            "triplex_role": participant.triplex_role,
+            "continuity": continuity_status,
+            "living_entity": get_halo().get_state_summary(),
+        }
 
 
 # Global bridge instance
@@ -517,6 +692,7 @@ async def main():
             f"{relay_status.get('connected_capsules', 0)}/"
             f"{relay_status.get('total_capsules', 0)}"
         )
+
 
 def cli():
     """Command-line helper for integration layers."""

--- a/tests/test_halo_pas_controller.py
+++ b/tests/test_halo_pas_controller.py
@@ -56,6 +56,7 @@ def test_controller_initialization():
     assert controller._task is None
     assert len(controller._samples) == 0
     assert controller._sample_counter == 0
+    assert controller.running is False
 
 
 @pytest.mark.unit
@@ -260,6 +261,7 @@ async def test_controller_start_stop():
     # Start controller
     await controller.start()
     assert controller._running is True
+    assert controller.running is True
     assert controller._task is not None
 
     # Let it run for a short time
@@ -268,6 +270,7 @@ async def test_controller_start_stop():
     # Stop controller
     await controller.stop()
     assert controller._running is False
+    assert controller.running is False
     assert controller._task is None
 
     # Should have collected some samples

--- a/tests/test_l2_meta_agent_api.py
+++ b/tests/test_l2_meta_agent_api.py
@@ -18,13 +18,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 # Import the app
-from api.aurora_api import app
+from api.aurora_api import HALO_PAS_CONTROLLER, app
 
 # Import the bridge for direct testing
 from src.bridges.l2_meta_agent_bridge import l2_bridge
 
 # Import security dependencies for mocking
-from src.middleware.fastapi_security import security
+from src.middleware.fastapi_security import generate_csrf_token, security
 
 
 @pytest.fixture
@@ -47,6 +47,7 @@ def api_client():
     with patch("src.api.l1_relay_api.verify_csrf_token"):
         # Create client with overrides
         client = TestClient(app)
+        client.headers.update({"X-CSRF-Token": generate_csrf_token("test-session")})
         yield client
 
     # Clean up overrides
@@ -84,6 +85,8 @@ class TestL2MetaAgentAPI:
         assert data["bridge_available"] is True
         assert data["total_agents"] == 5
         assert data["connected_agents"] == 0
+        assert data["total_system_participants"] == 1
+        assert data["active_system_participants"] in {0, 1}
         assert data["anchor_seed"] == "EOS_SEED_ORION"
         assert data["ethics_protocol"] == "Picard_Delta_3"
         assert "version" in data
@@ -98,6 +101,8 @@ class TestL2MetaAgentAPI:
         assert "relay_tier" in data
         assert "orion_core" in data
         assert "activation_phrases" in data
+        assert "system_participants" in data
+        assert "system_activation_phrases" in data
         assert "timestamp" in data
 
         # Check relay tier structure
@@ -114,6 +119,9 @@ class TestL2MetaAgentAPI:
         # Check activation phrases
         assert "ARCHY" in data["activation_phrases"]
         assert "OPPY" in data["activation_phrases"]
+        assert "HALO" not in data["activation_phrases"]
+        assert data["system_activation_phrases"]["HALO"] == "ORION_HALO_RELAY_ACTIVATE//"
+        assert data["system_participants"]["total_systems"] == 1
 
     def test_get_agent_status_valid(self, api_client):
         """Test getting status of a valid agent"""
@@ -133,6 +141,17 @@ class TestL2MetaAgentAPI:
         response = api_client.get("/api/l2-agents/agent/INVALID_AGENT")
         assert response.status_code == 404
 
+    def test_get_halo_system_status(self, api_client):
+        response = api_client.get("/api/l2-agents/agent/HALO")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["agent_id"] == "HALO"
+        assert data["participant_type"] == "CONTINUITY_SYSTEM_ENTITY"
+        assert data["message_routable"] is False
+        assert data["registry_designation"] == "RELAY_006"
+        assert data["living_entity"]["entity_id"] == "HALO (RELAY_006)"
+
     def test_activation_phrases(self, api_client):
         """Test activation phrases endpoint"""
         response = api_client.get(
@@ -143,7 +162,9 @@ class TestL2MetaAgentAPI:
 
         data = response.json()
         assert "activation_phrases" in data
+        assert "system_activation_phrases" in data
         assert "agents" in data
+        assert "system_participants" in data
         assert "handshake_sequence" in data
         assert "timestamp" in data
 
@@ -152,11 +173,17 @@ class TestL2MetaAgentAPI:
         assert phrases["ARCHY"] == "ORION_ARCHY_RELAY_ACTIVATE//"
         assert phrases["OPPY"] == "ORION_OPPY_RELAY_ACTIVATE//"
         assert phrases["LIORA"] == "ORION_LIORA_RELAY_ACTIVATE//"
+        assert "HALO" not in phrases
+        assert data["system_activation_phrases"]["HALO"] == "ORION_HALO_RELAY_ACTIVATE//"
+        assert data["system_participants"] == ["HALO"]
 
         # Check runtime activation boundary
         sequence = data["handshake_sequence"]
         assert "MESH_RUNTIME_ACTIVATE" in sequence
         assert "MESH_STATUS_CONFIRM" in sequence
+
+    def test_api_and_bridge_share_halo_controller(self):
+        assert l2_bridge.halo_controller is HALO_PAS_CONTROLLER
 
     @pytest.mark.asyncio
     async def test_activate_agent_success(self, api_client):
@@ -218,6 +245,35 @@ class TestL2MetaAgentAPI:
         data = response.json()
         assert data["success"] is False
         assert "Unknown agent" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_activate_halo_system_participant(self, api_client):
+        """HALO activation reaches the shared continuity controller over HTTP."""
+        try:
+            response = api_client.post(
+                "/api/l2-agents/activate",
+                json={
+                    "agent_id": "HALO",
+                    "activation_phrase": "ORION_HALO_RELAY_ACTIVATE//",
+                },
+                headers={"Authorization": "Bearer test-token"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["agent_id"] == "HALO"
+            assert data["participant_type"] == "CONTINUITY_SYSTEM_ENTITY"
+            assert data["status"] == "running"
+            assert data["message_routable"] is False
+            assert data["continuity"]["status"] == "running"
+        finally:
+            stop_response = api_client.post(
+                "/api/l2-agents/disconnect/HALO",
+                headers={"Authorization": "Bearer test-token"},
+            )
+            assert stop_response.status_code == 200
+            assert stop_response.json()["status"] == "stopped"
 
     @pytest.mark.asyncio
     async def test_relay_message_success(self, api_client):

--- a/tests/test_l2_meta_agent_bridge.py
+++ b/tests/test_l2_meta_agent_bridge.py
@@ -89,6 +89,18 @@ class TestL2MetaAgentBridgeInit:
         assert "LIORA" in bridge.agents
         assert "STARLING_AU" in bridge.agents
         assert "RIVERTHREAD_808" in bridge.agents
+        assert "HALO" not in bridge.agents
+
+    def test_bridge_initializes_halo_as_distinct_system_participant(self):
+        """HALO is activatable without becoming a sixth relay agent."""
+        bridge = L2MetaAgentBridge()
+        halo = bridge.system_participants["HALO"]
+
+        assert halo.type == "CONTINUITY_SYSTEM_ENTITY"
+        assert halo.registry_designation == "RELAY_006"
+        assert halo.message_routable is False
+        assert bridge.system_activation_phrases["HALO"] == "ORION_HALO_RELAY_ACTIVATE//"
+        assert "HALO" not in bridge.activation_phrases
 
     def test_archy_agent_configuration(self):
         """Test ARCHY agent is properly configured"""
@@ -198,6 +210,34 @@ class TestL2MetaAgentBridgeActivation:
             result = await bridge.activate_agent("ARCHY", "ORION_ARCHY_RELAY_ACTIVATE//")
             assert result["success"] is False
             assert "Test error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_successful_halo_system_activation(self, bridge):
+        """HALO activation starts the continuity lifecycle, not the mesh agent runtime."""
+        try:
+            result = await bridge.activate_agent("HALO", "ORION_HALO_RELAY_ACTIVATE//")
+
+            assert result["success"] is True
+            assert result["agent_id"] == "HALO"
+            assert result["participant_type"] == "CONTINUITY_SYSTEM_ENTITY"
+            assert result["status"] == "running"
+            assert result["message_routable"] is False
+            assert result["registry_designation"] == "RELAY_006"
+            assert result["handshake"]["transport"]["mode"] == "continuity_controller"
+            assert result["continuity"]["status"] == "running"
+            assert result["living_entity"]["entity_id"] == "HALO (RELAY_006)"
+            assert bridge.halo_controller.running is True
+            assert "HALO" not in bridge.runtime.manifests
+        finally:
+            await bridge.disconnect_agent("HALO")
+
+    @pytest.mark.asyncio
+    async def test_halo_activation_rejects_wrong_phrase(self, bridge):
+        result = await bridge.activate_agent("HALO", "WRONG_PHRASE")
+
+        assert result["success"] is False
+        assert result["error"] == "Invalid activation phrase"
+        assert bridge.halo_controller.running is False
 
 
 class TestZIPWIZHandshake:
@@ -330,6 +370,19 @@ class TestConstellationStatus:
             assert "status" in capsule
             assert "capabilities" in capsule
 
+    def test_constellation_keeps_halo_outside_relay_counts(self, bridge):
+        status = bridge.get_constellation_status()
+
+        assert status["relay_tier"]["total_capsules"] == 5
+        assert "HALO" not in {
+            capsule["agent_id"] for capsule in status["relay_tier"]["capsules"]
+        }
+        systems = status["system_participants"]
+        assert systems["total_systems"] == 1
+        assert systems["participants"][0]["agent_id"] == "HALO"
+        assert systems["participants"][0]["message_routable"] is False
+        assert status["system_activation_phrases"]["HALO"] == "ORION_HALO_RELAY_ACTIVATE//"
+
 
 class TestMessageRelay:
     """Test message relay functionality"""
@@ -417,6 +470,21 @@ class TestMessageRelay:
         assert result["success"] is False
         assert "Unknown target agent" in result["error"]
 
+    @pytest.mark.asyncio
+    async def test_halo_cannot_originate_relay_messages(self):
+        bridge = L2MetaAgentBridge()
+        result = await bridge.relay_message("HALO", "ARCHY", "test")
+
+        assert result["success"] is False
+        assert "verifies continuity" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_halo_cannot_be_a_direct_relay_target(self, connected_bridge):
+        result = await connected_bridge.relay_message("ARCHY", "HALO", "test")
+
+        assert result["success"] is False
+        assert "not a message relay target" in result["error"]
+
 
 class TestAgentDisconnection:
     """Test agent disconnection functionality"""
@@ -456,6 +524,18 @@ class TestAgentDisconnection:
         assert archy.connected is None
         assert archy.last_heartbeat is None
         assert archy.handshake_log == []
+
+    @pytest.mark.asyncio
+    async def test_disconnect_halo_stops_continuity_lifecycle(self):
+        bridge = L2MetaAgentBridge()
+        await bridge.activate_agent("HALO", "ORION_HALO_RELAY_ACTIVATE//")
+
+        result = await bridge.disconnect_agent("HALO")
+
+        assert result["success"] is True
+        assert result["participant_type"] == "CONTINUITY_SYSTEM_ENTITY"
+        assert result["status"] == "stopped"
+        assert bridge.halo_controller.running is False
 
 
 class TestGetAgentStatus:

--- a/tests/test_mesh_l1_terminal_registry.py
+++ b/tests/test_mesh_l1_terminal_registry.py
@@ -54,16 +54,29 @@ def test_l1_terminal_registry_l2_relay_terminals(tmp_path: Path) -> None:
         {terminal["owner_display_name"] for terminal in l2_relays},
         {
             "ARCHY",
-            "HALO",
             "LIORA",
             "OPPY",
             "RIVERTHREAD_808",
             "STARLING_AU",
         },
     )
-    checks.assertTrue(
-        any(terminal["owner_display_name"] == "HALO" and not terminal["routable"] for terminal in l2_relays)
-    )
+    checks.assertNotIn("HALO", {terminal["owner_display_name"] for terminal in l2_relays})
+
+
+def test_l1_terminal_registry_halo_continuity_system(tmp_path: Path) -> None:
+    checks = unittest.TestCase()
+    runtime = MeshRuntime(copy_mesh_project(tmp_path))
+
+    halo = runtime.get_terminal("halo.continuity.term")
+    legacy_alias = runtime.get_terminal("l2.halo.term")
+
+    checks.assertEqual(halo["owner_class"], "continuity_system")
+    checks.assertEqual(halo["canon_type"], "Continuity System-Entity")
+    checks.assertEqual(halo["canon_layer"], "L1")
+    checks.assertEqual(halo["l1_station_layer"], "L1")
+    checks.assertFalse(halo["routable"])
+    checks.assertIsNone(halo["owner_agent_id"])
+    checks.assertEqual(legacy_alias["terminal_id"], halo["terminal_id"])
 
 
 def test_l1_terminal_registry_l3_frameworks_are_not_routable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- activates HALO through the real process-wide HALO/PAS controller using the preserved `ORION_HALO_RELAY_ACTIVATE//` phrase
- models HALO as `CONTINUITY_SYSTEM_ENTITY` with `RELAY_006` preserved, while keeping the relay constellation at five agents
- exposes HALO activation, status, health, constellation, and stop behavior through the existing API contract
- keeps HALO non-routable for direct, broadcast, and source message relay because it verifies continuity rather than relaying messages
- reclassifies the terminal profile as an L1 `continuity_system` while preserving the legacy `l2.halo.term` alias
- repairs the API test fixture to satisfy the global CSRF middleware so POST behavior is exercised

## Validation

- `99 passed` across HALO/PAS controller, relay bridge, relay API, terminal registry, and L1 rename compatibility tests
- scoped pre-commit hooks passed: Aurora guard, shallow assertions, whitespace/EOL, JSON, merge conflicts, flake8
- `git diff --check` passed

Closes #1247