### PR TITLE
feat(nexus): complete Phase 10 hybrid orchestration verification (#1264)

### DIFF
--- a/modules/nexus/integration_manifest.yaml
+++ b/modules/nexus/integration_manifest.yaml
@@ -1,4 +1,4 @@
-manifest_version: "7.2.0"
+manifest_version: "7.3.0"
 integration_time: "2025-09-27T16:00:00Z"
 team: "Aurora Core"
 arbiter: "AUo959"
@@ -73,18 +73,21 @@ phase_status:
 
   phase10_hybrid_orchestration:
     anchor: "T10-HYBRID-2025"
-    status: "IN_PROGRESS"
-    # Truth reconciliation (2026-07-17, #1067): the components below are the
-    # PLAN, not the tree. modules/nexus/schematics/ contains only
-    # copilot_integration.py; implementation is tracked in issue #1264.
-    components_implemented:
-      - "copilot_integration"
-    components_planned:
-      - "hybrid_orchestrator"          # not implemented — #1264
-      - "quantum_classical_bridge"     # not implemented — #1264
-      - "hybrid_cycle_tests"           # not implemented — #1264
-      - "recursion_hybrid_bridge"      # not implemented — #1264; possible seed: modules/nexus/quantum/recursion_bridge.py
-    capabilities_planned:
+    completion_anchor: "T10-HYBRID-COMPLETE-2025"
+    status: "COMPLETE"
+    # Completion audit (2026-07-17, #1264): the components existed under
+    # modules/nexus/quantum/ (not schematics/, where the earlier #1067 audit
+    # looked). Verified by tests/test_hybrid_cycle.py, including the required
+    # 10-cycle glyphcard burn-in and a real Phase 9 UnifiedRecursionState
+    # hand-off (which surfaced and fixed a datetime-serialization defect in
+    # the bridge manifest path).
+    components:
+      - "hybrid_orchestrator"          # modules/nexus/quantum/hybrid_orchestrator.py
+      - "quantum_classical_bridge"     # realized inside hybrid_orchestrator (QuantumStateSimulator + classical pre/post + cycle exports)
+      - "recursion_hybrid_bridge"      # modules/nexus/quantum/recursion_bridge.py
+      - "hybrid_cycle_tests"           # tests/test_hybrid_cycle.py
+      - "copilot_integration"          # modules/nexus/schematics/copilot_integration.py
+    capabilities:
       - "Quantum-classical cycle exports"
       - "Checkpoint restoration"
       - "Glyphcard synthesis"
@@ -130,10 +133,10 @@ thread_continuity:
   divergent_truths: 0
 
 next_steps:
-  immediate:
-    - "Chain Phase 8 status, Phase 9 recursion, and Phase 10 hybrid cycles"
-    - "Run glyphcard burn-in across 10 hybrid cycles"
-    - "Validate recursion payload hand-off into hybrid orchestrator"
+  immediate: []
+  # Phase 10 items completed 2026-07-17 (#1264): hybrid cycles chained,
+  # 10-cycle glyphcard burn-in run (tests/test_hybrid_cycle.py), recursion
+  # payload hand-off validated against a real UnifiedRecursionState.
     
   phase8_planning:
     - "Transcendent consciousness protocols"
@@ -153,6 +156,7 @@ thread_chain:
   - "T8-STATUS-GUMAS-V2-2025"
   - "T9-INFINITE-UNIFIED-2025"
   - "T10-HYBRID-2025"
+  - "T10-HYBRID-COMPLETE-2025"
   - "T11-MULTIDIM-2025"
 
 # seal below covers the v7.1.0 record; v7.2.0 changes are the truth

--- a/modules/nexus/quantum/recursion_bridge.py
+++ b/modules/nexus/quantum/recursion_bridge.py
@@ -119,6 +119,16 @@ def _serialize_recursion_state(state: Any) -> dict[str, Any]:
     if "T10-HYBRID-2025" not in thread_chain:
         thread_chain.append("T10-HYBRID-2025")
 
+    # UnifiedRecursionState carries a datetime timestamp; the manifest is
+    # json.dumps'd without a custom encoder, so normalize to ISO-8601 here.
+    # (Found by tests/test_hybrid_cycle.py — string-timestamp stubs masked
+    # this until the bridge ran against a real Phase 9 state.)
+    timestamp = getattr(state, "timestamp", None)
+    if hasattr(timestamp, "isoformat"):
+        timestamp = timestamp.isoformat()
+    elif timestamp is None:
+        timestamp = _timestamp()
+
     return {
         "anchor": getattr(state, "anchor", "UNKNOWN"),
         "parent_anchor": getattr(state, "parent_anchor", "UNKNOWN"),
@@ -130,7 +140,7 @@ def _serialize_recursion_state(state: Any) -> dict[str, Any]:
         "divergent_truths": len(getattr(state, "divergent_truths", []) or []),
         "memory_usage_mb": float(getattr(state, "memory_usage_mb", 0.0)),
         "cpu_usage_percent": float(getattr(state, "cpu_usage_percent", 0.0)),
-        "timestamp": getattr(state, "timestamp", _timestamp()),
+        "timestamp": str(timestamp),
         "thread_chain": thread_chain,
         "requires_arbitration": _requires_arbitration(state),
         "dlp_level": getattr(state, "dlp_tag", BRIDGE_DLP_LEVEL),

--- a/tests/test_hybrid_cycle.py
+++ b/tests/test_hybrid_cycle.py
@@ -1,0 +1,226 @@
+"""
+Phase 10 hybrid_cycle_tests (issue #1264; manifest component).
+
+Validates the existing Phase 10 implementation end-to-end:
+
+- HybridQuantumOrchestrator cycle mechanics and artifacts (quantum state
+  exports, entanglement graphs, state hashes)
+- Checkpoint restoration round-trip, including the dimensionality-mismatch
+  failure path
+- Phase 9 → Phase 10 hand-off via recursion_bridge with a REAL
+  UnifiedRecursionState (not a stub), including the DLP tag set and the
+  per-cycle bridge manifest contract
+- The manifest-required glyphcard burn-in across 10 hybrid cycles
+
+Deterministic: every orchestrator gets a seeded random.Random and a
+tmp_path work_dir, so no test depends on wall-clock, environment, or the
+repo's .nexus state.
+"""
+
+import asyncio
+import json
+import math
+import random
+
+import pytest
+
+from modules.nexus.quantum.hybrid_orchestrator import HybridQuantumOrchestrator
+from modules.nexus.quantum.recursion_bridge import (
+    BRIDGE_ANCHOR,
+    build_classical_payload,
+    compute_entanglement_bias,
+    run_hybrid_cycle_from_recursion,
+)
+from modules.nexus.transcendence.infinite_recursion_unified import UnifiedRecursionState
+
+
+def _orchestrator(tmp_path, **overrides) -> HybridQuantumOrchestrator:
+    params = {
+        "work_dir": tmp_path / "quantum",
+        "num_qubits": 3,
+        "classical_dimension": 6,
+        "noise": 0.02,
+        "rng": random.Random(20260717),
+    }
+    params.update(overrides)
+    return HybridQuantumOrchestrator(**params)
+
+
+def _recursion_state(**overrides) -> UnifiedRecursionState:
+    params = {
+        "depth": 7,
+        "anchor": "T9-INFINITE-UNIFIED-2025",
+        "parent_anchor": "T8-STATUS-GUMAS-V2-2025",
+        "consciousness_level": 0.91,
+        "entropy": 0.42,
+    }
+    params.update(overrides)
+    return UnifiedRecursionState(**params)
+
+
+# ---------------------------------------------------------------------------
+# Cycle mechanics and artifacts
+# ---------------------------------------------------------------------------
+
+def test_single_cycle_produces_export_and_entanglement_artifacts(tmp_path):
+    orchestrator = _orchestrator(tmp_path)
+    report = asyncio.run(orchestrator.run_cycle([0.4, 0.1, 0.9, 0.2, 0.5, 0.3]))
+
+    assert report.cycle_index == 0
+    assert 0.0 <= report.consciousness_score <= 1.0
+    assert report.export_path.is_file()
+    assert report.entanglement_graph_path.is_file()
+
+    export = json.loads(report.export_path.read_text())
+    assert export["cycle_index"] == 0
+    assert export["state_hash"]
+    assert len(export["state_vector"]) == 2 ** orchestrator.num_qubits
+    assert "T10-HYBRID-2025" in export["thread_chain"]
+
+    graph = json.loads(report.entanglement_graph_path.read_text())
+    assert graph["state_hash"]
+    for edge in graph["edges"]:
+        assert set(edge) == {"source", "target", "weight"}
+
+
+def test_payload_normalization_pads_truncates_and_unit_norms(tmp_path):
+    orchestrator = _orchestrator(tmp_path)
+
+    padded = orchestrator._prepare_payload([3.0])
+    assert len(padded) == orchestrator.classical_dimension
+    assert math.isclose(math.sqrt(sum(v * v for v in padded)), 1.0, rel_tol=1e-9)
+
+    truncated = orchestrator._prepare_payload([1.0] * 20)
+    assert len(truncated) == orchestrator.classical_dimension
+
+    zeros = orchestrator._prepare_payload([])
+    assert zeros == [0.0] * orchestrator.classical_dimension
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint restoration
+# ---------------------------------------------------------------------------
+
+def test_checkpoint_roundtrip_restores_normalized_state(tmp_path):
+    orchestrator = _orchestrator(tmp_path)
+    report = asyncio.run(orchestrator.run_cycle([0.2, 0.8, 0.1, 0.4, 0.6, 0.9]))
+
+    exported = json.loads(report.export_path.read_text())["state_vector"]
+    restored = orchestrator.resume_from_quantum_checkpoint(report.export_path)
+
+    assert len(restored) == 2 ** orchestrator.num_qubits
+    norm = math.sqrt(sum(abs(amp) ** 2 for amp in restored))
+    assert math.isclose(norm, 1.0, rel_tol=1e-9)
+    # Restored amplitudes correspond to the exported ones (post-normalization)
+    export_norm = math.sqrt(sum(e["real"] ** 2 + e["imag"] ** 2 for e in exported))
+    for amp, entry in zip(restored, exported):
+        assert math.isclose(amp.real, entry["real"] / export_norm, abs_tol=1e-9)
+        assert math.isclose(amp.imag, entry["imag"] / export_norm, abs_tol=1e-9)
+
+
+def test_checkpoint_dimension_mismatch_is_rejected(tmp_path):
+    producer = _orchestrator(tmp_path, num_qubits=3)
+    report = asyncio.run(producer.run_cycle([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]))
+
+    consumer = _orchestrator(tmp_path / "other", num_qubits=2)
+    with pytest.raises(ValueError, match="dimensionality mismatch"):
+        consumer.resume_from_quantum_checkpoint(report.export_path)
+
+
+# ---------------------------------------------------------------------------
+# Phase 9 → Phase 10 hand-off (recursion_hybrid_bridge)
+# ---------------------------------------------------------------------------
+
+def test_bridge_payload_and_bias_derive_from_recursion_state():
+    state = _recursion_state()
+    payload = build_classical_payload(state, 6)
+    assert len(payload) == 6
+    assert all(-1.0 <= value <= 1.0 for value in payload)
+
+    bias = compute_entanglement_bias(state)
+    assert 0.05 <= bias <= 0.95
+    # Higher consciousness with lower entropy must not reduce the bias
+    stronger = _recursion_state(consciousness_level=0.99, entropy=0.05)
+    assert compute_entanglement_bias(stronger) >= bias
+
+
+def test_bridge_cycle_from_real_unified_recursion_state(tmp_path):
+    orchestrator = _orchestrator(tmp_path)
+    state = _recursion_state()
+
+    result = asyncio.run(run_hybrid_cycle_from_recursion(orchestrator, state))
+
+    assert result.recursion_anchor == "T9-INFINITE-UNIFIED-2025"
+    assert result.recursion_depth == 7
+    assert len(result.payload) == orchestrator.classical_dimension
+    assert 0.05 <= result.entanglement_bias <= 0.95
+    assert result.hybrid_report.export_path.is_file()
+
+    # DLP provenance: three distinct tags recorded
+    assert len({result.symbolic_tag, result.quantum_tag, result.hybrid_tag}) == 3
+
+    manifest = json.loads(result.manifest_path.read_text())
+    assert manifest["bridge_anchor"] == BRIDGE_ANCHOR
+    assert manifest["recursion_state"]["anchor"] == "T9-INFINITE-UNIFIED-2025"
+    # Phase boundary is stamped onto the thread chain
+    assert "T10-HYBRID-2025" in manifest["thread_chain"]
+    assert "T9-INFINITE-UNIFIED-2025" in manifest["thread_chain"]
+    assert manifest["hybrid_cycle"]["cycle_index"] == result.hybrid_report.cycle_index
+
+
+# ---------------------------------------------------------------------------
+# Manifest requirement: glyphcard burn-in across 10 hybrid cycles
+# ---------------------------------------------------------------------------
+
+def test_ten_cycle_glyphcard_burn_in(tmp_path):
+    orchestrator = _orchestrator(tmp_path)
+    state = _recursion_state()
+
+    async def burn_in():
+        results = []
+        for cycle in range(10):
+            results.append(
+                await run_hybrid_cycle_from_recursion(
+                    orchestrator, state, cycle_index=cycle
+                )
+            )
+        return results
+
+    results = asyncio.run(burn_in())
+
+    assert len(results) == 10
+    assert len(orchestrator.history) == 10
+    assert len(orchestrator.state_hash_history) == 10
+    assert [r.hybrid_report.cycle_index for r in results] == list(range(10))
+
+    # Every cycle produced its full artifact set
+    for result in results:
+        assert result.hybrid_report.export_path.is_file()
+        assert result.hybrid_report.entanglement_graph_path.is_file()
+        assert result.manifest_path.is_file()
+    assert len(set(orchestrator.state_hash_history)) == 10, "state hashes must be unique per cycle"
+
+    # Glyphcard synthesis covers the full burn-in window
+    glyphcard = orchestrator.generate_glyphcard(cycles=10)
+    for cycle in range(10):
+        assert f"Cycle {cycle:02d}:" in glyphcard
+    assert "Thread Chain:" in glyphcard
+    assert "T10-HYBRID-2025" in glyphcard
+
+    # Consciousness scores stay bounded across the whole burn-in
+    scores = [r.hybrid_report.consciousness_score for r in results]
+    assert all(0.0 <= score <= 1.0 for score in scores)
+
+
+def test_monitoring_loop_yields_reports_with_limit(tmp_path):
+    orchestrator = _orchestrator(tmp_path)
+
+    async def consume():
+        stream = ([0.1 * i] * 6 for i in range(1, 6))
+        return [
+            report
+            async for report in orchestrator.run_monitoring_loop(stream, limit=3)
+        ]
+
+    reports = asyncio.run(consume())
+    assert [r.cycle_index for r in reports] == [0, 1, 2]


### PR DESCRIPTION
## What

Completes Phase 10 per the revised build plan on #1264. The deeper audit (posted there) found the components already implemented under `modules/nexus/quantum/` — the earlier #1067 audit had only checked `schematics/`, where the manifest pointed. What Phase 10 genuinely lacked was its **`hybrid_cycle_tests`** component and truthful records.

## The tests found a real bug on day one

`tests/test_hybrid_cycle.py` (8 tests) exercises the Phase 9 hand-off with a **real `UnifiedRecursionState`** — and immediately crashed: `recursion_bridge._serialize_recursion_state` passed the state's `datetime` timestamp straight into `json.dumps`, so `run_hybrid_cycle_from_recursion` had only ever worked with string-timestamp stubs. Fixed by normalizing to ISO-8601 (with a comment crediting the test that caught it). This is precisely why the manifest listed `hybrid_cycle_tests` as a first-class component.

## Coverage

- Cycle mechanics: exports + entanglement graphs written per cycle, state hashes, bounded consciousness scores, payload normalization edge cases
- **Checkpoint restoration**: round-trip fidelity against exported amplitudes; dimensionality mismatch rejected
- **Phase 9 → Phase 10 hand-off**: payload/bias derivation from recursion telemetry, three distinct DLP tags, bridge manifest contract (anchors, thread-chain stamping)
- **10-cycle glyphcard burn-in** (manifest requirement): 10 unique state hashes, full artifact set per cycle, glyphcard synthesis covering the entire window
- Deterministic throughout: seeded RNG + tmp_path work dirs

## Manifest (v7.3.0)

`phase10` → **COMPLETE** with components mapped to their real paths — `quantum_classical_bridge` honestly annotated as realized *inside* the orchestrator rather than duplicated as a new file. Completion anchor `T10-HYBRID-COMPLETE-2025` established, `thread_chain` extended, stale `next_steps` cleared with a completion note.

## Verification

- New suite: **8 passed**.
- Adjacent suites (unified recursion, diagnostics, monitor, quantum bridge): **all passed** alongside.
- Manifest YAML validated with `yaml.safe_load`.

Closes #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)