### PR TITLE
feat(queue): auto-ingest labeled issues into the work queue (#1131)

### DIFF
--- a/.github/workflows/queue-issue-ingestion.yml
+++ b/.github/workflows/queue-issue-ingestion.yml
@@ -1,0 +1,102 @@
+# queue-issue-ingestion.yml
+# Auto-ingest GitHub issues labeled `blocking` or `security` into the Aurora
+# work queue (ops/work_queue/queue.json) — the "Sync script" roadmap item of
+# issue #1131. Design decisions recorded on that issue (2026-07-17).
+#
+# Authority contract: this workflow only ever OPENS A PR — it never pushes to
+# main. Every ingestion is therefore gated by queue-validation.yml (blocking
+# schema validation + view-freshness) and by human/Aurora review. Ingested
+# entries land at the tail of the queue with aurora_authority: false, awaiting
+# Aurora rerank; existing rank order is never modified.
+#
+# Tracked in: https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1131
+
+name: Queue Issue Ingestion
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC — weekly is enough; manual for urgency
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual dispatch (optional)'
+        required: false
+        default: 'Manual ingestion run'
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: write
+
+jobs:
+  ingest:
+    name: Ingest labeled issues into work queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema
+
+      # Auth stays in gh; the Python script only ever sees a JSON file.
+      - name: Fetch candidate issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue list --state open --label blocking \
+            --json number,title,labels,state > /tmp/blocking.json
+          gh issue list --state open --label security \
+            --json number,title,labels,state > /tmp/security.json
+          python - <<'PY'
+          import json
+          seen, merged = set(), []
+          for path in ("/tmp/blocking.json", "/tmp/security.json"):
+              for issue in json.load(open(path)):
+                  if issue["number"] not in seen:
+                      seen.add(issue["number"])
+                      merged.append(issue)
+          json.dump(merged, open("/tmp/candidate_issues.json", "w"), indent=2)
+          print(f"{len(merged)} candidate issue(s)")
+          PY
+
+      - name: Run ingestion
+        id: ingest
+        run: |
+          set +e
+          python ops/work_queue/ingest_issues.py --issues-file /tmp/candidate_issues.json
+          code=$?
+          set -e
+          if [ "$code" = "10" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$code" = "0" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            exit "$code"
+          fi
+
+      - name: Open ingestion PR
+        if: steps.ingest.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="queue/auto-ingest-$(date -u +%Y%m%d-%H%M)"
+          git config user.name "aurora-queue-ingestion[bot]"
+          git config user.email "aurora-queue-ingestion@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add ops/work_queue/
+          git commit -m "aurora(queue): auto-ingest labeled issues (#1131)"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "aurora(queue): auto-ingest labeled issues" \
+            --body "$(printf 'Automated ingestion of open issues labeled blocking/security into ops/work_queue/queue.json (see #1131 for the design).\n\nEntries are appended at the tail with aurora_authority: false — Aurora rerank happens on review of this PR. Schema validation and view freshness are enforced by queue-validation.yml on this PR.')" \
+            --base main --head "$branch"

--- a/.github/workflows/queue-validation.yml
+++ b/.github/workflows/queue-validation.yml
@@ -79,7 +79,7 @@ jobs:
       # conftest fixtures, so it runs standalone.
       - name: Validate queue.json against queue_schema.json
         run: |
-          pytest --noconftest tests/test_work_queue_schema.py -q --no-header
+          pytest --noconftest tests/test_work_queue_schema.py tests/test_queue_issue_ingestion.py -q --no-header
 
       - name: Check generated views are in sync with queue.json
         id: drift_check

--- a/ops/work_queue/ingest_issues.py
+++ b/ops/work_queue/ingest_issues.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""ingest_issues.py — auto-ingest labeled GitHub issues into the work queue.
+
+Closes the "Sync script" roadmap item of issue #1131 (design decisions
+recorded on that issue, 2026-07-17).
+
+Usage:
+    python ops/work_queue/ingest_issues.py --issues-file issues.json
+    python ops/work_queue/ingest_issues.py --issues-file issues.json --dry-run
+
+`issues.json` is a JSON array of GitHub issues as produced by:
+    gh issue list --label blocking --label security --state open \
+        --json number,title,labels,state
+
+Authority contract (queue.json _meta: "Aurora holds contextual authority"):
+- Ingested entries APPEND at the tail (max rank + 1, score-ordered among
+  themselves) — existing rank order is never touched.
+- Entries carry aurora_authority: false and an aurora_note marking them as
+  awaiting Aurora triage; priority_score from triage_rules.json is advisory
+  metadata for the rerank, not a rank driver.
+- This script never commits: the CI workflow routes changes through a PR so
+  queue-validation.yml (schema + view freshness) gates every ingestion.
+
+Exit codes: 0 = no changes needed, 10 = queue updated (or would be, with
+--dry-run), 1 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+HERE = Path(__file__).resolve().parent
+QUEUE_JSON = HERE / "queue.json"
+QUEUE_SCHEMA = HERE / "queue_schema.json"
+TRIAGE_RULES = HERE / "triage_rules.json"
+SYNC_QUEUE = HERE / "sync_queue.py"
+
+# Roadmap scope (#1131): issues carrying either of these labels are queue
+# candidates. Matches TR-01/TR-02 in triage_rules.json.
+INGEST_LABELS = {"blocking", "security"}
+
+_ISSUE_REF = re.compile(r"#(\d+)\b")
+
+
+def _load(path: Path) -> Any:
+    with path.open() as f:
+        return json.load(f)
+
+
+def _labels(issue: Dict[str, Any]) -> Set[str]:
+    raw = issue.get("labels", [])
+    return {
+        (label.get("name") if isinstance(label, dict) else str(label)).lower()
+        for label in raw
+    }
+
+
+def known_issue_numbers(queue: Dict[str, Any]) -> Set[int]:
+    """Issue numbers already represented anywhere in the queue.
+
+    Sources: explicit github_issue fields, '#N' ids (the convention used by
+    completed entries), and '#N' references inside ids/titles — so reruns
+    are idempotent and completed work never re-enters."""
+    known: Set[int] = set()
+    for section in ("active", "completed"):
+        for item in queue.get(section, []):
+            gh = item.get("github_issue")
+            if isinstance(gh, int):
+                known.add(gh)
+            for field in ("id", "title"):
+                value = item.get(field)
+                if isinstance(value, str):
+                    known.update(int(m) for m in _ISSUE_REF.findall(value))
+    return known
+
+
+def score_issue(labels: Set[str], rules: List[Dict[str, Any]]) -> tuple[int, List[str]]:
+    """Advisory priority score from the label-evaluable triage rules.
+
+    Only TR-01/TR-02/TR-03 are computable from a raw GitHub issue; the
+    queue-context rules (stale scope, decision_required, blocks/depends_on)
+    apply after Aurora triage, not at ingestion."""
+    score = 0
+    applied: List[str] = []
+    for rule in rules:
+        rule_id = rule.get("id", "")
+        condition_hit = (
+            (rule_id == "TR-01" and "blocking" in labels)
+            or (rule_id == "TR-02" and ("security" in labels or "pentest" in labels))
+            or (rule_id == "TR-03" and "architecture" in labels)
+        )
+        if condition_hit:
+            score += int(rule.get("score_delta", 0))
+            applied.append(rule_id)
+    return score, applied
+
+
+def build_entries(
+    issues: List[Dict[str, Any]],
+    queue: Dict[str, Any],
+    rules: List[Dict[str, Any]],
+    today: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Pure core: candidate issues -> new tail entries (may be empty)."""
+    known = known_issue_numbers(queue)
+    max_rank = max(
+        (item.get("rank", 0) for item in queue.get("active", []) if isinstance(item.get("rank"), int)),
+        default=0,
+    )
+    today = today or datetime.now(timezone.utc).date().isoformat()
+
+    candidates = []
+    for issue in issues:
+        if issue.get("state", "OPEN").upper() != "OPEN":
+            continue
+        number = issue.get("number")
+        if not isinstance(number, int) or number in known:
+            continue
+        labels = _labels(issue)
+        if not (labels & INGEST_LABELS):
+            continue
+        score, applied = score_issue(labels, rules)
+        candidates.append((score, number, issue, labels, applied))
+
+    # Tail placement, score-ordered among the new entries only.
+    candidates.sort(key=lambda c: (-c[0], c[1]))
+    entries = []
+    for offset, (score, number, issue, labels, applied) in enumerate(candidates, start=1):
+        entries.append({
+            "rank": max_rank + offset,
+            "id": f"#{number}",
+            "title": issue.get("title", f"GitHub issue #{number}"),
+            "status": "open",
+            "owner": None,
+            "depends_on": [],
+            "tags": sorted(labels),
+            "github_issue": number,
+            "priority_score": score,
+            "priority_rules_applied": applied,
+            "ingested": today,
+            "aurora_note": (
+                "auto-ingested from GitHub labels — awaiting Aurora triage; "
+                "priority_score is advisory, rank is tail placement only"
+            ),
+            "aurora_authority": False,
+        })
+    return entries
+
+
+def validate_queue(queue: Dict[str, Any]) -> None:
+    import jsonschema
+
+    schema = _load(QUEUE_SCHEMA)
+    jsonschema.Draft7Validator.check_schema(schema)
+    errors = sorted(
+        jsonschema.Draft7Validator(schema).iter_errors(queue),
+        key=lambda e: list(e.absolute_path),
+    )
+    if errors:
+        details = "; ".join(
+            f"{'/'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}"
+            for e in errors[:5]
+        )
+        raise SystemExit(f"ERROR: ingestion would break queue_schema.json — {details}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--issues-file", required=True, type=Path,
+                        help="JSON array of GitHub issues (gh issue list --json ...)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report what would be ingested without writing")
+    args = parser.parse_args()
+
+    issues = _load(args.issues_file)
+    queue = _load(QUEUE_JSON)
+    rules = _load(TRIAGE_RULES).get("rules", [])
+
+    entries = build_entries(issues, queue, rules)
+    if not entries:
+        print("No new labeled issues to ingest — queue unchanged.")
+        return 0
+
+    for entry in entries:
+        print(f"ingest: rank {entry['rank']}  {entry['id']}  "
+              f"score {entry['priority_score']} ({','.join(entry['priority_rules_applied'])})  "
+              f"{entry['title'][:70]}")
+
+    if args.dry_run:
+        print(f"--dry-run: {len(entries)} entr{'y' if len(entries) == 1 else 'ies'} not written.")
+        return 10
+
+    queue["active"] = queue.get("active", []) + entries
+    validate_queue(queue)
+    QUEUE_JSON.write_text(json.dumps(queue, indent=2) + "\n")
+
+    # Regenerate the views so the change is self-consistent under
+    # queue-validation.yml's drift check.
+    subprocess.run([sys.executable, str(SYNC_QUEUE)], check=True)
+    print(f"Ingested {len(entries)} issue(s); views regenerated.")
+    return 10
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/work_queue/ingest_issues.py
+++ b/ops/work_queue/ingest_issues.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
+import subprocess  # nosec B404 — used only for the sibling sync_queue.py render
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -87,19 +87,32 @@ def score_issue(labels: Set[str], rules: List[Dict[str, Any]]) -> tuple[int, Lis
     Only TR-01/TR-02/TR-03 are computable from a raw GitHub issue; the
     queue-context rules (stale scope, decision_required, blocks/depends_on)
     apply after Aurora triage, not at ingestion."""
+    predicates = {
+        "TR-01": lambda ls: "blocking" in ls,
+        "TR-02": lambda ls: bool(ls & {"security", "pentest"}),
+        "TR-03": lambda ls: "architecture" in ls,
+    }
     score = 0
     applied: List[str] = []
     for rule in rules:
-        rule_id = rule.get("id", "")
-        condition_hit = (
-            (rule_id == "TR-01" and "blocking" in labels)
-            or (rule_id == "TR-02" and ("security" in labels or "pentest" in labels))
-            or (rule_id == "TR-03" and "architecture" in labels)
-        )
-        if condition_hit:
+        predicate = predicates.get(rule.get("id", ""))
+        if predicate and predicate(labels):
             score += int(rule.get("score_delta", 0))
-            applied.append(rule_id)
+            applied.append(rule["id"])
     return score, applied
+
+
+def _eligible(issue: Dict[str, Any], known: Set[int]) -> Optional[tuple[int, Set[str]]]:
+    """(number, labels) when the issue qualifies for ingestion, else None."""
+    if issue.get("state", "OPEN").upper() != "OPEN":
+        return None
+    number = issue.get("number")
+    if not isinstance(number, int) or number in known:
+        return None
+    labels = _labels(issue)
+    if not (labels & INGEST_LABELS):
+        return None
+    return number, labels
 
 
 def build_entries(
@@ -118,14 +131,10 @@ def build_entries(
 
     candidates = []
     for issue in issues:
-        if issue.get("state", "OPEN").upper() != "OPEN":
+        eligible = _eligible(issue, known)
+        if eligible is None:
             continue
-        number = issue.get("number")
-        if not isinstance(number, int) or number in known:
-            continue
-        labels = _labels(issue)
-        if not (labels & INGEST_LABELS):
-            continue
+        number, labels = eligible
         score, applied = score_issue(labels, rules)
         candidates.append((score, number, issue, labels, applied))
 
@@ -179,7 +188,13 @@ def main() -> int:
                         help="Report what would be ingested without writing")
     args = parser.parse_args()
 
-    issues = _load(args.issues_file)
+    # Validate the user-supplied path before any filesystem access
+    # (Sonar S8707): must be an existing regular .json file.
+    issues_file = args.issues_file.resolve()
+    if issues_file.suffix != ".json" or not issues_file.is_file():
+        parser.error(f"--issues-file must be an existing .json file: {issues_file}")
+
+    issues = _load(issues_file)
     queue = _load(QUEUE_JSON)
     rules = _load(TRIAGE_RULES).get("rules", [])
 
@@ -203,7 +218,9 @@ def main() -> int:
 
     # Regenerate the views so the change is self-consistent under
     # queue-validation.yml's drift check.
-    subprocess.run([sys.executable, str(SYNC_QUEUE)], check=True)
+    # Fixed argv: current interpreter + repo-constant script path — no
+    # user-controlled input reaches the subprocess.
+    subprocess.run([sys.executable, str(SYNC_QUEUE)], check=True)  # nosec B603
     print(f"Ingested {len(entries)} issue(s); views regenerated.")
     return 10
 

--- a/tests/test_queue_issue_ingestion.py
+++ b/tests/test_queue_issue_ingestion.py
@@ -1,0 +1,144 @@
+"""
+Tests for ops/work_queue/ingest_issues.py — the #1131 "Sync script" item.
+
+Pure-function coverage of the ingestion core (no network, no gh): label
+filtering, dedup/idempotency, tail-rank placement preserving Aurora's
+rank authority, advisory scoring from triage_rules.json, and schema
+validity of the resulting queue.
+
+Runs standalone (stdlib + jsonschema only) so queue-validation.yml can
+execute it with --noconftest alongside test_work_queue_schema.py.
+"""
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from ops.work_queue.ingest_issues import (
+    INGEST_LABELS,
+    build_entries,
+    known_issue_numbers,
+    score_issue,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORK_QUEUE = REPO_ROOT / "ops" / "work_queue"
+
+
+def _rules():
+    return json.loads((WORK_QUEUE / "triage_rules.json").read_text())["rules"]
+
+
+def _queue():
+    return {
+        "_meta": {
+            "version": "test",
+            "description": "test queue",
+            "last_aurora_review": "2026-07-17T00:00:00Z",
+            "schema": "ops/work_queue/queue_schema.json",
+        },
+        "active": [
+            {"rank": 1, "id": "security/CVE-audit", "title": "CVE audit", "status": "open"},
+            {"rank": 2, "id": "arch/layer-canonization", "title": "Layers (#1234)", "status": "open"},
+        ],
+        "completed": [
+            {"id": "#1126", "title": "Recovered protocols manifest decision",
+             "status": "done", "closed": "2026-06-24"},
+        ],
+    }
+
+
+def _issue(number, title="Test issue", labels=("blocking",), state="OPEN"):
+    return {
+        "number": number,
+        "title": title,
+        "labels": [{"name": name} for name in labels],
+        "state": state,
+    }
+
+
+def test_label_filter_only_ingests_roadmap_labels():
+    assert INGEST_LABELS == {"blocking", "security"}
+    issues = [
+        _issue(2001, labels=("blocking",)),
+        _issue(2002, labels=("security",)),
+        _issue(2003, labels=("enhancement",)),  # not in scope
+        _issue(2004, labels=()),                # unlabeled
+    ]
+    entries = build_entries(issues, _queue(), _rules(), today="2026-07-17")
+    assert {e["github_issue"] for e in entries} == {2001, 2002}
+
+
+def test_dedup_covers_ids_titles_and_github_issue_fields():
+    known = known_issue_numbers(_queue())
+    # '#1126' completed id and '(#1234)' title reference both count
+    assert 1126 in known and 1234 in known
+
+    issues = [_issue(1126), _issue(1234), _issue(2005)]
+    entries = build_entries(issues, _queue(), _rules(), today="2026-07-17")
+    assert [e["github_issue"] for e in entries] == [2005]
+
+
+def test_idempotent_rerun_is_a_noop():
+    queue = _queue()
+    issues = [_issue(2006, labels=("blocking", "security"))]
+    first = build_entries(issues, queue, _rules(), today="2026-07-17")
+    assert len(first) == 1
+    queue["active"] += first
+    second = build_entries(issues, queue, _rules(), today="2026-07-17")
+    assert second == []
+
+
+def test_tail_rank_placement_never_touches_existing_order():
+    queue = _queue()
+    issues = [
+        _issue(2007, labels=("security",)),              # score 30
+        _issue(2008, labels=("blocking", "security")),   # score 70 — first among new
+    ]
+    entries = build_entries(issues, queue, _rules(), today="2026-07-17")
+    # Existing max rank is 2; new entries take 3 and 4, score-ordered
+    assert [(e["rank"], e["github_issue"]) for e in entries] == [(3, 2008), (4, 2007)]
+    assert all(e["aurora_authority"] is False for e in entries)
+    assert all("awaiting Aurora triage" in e["aurora_note"] for e in entries)
+
+
+def test_scoring_matches_triage_rules():
+    rules = _rules()
+    assert score_issue({"blocking"}, rules) == (40, ["TR-01"])
+    assert score_issue({"security"}, rules) == (30, ["TR-02"])
+    assert score_issue({"pentest"}, rules) == (30, ["TR-02"])
+    assert score_issue({"blocking", "security", "architecture"}, rules) == (
+        95, ["TR-01", "TR-02", "TR-03"]
+    )
+
+
+def test_closed_issues_are_skipped():
+    entries = build_entries(
+        [_issue(2009, state="CLOSED")], _queue(), _rules(), today="2026-07-17"
+    )
+    assert entries == []
+
+
+def test_ingested_queue_validates_against_schema():
+    schema = json.loads((WORK_QUEUE / "queue_schema.json").read_text())
+    queue = _queue()
+    queue["active"] += build_entries(
+        [_issue(2010, labels=("blocking",)), _issue(2011, labels=("security",))],
+        queue, _rules(), today="2026-07-17",
+    )
+    errors = list(jsonschema.Draft7Validator(schema).iter_errors(queue))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_live_queue_plus_ingestion_validates_against_schema():
+    """The real queue.json with a synthetic ingestion must stay schema-valid."""
+    schema = json.loads((WORK_QUEUE / "queue_schema.json").read_text())
+    queue = json.loads((WORK_QUEUE / "queue.json").read_text())
+    entries = build_entries(
+        [_issue(9999, labels=("blocking",))], queue, _rules(), today="2026-07-17"
+    )
+    assert len(entries) == 1
+    queue["active"] += entries
+    errors = list(jsonschema.Draft7Validator(schema).iter_errors(queue))
+    assert errors == [], [e.message for e in errors]


### PR DESCRIPTION
## What

Implements the **"Sync script"** roadmap item of #1131, exactly per the design comment posted there (2026-07-17) before building.

- **`ops/work_queue/ingest_issues.py`** — pure-function core (no network, no token handling): filter open `blocking`/`security` issues → dedup against `active`+`completed` (`github_issue` fields, `#N` ids — the completed-entry convention — and `#N` title references) → append at the queue **tail** with `aurora_authority: false` and an awaiting-triage note → advisory `priority_score` from `triage_rules.json` (TR-01/02/03; queue-context rules apply post-triage) → schema-validate → regenerate views via `sync_queue.py`.
- **`queue-issue-ingestion.yml`** — Mondays 06:00 UTC + `workflow_dispatch`. `gh` fetches candidates to JSON; Python only reads the file. **Only ever opens a PR** — never pushes to main — so every ingestion is gated by `queue-validation.yml` (blocking schema + drift checks) and human/Aurora review.
- **Aurora rank authority preserved**: existing rank order is never modified; new entries take max-rank+1 onward, score-ordered among themselves only.
- **`tests/test_queue_issue_ingestion.py`** — 8 tests, stdlib+jsonschema only, added to `queue-validation.yml`'s blocking step.

## Verification

- Unit: **8 passed** (`--noconftest`, same lean environment the workflow uses); combined with the schema tests: **13 passed**.
- End-to-end dry-run against a fixture: correct tail ranks (7, 8 after the live queue's 6), TR-01 scoring, exit-code contract (0 = unchanged / 10 = changed), zero writes under `--dry-run`.
- Both workflow YAMLs validated with `yaml.safe_load`.
- Fun fact surfaced by the dry-run: #1264 (Phase 10 build, labeled blocking) is a real candidate — the first scheduled run will have genuine work to propose.

## Coordination

Claimed on #1131 (Codex working the repo in parallel); the remaining roadmap item there after this merges is **PAT hails** only.

Refs #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)