### PR TITLE
test(nexus): Phase 10 markers + Codacy disposition for #1268 (#1269)

### DIFF
--- a/tests/test_hybrid_cycle.py
+++ b/tests/test_hybrid_cycle.py
@@ -33,6 +33,11 @@ from modules.nexus.quantum.recursion_bridge import (
 )
 from modules.nexus.transcendence.infinite_recursion_unified import UnifiedRecursionState
 
+# Component markers per tests/README_TESTING.md; every test also carries
+# @pytest.mark.critical so the suite runs in the blocking selective CI lane
+# (aurora-ci-minimal greps for the literal decorator string).
+pytestmark = [pytest.mark.integration, pytest.mark.quantum]
+
 
 def _orchestrator(tmp_path, **overrides) -> HybridQuantumOrchestrator:
     params = {
@@ -40,7 +45,7 @@ def _orchestrator(tmp_path, **overrides) -> HybridQuantumOrchestrator:
         "num_qubits": 3,
         "classical_dimension": 6,
         "noise": 0.02,
-        "rng": random.Random(20260717),
+        "rng": random.Random(20260717),  # nosec B311 — deterministic test seed, not cryptographic
     }
     params.update(overrides)
     return HybridQuantumOrchestrator(**params)
@@ -62,6 +67,7 @@ def _recursion_state(**overrides) -> UnifiedRecursionState:
 # Cycle mechanics and artifacts
 # ---------------------------------------------------------------------------
 
+@pytest.mark.critical
 def test_single_cycle_produces_export_and_entanglement_artifacts(tmp_path):
     orchestrator = _orchestrator(tmp_path)
     report = asyncio.run(orchestrator.run_cycle([0.4, 0.1, 0.9, 0.2, 0.5, 0.3]))
@@ -83,6 +89,7 @@ def test_single_cycle_produces_export_and_entanglement_artifacts(tmp_path):
         assert set(edge) == {"source", "target", "weight"}
 
 
+@pytest.mark.critical
 def test_payload_normalization_pads_truncates_and_unit_norms(tmp_path):
     orchestrator = _orchestrator(tmp_path)
 
@@ -101,6 +108,7 @@ def test_payload_normalization_pads_truncates_and_unit_norms(tmp_path):
 # Checkpoint restoration
 # ---------------------------------------------------------------------------
 
+@pytest.mark.critical
 def test_checkpoint_roundtrip_restores_normalized_state(tmp_path):
     orchestrator = _orchestrator(tmp_path)
     report = asyncio.run(orchestrator.run_cycle([0.2, 0.8, 0.1, 0.4, 0.6, 0.9]))
@@ -118,6 +126,7 @@ def test_checkpoint_roundtrip_restores_normalized_state(tmp_path):
         assert math.isclose(amp.imag, entry["imag"] / export_norm, abs_tol=1e-9)
 
 
+@pytest.mark.critical
 def test_checkpoint_dimension_mismatch_is_rejected(tmp_path):
     producer = _orchestrator(tmp_path, num_qubits=3)
     report = asyncio.run(producer.run_cycle([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]))
@@ -131,6 +140,7 @@ def test_checkpoint_dimension_mismatch_is_rejected(tmp_path):
 # Phase 9 → Phase 10 hand-off (recursion_hybrid_bridge)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.critical
 def test_bridge_payload_and_bias_derive_from_recursion_state():
     state = _recursion_state()
     payload = build_classical_payload(state, 6)
@@ -144,6 +154,7 @@ def test_bridge_payload_and_bias_derive_from_recursion_state():
     assert compute_entanglement_bias(stronger) >= bias
 
 
+@pytest.mark.critical
 def test_bridge_cycle_from_real_unified_recursion_state(tmp_path):
     orchestrator = _orchestrator(tmp_path)
     state = _recursion_state()
@@ -172,6 +183,7 @@ def test_bridge_cycle_from_real_unified_recursion_state(tmp_path):
 # Manifest requirement: glyphcard burn-in across 10 hybrid cycles
 # ---------------------------------------------------------------------------
 
+@pytest.mark.critical
 def test_ten_cycle_glyphcard_burn_in(tmp_path):
     orchestrator = _orchestrator(tmp_path)
     state = _recursion_state()
@@ -212,6 +224,7 @@ def test_ten_cycle_glyphcard_burn_in(tmp_path):
     assert all(0.0 <= score <= 1.0 for score in scores)
 
 
+@pytest.mark.critical
 def test_monitoring_loop_yields_reports_with_limit(tmp_path):
     orchestrator = _orchestrator(tmp_path)
 


### PR DESCRIPTION
## What

Short-term follow-up to #1268, per #1269's scope.

### Markers

`tests/test_hybrid_cycle.py` now carries file-level `pytestmark = [integration, quantum]` (component markers per `tests/README_TESTING.md`) and **`@pytest.mark.critical` on each of the eight tests** — the per-test decorator form matters because `aurora-ci-minimal`'s blocking step greps for the literal decorator string to build its file list, then filters with `-m "critical or smoke"`. Verified:

- `pytest -m "critical or smoke" tests/test_hybrid_cycle.py` → **8 passed** (selected by the intended lane)
- `pytest -m quantum` → 8 passed; direct run unchanged
- The CI grep now includes the file (checked with the workflow's own grep expression)
- Adjacent suites (unified recursion, diagnostics, monitor, quantum bridge): **35 passed** together

### Codacy disposition — all 46 findings from #1268, individually classed

| Findings | Rule | Disposition |
|---|---|---|
| 45 | B101 "Use of assert detected" (all in `tests/test_hybrid_cycle.py`) | **Test-only tool noise.** `assert` is the pytest idiom; `-O` stripping doesn't apply to test runs. Same documented false-positive class dispositioned on #1238/#1241/#1243/#1245. No change. |
| 1 | B311 "Standard pseudo-random generators are not suitable for security/cryptographic purposes" (`random.Random(20260717)` test fixture) | **Not a cryptographic use** — it's the deliberate deterministic seed that makes the suite reproducible. Suppressed narrowly with `# nosec B311` + inline rationale, matching the repo's existing nosec-with-justification pattern (`ops/work_queue/ingest_issues.py`). |

**Actionable defects: zero.** The `ACTION_REQUIRED` state on #1268 was the known Codacy behavior on assert-heavy test PRs (cf. the established pattern notes in this repo's session records).

### Guardrails respected

No change to Phase 10 completion semantics, the v7.3.0 manifest, or any production module. Kept clear of the #1231/#1270 docs lane.

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)