### PR TITLE
feat(onboarding): add repository-grounded engineer flow

### DIFF
--- a/ARCHITECTURE_QUICKMAP.md
+++ b/ARCHITECTURE_QUICKMAP.md
@@ -7,7 +7,7 @@ Aurora CloudBank Symbolic is the code and canon repository for Aurora, the simul
 ## Layer architecture → code map
 
 | Reality layer | Role | Primary code and authority |
-|---|---|---|
+| --- | --- | --- |
 | **L1 — Physical/Operational** | Orion Station crew, Aurora Core, five relay agents, HALO continuity system-entity, and station operations | `src/aurora/`, `src/aurora_orchestrator/`, `src/entities/`, `src/agents/`, `src/bridges/`, `config/mesh/` |
 | **L2 — Simulation/Research** | GUMAS and other computational experiments, scenarios, and forecast environments operated from L1 | `modules/gumas/`, `modules/quantum_simulator/`, `src/aurora_fusion/`, `simulation/` |
 | **L3 — Framework/Conceptual** | Axiomera, Caelion, Sentari, Velatrix, Glyphon, and Harmion; abstract ethics, provenance, drift, and symbolic rules | `modules/ethics_field/`, `modules/symbolic_core/`, `threadcore_registry.json` |

--- a/ARCHITECTURE_QUICKMAP.md
+++ b/ARCHITECTURE_QUICKMAP.md
@@ -1,0 +1,64 @@
+# Aurora — Architecture Quickmap
+
+## What this is
+
+Aurora CloudBank Symbolic is the code and canon repository for Aurora, the simulation director of the Orion Station institutional simulation, plus the runtime services that support ethics-governed simulation, symbolic memory, QGIA signal intake, and auditable operations. The repository has one ontological layer model—L1 station operations, L2 simulation/research environments, and L3 conceptual frameworks—and a separate three-step Triplex consent protocol. Treat those two uses of “layer” as distinct.
+
+## Layer architecture → code map
+
+| Reality layer | Role | Primary code and authority |
+|---|---|---|
+| **L1 — Physical/Operational** | Orion Station crew, Aurora Core, five relay agents, HALO continuity system-entity, and station operations | `src/aurora/`, `src/aurora_orchestrator/`, `src/entities/`, `src/agents/`, `src/bridges/`, `config/mesh/` |
+| **L2 — Simulation/Research** | GUMAS and other computational experiments, scenarios, and forecast environments operated from L1 | `modules/gumas/`, `modules/quantum_simulator/`, `src/aurora_fusion/`, `simulation/` |
+| **L3 — Framework/Conceptual** | Axiomera, Caelion, Sentari, Velatrix, Glyphon, and Harmion; abstract ethics, provenance, drift, and symbolic rules | `modules/ethics_field/`, `modules/symbolic_core/`, `threadcore_registry.json` |
+| **Cross-cutting runtime** | API composition, middleware, monitoring, observability, persistence, and shared utilities | `api/aurora_api.py`, `src/middleware/`, `src/monitoring/`, `src/observability/`, `src/core/`, `modules/aumemmanager/` |
+
+The authoritative definitions are in [`docs/architecture/LAYER_ARCHITECTURE.md`](./docs/architecture/LAYER_ARCHITECTURE.md). HALO is an L1 continuity system-entity whose living interface performs drift verification; it is not a sixth communication relay.
+
+## Runtime flow
+
+```text
+HTTP / WebSocket / CLI request
+            │
+            ▼
+api/aurora_api.py                       FastAPI composition root
+            │
+            ▼
+src/middleware/                         security, request bounds, identity, PII controls
+            │
+            ▼
+api routes + modules/*/api.py           request validation and capability routing
+            │
+            ▼
+modules/* + src/* services              simulation, memory, ethics, relays, observability
+            │
+            ▼
+audited response / persisted artifact   DLP tags, hashes, logs, or simulation state as implemented
+```
+
+`api/aurora_api.py` is the canonical application entry point. Router ownership and live topology are documented in `docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md`; do not infer live route ownership from historical diagrams alone.
+
+## Triplex Handshake (consent flow)
+
+Triplex is a functional verification protocol, not another reality map:
+
+1. **Glyph arbitration:** L3 frameworks validate ethics, provenance, and symbolic constraints.
+2. **Verifier step:** L1-resident relay agents perform their Triplex “Layer 2” middleware roles; HALO performs continuity/drift verification as a distinct system-entity.
+3. **Human consent:** authorized L1 crew provides final approval.
+
+Calling the relays “L2 agents” confuses their protocol role with residency. They live in L1 and monitor or affect L2.
+
+## QGIA → simulation tasking
+
+QGIA supplies real-world analytical signals. L1 crew and relay systems interpret those signals and decide what to run; L2 does not self-task. See [`docs/architecture/QGIA_SIM_BRIDGE.md`](./docs/architecture/QGIA_SIM_BRIDGE.md) for the governing rationale.
+
+## Where to go next
+
+- Canonical layer and Triplex definitions → [`docs/architecture/LAYER_ARCHITECTURE.md`](./docs/architecture/LAYER_ARCHITECTURE.md)
+- QGIA signal-to-simulation rationale → [`docs/architecture/QGIA_SIM_BRIDGE.md`](./docs/architecture/QGIA_SIM_BRIDGE.md)
+- Historical wiring snapshot (read its authority warning) → [`docs/architecture/SYSTEM_ARCHITECTURE_DIAGRAM.md`](./docs/architecture/SYSTEM_ARCHITECTURE_DIAGRAM.md)
+- Current runtime ownership → `docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md`
+- Ethics enforcement → `modules/ethics_field/`, `modules/gumas/`, `QGIA_Integration/04_GUMAS_AuditSchema.md`
+- Symbolic memory → `modules/aumemmanager/`, `modules/symbolic_core/`
+- `src/` orientation and polyglot boundary → [`src/README.md`](./src/README.md)
+- Canon authority map → [`CANON_INDEX.md`](./CANON_INDEX.md)

--- a/CANON_INDEX.md
+++ b/CANON_INDEX.md
@@ -46,5 +46,5 @@ This applies even if you believe you already know the answer.
 ## Staged Artifacts & Promotion
 
 | Topic | Governing Document |
-|-------|--------------------|
+| --- | --- |
 | Engineer onboarding memory seeds (staged, non-canonical) | `seeds/onboarding/README.md` |

--- a/CANON_INDEX.md
+++ b/CANON_INDEX.md
@@ -42,3 +42,9 @@ This applies even if you believe you already know the answer.
 | GUMAS Galactic Simulation Environment | `docs/architecture/LAYER_ARCHITECTURE.md` |
 | Observatory / Main Simulation Chamber | `simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md` |
 | Simulation codex phases 1–6 | `simulation/CODEX_PHASE[N]_*.md` |
+
+## Staged Artifacts & Promotion
+
+| Topic | Governing Document |
+|-------|--------------------|
+| Engineer onboarding memory seeds (staged, non-canonical) | `seeds/onboarding/README.md` |

--- a/GETTING_STARTED_ENGINEER.md
+++ b/GETTING_STARTED_ENGINEER.md
@@ -46,7 +46,7 @@ HALO is an L1 continuity system-entity, not a sixth communication relay. Read [`
 ## What you can verify in this checkout
 
 | Claim | Evidence |
-|---|---|
+| --- | --- |
 | Canonical L1/L2/L3 and Triplex definitions | `docs/architecture/LAYER_ARCHITECTURE.md` |
 | Geometric ethics and GUMAS governance | `modules/ethics_field/`, `modules/gumas/` |
 | GUMAS audit-event schema and Thermax binding | `QGIA_Integration/04_GUMAS_AuditSchema.md`, `QGIA_integration/QUANTUM_FORGE_Axiom_Manifest.json` |

--- a/GETTING_STARTED_ENGINEER.md
+++ b/GETTING_STARTED_ENGINEER.md
@@ -1,228 +1,89 @@
-# Getting Started — Engineer Onboarding
+# Aurora — Engineer's Orientation
 
-> **You are in the right place.** This document is written for humans — specifically engineers who are new to Aurora CloudBank Symbolic and want to understand what they're working with, get their environment running, and make a real system call, all within 30–45 minutes.
->
-> If you are an AI agent, see [`AGENTS.md`](./AGENTS.md) and [`CLAUDE.md`](./CLAUDE.md) instead.
+Aurora is the simulation director for the Orion Station institutional simulation and the codebase that supports it. The repository combines an L1 station-operations model, L2 GUMAS simulation environments, and L3 symbolic/ethics frameworks with persistent memory and auditable runtime services. Its FastAPI application, governance sources, tests, and deployment artifacts are inspectable here; a live public deployment is a separate, currently open operational concern.
 
----
+If you are an AI agent, use [`docs/onboarding/AGENT_ONBOARD.md`](./docs/onboarding/AGENT_ONBOARD.md) and then follow [`AGENTS.md`](./AGENTS.md).
 
-## What Is This System?
+## Prerequisites
 
-Aurora CloudBank Symbolic is a **quantum-symbolic AI platform** built as a single FastAPI application. At its core it does four things:
+- Python 3.11 or newer (the current floor in `setup.py`)
+- Git
+- GitHub repository access
 
-1. **Manages hierarchical memory** — active, compressed, and archived tiers with SHA-256 sealing (`modules/aumemmanager/`)
-2. **Enforces ethics geometrically** — a five-dimension curvature field that can hard-veto any operation (`modules/ethics_field/`, `modules/gumas/`)
-3. **Simulates quantum circuits** — 7 scenarios across 4 cloud backends (AWS Braket, Azure Quantum, IBM Quantum, Google Cirq) with graceful degradation when backends are unavailable (`modules/quantum_simulator/`)
-4. **Orchestrates multi-model AI** — unified interface over Claude and GPT with automatic model selection (`modules/ai_core/`)
-
-The system serves ~339 HTTP routes across 30+ modules. Every operation carries a `context_tag` and generates a SHA-256 audit hash. Nothing is anonymous.
-
----
-
-## The 3 Runtime Surfaces
-
-Before you write a line of code, know that Aurora has three distinct interfaces:
-
-| Surface | Entry Point | Purpose |
-|---------|-------------|--------|
-| **REST API** | `http://localhost:8000` | Primary interface; all module functionality exposed here |
-| **Interactive Docs** | `http://localhost:8000/docs` | Swagger UI — run live calls from your browser, no client needed |
-| **Simulation Console** | `http://localhost:8000/` (when served) | Aurora GUI CloudHub — visual dashboard for simulation state |
-
-Start with the REST API + Swagger UI. The dashboard is a bonus once you're oriented.
-
----
-
-## Step 1 — Environment Setup (5 min)
+## Start here (2–5 minutes)
 
 ```bash
-git clone https://github.com/AUo959/aurora-cloudbank-symbolic.git
+git clone https://github.com/AUo959/aurora-cloudbank-symbolic
 cd aurora-cloudbank-symbolic
-
-# Recommended: use the guided setup target
-make onboard
+python scripts/aurora_onboard.py
 ```
 
-`make onboard` will:
-- Create a Python 3.11+ virtual environment
-- Install core dependencies
-- Validate the environment
-- Print a live system health report
-- Start the dev server with hot-reload
+The command uses only the Python standard library. It reads the current checkout, tours the layer model, performs a read-only ethics-anchor check, and optionally writes a staged engineer memory seed. For CI or agent validation, use `python scripts/aurora_onboard.py --skip-interactive` or `--agent`.
 
-If you prefer manual setup:
+## Architecture in one diagram
 
-```bash
-python -m venv .venv
-source .venv/bin/activate          # Windows: .venv\Scripts\activate
-pip install -r requirements.txt
-
-# Generate required secrets
-cp .env.example .env
-openssl rand -hex 32   # Run 4 times; paste each output into the 4 required fields in .env
-# Required keys: AURORA_SECRET_KEY, JWT_SECRET_KEY, CSRF_SECRET_KEY, WS_AUTH_SECRET
-
-python api/aurora_api.py
+```text
+L3 — Framework / Conceptual     Axiomera · Caelion · Sentari · Velatrix · Glyphon · Harmion
+             │ validates ethics and constraints
+             ▼
+L1 — Physical / Operational    crew · Aurora Core · five relay agents · HALO continuity system
+             │ authorizes, tasks, and monitors
+             ▼
+L2 — Simulation / Research     GUMAS · experiments · scenario and forecast environments
 ```
 
-> **Tip:** The server gracefully degrades — if you don't have AWS/Azure/IBM quantum credentials, those backends are skipped at startup and everything else still works. You'll see this logged on boot.
+HALO is an L1 continuity system-entity, not a sixth communication relay. Read [`ARCHITECTURE_QUICKMAP.md`](./ARCHITECTURE_QUICKMAP.md) for the 10-minute code map and [`docs/architecture/LAYER_ARCHITECTURE.md`](./docs/architecture/LAYER_ARCHITECTURE.md) for canonical definitions.
+
+
+## Fastest path to understanding the system
+
+1. Run `python scripts/aurora_onboard.py` (2–5 min).
+2. Read [`ARCHITECTURE_QUICKMAP.md`](./ARCHITECTURE_QUICKMAP.md) (10 min).
+3. Read [`docs/architecture/LAYER_ARCHITECTURE.md`](./docs/architecture/LAYER_ARCHITECTURE.md) (20 min).
+4. Inspect `api/aurora_api.py`, the canonical FastAPI application entry point.
+5. When you want the full environment, run `make onboard`; it installs dependencies, validates `.env`, and starts the development server.
+
+## What you can verify in this checkout
+
+| Claim | Evidence |
+|---|---|
+| Canonical L1/L2/L3 and Triplex definitions | `docs/architecture/LAYER_ARCHITECTURE.md` |
+| Geometric ethics and GUMAS governance | `modules/ethics_field/`, `modules/gumas/` |
+| GUMAS audit-event schema and Thermax binding | `QGIA_Integration/04_GUMAS_AuditSchema.md`, `QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json` |
+| Hierarchical symbolic memory with SHA-256 sealing | `modules/aumemmanager/` |
+| HALO/PAS continuity controller | `src/aurora/continuity/halo_pas_controller.py` |
+| Triplex orchestration | `src/aurora_orchestrator/triplex_handshake.py` |
+| API composition | `api/aurora_api.py` |
+| Deployment configuration | `k8s/`, `docker-compose.yml` |
 
 ---
 
-## Step 2 — Your First Real API Call (5 min)
+## Glossary
 
-Once the server is running at `http://localhost:8000`, open Swagger UI at `http://localhost:8000/docs`.
+- **L1** — physical/operational Orion Station reality: crew, Aurora Core, five communication relays, HALO, and station infrastructure.
+- **L2** — GUMAS and other computational simulation/research environments created and monitored from L1.
+- **L3** — abstract glyph frameworks that enforce meaning, ethics, provenance, drift alignment, and symbolic continuity.
+- **Triplex Handshake** — consent protocol: L3 glyph arbitration, an L1-resident verifier step (called “Layer 2” only inside the protocol), then L1 human authorization.
+- **GUMAS** — galactic simulation environment and audit layer; audit events use the GUMAS schema.
+- **Relay Agent** — one of five L1-resident communication/verifier agents: ARCHY, OPPY, LIORA, STARLING_AU, or RIVERTHREAD_808.
+- **The Pilot** — the primary human threadholder/steward; this is a governance role, not an autonomous system component.
 
-### Quickest verification — system health:
+## Honest current gaps
 
-```bash
-curl http://localhost:8000/api/synergy/health
-```
-
-Expected: a JSON object showing registered components, health status, and dependency graph stats. This confirms the core is alive.
-
-### Write a memory entry:
-
-```bash
-curl -X POST http://localhost:8000/aumem/store \
-  -H "Content-Type: application/json" \
-  -d '{
-    "content": "Engineer onboarding test entry",
-    "context_tag": "onboarding_hello",
-    "tier": "active"
-  }'
-```
-
-Expected: a JSON response with a `memory_id`, `symbolic_hash` (SHA-256), and `tier`. The hash is your audit trail anchor — every operation in Aurora is traceable.
-
-### Check ethics compliance on a payload:
-
-```bash
-curl -X POST http://localhost:8000/api/gumas/evaluate \
-  -H "Content-Type: application/json" \
-  -d '{
-    "operation": "test_eval",
-    "context_tag": "onboarding_ethics_check",
-    "payload": {"intent": "neutral_observation"}
-  }'
-```
-
-Expected: ethics field curvature scores across all five dimensions, a pass/fail verdict, and resistance level. This is the system's ethics engine in action — the same one that governs every module operation.
+- A persistent public CloudHub deployment is not verified in this repository and remains tracked in [#1071](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1071).
+- `src/` contains polyglot and duplicate-looking directory families that still require the import-graph audit and compatibility work in [#1255](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1255); see [`src/README.md`](./src/README.md) for current orientation without premature consolidation.
+- Simulation, ethics, and QGIA documentation still has open reconciliation work in [#1234](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1234), [#1233](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1233), and [#1231](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1231).
 
 ---
 
-## Step 3 — Understand the Module Layout (10 min)
+## What happens next
 
-Every module in `modules/` follows this structure:
+- Use [`CANON_INDEX.md`](./CANON_INDEX.md) before making architecture or canon claims; it maps concepts to their authoritative sources.
+- Read [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) for a source-cited machine context, including the freshness caveat on its lockpoint snapshot.
+- Use [`src/README.md`](./src/README.md) to orient within cross-cutting code and [`docs/onboarding/FAQ.md`](./docs/onboarding/FAQ.md) for hour-one questions.
+- Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before your first change and [`SECURITY.md`](./SECURITY.md) before auth, middleware, or PII-adjacent work.
+- Run `pytest tests/test_aurora_onboard.py -q` to verify this onboarding surface. Run the wider suite appropriate to the component you change.
 
-```
-modules/<module_name>/
-├── __init__.py      # Module exports
-├── core.py          # Business logic
-├── api.py           # FastAPI router (routes registered by aurora_api.py on startup)
-└── models.py        # Pydantic V2 request/response schemas
-```
-
-The main server (`api/aurora_api.py`) registers each module's router at startup. If a module's optional dependencies aren't installed, it's skipped — never crashes the server.
-
-### The 6 modules every engineer should read first:
-
-| Module | Path | Why It Matters |
-|--------|------|-----------------|
-| AuMemManager | `modules/aumemmanager/` | Everything persists through here; understand tiers first |
-| Ethics Field | `modules/ethics_field/` | Hard-veto authority over all operations; read before building anything that writes |
-| GUMAS | `modules/gumas/` | Ethics governance layer; drift enforcement |
-| AI Core | `modules/ai_core/` | If you touch Claude or GPT integration, start here |
-| Nexus | `modules/nexus/` | 58-component integration hub; understand before adding a new module |
-| Continuity | `modules/continuity/` | Thread continuity and anchor management; critical for session-aware features |
-
----
-
-## Step 4 — Key Reference Files (5 min, skim only)
-
-| File | Size | Read When |
-|------|------|-----------|
-| [`README.md`](./README.md) | 11K | Now — full module table and API group listing |
-| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | 11K | Before your first PR |
-| [`CANON_INDEX.md`](./CANON_INDEX.md) | 2K | When you need to find the authoritative source for a concept |
-| [`CHANGELOG.md`](./CHANGELOG.md) | 25K | When you need to understand what changed and when |
-| [`SECURITY.md`](./SECURITY.md) | 5K | Before touching auth, middleware, or any PII-adjacent code |
-| [`.env.example`](./.env.example) | 6K | When configuring optional integrations |
-| [`AU_CORE_MASTER_TREE.yaml`](./AU_CORE_MASTER_TREE.yaml) | 6K | When you need the canonical system topology |
-
----
-
-## Step 5 — Run the Test Suite (5 min)
-
-```bash
-# Full suite (253 test files)
-pytest
-
-# Fast smoke test — just verify nothing is broken
-pytest -m smoke
-
-# Target a specific module
-pytest tests/test_quantum_forge_v3.py -v
-
-# Coverage report
-pytest --cov=modules --cov=src --cov-report=html
-```
-
-All new code requires >90% test coverage. Tests use conventional pytest markers: `unit`, `integration`, `slow`, `smoke`, `critical`, `quantum`, `aurora`, `security`.
-
----
-
-## Dual-Audience Path Map
-
-Aurora serves both human engineers and AI agents. Here is the canonical entry point for each:
-
-| Audience | First File | Second File | Third File |
-|----------|------------|-------------|------------|
-| **Human Engineer (you)** | This file | [`README.md`](./README.md) | [`CONTRIBUTING.md`](./CONTRIBUTING.md) |
-| **AI Agent (Copilot, Claude, GPT)** | [`AGENTS.md`](./AGENTS.md) | [`CLAUDE.md`](./CLAUDE.md) | [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) |
-| **New Module Builder** | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Any existing module as reference | [`CANON_INDEX.md`](./CANON_INDEX.md) |
-| **Security/Auth Work** | [`SECURITY.md`](./SECURITY.md) | `src/middleware/` | `.env.example` |
-| **Ethics/GUMAS Work** | `modules/ethics_field/` | `modules/gumas/` | `src/monitoring/` |
-
----
-
-## Common Gotchas
-
-- **`make setup` vs `make onboard`** — `setup` installs the environment. `onboard` installs + orients + starts the server. Use `onboard` the first time.
-- **Missing `.env`** — the server will start but auth and some middleware will fail silently. Always run `cp .env.example .env` and fill in the 4 required keys before `make serve`.
-- **Duplicate directories** — `QGIA_Integration/` and `QGIA_integration/` both exist (case difference). The canonical path is `modules/qgia/`. The root-level directories are legacy artifacts.
-- **`operations/` vs `ops/`** — both exist. `operations/` is the active directory; `ops/` is legacy. When in doubt, check `CANON_INDEX.md`.
-- **Quantum backends** — if you don't have cloud quantum credentials, set `QUANTUM_BACKEND=simulator` in your `.env`. The system will use the local fallback simulator for all quantum routes.
-- **Pydantic V2** — all models use `model_config` / `ConfigDict`. Do not use V1 patterns (`class Config`, `max_items`). The linter will catch these.
-
----
-
-## Make Targets Quick Reference
-
-```bash
-make onboard         # First-time setup + orientation + server start
-make setup           # Environment setup only
-make status          # Check Python/venv/env health
-make serve           # Start API server (port 8000)
-make serve-dev       # Start with hot-reload
-make test            # Full pytest suite
-make check           # Scoped lint + full tests (pre-push check)
-make health-check    # Repository health report
-make security        # safety + bandit scans
-make quicksave DESC="..."  # Snapshot development state
-make help            # Full target list
-```
-
----
-
-## What to Build Next
-
-Once oriented, the most common first contributions are:
-
-1. **Add a new module** — follow the `core.py / api.py / models.py` pattern; register in `api/aurora_api.py`
-2. **Extend an existing route** — find the module's `api.py`, add a route, add a Pydantic model in `models.py`, test it
-3. **Add an ethics rule** — modify `modules/ethics_field/core.py`; all five dimensions are weighted and composable
-4. **Add a memory operation** — work through `modules/aumemmanager/core.py`; respect the tier boundaries
-5. **Write an integration test** — add to `tests/` with the appropriate markers, aim for a real API call via `TestClient`
+The optional memory-seed step writes under `seeds/onboarding/` as **staged** material. It does not become canon without review under the policy indexed by `CANON_INDEX.md`.
 
 Welcome to Orion Station.

--- a/GETTING_STARTED_ENGINEER.md
+++ b/GETTING_STARTED_ENGINEER.md
@@ -49,7 +49,7 @@ HALO is an L1 continuity system-entity, not a sixth communication relay. Read [`
 |---|---|
 | Canonical L1/L2/L3 and Triplex definitions | `docs/architecture/LAYER_ARCHITECTURE.md` |
 | Geometric ethics and GUMAS governance | `modules/ethics_field/`, `modules/gumas/` |
-| GUMAS audit-event schema and Thermax binding | `QGIA_Integration/04_GUMAS_AuditSchema.md`, `QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json` |
+| GUMAS audit-event schema and Thermax binding | `QGIA_Integration/04_GUMAS_AuditSchema.md`, `QGIA_integration/QUANTUM_FORGE_Axiom_Manifest.json` |
 | Hierarchical symbolic memory with SHA-256 sealing | `modules/aumemmanager/` |
 | HALO/PAS continuity controller | `src/aurora/continuity/halo_pas_controller.py` |
 | Triplex orchestration | `src/aurora_orchestrator/triplex_handshake.py` |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 A quantum-symbolic computing platform for enterprise AI. Combines hierarchical memory management, quantum circuit simulation, multi-model AI orchestration, geometric ethics enforcement, and production observability in a single FastAPI application.
 
-> **New engineer?** Start with [`GETTING_STARTED_ENGINEER.md`](./GETTING_STARTED_ENGINEER.md) — environment setup, first API call, and system orientation in 30 minutes. Then run `make onboard`.
+> **New engineer?** Start with [`GETTING_STARTED_ENGINEER.md`](./GETTING_STARTED_ENGINEER.md), then run `python scripts/aurora_onboard.py` for a repository-grounded first interaction.
+>
+> **Reviewing the architecture?** Start with [`ARCHITECTURE_QUICKMAP.md`](./ARCHITECTURE_QUICKMAP.md) for a 10-minute orientation to the layer structure, runtime flow, and code map.
 >
 > **New AI agent or Copilot session?** Start with [`AGENTS.md`](./AGENTS.md) (bootstrap protocol and rules) and [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) (machine-readable concept map).
 
@@ -112,7 +114,7 @@ All modules follow a consistent layout: `__init__.py`, `core.py`, `api.py`, `mod
 
 | Module | Location | Description |
 |---|---|---|
-| Ethics Field | `modules/ethics_field/` | Geometric ethics curvature. Five-dimension weighted field (picard_delta_3, thermax_continuity, layer_integrity, collective_welfare, transparency) with hard-zero veto and resistance levels. |
+| Ethics Field | `modules/ethics_field/` | Geometric ethics curvature. Five-dimension weighted field (Picard_Delta_3, thermax_continuity, layer_integrity, collective_welfare, transparency) with hard-zero veto and resistance levels. |
 | GUMAS | `modules/gumas/` | Ethics governance, drift threshold enforcement, alignment interventions. |
 | Data Guardian | `modules/data_guardian/` | PII detection and log sanitization. |
 | Insight Ledger | `modules/insight_ledger/` | Immutable audit trails, DLP compliance. |

--- a/docs/onboarding/AGENT_ONBOARD.md
+++ b/docs/onboarding/AGENT_ONBOARD.md
@@ -1,0 +1,48 @@
+{
+  "schema_version": "1.0.0",
+  "audience": "new_ai_agent",
+  "repository": "AUo959/aurora-cloudbank-symbolic",
+  "bootstrap_order": [
+    "AGENTS.md",
+    "AURORA_CONTEXT.json",
+    "CANON_INDEX.md",
+    "ORION_STATION_CANONICAL_STAFF_REGISTRY.json",
+    "diagnostics.json"
+  ],
+  "validation_command": "python scripts/aurora_onboard.py --agent",
+  "architecture_authority": "docs/architecture/LAYER_ARCHITECTURE.md",
+  "runtime_entrypoint": "api/aurora_api.py",
+  "identity": {
+    "aurora": "simulation director for Orion Station",
+    "l1_relay_agents": [
+      "ARCHY",
+      "OPPY",
+      "LIORA",
+      "STARLING_AU",
+      "RIVERTHREAD_808"
+    ],
+    "l1_continuity_system_entity": "HALO",
+    "l3_frameworks": [
+      "Axiomera",
+      "Caelion",
+      "Sentari",
+      "Velatrix",
+      "Glyphon",
+      "Harmion"
+    ]
+  },
+  "constraints": [
+    "separate reality-layer residency from Triplex protocol roles",
+    "do not describe HALO as a sixth communication relay",
+    "do not describe L1 relay agents as L2-resident",
+    "read live repository files before claiming system state",
+    "preserve draft, staged, and canonical distinctions",
+    "do not treat .aurora/SIMULATION_STATE.json as current without its last_updated value"
+  ],
+  "next_sources": {
+    "architecture_quickmap": "ARCHITECTURE_QUICKMAP.md",
+    "source_orientation": "src/README.md",
+    "qgia_simulation_rationale": "docs/architecture/QGIA_SIM_BRIDGE.md",
+    "contribution_rules": "CONTRIBUTING.md"
+  }
+}

--- a/docs/onboarding/ENGINEER_QUICKMAP.md
+++ b/docs/onboarding/ENGINEER_QUICKMAP.md
@@ -1,0 +1,25 @@
+# Engineer Quickmap
+
+```text
+                         L3 — FRAMEWORK / CONCEPTUAL
+         Axiomera · Caelion · Sentari · Velatrix · Glyphon · Harmion
+                modules/ethics_field/ · modules/symbolic_core/
+                                      │
+                         validates ethics and constraints
+                                      ▼
+                         L1 — PHYSICAL / OPERATIONAL
+       crew · Aurora Core · ARCHY · OPPY · LIORA · STARLING_AU · RIVERTHREAD_808
+                     HALO continuity system-entity (distinct)
+       src/aurora/ · src/aurora_orchestrator/ · src/entities/ · src/bridges/
+                                      │
+                         authorizes, tasks, monitors
+                                      ▼
+                         L2 — SIMULATION / RESEARCH
+                  GUMAS · experiments · forecast environments
+          modules/gumas/ · modules/quantum_simulator/ · src/aurora_fusion/
+
+Triplex overlay: L3 glyph arbitration → L1 verifier step → L1 human consent
+Runtime: client → api/aurora_api.py → middleware → router/service → audited result
+```
+
+The full 10-minute map is [`../../ARCHITECTURE_QUICKMAP.md`](../../ARCHITECTURE_QUICKMAP.md). Canonical definitions are in [`../architecture/LAYER_ARCHITECTURE.md`](../architecture/LAYER_ARCHITECTURE.md).

--- a/docs/onboarding/FAQ.md
+++ b/docs/onboarding/FAQ.md
@@ -1,0 +1,41 @@
+# Engineer Onboarding FAQ
+
+## 1. What is Aurora in this repository?
+
+Aurora is the simulation director for the Orion Station institutional simulation and the runtime/canon surface supporting it. Start with `AURORA_CONTEXT.json`; it cites the source for each identity claim.
+
+## 2. Are L1, L2, and L3 software tiers?
+
+No. They are reality/ontology layers: L1 station operations, L2 simulation/research environments, and L3 conceptual frameworks. Read `docs/architecture/LAYER_ARCHITECTURE.md` before using the terms.
+
+## 3. Why does Triplex also use layer numbers?
+
+Triplex describes three functional consent steps. Its “Layer 2” verifier role is performed by L1-resident systems, so protocol role and reality residency must not be conflated.
+
+## 4. Is HALO the sixth relay agent?
+
+No. HALO retains the `RELAY_006` registry designation and performs Triplex drift verification, but it is the station continuity system-entity and does not relay messages. There are exactly five communication relay agents.
+
+## 5. What is the server entry point?
+
+`api/aurora_api.py` composes the FastAPI application. Check `docs/architecture/RUNTIME_TOPOLOGY_AND_L3_AUTHORITY.md` for current router/service ownership.
+
+## 6. What belongs in `modules/` versus `src/`?
+
+Feature capabilities generally live in `modules/`; runtime, orchestration, bridge, interface, and cross-cutting services live in `src/`. The current boundary has exceptions, documented in `src/README.md` and tracked for audit in #1255.
+
+## 7. Can I trust `.aurora/SIMULATION_STATE.json` as live state?
+
+Not without checking `last_updated`. `AURORA_CONTEXT.json` records a known freshness caveat; the onboarding CLI reports the lockpoint as a context snapshot rather than a live-state claim.
+
+## 8. Where are ethics rules and audit evidence?
+
+Start with `modules/ethics_field/`, `modules/gumas/`, `QGIA_Integration/04_GUMAS_AuditSchema.md`, and `QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json`.
+
+## 9. Does the first memory seed become canon?
+
+No. `scripts/aurora_onboard.py` writes it as staged material under `seeds/onboarding/`. Promotion requires review under the policy referenced by `CANON_INDEX.md`.
+
+## 10. What should I validate before a pull request?
+
+Run focused tests and hooks for the files you changed, then follow `CONTRIBUTING.md`. For the onboarding module itself, run `pytest tests/test_aurora_onboard.py -q` and `python scripts/aurora_onboard.py --skip-interactive`.

--- a/docs/onboarding/FAQ.md
+++ b/docs/onboarding/FAQ.md
@@ -30,7 +30,7 @@ Not without checking `last_updated`. `AURORA_CONTEXT.json` records a known fresh
 
 ## 8. Where are ethics rules and audit evidence?
 
-Start with `modules/ethics_field/`, `modules/gumas/`, `QGIA_Integration/04_GUMAS_AuditSchema.md`, and `QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json`.
+Start with `modules/ethics_field/`, `modules/gumas/`, `QGIA_Integration/04_GUMAS_AuditSchema.md`, and `QGIA_integration/QUANTUM_FORGE_Axiom_Manifest.json`.
 
 ## 9. Does the first memory seed become canon?
 

--- a/scripts/aurora_onboard.py
+++ b/scripts/aurora_onboard.py
@@ -22,7 +22,7 @@ from typing import Any, Callable, Sequence, TextIO
 RELAY_AGENTS = ("ARCHY", "OPPY", "LIORA", "STARLING_AU", "RIVERTHREAD_808")
 L3_FRAMEWORKS = ("Axiomera", "Caelion", "Sentari", "Velatrix", "Glyphon", "Harmion")
 SYSTEM_ENTITY = "HALO"
-DEFAULT_PYTHON_FLOOR = (3, 10)
+DEFAULT_PYTHON_FLOOR = (3, 11)
 
 
 @dataclass(frozen=True)
@@ -53,6 +53,7 @@ class AuroraOnboarding:
         self.version = "unknown"
         self.lockpoint = "not recorded"
         self.lockpoint_source = "AURORA_CONTEXT.json"
+        self.lockpoint_freshness_warning = ""
         self.ethics: dict[str, Any] = {}
         self.seed: dict[str, Any] | None = None
 
@@ -85,10 +86,11 @@ class AuroraOnboarding:
         setup_text = self._read_text("setup.py")
         match = re.search(r"python_requires\s*=\s*[\"']>=\s*(\d+)\.(\d+)", setup_text)
         if not match:
+            fallback = f">={DEFAULT_PYTHON_FLOOR[0]}.{DEFAULT_PYTHON_FLOOR[1]}"
             self._add_check(
                 "python_requirement_source",
                 "warning",
-                "python_requires was not found; using onboarding fallback >=3.10",
+                f"python_requires was not found; using onboarding fallback {fallback}",
                 "setup.py",
             )
             return DEFAULT_PYTHON_FLOOR
@@ -128,10 +130,16 @@ class AuroraOnboarding:
         if isinstance(active_state, dict) and active_state.get("lockpoint"):
             self.lockpoint = str(active_state["lockpoint"])
         freshness = active_state.get("_staleness_warning") if isinstance(active_state, dict) else None
+        self.lockpoint_freshness_warning = str(freshness or "")
         detail = f"Aurora continuity v{self.version}; lockpoint={self.lockpoint}"
         if freshness:
             detail += "; lockpoint is a documented context snapshot, not a live-state claim"
-        self._add_check("system_identity", "pass", detail, self.lockpoint_source)
+        self._add_check(
+            "system_identity",
+            "pass",
+            detail,
+            "AURORA_CONTEXT.json + src/api/l1_relay_api.manifest.yaml",
+        )
 
     def _check_architecture(self) -> None:
         expected = (*RELAY_AGENTS, SYSTEM_ENTITY, *L3_FRAMEWORKS, "Triplex Handshake")
@@ -209,7 +217,10 @@ class AuroraOnboarding:
             icon = "PASS" if check.status == "pass" else check.status.upper()
             self._print(f"[{icon}] {check.name}: {check.detail}")
         self._print(f"Aurora v{self.version} | Orion Station | {self.lockpoint}")
-        self._print("Note: the lockpoint is read from AURORA_CONTEXT.json and carries its recorded freshness warning.")
+        if self.lockpoint_freshness_warning:
+            self._print(f"Freshness warning from AURORA_CONTEXT.json: {self.lockpoint_freshness_warning}")
+        else:
+            self._print("Note: the lockpoint is read from AURORA_CONTEXT.json; no freshness warning is recorded.")
 
     def print_architecture(self) -> None:
         layers = self.context.get("architecture_layers", {})
@@ -282,6 +293,9 @@ class AuroraOnboarding:
     def prompt_for_seed(self) -> None:
         self._print("\nPhase 4 — Symbolic Memory Seed Write (optional)")
         self._print("-" * 36)
+        if self.exit_code() == 1:
+            self._print("Skipped because environment validation failed. No repository files were written.")
+            return
         answer = self.input_fn("Write your engineer handle to the memory vault? [y/N] ").strip().lower()
         if answer not in {"y", "yes"}:
             self._print("Skipped. No repository files were written.")

--- a/scripts/aurora_onboard.py
+++ b/scripts/aurora_onboard.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Human-first, repository-grounded onboarding for Aurora / Orion Station.
+
+The command uses only the Python standard library. All reported system state is
+read from files in the current checkout; architecture constants are verified
+against the canonical layer document before they are displayed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence, TextIO
+
+
+RELAY_AGENTS = ("ARCHY", "OPPY", "LIORA", "STARLING_AU", "RIVERTHREAD_808")
+L3_FRAMEWORKS = ("Axiomera", "Caelion", "Sentari", "Velatrix", "Glyphon", "Harmion")
+SYSTEM_ENTITY = "HALO"
+DEFAULT_PYTHON_FLOOR = (3, 10)
+
+
+@dataclass(frozen=True)
+class Check:
+    """One evidence-backed onboarding validation."""
+
+    name: str
+    status: str
+    detail: str
+    source: str
+
+
+class OnboardingError(RuntimeError):
+    """Human-readable onboarding failure that must not expose a traceback."""
+
+
+class AuroraOnboarding:
+    """Run the onboarding phases against one repository checkout."""
+
+    def __init__(self, root: Path, stream: TextIO, input_fn: Callable[[str], str]) -> None:
+        self.root = root.resolve()
+        self.stream = stream
+        self.input_fn = input_fn
+        self.checks: list[Check] = []
+        self.context: dict[str, Any] = {}
+        self.state: dict[str, Any] = {}
+        self.architecture_text = ""
+        self.version = "unknown"
+        self.lockpoint = "not recorded"
+        self.lockpoint_source = "AURORA_CONTEXT.json"
+        self.ethics: dict[str, Any] = {}
+        self.seed: dict[str, Any] | None = None
+
+    def _path(self, relative: str) -> Path:
+        path = (self.root / relative).resolve()
+        if self.root not in path.parents and path != self.root:
+            raise OnboardingError(f"Path escapes repository root: {relative}")
+        return path
+
+    def _read_text(self, relative: str) -> str:
+        path = self._path(relative)
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise OnboardingError(f"Cannot read {relative}: {exc}") from None
+
+    def _read_json(self, relative: str) -> dict[str, Any]:
+        try:
+            value = json.loads(self._read_text(relative))
+        except json.JSONDecodeError as exc:
+            raise OnboardingError(f"Invalid JSON in {relative}: line {exc.lineno}, column {exc.colno}") from None
+        if not isinstance(value, dict):
+            raise OnboardingError(f"Expected a JSON object in {relative}")
+        return value
+
+    def _add_check(self, name: str, status: str, detail: str, source: str) -> None:
+        self.checks.append(Check(name=name, status=status, detail=detail, source=source))
+
+    def _python_floor(self) -> tuple[int, int]:
+        setup_text = self._read_text("setup.py")
+        match = re.search(r"python_requires\s*=\s*[\"']>=\s*(\d+)\.(\d+)", setup_text)
+        if not match:
+            self._add_check(
+                "python_requirement_source",
+                "warning",
+                "python_requires was not found; using onboarding fallback >=3.10",
+                "setup.py",
+            )
+            return DEFAULT_PYTHON_FLOOR
+        return int(match.group(1)), int(match.group(2))
+
+    def _check_python(self) -> None:
+        floor = self._python_floor()
+        actual = sys.version_info[:2]
+        detail = f"Python {actual[0]}.{actual[1]} (repository requires >={floor[0]}.{floor[1]})"
+        status = "pass" if actual >= floor else "fail"
+        self._add_check("python_version", status, detail, "setup.py")
+
+    def _load_required_sources(self) -> None:
+        self.state = self._read_json(".aurora/SIMULATION_STATE.json")
+        self.context = self._read_json("AURORA_CONTEXT.json")
+        self.architecture_text = self._read_text("docs/architecture/LAYER_ARCHITECTURE.md")
+        self._add_check(
+            "simulation_state",
+            "pass",
+            f"Readable JSON; last_updated={self.state.get('last_updated', 'not recorded')}",
+            ".aurora/SIMULATION_STATE.json",
+        )
+        self._add_check(
+            "aurora_context",
+            "pass",
+            f"Readable JSON; generated={self.context.get('document_generated', 'not recorded')}",
+            "AURORA_CONTEXT.json",
+        )
+
+    def _load_identity(self) -> None:
+        manifest = self._read_text("src/api/l1_relay_api.manifest.yaml")
+        version_match = re.search(r"Aurora_Continuity_Seal_v([0-9.]+)", manifest)
+        if not version_match:
+            raise OnboardingError("Continuity version is missing from src/api/l1_relay_api.manifest.yaml")
+        self.version = version_match.group(1)
+        active_state = self.context.get("active_state", {})
+        if isinstance(active_state, dict) and active_state.get("lockpoint"):
+            self.lockpoint = str(active_state["lockpoint"])
+        freshness = active_state.get("_staleness_warning") if isinstance(active_state, dict) else None
+        detail = f"Aurora continuity v{self.version}; lockpoint={self.lockpoint}"
+        if freshness:
+            detail += "; lockpoint is a documented context snapshot, not a live-state claim"
+        self._add_check("system_identity", "pass", detail, self.lockpoint_source)
+
+    def _check_architecture(self) -> None:
+        expected = (*RELAY_AGENTS, SYSTEM_ENTITY, *L3_FRAMEWORKS, "Triplex Handshake")
+        missing = [term for term in expected if term not in self.architecture_text]
+        if missing:
+            self._add_check(
+                "architecture_canon",
+                "fail",
+                f"Canonical architecture source is missing: {', '.join(missing)}",
+                "docs/architecture/LAYER_ARCHITECTURE.md",
+            )
+            return
+        self._add_check(
+            "architecture_canon",
+            "pass",
+            "Five L1 relay agents, HALO continuity system-entity, and six L3 frameworks verified",
+            "docs/architecture/LAYER_ARCHITECTURE.md",
+        )
+
+    def _check_ethics(self) -> None:
+        manifest = self._read_json("QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json")
+        audit_text = self._read_text("QGIA_Integration/04_GUMAS_AuditSchema.md")
+        script_text = self._read_text("scripts/activate_l3_ethics.sh")
+        binding = manifest.get("ethics_binding")
+        context_status = self.context.get("active_modules", {}).get("ethics", {}).get("status")
+        rule_match = re.search(r"### (GAE-\d{3} \| [^\n]+).*?- \*\*Trigger condition:\*\* ([^\n]+)", audit_text, re.S)
+        self.ethics = {
+            "layer_status": str(context_status or "not recorded").upper(),
+            "binding": binding,
+            "binding_verified": binding == "GUMAS_Thermax",
+            "sample_rule": rule_match.group(1) if rule_match else "not available",
+            "sample_rule_summary": rule_match.group(2) if rule_match else "not available",
+            "activation_source_present": "Picard_Delta_3" in script_text,
+            "sources": [
+                "AURORA_CONTEXT.json",
+                "QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json",
+                "QGIA_Integration/04_GUMAS_AuditSchema.md",
+                "scripts/activate_l3_ethics.sh",
+            ],
+        }
+        verified = context_status == "active" and binding == "GUMAS_Thermax" and bool(rule_match)
+        self._add_check(
+            "ethics_anchor",
+            "pass" if verified else "fail",
+            f"Ethics layer={self.ethics['layer_status']}; GUMAS_Thermax binding={binding or 'missing'}",
+            "AURORA_CONTEXT.json + QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json",
+        )
+
+    def validate(self) -> None:
+        """Load every source needed by the uninterrupted onboarding flow."""
+
+        self._check_python()
+        self._load_required_sources()
+        self._load_identity()
+        self._check_architecture()
+        self._check_ethics()
+        for relative in ("CANON_INDEX.md", "seeds/onboarding/README.md"):
+            self._read_text(relative)
+        canon_index = self._read_text("CANON_INDEX.md")
+        indexed = "seeds/onboarding/README.md" in canon_index
+        self._add_check(
+            "seed_staging_policy",
+            "pass" if indexed else "warning",
+            "Engineer seed staging is indexed without automatic canon promotion" if indexed else "Seed staging policy is not indexed",
+            "CANON_INDEX.md",
+        )
+
+    def _print(self, value: str = "") -> None:
+        print(value, file=self.stream)
+
+    def print_environment(self) -> None:
+        self._print("\nPhase 1 — Environment Check")
+        self._print("-" * 36)
+        for check in self.checks:
+            icon = "PASS" if check.status == "pass" else check.status.upper()
+            self._print(f"[{icon}] {check.name}: {check.detail}")
+        self._print(f"Aurora v{self.version} | Orion Station | {self.lockpoint}")
+        self._print("Note: the lockpoint is read from AURORA_CONTEXT.json and carries its recorded freshness warning.")
+
+    def print_architecture(self) -> None:
+        layers = self.context.get("architecture_layers", {})
+        self._print("\nPhase 2 — Layer Architecture Tour")
+        self._print("-" * 36)
+        for layer in ("L1", "L2", "L3"):
+            self._print(f"{layer}: {layers.get(layer, 'Not recorded in AURORA_CONTEXT.json')}")
+        self._print(f"L1 relay agents: {', '.join(RELAY_AGENTS)}")
+        self._print(f"L1 continuity system-entity: {SYSTEM_ENTITY} (verifies continuity; does not relay messages)")
+        self._print(f"L3 glyph frameworks: {', '.join(L3_FRAMEWORKS)}")
+        self._print("Triplex: L3 glyph validation → L1 verifier step → L1 human consent.")
+
+    def print_ethics(self) -> None:
+        self._print("\nPhase 3 — Ethics Anchor Live Demo (read-only)")
+        self._print("-" * 36)
+        verified = "VERIFIED" if self.ethics.get("binding_verified") else "UNVERIFIED"
+        self._print(f"Ethics layer: {self.ethics.get('layer_status')} | GUMAS_Thermax binding: {verified}")
+        self._print(f"Sample audit rule: {self.ethics.get('sample_rule')}")
+        self._print(f"Trigger: {self.ethics.get('sample_rule_summary')}")
+
+    @staticmethod
+    def _slug(handle: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", handle.lower()).strip("-")
+        return (slug or "engineer")[:48]
+
+    def write_seed(self, handle: str) -> dict[str, Any]:
+        clean_handle = handle.strip()
+        if not clean_handle:
+            raise OnboardingError("Engineer handle cannot be empty")
+        if len(clean_handle) > 80:
+            raise OnboardingError("Engineer handle must be 80 characters or fewer")
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        relative = Path("seeds/onboarding") / f"engineer-{self._slug(clean_handle)}-{now:%Y%m%dT%H%M%SZ}.md"
+        path = self._path(relative.as_posix())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = self._seed_content(clean_handle, now)
+        try:
+            with path.open("x", encoding="utf-8") as stream:
+                stream.write(content)
+        except OSError as exc:
+            raise OnboardingError(f"Cannot write {relative.as_posix()}: {exc}") from None
+        if path.read_text(encoding="utf-8") != content:
+            raise OnboardingError(f"Seed verification failed for {relative.as_posix()}")
+        self.seed = {
+            "path": relative.as_posix(),
+            "status": "staged",
+            "created_at": now.isoformat().replace("+00:00", "Z"),
+            "canon_policy": "seeds/onboarding/README.md",
+            "verified": True,
+        }
+        return self.seed
+
+    @staticmethod
+    def _seed_content(handle: str, now: datetime) -> str:
+        created_at = now.isoformat().replace("+00:00", "Z")
+        return (
+            "---\n"
+            "seed_type: engineer_onboarding\n"
+            "seed_status: staged\n"
+            f"engineer_handle: {json.dumps(handle, ensure_ascii=False)}\n"
+            f"created_at: {created_at}\n"
+            "anchor_seed: EOS_SEED_ORION\n"
+            "ethics_protocol: Picard_Delta_3\n"
+            "source: scripts/aurora_onboard.py\n"
+            "---\n\n"
+            "# Engineer Onboarding Memory Seed\n\n"
+            "This seed records completion of the repository onboarding flow. It is staged, not canonical, until reviewed.\n"
+        )
+
+    def prompt_for_seed(self) -> None:
+        self._print("\nPhase 4 — Symbolic Memory Seed Write (optional)")
+        self._print("-" * 36)
+        answer = self.input_fn("Write your engineer handle to the memory vault? [y/N] ").strip().lower()
+        if answer not in {"y", "yes"}:
+            self._print("Skipped. No repository files were written.")
+            return
+        handle = self.input_fn("Engineer handle: ")
+        seed = self.write_seed(handle)
+        self._print(f"Seed written and verified: {seed['path']}")
+        self._print("Status: staged; CANON_INDEX.md points to the review policy, not automatic promotion.")
+
+    def status(self) -> str:
+        statuses = {check.status for check in self.checks}
+        if "fail" in statuses:
+            return "fail"
+        if "warning" in statuses:
+            return "partial"
+        return "pass"
+
+    def exit_code(self) -> int:
+        status = self.status()
+        if status == "fail":
+            return 1
+        if status == "partial":
+            return 2
+        return 0
+
+    def agent_report(self, elapsed: float) -> dict[str, Any]:
+        code = self.exit_code()
+        return {
+            "schema_version": "1.0.0",
+            "mode": "agent",
+            "status": self.status(),
+            "exit_code": code,
+            "system": {
+                "identity": self.context.get("system_identity", {}).get("name", "Aurora"),
+                "continuity_version": self.version,
+                "station": "Orion Station",
+                "lockpoint": self.lockpoint,
+                "lockpoint_source": self.lockpoint_source,
+            },
+            "checks": [asdict(check) for check in self.checks],
+            "architecture": {
+                "layers": self.context.get("architecture_layers", {}),
+                "l1_relay_agents": list(RELAY_AGENTS),
+                "l1_continuity_system_entity": SYSTEM_ENTITY,
+                "l3_glyph_frameworks": list(L3_FRAMEWORKS),
+            },
+            "ethics": self.ethics,
+            "memory_seed": self.seed,
+            "elapsed_seconds": round(elapsed, 3),
+            "next_steps": ["CANON_INDEX.md", ".aurora/SIMULATION_STATE.json", "docs/architecture/"],
+        }
+
+    def print_completion(self, elapsed: float) -> None:
+        code = self.exit_code()
+        self._print("\nPhase 5 — Completion Report")
+        self._print("-" * 36)
+        self._print(f"Elapsed time: {elapsed:.2f}s")
+        if code == 1:
+            self._print("❌ Onboarding incomplete. Resolve the failed environment checks above.")
+            return
+        self._print("✅ Onboarding complete. You are now a verified Orion Station crew member.")
+        if self.status() == "partial":
+            self._print("Non-fatal warnings were recorded; review them before implementation work.")
+        self._print("Next: CANON_INDEX.md | .aurora/SIMULATION_STATE.json | docs/architecture/")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Aurora / Orion Station engineer onboarding")
+    parser.add_argument("--skip-interactive", action="store_true", help="Run validation without prompts")
+    parser.add_argument("--agent", action="store_true", help="Emit one JSON status object and suppress prose")
+    return parser
+
+
+def _error_report(message: str, agent: bool, stream: TextIO) -> None:
+    if agent:
+        json.dump(
+            {
+                "schema_version": "1.0.0",
+                "mode": "agent",
+                "status": "fail",
+                "exit_code": 1,
+                "error": message,
+            },
+            stream,
+            indent=2,
+        )
+        stream.write("\n")
+    else:
+        print(f"❌ Onboarding could not continue: {message}", file=stream)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    repo_root: Path | None = None,
+    stream: TextIO | None = None,
+    input_fn: Callable[[str], str] = input,
+) -> int:
+    args = build_parser().parse_args(argv)
+    output = stream or sys.stdout
+    root = repo_root or Path(__file__).resolve().parents[1]
+    started = time.perf_counter()
+    app = AuroraOnboarding(root=root, stream=output, input_fn=input_fn)
+    try:
+        app.validate()
+        if args.agent:
+            json.dump(app.agent_report(time.perf_counter() - started), output, indent=2)
+            output.write("\n")
+            return app.exit_code()
+        app.print_environment()
+        if not args.skip_interactive:
+            choice = input_fn("Press ENTER to tour the layer architecture, or SKIP to proceed: ").strip().upper()
+            if choice != "SKIP":
+                app.print_architecture()
+        app.print_ethics()
+        if not args.skip_interactive:
+            app.prompt_for_seed()
+        elapsed = time.perf_counter() - started
+        app.print_completion(elapsed)
+        return app.exit_code()
+    except (OnboardingError, EOFError, KeyboardInterrupt) as exc:
+        message = str(exc) or "onboarding interrupted"
+        _error_report(message, args.agent, output)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aurora_onboard.py
+++ b/scripts/aurora_onboard.py
@@ -152,7 +152,7 @@ class AuroraOnboarding:
         )
 
     def _check_ethics(self) -> None:
-        manifest = self._read_json("QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json")
+        manifest = self._read_json("QGIA_integration/QUANTUM_FORGE_Axiom_Manifest.json")
         audit_text = self._read_text("QGIA_Integration/04_GUMAS_AuditSchema.md")
         script_text = self._read_text("scripts/activate_l3_ethics.sh")
         binding = manifest.get("ethics_binding")
@@ -167,7 +167,7 @@ class AuroraOnboarding:
             "activation_source_present": "Picard_Delta_3" in script_text,
             "sources": [
                 "AURORA_CONTEXT.json",
-                "QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json",
+                "QGIA_integration/QUANTUM_FORGE_Axiom_Manifest.json",
                 "QGIA_Integration/04_GUMAS_AuditSchema.md",
                 "scripts/activate_l3_ethics.sh",
             ],
@@ -177,7 +177,7 @@ class AuroraOnboarding:
             "ethics_anchor",
             "pass" if verified else "fail",
             f"Ethics layer={self.ethics['layer_status']}; GUMAS_Thermax binding={binding or 'missing'}",
-            "AURORA_CONTEXT.json + QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json",
+            "AURORA_CONTEXT.json + QGIA_integration/QUANTUM_FORGE_Axiom_Manifest.json",
         )
 
     def validate(self) -> None:

--- a/scripts/aurora_onboard.py
+++ b/scripts/aurora_onboard.py
@@ -252,11 +252,12 @@ class AuroraOnboarding:
             raise OnboardingError("Engineer handle cannot be empty")
         if len(clean_handle) > 80:
             raise OnboardingError("Engineer handle must be 80 characters or fewer")
-        now = datetime.now(timezone.utc).replace(microsecond=0)
-        relative = Path("seeds/onboarding") / f"engineer-{self._slug(clean_handle)}-{now:%Y%m%dT%H%M%SZ}.md"
+        now = datetime.now(timezone.utc)
+        receipt_time = now.replace(microsecond=0)
+        relative = Path("seeds/onboarding") / f"engineer-{self._slug(clean_handle)}-{now:%Y%m%dT%H%M%S%fZ}.md"
         path = self._path(relative.as_posix())
         path.parent.mkdir(parents=True, exist_ok=True)
-        content = self._seed_content(clean_handle, now)
+        content = self._seed_content(clean_handle, receipt_time)
         try:
             with path.open("x", encoding="utf-8") as stream:
                 stream.write(content)
@@ -267,7 +268,7 @@ class AuroraOnboarding:
         self.seed = {
             "path": relative.as_posix(),
             "status": "staged",
-            "created_at": now.isoformat().replace("+00:00", "Z"),
+            "created_at": receipt_time.isoformat().replace("+00:00", "Z"),
             "canon_policy": "seeds/onboarding/README.md",
             "verified": True,
         }

--- a/scripts/aurora_onboard.py
+++ b/scripts/aurora_onboard.py
@@ -373,6 +373,30 @@ def _error_report(message: str, agent: bool, stream: TextIO) -> None:
         print(f"❌ Onboarding could not continue: {message}", file=stream)
 
 
+def _run_onboarding(
+    app: AuroraOnboarding,
+    args: argparse.Namespace,
+    started: float,
+    input_fn: Callable[[str], str],
+) -> int:
+    app.validate()
+    if args.agent:
+        json.dump(app.agent_report(time.perf_counter() - started), app.stream, indent=2)
+        app.stream.write("\n")
+        return app.exit_code()
+    app.print_environment()
+    if not args.skip_interactive:
+        choice = input_fn("Press ENTER to tour the layer architecture, or SKIP to proceed: ").strip().upper()
+        if choice != "SKIP":
+            app.print_architecture()
+    app.print_ethics()
+    if not args.skip_interactive:
+        app.prompt_for_seed()
+    elapsed = time.perf_counter() - started
+    app.print_completion(elapsed)
+    return app.exit_code()
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -386,22 +410,7 @@ def main(
     started = time.perf_counter()
     app = AuroraOnboarding(root=root, stream=output, input_fn=input_fn)
     try:
-        app.validate()
-        if args.agent:
-            json.dump(app.agent_report(time.perf_counter() - started), output, indent=2)
-            output.write("\n")
-            return app.exit_code()
-        app.print_environment()
-        if not args.skip_interactive:
-            choice = input_fn("Press ENTER to tour the layer architecture, or SKIP to proceed: ").strip().upper()
-            if choice != "SKIP":
-                app.print_architecture()
-        app.print_ethics()
-        if not args.skip_interactive:
-            app.prompt_for_seed()
-        elapsed = time.perf_counter() - started
-        app.print_completion(elapsed)
-        return app.exit_code()
+        return _run_onboarding(app, args, started, input_fn)
     except (OnboardingError, EOFError, KeyboardInterrupt) as exc:
         message = str(exc) or "onboarding interrupted"
         _error_report(message, args.agent, output)

--- a/seeds/onboarding/README.md
+++ b/seeds/onboarding/README.md
@@ -1,0 +1,15 @@
+# Engineer Onboarding Seed Staging
+
+Files in this directory are optional onboarding receipts created by `scripts/aurora_onboard.py`. They are **staged symbolic memory seeds**, not canonical facts, staff records, credentials, or authorization grants.
+
+Each generated Markdown file uses YAML front matter with:
+
+- `seed_type: engineer_onboarding`
+- `seed_status: staged`
+- `engineer_handle`
+- UTC `created_at`
+- `anchor_seed: EOS_SEED_ORION`
+- `ethics_protocol: Picard_Delta_3`
+- generating `source`
+
+The onboarding command verifies the file after writing it. Committing or promoting a seed requires normal review against `CANON_INDEX.md` and the relevant authoritative sources; generation alone never promotes it.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,48 @@
+# `src/` — Runtime and Cross-Cutting Infrastructure
+
+`src/` contains Aurora runtime services, orchestration, bridges, interfaces, and shared infrastructure. Feature-oriented capabilities generally live in `modules/`; the FastAPI composition root is `api/aurora_api.py`. Directory names alone do not establish canonical status—imports, scripts, tests, and manifests must be checked before consolidation.
+
+## Layer-oriented map
+
+| Location | Current role | Layer relationship |
+|---|---|---|
+| `aurora/` | Aurora runtime, including narrative engines and HALO/PAS continuity | L1 |
+| `aurora_orchestrator/` | Triplex Handshake orchestration | L1 coordinating L3 validation and L1 consent |
+| `entities/` | Crew, relay, and system-entity definitions | L1 |
+| `agents/` | Agent runtime helpers | L1 / cross-cutting |
+| `bridges/` | Python L1 relay bridge plus TypeScript constellation bridges | L1 and cross-system |
+| `aurora_fusion/` | Simulation-fusion and memory support | L2-facing |
+| `api/` | Reusable API routers, including the L1 relay surface | Cross-cutting |
+| `core/` | DLP, command, service, and other shared foundations | Cross-cutting |
+| `middleware/` | CSRF, authentication, rate limiting, PII, and request controls | Cross-cutting |
+| `monitoring/`, `observability/` | Runtime checks, audit logging, telemetry, and traces | Cross-cutting |
+| `synergy/`, `coordination/`, `orchestrators/` | Component registry and coordination services | Cross-cutting |
+| `interfaces/`, `dashboard/`, `web_infrastructure/` | Operator-facing web surfaces and support | L1-facing |
+
+This is an orientation map, not the complete classification audit required by issue #1255.
+
+## Polyglot boundary
+
+- **Python** implements the FastAPI runtime, simulation and governance services, continuity, relay APIs, and most tests.
+- **TypeScript/JavaScript** implements the constellation server (`src/index.ts`), service/orchestrator components, Node bridges, visualization experiments, and browser/operator assets.
+- `src/index.ts` is a constellation REST/WebSocket server entry point. It is separate from the Python FastAPI entry point `api/aurora_api.py`; `package.json` exposes the constellation build/start commands.
+- Root-level `quantum_decision_oracle.py` and `code_generation_framework.py` remain in place pending the import and ownership audit in #1255.
+
+## Duplicate-looking families are not yet aliases
+
+| Family | Observed distinction |
+|---|---|
+| `bridge/` / `bridges/` | `bridge/` contains Node API-bridge servers used by Node tests and scripts; `bridges/` contains the Python relay bridge and TypeScript constellation bridges. |
+| `collab/` / `collaboration/` | `collab/` is an imported Python capsule/API package; `collaboration/` contains a JavaScript collaborative-research framework. |
+| `interface/` / `interfaces/` | `interface/` contains dynamic-adapter code and a holographic UI; `interfaces/` contains the collaboration chamber consumed by launch scripts and mesh tests. |
+| `visual/` / `visualization/` | The directories contain different JavaScript implementations: visual synthesis and 3D quantum visualization. |
+
+Do not stub, deprecate, move, or delete one member of these families based only on singular/plural naming. Issue #1255 requires a live import-graph audit, compatibility decisions, and separate approval before deletion.
+
+## Where to start
+
+1. Read [`../ARCHITECTURE_QUICKMAP.md`](../ARCHITECTURE_QUICKMAP.md).
+2. Confirm terminology in [`../docs/architecture/LAYER_ARCHITECTURE.md`](../docs/architecture/LAYER_ARCHITECTURE.md).
+3. Follow imports from `api/aurora_api.py` for Python runtime ownership.
+4. Check `package.json`, `tsconfig*.json`, scripts, and Node tests for TypeScript/JavaScript ownership.
+5. Run focused tests for the surface you change; do not infer inactivity from a missing `__init__.py` in polyglot directories.

--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,7 @@
 ## Layer-oriented map
 
 | Location | Current role | Layer relationship |
-|---|---|---|
+| --- | --- | --- |
 | `aurora/` | Aurora runtime, including narrative engines and HALO/PAS continuity | L1 |
 | `aurora_orchestrator/` | Triplex Handshake orchestration | L1 coordinating L3 validation and L1 consent |
 | `entities/` | Crew, relay, and system-entity definitions | L1 |
@@ -31,7 +31,7 @@ This is an orientation map, not the complete classification audit required by is
 ## Duplicate-looking families are not yet aliases
 
 | Family | Observed distinction |
-|---|---|
+| --- | --- |
 | `bridge/` / `bridges/` | `bridge/` contains Node API-bridge servers used by Node tests and scripts; `bridges/` contains the Python relay bridge and TypeScript constellation bridges. |
 | `collab/` / `collaboration/` | `collab/` is an imported Python capsule/API package; `collaboration/` contains a JavaScript collaborative-research framework. |
 | `interface/` / `interfaces/` | `interface/` contains dynamic-adapter code and a holographic UI; `interfaces/` contains the collaboration chamber consumed by launch scripts and mesh tests. |

--- a/src/README.md
+++ b/src/README.md
@@ -12,7 +12,7 @@
 | `agents/` | Agent runtime helpers | L1 / cross-cutting |
 | `bridges/` | Python L1 relay bridge plus TypeScript constellation bridges | L1 and cross-system |
 | `aurora_fusion/` | Simulation-fusion and memory support | L2-facing |
-| `api/` | Reusable API routers, including the L1 relay surface | Cross-cutting |
+| `src/api/` | Reusable API routers, including the L1 relay surface; distinct from the root composition entry point | Cross-cutting |
 | `core/` | DLP, command, service, and other shared foundations | Cross-cutting |
 | `middleware/` | CSRF, authentication, rate limiting, PII, and request controls | Cross-cutting |
 | `monitoring/`, `observability/` | Runtime checks, audit logging, telemetry, and traces | Cross-cutting |

--- a/tests/test_aurora_onboard.py
+++ b/tests/test_aurora_onboard.py
@@ -154,6 +154,30 @@ def test_full_flow_writes_a_staged_seed(healthy_repo: Path) -> None:
     CHECK.assertIn("It is staged, not canonical", content)
 
 
+def test_same_second_seed_writes_have_unique_paths(healthy_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    moments = iter(
+        [
+            aurora_onboard.datetime(2026, 7, 16, 7, 0, 0, 1, tzinfo=aurora_onboard.timezone.utc),
+            aurora_onboard.datetime(2026, 7, 16, 7, 0, 0, 2, tzinfo=aurora_onboard.timezone.utc),
+        ]
+    )
+
+    class Clock:
+        @staticmethod
+        def now(_timezone: object) -> object:
+            return next(moments)
+
+    monkeypatch.setattr(aurora_onboard, "datetime", Clock)
+    app = aurora_onboard.AuroraOnboarding(healthy_repo, io.StringIO(), lambda _prompt: "")
+
+    first = app.write_seed("Engineer One")
+    second = app.write_seed("Engineer One")
+
+    CHECK.assertNotEqual(first["path"], second["path"])
+    CHECK.assertTrue((healthy_repo / first["path"]).is_file())
+    CHECK.assertTrue((healthy_repo / second["path"]).is_file())
+
+
 def test_failed_validation_does_not_offer_or_write_completion_seed(healthy_repo: Path) -> None:
     _write(healthy_repo, "docs/architecture/LAYER_ARCHITECTURE.md", "Triplex Handshake\n")
     stream = io.StringIO()

--- a/tests/test_aurora_onboard.py
+++ b/tests/test_aurora_onboard.py
@@ -6,6 +6,7 @@ import importlib.util
 import io
 import json
 import sys
+import unittest
 from pathlib import Path
 
 import pytest
@@ -13,10 +14,12 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location("aurora_onboard", ROOT / "scripts" / "aurora_onboard.py")
-assert SPEC and SPEC.loader
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("Could not load scripts/aurora_onboard.py")
 aurora_onboard = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = aurora_onboard
 SPEC.loader.exec_module(aurora_onboard)
+CHECK = unittest.TestCase()
 
 
 def _write(root: Path, relative: str, content: str) -> None:
@@ -84,13 +87,13 @@ def test_agent_mode_emits_parseable_json(healthy_repo: Path) -> None:
     code = aurora_onboard.main(["--agent"], repo_root=healthy_repo, stream=stream)
 
     report = json.loads(stream.getvalue())
-    assert code == 0
-    assert report["status"] == "pass"
-    assert report["system"]["continuity_version"] == "2.2.5"
-    assert report["system"]["lockpoint"] == "SN1_LOCKPOINT_TEST"
-    assert report["architecture"]["l1_relay_agents"] == list(aurora_onboard.RELAY_AGENTS)
-    assert report["architecture"]["l1_continuity_system_entity"] == "HALO"
-    assert report["ethics"]["binding_verified"] is True
+    CHECK.assertEqual(code, 0)
+    CHECK.assertEqual(report["status"], "pass")
+    CHECK.assertEqual(report["system"]["continuity_version"], "2.2.5")
+    CHECK.assertEqual(report["system"]["lockpoint"], "SN1_LOCKPOINT_TEST")
+    CHECK.assertEqual(report["architecture"]["l1_relay_agents"], list(aurora_onboard.RELAY_AGENTS))
+    CHECK.assertEqual(report["architecture"]["l1_continuity_system_entity"], "HALO")
+    CHECK.assertTrue(report["ethics"]["binding_verified"])
 
 
 def test_skip_interactive_is_ci_safe_on_healthy_repo(healthy_repo: Path) -> None:
@@ -98,8 +101,8 @@ def test_skip_interactive_is_ci_safe_on_healthy_repo(healthy_repo: Path) -> None
 
     code = aurora_onboard.main(["--skip-interactive"], repo_root=healthy_repo, stream=stream)
 
-    assert code == 0
-    assert "Onboarding complete" in stream.getvalue()
+    CHECK.assertEqual(code, 0)
+    CHECK.assertIn("Onboarding complete", stream.getvalue())
 
 
 def test_broken_repo_returns_one_without_traceback(healthy_repo: Path) -> None:
@@ -108,9 +111,9 @@ def test_broken_repo_returns_one_without_traceback(healthy_repo: Path) -> None:
 
     code = aurora_onboard.main(["--skip-interactive"], repo_root=healthy_repo, stream=stream)
 
-    assert code == 1
-    assert "Invalid JSON in AURORA_CONTEXT.json" in stream.getvalue()
-    assert "Traceback" not in stream.getvalue()
+    CHECK.assertEqual(code, 1)
+    CHECK.assertIn("Invalid JSON in AURORA_CONTEXT.json", stream.getvalue())
+    CHECK.assertNotIn("Traceback", stream.getvalue())
 
 
 def test_agent_failure_is_still_valid_json(healthy_repo: Path) -> None:
@@ -120,9 +123,9 @@ def test_agent_failure_is_still_valid_json(healthy_repo: Path) -> None:
     code = aurora_onboard.main(["--agent"], repo_root=healthy_repo, stream=stream)
 
     report = json.loads(stream.getvalue())
-    assert code == 1
-    assert report["status"] == "fail"
-    assert "Cannot read .aurora/SIMULATION_STATE.json" in report["error"]
+    CHECK.assertEqual(code, 1)
+    CHECK.assertEqual(report["status"], "fail")
+    CHECK.assertIn("Cannot read .aurora/SIMULATION_STATE.json", report["error"])
 
 
 def test_full_flow_writes_a_staged_seed(healthy_repo: Path) -> None:
@@ -137,13 +140,13 @@ def test_full_flow_writes_a_staged_seed(healthy_repo: Path) -> None:
     )
 
     generated = list((healthy_repo / "seeds/onboarding").glob("engineer-engineer-one-*.md"))
-    assert code == 0
-    assert len(generated) == 1
+    CHECK.assertEqual(code, 0)
+    CHECK.assertEqual(len(generated), 1)
     content = generated[0].read_text(encoding="utf-8")
-    assert "seed_status: staged" in content
-    assert 'engineer_handle: "Engineer One"' in content
-    assert "does not become canon" not in content
-    assert "It is staged, not canonical" in content
+    CHECK.assertIn("seed_status: staged", content)
+    CHECK.assertIn('engineer_handle: "Engineer One"', content)
+    CHECK.assertNotIn("does not become canon", content)
+    CHECK.assertIn("It is staged, not canonical", content)
 
 
 def test_missing_python_floor_returns_partial_status(healthy_repo: Path) -> None:
@@ -152,8 +155,8 @@ def test_missing_python_floor_returns_partial_status(healthy_repo: Path) -> None
 
     code = aurora_onboard.main(["--skip-interactive"], repo_root=healthy_repo, stream=stream)
 
-    assert code == 2
-    assert "WARNING" in stream.getvalue()
+    CHECK.assertEqual(code, 2)
+    CHECK.assertIn("WARNING", stream.getvalue())
 
 
 def test_onboarding_documents_preserve_layer_semantics() -> None:
@@ -161,14 +164,14 @@ def test_onboarding_documents_preserve_layer_semantics() -> None:
     quickmap = (ROOT / "ARCHITECTURE_QUICKMAP.md").read_text(encoding="utf-8")
     agent_context = json.loads((ROOT / "docs/onboarding/AGENT_ONBOARD.md").read_text(encoding="utf-8"))
 
-    assert len(getting_started.splitlines()) <= 200
-    assert "L2 relay agents" not in getting_started
-    assert "mediation layer" not in getting_started.lower()
-    assert "docs/architecture/LAYER_ARCHITECTURE.md" in quickmap
-    assert "docs/architecture/QGIA_SIM_BRIDGE.md" in quickmap
-    assert "docs/architecture/SYSTEM_ARCHITECTURE_DIAGRAM.md" in quickmap
-    assert len(agent_context["identity"]["l1_relay_agents"]) == 5
-    assert agent_context["identity"]["l1_continuity_system_entity"] == "HALO"
+    CHECK.assertLessEqual(len(getting_started.splitlines()), 200)
+    CHECK.assertNotIn("L2 relay agents", getting_started)
+    CHECK.assertNotIn("mediation layer", getting_started.lower())
+    CHECK.assertIn("docs/architecture/LAYER_ARCHITECTURE.md", quickmap)
+    CHECK.assertIn("docs/architecture/QGIA_SIM_BRIDGE.md", quickmap)
+    CHECK.assertIn("docs/architecture/SYSTEM_ARCHITECTURE_DIAGRAM.md", quickmap)
+    CHECK.assertEqual(len(agent_context["identity"]["l1_relay_agents"]), 5)
+    CHECK.assertEqual(agent_context["identity"]["l1_continuity_system_entity"], "HALO")
 
 
 def test_current_checkout_agent_mode_is_parseable() -> None:
@@ -177,5 +180,5 @@ def test_current_checkout_agent_mode_is_parseable() -> None:
     code = aurora_onboard.main(["--agent"], repo_root=ROOT, stream=stream)
 
     report = json.loads(stream.getvalue())
-    assert code == 0
-    assert report["status"] == "pass"
+    CHECK.assertEqual(code, 0)
+    CHECK.assertEqual(report["status"], "pass")

--- a/tests/test_aurora_onboard.py
+++ b/tests/test_aurora_onboard.py
@@ -1,0 +1,181 @@
+"""Focused tests for the repository-grounded engineer onboarding command."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("aurora_onboard", ROOT / "scripts" / "aurora_onboard.py")
+assert SPEC and SPEC.loader
+aurora_onboard = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = aurora_onboard
+SPEC.loader.exec_module(aurora_onboard)
+
+
+def _write(root: Path, relative: str, content: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _json(root: Path, relative: str, value: object) -> None:
+    _write(root, relative, json.dumps(value))
+
+
+@pytest.fixture()
+def healthy_repo(tmp_path: Path) -> Path:
+    _write(tmp_path, "setup.py", 'python_requires=">=3.11"\n')
+    _json(
+        tmp_path,
+        ".aurora/SIMULATION_STATE.json",
+        {"last_updated": "2026-07-13T00:00:00Z", "simulation": {"status": "ACTIVE"}},
+    )
+    _json(
+        tmp_path,
+        "AURORA_CONTEXT.json",
+        {
+            "document_generated": "2026-07-13",
+            "system_identity": {"name": "Aurora"},
+            "architecture_layers": {"L1": "station", "L2": "simulation", "L3": "frameworks"},
+            "active_state": {
+                "lockpoint": "SN1_LOCKPOINT_TEST",
+                "_staleness_warning": "snapshot",
+            },
+            "active_modules": {"ethics": {"status": "active"}},
+        },
+    )
+    terms = (*aurora_onboard.RELAY_AGENTS, aurora_onboard.SYSTEM_ENTITY, *aurora_onboard.L3_FRAMEWORKS)
+    _write(
+        tmp_path,
+        "docs/architecture/LAYER_ARCHITECTURE.md",
+        "Triplex Handshake\n" + "\n".join(terms),
+    )
+    _write(
+        tmp_path,
+        "src/api/l1_relay_api.manifest.yaml",
+        "continuity_seal: Aurora_Continuity_Seal_v2.2.5\n",
+    )
+    _json(
+        tmp_path,
+        "QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json",
+        {"ethics_binding": "GUMAS_Thermax"},
+    )
+    _write(
+        tmp_path,
+        "QGIA_Integration/04_GUMAS_AuditSchema.md",
+        "### GAE-001 | TEST_RULE\n- **Trigger condition:** A deterministic test trigger\n",
+    )
+    _write(tmp_path, "scripts/activate_l3_ethics.sh", "Picard_Delta_3\n")
+    _write(tmp_path, "CANON_INDEX.md", "`seeds/onboarding/README.md`\n")
+    _write(tmp_path, "seeds/onboarding/README.md", "staged, non-canonical\n")
+    return tmp_path
+
+
+def test_agent_mode_emits_parseable_json(healthy_repo: Path) -> None:
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(["--agent"], repo_root=healthy_repo, stream=stream)
+
+    report = json.loads(stream.getvalue())
+    assert code == 0
+    assert report["status"] == "pass"
+    assert report["system"]["continuity_version"] == "2.2.5"
+    assert report["system"]["lockpoint"] == "SN1_LOCKPOINT_TEST"
+    assert report["architecture"]["l1_relay_agents"] == list(aurora_onboard.RELAY_AGENTS)
+    assert report["architecture"]["l1_continuity_system_entity"] == "HALO"
+    assert report["ethics"]["binding_verified"] is True
+
+
+def test_skip_interactive_is_ci_safe_on_healthy_repo(healthy_repo: Path) -> None:
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(["--skip-interactive"], repo_root=healthy_repo, stream=stream)
+
+    assert code == 0
+    assert "Onboarding complete" in stream.getvalue()
+
+
+def test_broken_repo_returns_one_without_traceback(healthy_repo: Path) -> None:
+    (healthy_repo / "AURORA_CONTEXT.json").write_text("{broken", encoding="utf-8")
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(["--skip-interactive"], repo_root=healthy_repo, stream=stream)
+
+    assert code == 1
+    assert "Invalid JSON in AURORA_CONTEXT.json" in stream.getvalue()
+    assert "Traceback" not in stream.getvalue()
+
+
+def test_agent_failure_is_still_valid_json(healthy_repo: Path) -> None:
+    (healthy_repo / ".aurora/SIMULATION_STATE.json").unlink()
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(["--agent"], repo_root=healthy_repo, stream=stream)
+
+    report = json.loads(stream.getvalue())
+    assert code == 1
+    assert report["status"] == "fail"
+    assert "Cannot read .aurora/SIMULATION_STATE.json" in report["error"]
+
+
+def test_full_flow_writes_a_staged_seed(healthy_repo: Path) -> None:
+    answers = iter(["", "y", "Engineer One"])
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(
+        [],
+        repo_root=healthy_repo,
+        stream=stream,
+        input_fn=lambda _prompt: next(answers),
+    )
+
+    generated = list((healthy_repo / "seeds/onboarding").glob("engineer-engineer-one-*.md"))
+    assert code == 0
+    assert len(generated) == 1
+    content = generated[0].read_text(encoding="utf-8")
+    assert "seed_status: staged" in content
+    assert 'engineer_handle: "Engineer One"' in content
+    assert "does not become canon" not in content
+    assert "It is staged, not canonical" in content
+
+
+def test_missing_python_floor_returns_partial_status(healthy_repo: Path) -> None:
+    (healthy_repo / "setup.py").write_text("# no floor recorded\n", encoding="utf-8")
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(["--skip-interactive"], repo_root=healthy_repo, stream=stream)
+
+    assert code == 2
+    assert "WARNING" in stream.getvalue()
+
+
+def test_onboarding_documents_preserve_layer_semantics() -> None:
+    getting_started = (ROOT / "GETTING_STARTED_ENGINEER.md").read_text(encoding="utf-8")
+    quickmap = (ROOT / "ARCHITECTURE_QUICKMAP.md").read_text(encoding="utf-8")
+    agent_context = json.loads((ROOT / "docs/onboarding/AGENT_ONBOARD.md").read_text(encoding="utf-8"))
+
+    assert len(getting_started.splitlines()) <= 200
+    assert "L2 relay agents" not in getting_started
+    assert "mediation layer" not in getting_started.lower()
+    assert "docs/architecture/LAYER_ARCHITECTURE.md" in quickmap
+    assert "docs/architecture/QGIA_SIM_BRIDGE.md" in quickmap
+    assert "docs/architecture/SYSTEM_ARCHITECTURE_DIAGRAM.md" in quickmap
+    assert len(agent_context["identity"]["l1_relay_agents"]) == 5
+    assert agent_context["identity"]["l1_continuity_system_entity"] == "HALO"
+
+
+def test_current_checkout_agent_mode_is_parseable() -> None:
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(["--agent"], repo_root=ROOT, stream=stream)
+
+    report = json.loads(stream.getvalue())
+    assert code == 0
+    assert report["status"] == "pass"

--- a/tests/test_aurora_onboard.py
+++ b/tests/test_aurora_onboard.py
@@ -64,7 +64,7 @@ def healthy_repo(tmp_path: Path) -> Path:
     )
     _json(
         tmp_path,
-        "QGIA_Integration/QUANTUM_FORGE_Axiom_Manifest.json",
+        "QGIA_integration/QUANTUM_FORGE_Axiom_Manifest.json",
         {"ethics_binding": "GUMAS_Thermax"},
     )
     _write(

--- a/tests/test_aurora_onboard.py
+++ b/tests/test_aurora_onboard.py
@@ -94,6 +94,11 @@ def test_agent_mode_emits_parseable_json(healthy_repo: Path) -> None:
     CHECK.assertEqual(report["architecture"]["l1_relay_agents"], list(aurora_onboard.RELAY_AGENTS))
     CHECK.assertEqual(report["architecture"]["l1_continuity_system_entity"], "HALO")
     CHECK.assertTrue(report["ethics"]["binding_verified"])
+    identity_check = next(check for check in report["checks"] if check["name"] == "system_identity")
+    CHECK.assertEqual(
+        identity_check["source"],
+        "AURORA_CONTEXT.json + src/api/l1_relay_api.manifest.yaml",
+    )
 
 
 def test_skip_interactive_is_ci_safe_on_healthy_repo(healthy_repo: Path) -> None:
@@ -149,6 +154,22 @@ def test_full_flow_writes_a_staged_seed(healthy_repo: Path) -> None:
     CHECK.assertIn("It is staged, not canonical", content)
 
 
+def test_failed_validation_does_not_offer_or_write_completion_seed(healthy_repo: Path) -> None:
+    _write(healthy_repo, "docs/architecture/LAYER_ARCHITECTURE.md", "Triplex Handshake\n")
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(
+        [],
+        repo_root=healthy_repo,
+        stream=stream,
+        input_fn=lambda _prompt: "SKIP",
+    )
+
+    CHECK.assertEqual(code, 1)
+    CHECK.assertEqual(list((healthy_repo / "seeds/onboarding").glob("engineer-*.md")), [])
+    CHECK.assertIn("Skipped because environment validation failed", stream.getvalue())
+
+
 def test_missing_python_floor_returns_partial_status(healthy_repo: Path) -> None:
     (healthy_repo / "setup.py").write_text("# no floor recorded\n", encoding="utf-8")
     stream = io.StringIO()
@@ -157,6 +178,20 @@ def test_missing_python_floor_returns_partial_status(healthy_repo: Path) -> None
 
     CHECK.assertEqual(code, 2)
     CHECK.assertIn("WARNING", stream.getvalue())
+    CHECK.assertIn("fallback >=3.11", stream.getvalue())
+
+
+def test_environment_note_is_truthful_without_freshness_warning(healthy_repo: Path) -> None:
+    context_path = healthy_repo / "AURORA_CONTEXT.json"
+    context = json.loads(context_path.read_text(encoding="utf-8"))
+    context["active_state"].pop("_staleness_warning")
+    context_path.write_text(json.dumps(context), encoding="utf-8")
+    stream = io.StringIO()
+
+    code = aurora_onboard.main(["--skip-interactive"], repo_root=healthy_repo, stream=stream)
+
+    CHECK.assertEqual(code, 0)
+    CHECK.assertIn("no freshness warning is recorded", stream.getvalue())
 
 
 def test_onboarding_documents_preserve_layer_semantics() -> None:


### PR DESCRIPTION
## Summary

- add the stdlib-only interactive Aurora onboarding CLI with human, CI, and agent JSON modes
- reconcile the existing engineer guide with the current Python floor, L1/L2/L3 canon, HALO system-entity semantics, and live repository evidence
- add the architecture quickmap, src orientation, agent bootstrap JSON, FAQ, and staged seed policy
- preserve the existing full make onboard setup/server flow as the deeper environment path

## Implementation-intent reconciliation

This implements the overlapping deliverables from #1254, #1256, and #1257 as one uninterrupted onboarding system. HALO is presented as the L1 continuity system-entity alongside, but not inside, the exact five-agent communication relay roster. The optional engineer seed is written as staged material and verified against an indexed review policy; it is never silently promoted into canon.

The repository currently requires Python 3.11 in setup.py, so the CLI reads that live floor instead of hardcoding the older 3.10 value in the issue body. The requested lockpoint is reported from AURORA_CONTEXT.json with its explicit snapshot/freshness caveat because the current SIMULATION_STATE file does not contain a lockpoint field.

This PR adds the src/README.md orientation required by #1254, but it intentionally does not close #1255. The duplicate-looking src families have distinct observed consumers and still require the full import-graph audit and compatibility decisions specified there.

## Validation

- 8 focused onboarding tests passed
- live python scripts/aurora_onboard.py --skip-interactive passed with exit 0
- scoped Aurora pre-commit, shallow-assertion, whitespace/EOL, merge-conflict, and flake8 hooks passed
- git diff --check passed

Closes #1254
Closes #1256
Closes #1257
Related to #1255