### PR TITLE
feat(opal2): establish tool foundry runtime

### DIFF
--- a/docs/architecture/OPAL2_FOUNDRY_ARCHITECTURE.md
+++ b/docs/architecture/OPAL2_FOUNDRY_ARCHITECTURE.md
@@ -57,7 +57,7 @@ reference tools (glyph renderer today; regex and others later)
         `-- Aurora adapter / policy profile
 ```
 
-Aurora-specific anchors, DLP classifications, Picard_Delta_3s, and continuity
+Aurora-specific anchors, DLP classifications, Picard_Delta_3, and continuity
 fields must enter through a policy profile or adapter. They must not be added
 as required fields in `ToolManifest` or `ToolExecutionContext`.
 

--- a/docs/architecture/OPAL2_FOUNDRY_ARCHITECTURE.md
+++ b/docs/architecture/OPAL2_FOUNDRY_ARCHITECTURE.md
@@ -1,0 +1,178 @@
+# OPAL2 Tool Foundry Architecture
+
+**Status:** Phase 1 implementation baseline
+
+**Runtime topology:** standalone service
+
+**Reference implementation:** `modules/opal2/`
+
+**Primary reference tool:** `opal2.glyph.render`
+
+## Definition
+
+OPAL2 is a portable tool foundry: a workshop and runtime for describing,
+registering, validating, executing, and eventually packaging modular tools.
+Aurora is the first platform integration profile, not a dependency of the
+portable foundry contract.
+
+The symbolic glyph and rendering stack is the first reference tool produced by
+the foundry. It is not the complete definition of OPAL2.
+
+## Phase 1 boundary
+
+Phase 1 establishes a small executable spine:
+
+- a neutral `ToolManifest` with input/output schemas and portability metadata;
+- an asynchronous `Opal2Tool` interface;
+- an explicit trusted-tool registry;
+- a standard execution envelope with run ID, duration, and manifest digest;
+- the existing glyph renderer adapted as `opal2.glyph.render`;
+- standalone discovery and execution endpoints;
+- compatibility routing from the existing `/render` endpoint through the
+  foundry registry.
+
+Phase 1 does **not** claim that packaging, remote installation, multi-tenant
+isolation, or general third-party loading is complete.
+
+## Runtime topology
+
+OPAL2 remains a standalone FastAPI service. It is not mounted inside the main
+Aurora API. This preserves its independent WebSocket lifecycle and security
+middleware boundary.
+
+```text
+tool author or client
+        |
+        v
+OPAL2 standalone API
+        |
+        +-- tool manifest + validation
+        +-- explicit trusted registry
+        +-- execution + provenance
+        |
+        v
+reference tools (glyph renderer today; regex and others later)
+        |
+        +-- neutral consumer
+        `-- Aurora adapter / policy profile
+```
+
+Aurora-specific anchors, DLP classifications, Picard_Delta_3s, and continuity
+fields must enter through a policy profile or adapter. They must not be added
+as required fields in `ToolManifest` or `ToolExecutionContext`.
+
+## Tool contract
+
+Every tool declares:
+
+- stable ID, name, version, and description;
+- capabilities;
+- JSON-shaped input and output schemas;
+- runtime type and determinism claim;
+- declared side effects;
+- supported policy profiles;
+- intended export targets.
+
+Every run returns:
+
+- a unique run ID;
+- tool ID and version;
+- JSON-serializable output;
+- measured execution duration;
+- a SHA-256 digest of the exact manifest used;
+- runtime and selected policy-profile provenance.
+
+The Phase 1 validator implements the required top-level JSON-Schema subset:
+required fields, primitive types, enums, and `additionalProperties`. Full
+JSON-Schema conformance belongs to the packaging/conformance phase.
+
+## Trust boundary
+
+The foundry registry accepts explicit in-process tool instances only. It does
+not scan arbitrary directories or import user-supplied code. The older OPAL2
+plugin loader remains a visualization compatibility surface and is not the
+portable foundry installation mechanism.
+
+Remote or third-party packages must not be enabled until OPAL2 has:
+
+1. a versioned package manifest;
+2. digest and signature verification;
+3. dependency and SBOM validation;
+4. an isolated subprocess, container, or WASM execution boundary;
+5. capability and resource-limit enforcement;
+6. clean-room conformance tests.
+
+## Standalone API
+
+Existing compatibility routes remain available:
+
+- `POST /generate`
+- `POST /render`
+- `GET /plugins`
+- `GET /cache/stats`
+- `DELETE /cache/clear`
+- `WebSocket /ws`
+
+Foundry routes introduced in Phase 1:
+
+- `GET /tools` — list portable manifests;
+- `GET /tools/{tool_id}` — retrieve one manifest;
+- `POST /tools/{tool_id}/run` — validate and execute a registered tool.
+
+Mutating routes retain the standalone service's CSRF bearer-token contract.
+
+## Start and validate
+
+The service requires real secrets and refuses insecure defaults:
+
+```bash
+export CSRF_SECRET_KEY='<strong deployment secret>'
+export WS_AUTH_SECRET='<strong deployment secret>'
+uvicorn modules.opal2.api.opal2_api:app --host 127.0.0.1 --port 8001
+```
+
+Focused validation:
+
+```bash
+python -m compileall -q -x 'modules/opal2/staging' modules/opal2
+python -m pytest tests/test_opal2_foundry.py tests/test_opal2_api_routes.py -q
+```
+
+## Planned convergence
+
+### Phase 2: prove generality
+
+- Add an SDK/scaffold for authoring tools.
+- Restore a narrowly specified regex-generation tool as the first non-renderer
+  reference implementation.
+- Add full input/output conformance fixtures.
+- Introduce an Aurora adapter rather than direct runtime imports.
+
+### Phase 3: prove portability
+
+- Define a signed `.opaltool` archive containing the manifest, schemas,
+  implementation artifact, fixtures, digest, and SBOM.
+- Export and import the same tool in a clean neutral environment and a clean
+  Aurora environment.
+- Require matching fixture output and provenance digests.
+
+### Phase 4: workshop and scale
+
+- Add scaffold, build, test, run, export, and publish workflows.
+- Move execution into isolated workers.
+- Add an external artifact registry and queue-backed worker pools.
+- Extract the neutral core to an independent package or repository only after
+  the clean-room conformance suite is green.
+
+## Public proof flow
+
+The target public demonstration is:
+
+1. scaffold a regex tool;
+2. run its conformance fixtures;
+3. export one signed package;
+4. execute the same package in neutral OPAL2 and through the Aurora adapter;
+5. visualize its run and provenance through `opal2.glyph.render`.
+
+That flow proves that OPAL2 is a tool foundry rather than a renderer with a new
+name.

--- a/modules/opal2/README.md
+++ b/modules/opal2/README.md
@@ -1,8 +1,28 @@
-# 🔮 Opal2 Modular Visualization System - Expansion Pack
+# OPAL2 Tool Foundry
 
-## Overview
+> **Current direction:** OPAL2 is the standalone **Tool Foundry** for building,
+> registering, validating, and running portable tools. The visualization stack
+> in this directory is its first reference tool, not the full product identity.
+> See [OPAL2 Tool Foundry Architecture](../../docs/architecture/OPAL2_FOUNDRY_ARCHITECTURE.md).
 
-The Opal2 Modular System is a next-generation quantum-enhanced visualization framework designed for the Aurora CloudBank Symbolic repository. This expansion significantly enhances the existing Opal2 system with advanced quantum rendering capabilities, a flexible plugin architecture, and comprehensive configuration management.
+## Current implementation status
+
+Phase 1 provides a portable tool manifest, explicit trusted-tool registry,
+execution provenance, and the `opal2.glyph.render` reference tool. The
+standalone API exposes tool discovery and execution under `/tools` while
+preserving the existing `/generate`, `/render`, cache, plugin, and WebSocket
+routes.
+
+Packaging, remote installation, isolated workers, the Aurora adapter, and the
+regex reference tool remain planned work. The legacy dynamic plugin loader is
+not a trusted package-installation boundary.
+
+## Glyph visualization reference tool
+
+The surviving OPAL2 visualization stack is a quantum-enhanced rendering
+framework developed in Aurora CloudBank. It supplies the first foundry tool and
+retains its rendering, plugin, cache, configuration, and WebSocket surfaces for
+compatibility.
 
 ## 🚀 Key Features
 
@@ -108,7 +128,7 @@ from modules.opal2.api.opal2_api import app
 import uvicorn
 
 # Run the API server
-uvicorn.run(app, host="0.0.0.0", port=8000)
+uvicorn.run(app, host="127.0.0.1", port=8001)
 ```
 
 ## 📚 **API Documentation**

--- a/modules/opal2/api/opal2_api.py
+++ b/modules/opal2/api/opal2_api.py
@@ -328,6 +328,11 @@ async def _render_glyph_impl(request: RenderRequest) -> Dict[str, Any]:
         )
     except ToolInputError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (ToolNotFoundError, ToolOutputError) as exc:
+        logger.exception("Registered OPAL2 glyph tool failed", exc_info=exc)
+        raise HTTPException(
+            status_code=500, detail="glyph render tool execution failed"
+        ) from exc
 
     await glyph_cache.set_async(cache_key, tool_result.output)
     await notify_clients(

--- a/modules/opal2/api/opal2_api.py
+++ b/modules/opal2/api/opal2_api.py
@@ -18,28 +18,38 @@ import json
 import logging
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Annotated, Any, Dict, List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from src.middleware.fastapi_security import verify_csrf_token
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+from src.middleware.fastapi_security import verify_csrf_token
 
-from ...symbolic.symbolic_core import SymbolicCore
-from ..glyph_cache import GlyphCache
-from ..glyph_core import GlyphCore
-from ..plugin_system import PluginSystem
-from ..quantum_renderer import QuantumRenderer
+from modules.symbolic_core.symbolic_core import SymbolicCore
+
+from modules.opal2.glyph_cache import GlyphCache
+from modules.opal2.glyph_core import GlyphCore
+from modules.opal2.plugin_system import PluginSystem
+from modules.opal2.quantum_renderer import QuantumRenderer
+from modules.opal2.tool_contract import (
+    ToolExecutionContext,
+    ToolInputError,
+    ToolOutputError,
+    json_ready,
+)
+from modules.opal2.tool_registry import ToolNotFoundError, ToolRegistry
+from modules.opal2.tools import GLYPH_RENDER_TOOL_ID, GlyphRenderTool
 
 security = HTTPBearer()
 logger = logging.getLogger(__name__)
 
 app = FastAPI(
-    title="Opal2 Modular Visualization System",
-    description="Quantum-enhanced modular visualization with real-time rendering",
-    version="2.0.0",
+    title="OPAL2 Tool Foundry",
+    description="Portable tool registry and runtime with symbolic visualization reference tools",
+    version="2.1.0",
 )
 
 glyph_core = GlyphCore()
@@ -47,6 +57,7 @@ glyph_cache = GlyphCache()
 quantum_renderer = QuantumRenderer()
 plugin_system = PluginSystem()
 symbolic_core = SymbolicCore()
+tool_registry = ToolRegistry((GlyphRenderTool(quantum_renderer),))
 
 active_connections: List[WebSocket] = []
 
@@ -55,18 +66,31 @@ class RenderRequest(BaseModel):
     """Request model for quantum rendering."""
 
     glyph_data: Dict[str, Any] = Field(..., description="Glyph configuration data")
-    renderer_type: str = Field(default="webgl", description="Renderer type (webgl, canvas, svg)")
-    dimensions: Dict[str, int] = Field(default={"width": 800, "height": 600}, description="Render dimensions")
-    quantum_params: Optional[Dict[str, float]] = Field(default=None, description="Quantum enhancement parameters")
-    cache_key: Optional[str] = Field(default=None, description="Cache key for optimization")
+    renderer_type: str = Field(
+        default="webgl", description="Renderer type (webgl, canvas, svg)"
+    )
+    dimensions: Dict[str, int] = Field(
+        default_factory=lambda: {"width": 800, "height": 600},
+        description="Render dimensions",
+    )
+    quantum_params: Optional[Dict[str, float]] = Field(
+        default=None, description="Quantum enhancement parameters"
+    )
+    cache_key: Optional[str] = Field(
+        default=None, description="Cache key for optimization"
+    )
 
 
 class GlyphGenerationRequest(BaseModel):
     """Request model for glyph generation."""
 
     symbolic_expression: str = Field(..., description="Symbolic expression to render")
-    style_params: Dict[str, Any] = Field(default={}, description="Style parameters")
-    quantum_enhancement: bool = Field(default=True, description="Enable quantum enhancement")
+    style_params: Dict[str, Any] = Field(
+        default_factory=dict, description="Style parameters"
+    )
+    quantum_enhancement: bool = Field(
+        default=True, description="Enable quantum enhancement"
+    )
 
 
 class WebSocketMessage(BaseModel):
@@ -77,13 +101,21 @@ class WebSocketMessage(BaseModel):
     timestamp: datetime = Field(default_factory=datetime.now)
 
 
+class ToolRunRequest(BaseModel):
+    """Portable request envelope for a registered OPAL2 tool."""
+
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    policy_profile: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
 @app.get("/")
 async def root() -> Dict[str, Any]:
     """Return system status."""
 
     return {
-        "system": "Opal2 Modular Visualization System",
-        "version": "2.0.0",
+        "system": "OPAL2 Tool Foundry",
+        "version": "2.1.0",
         "status": "operational",
         "timestamp": datetime.now().isoformat(),
         "components": {
@@ -91,7 +123,9 @@ async def root() -> Dict[str, Any]:
             "quantum_renderer": "active",
             "plugin_system": "active",
             "cache_system": "active",
+            "tool_registry": "active",
         },
+        "tools": [manifest["tool_id"] for manifest in tool_registry.list_manifests()],
     }
 
 
@@ -105,6 +139,7 @@ async def health_check() -> Dict[str, Any]:
             "quantum_renderer": await test_quantum_renderer(),
             "plugin_system": await test_plugin_system(),
             "cache_system": await test_cache_system(),
+            "tool_registry": await test_tool_registry(),
         }
     except Exception as exc:  # pragma: no cover - defensive logging path
         logger.exception("Health check failed", exc_info=exc)
@@ -123,7 +158,10 @@ async def health_check() -> Dict[str, Any]:
     }
 
 
-@app.post("/render")
+@app.post(
+    "/render",
+    responses={400: {"description": "Unsupported renderer or invalid render payload"}},
+)
 async def render_glyph(
     request: RenderRequest,
     token: HTTPAuthorizationCredentials = Depends(security),
@@ -149,6 +187,59 @@ async def list_plugins() -> Dict[str, Any]:
 
     plugins = plugin_system.list_plugins()
     return {"plugins": plugins, "count": len(plugins)}
+
+
+@app.get("/tools")
+async def list_tools() -> Dict[str, Any]:
+    """List trusted tools registered with the OPAL2 foundry."""
+
+    tools = tool_registry.list_manifests()
+    return {"tools": tools, "count": len(tools)}
+
+
+@app.get("/tools/{tool_id}", responses={404: {"description": "Tool not found"}})
+async def get_tool(tool_id: str) -> Dict[str, Any]:
+    """Return the portable manifest for one registered tool."""
+
+    try:
+        return {"tool": tool_registry.get_manifest(tool_id).to_dict()}
+    except ToolNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post(
+    "/tools/{tool_id}/run",
+    responses={
+        404: {"description": "Tool not found"},
+        422: {"description": "Tool input contract violation"},
+        500: {"description": "Tool output contract violation"},
+    },
+)
+async def run_tool(
+    tool_id: str,
+    request: ToolRunRequest,
+    token: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+) -> Dict[str, Any]:
+    """Execute one explicitly registered tool with CSRF validation."""
+
+    verify_csrf_token(token)
+    context = ToolExecutionContext(
+        policy_profile=request.policy_profile, metadata=request.metadata
+    )
+    try:
+        result = await tool_registry.run(tool_id, request.payload, context)
+    except ToolNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ToolInputError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except ToolOutputError as exc:
+        logger.exception(
+            "Registered OPAL2 tool violated its output contract", exc_info=exc
+        )
+        raise HTTPException(
+            status_code=500, detail="tool output contract violation"
+        ) from exc
+    return result.to_dict()
 
 
 @app.get("/cache/stats")
@@ -179,7 +270,9 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             message = json.loads(await websocket.receive_text())
             if message.get("type") == "ping":
                 await websocket.send_text(
-                    json.dumps({"type": "pong", "timestamp": datetime.now().isoformat()})
+                    json.dumps(
+                        {"type": "pong", "timestamp": datetime.now().isoformat()}
+                    )
                 )
             elif message.get("type") == "subscribe":
                 await websocket.send_text(
@@ -215,20 +308,28 @@ async def _render_glyph_impl(request: RenderRequest) -> Dict[str, Any]:
 
     cached_result = await glyph_cache.get_async(cache_key)
     if cached_result:
-        return {"success": True, "cached": True, "result": cached_result, "cache_key": cache_key}
+        return {
+            "success": True,
+            "cached": True,
+            "result": cached_result,
+            "cache_key": cache_key,
+        }
 
-    renderer_plugin = plugin_system.get_plugin(f"{request.renderer_type}_renderer")
-    if not renderer_plugin:
-        raise HTTPException(status_code=400, detail=f"Renderer type '{request.renderer_type}' not available")
+    try:
+        tool_result = await tool_registry.run(
+            GLYPH_RENDER_TOOL_ID,
+            {
+                "glyph_data": request.glyph_data,
+                "renderer": request.renderer_type,
+                "dimensions": request.dimensions,
+                "quantum_params": request.quantum_params or {},
+            },
+            ToolExecutionContext(metadata={"compatibility_route": "/render"}),
+        )
+    except ToolInputError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    render_result = await quantum_renderer.render_async(
-        glyph_data=request.glyph_data,
-        renderer=renderer_plugin,
-        dimensions=request.dimensions,
-        quantum_params=request.quantum_params or {},
-    )
-
-    await glyph_cache.set_async(cache_key, render_result)
+    await glyph_cache.set_async(cache_key, tool_result.output)
     await notify_clients(
         {
             "type": "render_complete",
@@ -240,16 +341,32 @@ async def _render_glyph_impl(request: RenderRequest) -> Dict[str, Any]:
         }
     )
 
-    return {"success": True, "cached": False, "result": render_result, "cache_key": cache_key}
+    return {
+        "success": True,
+        "cached": False,
+        "result": tool_result.output,
+        "cache_key": cache_key,
+        "tool_run": {
+            "run_id": tool_result.run_id,
+            "tool_id": tool_result.tool_id,
+            "tool_version": tool_result.tool_version,
+            "duration_ms": tool_result.duration_ms,
+            "provenance": dict(tool_result.provenance),
+        },
+    }
 
 
 async def _generate_glyph_impl(request: GlyphGenerationRequest) -> Dict[str, Any]:
     parsed_expression = symbolic_core.parse_expression(request.symbolic_expression)
     glyph_data = await glyph_core.generate_async(
-        expression=parsed_expression,
+        expression={
+            "symbol": request.symbolic_expression,
+            "analysis": parsed_expression,
+        },
         style_params=request.style_params,
         quantum_enhancement=request.quantum_enhancement,
     )
+    glyph_data = json_ready(glyph_data)
 
     cache_key = f"glyph_{uuid.uuid4().hex[:8]}"
     await glyph_cache.set_async(cache_key, glyph_data)
@@ -265,7 +382,7 @@ async def _generate_glyph_impl(request: GlyphGenerationRequest) -> Dict[str, Any
 async def test_glyph_core() -> Dict[str, Any]:
     try:
         result = await glyph_core.test_generation()
-        return {"healthy": True, "test_result": result}
+        return {"healthy": bool(result.get("success")), "test_result": result}
     except Exception as exc:  # pragma: no cover - defensive path
         return {"healthy": False, "error": str(exc)}
 
@@ -273,7 +390,7 @@ async def test_glyph_core() -> Dict[str, Any]:
 async def test_quantum_renderer() -> Dict[str, Any]:
     try:
         result = await quantum_renderer.test_render()
-        return {"healthy": True, "test_result": result}
+        return {"healthy": bool(result.get("success")), "test_result": result}
     except Exception as exc:  # pragma: no cover - defensive path
         return {"healthy": False, "error": str(exc)}
 
@@ -294,11 +411,20 @@ async def test_cache_system() -> Dict[str, Any]:
         return {"healthy": False, "error": str(exc)}
 
 
+async def test_tool_registry() -> Dict[str, Any]:
+    try:
+        tools = tool_registry.list_manifests()
+        return {"healthy": bool(tools), "tool_count": len(tools)}
+    except Exception as exc:  # pragma: no cover - defensive path
+        return {"healthy": False, "error": str(exc)}
+
+
 def _verify_token(token: HTTPAuthorizationCredentials | None) -> None:
     verify_csrf_token(token)
 
 
-app.mount("/static", StaticFiles(directory="static"), name="static")
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+app.mount("/static", StaticFiles(directory=str(_REPO_ROOT / "static")), name="static")
 
 
 @app.get("/demo", response_class=HTMLResponse)

--- a/modules/opal2/tool_contract.py
+++ b/modules/opal2/tool_contract.py
@@ -1,0 +1,230 @@
+"""Portable contracts for tools hosted by the OPAL2 foundry.
+
+The contract deliberately contains no Aurora-specific policy or continuity
+types. Platform policy is selected through ``policy_profile`` at execution
+time so the same tool can run in Aurora and in a neutral OPAL2 runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, Tuple
+
+
+JsonObject = Dict[str, Any]
+_TOOL_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+
+class ToolContractError(ValueError):
+    """Base error for invalid manifests and payloads."""
+
+
+class ToolInputError(ToolContractError):
+    """Raised when a tool payload violates its declared input contract."""
+
+
+class ToolOutputError(ToolContractError):
+    """Raised when a tool returns data that violates its output contract."""
+
+
+@dataclass(frozen=True)
+class ToolManifest:
+    """Machine-readable identity and execution contract for an OPAL2 tool."""
+
+    tool_id: str
+    name: str
+    version: str
+    description: str
+    capabilities: Tuple[str, ...]
+    input_schema: Mapping[str, Any]
+    output_schema: Mapping[str, Any]
+    runtime: str = "python"
+    deterministic: bool = False
+    side_effects: Tuple[str, ...] = ()
+    policy_profiles: Tuple[str, ...] = ()
+    export_targets: Tuple[str, ...] = ("python",)
+
+    def __post_init__(self) -> None:
+        if not _TOOL_ID_PATTERN.fullmatch(self.tool_id):
+            raise ToolContractError(
+                "tool_id must start with a lowercase letter or digit and contain only lowercase letters, "
+                "digits, dots, underscores, or hyphens"
+            )
+        if not self.name.strip():
+            raise ToolContractError("tool name must not be empty")
+        if not self.version.strip():
+            raise ToolContractError("tool version must not be empty")
+        for schema_name, schema in (
+            ("input_schema", self.input_schema),
+            ("output_schema", self.output_schema),
+        ):
+            if schema.get("type", "object") != "object":
+                raise ToolContractError(
+                    f"{schema_name} must describe a top-level object"
+                )
+
+    def to_dict(self) -> JsonObject:
+        """Return a JSON-serializable manifest representation."""
+
+        return {
+            "tool_id": self.tool_id,
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "capabilities": list(self.capabilities),
+            "input_schema": dict(self.input_schema),
+            "output_schema": dict(self.output_schema),
+            "runtime": self.runtime,
+            "deterministic": self.deterministic,
+            "side_effects": list(self.side_effects),
+            "policy_profiles": list(self.policy_profiles),
+            "export_targets": list(self.export_targets),
+        }
+
+
+@dataclass(frozen=True)
+class ToolExecutionContext:
+    """Portable context supplied to every tool execution."""
+
+    run_id: str = field(default_factory=lambda: f"opal2-run-{uuid.uuid4().hex}")
+    policy_profile: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True)
+class ToolRunResult:
+    """Standard execution envelope returned by the foundry registry."""
+
+    run_id: str
+    tool_id: str
+    tool_version: str
+    output: JsonObject
+    duration_ms: float
+    provenance: Mapping[str, Any]
+
+    def to_dict(self) -> JsonObject:
+        return {
+            "run_id": self.run_id,
+            "tool_id": self.tool_id,
+            "tool_version": self.tool_version,
+            "output": self.output,
+            "duration_ms": self.duration_ms,
+            "provenance": dict(self.provenance),
+        }
+
+
+class Opal2Tool(ABC):
+    """Base interface implemented by tools hosted by OPAL2."""
+
+    manifest: ToolManifest
+
+    def validate_input(self, payload: Mapping[str, Any]) -> None:
+        _validate_object(payload, self.manifest.input_schema, ToolInputError)
+
+    def validate_output(self, output: Mapping[str, Any]) -> None:
+        _validate_object(output, self.manifest.output_schema, ToolOutputError)
+
+    @abstractmethod
+    async def run(
+        self, payload: JsonObject, context: ToolExecutionContext
+    ) -> JsonObject:
+        """Execute the tool for a validated payload."""
+
+
+def _validate_object(
+    value: Mapping[str, Any],
+    schema: Mapping[str, Any],
+    error_type: type[ToolContractError],
+) -> None:
+    """Validate the small JSON-Schema subset required by Phase 1.
+
+    Full JSON-Schema conformance belongs in the packaging/conformance phase.
+    This runtime check intentionally covers top-level required fields, types,
+    and enums without adding another dependency to the portable core.
+    """
+
+    if not isinstance(value, Mapping):
+        raise error_type("payload must be an object")
+
+    _validate_required_fields(value, schema, error_type)
+
+    properties = schema.get("properties", {})
+    for field_name, field_value in value.items():
+        _validate_field(
+            field_name,
+            field_value,
+            properties.get(field_name),
+            schema.get("additionalProperties", True),
+            error_type,
+        )
+
+
+def _validate_required_fields(
+    value: Mapping[str, Any],
+    schema: Mapping[str, Any],
+    error_type: type[ToolContractError],
+) -> None:
+    missing_fields = [
+        field_name
+        for field_name in schema.get("required", ())
+        if field_name not in value
+    ]
+    if missing_fields:
+        raise error_type(f"missing required field: {missing_fields[0]}")
+
+
+def _validate_field(
+    field_name: str,
+    field_value: Any,
+    field_schema: Mapping[str, Any] | None,
+    additional_properties: bool,
+    error_type: type[ToolContractError],
+) -> None:
+    if field_schema is None:
+        if additional_properties is False:
+            raise error_type(f"unexpected field: {field_name}")
+        return
+
+    expected_type = field_schema.get("type")
+    if expected_type and not _matches_json_type(field_value, expected_type):
+        raise error_type(f"field '{field_name}' must be of type {expected_type}")
+
+    allowed_values = field_schema.get("enum")
+    if allowed_values is not None and field_value not in allowed_values:
+        raise error_type(f"field '{field_name}' must be one of {allowed_values}")
+
+
+def _matches_json_type(value: Any, expected_type: str) -> bool:
+    type_checks = {
+        "object": lambda item: isinstance(item, Mapping),
+        "array": lambda item: isinstance(item, (list, tuple)),
+        "string": lambda item: isinstance(item, str),
+        "integer": lambda item: isinstance(item, int) and not isinstance(item, bool),
+        "number": lambda item: (
+            isinstance(item, (int, float)) and not isinstance(item, bool)
+        ),
+        "boolean": lambda item: isinstance(item, bool),
+        "null": lambda item: item is None,
+    }
+    checker = type_checks.get(expected_type)
+    return checker(value) if checker else True
+
+
+def json_ready(value: Any) -> Any:
+    """Normalize common scientific Python values for API and package output."""
+
+    return json.loads(json.dumps(value, default=_json_default))
+
+
+def _json_default(value: Any) -> Any:
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    if hasattr(value, "item"):
+        return value.item()
+    return str(value)

--- a/modules/opal2/tool_registry.py
+++ b/modules/opal2/tool_registry.py
@@ -13,6 +13,7 @@ from .tool_contract import (
     ToolExecutionContext,
     ToolInputError,
     ToolManifest,
+    ToolOutputError,
     ToolRunResult,
 )
 
@@ -85,6 +86,12 @@ class ToolRegistry:
         output = await tool.run(dict(payload), execution_context)
         duration_ms = (perf_counter() - start) * 1000
         tool.validate_output(output)
+        try:
+            json.dumps(output, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise ToolOutputError(
+                "tool output must be JSON-serializable without non-finite numbers"
+            ) from exc
 
         manifest = tool.manifest.to_dict()
         manifest_digest = hashlib.sha256(

--- a/modules/opal2/tool_registry.py
+++ b/modules/opal2/tool_registry.py
@@ -1,0 +1,104 @@
+"""Explicit registry and execution boundary for OPAL2 tools."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from time import perf_counter
+from typing import Dict, Iterable
+
+from .tool_contract import (
+    JsonObject,
+    Opal2Tool,
+    ToolExecutionContext,
+    ToolInputError,
+    ToolManifest,
+    ToolRunResult,
+)
+
+
+class ToolRegistryError(RuntimeError):
+    """Base registry error."""
+
+
+class ToolAlreadyRegisteredError(ToolRegistryError):
+    """Raised when a duplicate tool ID is registered without replacement."""
+
+
+class ToolNotFoundError(ToolRegistryError):
+    """Raised when a requested tool is not registered."""
+
+
+class ToolRegistry:
+    """Registry for explicitly trusted OPAL2 tool instances.
+
+    Phase 1 intentionally does not discover or import arbitrary code. Package
+    verification, signatures, and sandboxed workers must exist before remote
+    or user-supplied tools can enter this registry.
+    """
+
+    def __init__(self, tools: Iterable[Opal2Tool] = ()) -> None:
+        self._tools: Dict[str, Opal2Tool] = {}
+        for tool in tools:
+            self.register(tool)
+
+    def register(self, tool: Opal2Tool, *, replace: bool = False) -> None:
+        if not isinstance(tool, Opal2Tool):
+            raise ToolRegistryError("registered tools must implement Opal2Tool")
+        tool_id = tool.manifest.tool_id
+        if tool_id in self._tools and not replace:
+            raise ToolAlreadyRegisteredError(f"tool already registered: {tool_id}")
+        self._tools[tool_id] = tool
+
+    def get(self, tool_id: str) -> Opal2Tool:
+        try:
+            return self._tools[tool_id]
+        except KeyError as exc:
+            raise ToolNotFoundError(f"tool not found: {tool_id}") from exc
+
+    def get_manifest(self, tool_id: str) -> ToolManifest:
+        return self.get(tool_id).manifest
+
+    def list_manifests(self) -> list[JsonObject]:
+        return [
+            self._tools[tool_id].manifest.to_dict() for tool_id in sorted(self._tools)
+        ]
+
+    async def run(
+        self,
+        tool_id: str,
+        payload: JsonObject,
+        context: ToolExecutionContext | None = None,
+    ) -> ToolRunResult:
+        tool = self.get(tool_id)
+        execution_context = context or ToolExecutionContext()
+        if (
+            execution_context.policy_profile
+            and execution_context.policy_profile not in tool.manifest.policy_profiles
+        ):
+            raise ToolInputError(
+                f"tool '{tool_id}' does not support policy profile: {execution_context.policy_profile}"
+            )
+        tool.validate_input(payload)
+
+        start = perf_counter()
+        output = await tool.run(dict(payload), execution_context)
+        duration_ms = (perf_counter() - start) * 1000
+        tool.validate_output(output)
+
+        manifest = tool.manifest.to_dict()
+        manifest_digest = hashlib.sha256(
+            json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return ToolRunResult(
+            run_id=execution_context.run_id,
+            tool_id=tool.manifest.tool_id,
+            tool_version=tool.manifest.version,
+            output=dict(output),
+            duration_ms=duration_ms,
+            provenance={
+                "manifest_sha256": manifest_digest,
+                "runtime": tool.manifest.runtime,
+                "policy_profile": execution_context.policy_profile,
+            },
+        )

--- a/modules/opal2/tools/__init__.py
+++ b/modules/opal2/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in reference tools shipped with the OPAL2 foundry."""
+
+from .glyph_render import GLYPH_RENDER_TOOL_ID, GlyphRenderTool
+
+__all__ = ["GLYPH_RENDER_TOOL_ID", "GlyphRenderTool"]

--- a/modules/opal2/tools/glyph_render.py
+++ b/modules/opal2/tools/glyph_render.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from ..quantum_renderer import QuantumRenderer
 from ..tool_contract import (
     JsonObject,
@@ -14,6 +16,8 @@ from ..tool_contract import (
 
 
 GLYPH_RENDER_TOOL_ID = "opal2.glyph.render"
+MIN_RENDER_DIMENSION = 100
+MAX_RENDER_DIMENSION = 4096
 
 
 class GlyphRenderTool(Opal2Tool):
@@ -42,7 +46,23 @@ class GlyphRenderTool(Opal2Tool):
                         "geometric_algebra",
                     ],
                 },
-                "dimensions": {"type": "object"},
+                "dimensions": {
+                    "type": "object",
+                    "required": ["width", "height"],
+                    "additionalProperties": False,
+                    "properties": {
+                        "width": {
+                            "type": "integer",
+                            "minimum": MIN_RENDER_DIMENSION,
+                            "maximum": MAX_RENDER_DIMENSION,
+                        },
+                        "height": {
+                            "type": "integer",
+                            "minimum": MIN_RENDER_DIMENSION,
+                            "maximum": MAX_RENDER_DIMENSION,
+                        },
+                    },
+                },
                 "quantum_params": {"type": "object"},
             },
         },
@@ -74,17 +94,51 @@ class GlyphRenderTool(Opal2Tool):
     def __init__(self, renderer: QuantumRenderer | None = None) -> None:
         self.renderer = renderer or QuantumRenderer()
 
+    @staticmethod
+    def _validated_dimensions(value: object) -> dict[str, int] | None:
+        """Validate renderer dimensions beyond the Phase 1 top-level schema subset."""
+
+        if value is None:
+            return None
+        if not isinstance(value, Mapping):
+            raise ToolInputError("dimensions must be an object")
+
+        expected_fields = {"width", "height"}
+        missing_fields = expected_fields - value.keys()
+        if missing_fields:
+            missing = sorted(missing_fields)[0]
+            raise ToolInputError(f"dimensions missing required field: {missing}")
+
+        unexpected_fields = value.keys() - expected_fields
+        if unexpected_fields:
+            unexpected = sorted(unexpected_fields)[0]
+            raise ToolInputError(f"dimensions contains unexpected field: {unexpected}")
+
+        dimensions: dict[str, int] = {}
+        for field_name in ("width", "height"):
+            field_value = value[field_name]
+            if not isinstance(field_value, int) or isinstance(field_value, bool):
+                raise ToolInputError(f"dimensions.{field_name} must be an integer")
+            if not MIN_RENDER_DIMENSION <= field_value <= MAX_RENDER_DIMENSION:
+                raise ToolInputError(
+                    f"dimensions.{field_name} must be between "
+                    f"{MIN_RENDER_DIMENSION} and {MAX_RENDER_DIMENSION}"
+                )
+            dimensions[field_name] = field_value
+        return dimensions
+
     async def run(
         self, payload: JsonObject, context: ToolExecutionContext
     ) -> JsonObject:
         renderer_name = payload.get("renderer", "webgl")
         if renderer_name not in self.renderer.list_renderers():
             raise ToolInputError(f"renderer is not available: {renderer_name}")
+        dimensions = self._validated_dimensions(payload.get("dimensions"))
 
         result = await self.renderer.render_async(
             glyph_data=payload["glyph_data"],
             renderer=renderer_name,
-            dimensions=payload.get("dimensions"),
+            dimensions=dimensions,
             quantum_params=payload.get("quantum_params"),
             metadata={
                 **dict(context.metadata),

--- a/modules/opal2/tools/glyph_render.py
+++ b/modules/opal2/tools/glyph_render.py
@@ -1,0 +1,95 @@
+"""Glyph renderer adapter implementing the portable OPAL2 tool contract."""
+
+from __future__ import annotations
+
+from ..quantum_renderer import QuantumRenderer
+from ..tool_contract import (
+    JsonObject,
+    Opal2Tool,
+    ToolExecutionContext,
+    ToolInputError,
+    ToolManifest,
+    json_ready,
+)
+
+
+GLYPH_RENDER_TOOL_ID = "opal2.glyph.render"
+
+
+class GlyphRenderTool(Opal2Tool):
+    """Expose the surviving OPAL2 renderer as the first foundry tool."""
+
+    manifest = ToolManifest(
+        tool_id=GLYPH_RENDER_TOOL_ID,
+        name="OPAL2 Glyph Renderer",
+        version="2.1.0",
+        description="Render symbolic glyph data through an OPAL2 rendering backend.",
+        capabilities=("symbolic-rendering", "glyph-rendering", "quantum-visualization"),
+        input_schema={
+            "type": "object",
+            "required": ["glyph_data"],
+            "additionalProperties": False,
+            "properties": {
+                "glyph_data": {"type": "object"},
+                "renderer": {
+                    "type": "string",
+                    "enum": [
+                        "webgl",
+                        "canvas",
+                        "svg",
+                        "quantum_field",
+                        "holographic",
+                        "geometric_algebra",
+                    ],
+                },
+                "dimensions": {"type": "object"},
+                "quantum_params": {"type": "object"},
+            },
+        },
+        output_schema={
+            "type": "object",
+            "required": [
+                "output",
+                "format",
+                "metadata",
+                "render_time",
+                "quantum_metrics",
+            ],
+            "properties": {
+                "output": {},
+                "format": {"type": "string"},
+                "metadata": {"type": "object"},
+                "render_time": {"type": "number"},
+                "quantum_metrics": {"type": "object"},
+                "cache_key": {},
+            },
+        },
+        runtime="python",
+        deterministic=False,
+        side_effects=(),
+        policy_profiles=("aurora",),
+        export_targets=("python", "oci"),
+    )
+
+    def __init__(self, renderer: QuantumRenderer | None = None) -> None:
+        self.renderer = renderer or QuantumRenderer()
+
+    async def run(
+        self, payload: JsonObject, context: ToolExecutionContext
+    ) -> JsonObject:
+        renderer_name = payload.get("renderer", "webgl")
+        if renderer_name not in self.renderer.list_renderers():
+            raise ToolInputError(f"renderer is not available: {renderer_name}")
+
+        result = await self.renderer.render_async(
+            glyph_data=payload["glyph_data"],
+            renderer=renderer_name,
+            dimensions=payload.get("dimensions"),
+            quantum_params=payload.get("quantum_params"),
+            metadata={
+                **dict(context.metadata),
+                "opal2_run_id": context.run_id,
+                "policy_profile": context.policy_profile,
+            },
+        )
+        return json_ready(result.to_dict())

--- a/modules/opal2/tools/glyph_render.py
+++ b/modules/opal2/tools/glyph_render.py
@@ -95,11 +95,9 @@ class GlyphRenderTool(Opal2Tool):
         self.renderer = renderer or QuantumRenderer()
 
     @staticmethod
-    def _validated_dimensions(value: object) -> dict[str, int] | None:
-        """Validate renderer dimensions beyond the Phase 1 top-level schema subset."""
+    def _dimension_mapping(value: object) -> Mapping[str, object]:
+        """Validate the dimension object's required and allowed fields."""
 
-        if value is None:
-            return None
         if not isinstance(value, Mapping):
             raise ToolInputError("dimensions must be an object")
 
@@ -113,19 +111,32 @@ class GlyphRenderTool(Opal2Tool):
         if unexpected_fields:
             unexpected = sorted(unexpected_fields)[0]
             raise ToolInputError(f"dimensions contains unexpected field: {unexpected}")
+        return value
 
-        dimensions: dict[str, int] = {}
-        for field_name in ("width", "height"):
-            field_value = value[field_name]
-            if not isinstance(field_value, int) or isinstance(field_value, bool):
-                raise ToolInputError(f"dimensions.{field_name} must be an integer")
-            if not MIN_RENDER_DIMENSION <= field_value <= MAX_RENDER_DIMENSION:
-                raise ToolInputError(
-                    f"dimensions.{field_name} must be between "
-                    f"{MIN_RENDER_DIMENSION} and {MAX_RENDER_DIMENSION}"
-                )
-            dimensions[field_name] = field_value
-        return dimensions
+    @staticmethod
+    def _validated_dimension(field_name: str, value: object) -> int:
+        """Validate one dimension against the established OPAL2 graphics bounds."""
+
+        if type(value) is not int:
+            raise ToolInputError(f"dimensions.{field_name} must be an integer")
+        if not MIN_RENDER_DIMENSION <= value <= MAX_RENDER_DIMENSION:
+            raise ToolInputError(
+                f"dimensions.{field_name} must be between "
+                f"{MIN_RENDER_DIMENSION} and {MAX_RENDER_DIMENSION}"
+            )
+        return value
+
+    @classmethod
+    def _validated_dimensions(cls, value: object) -> dict[str, int] | None:
+        """Validate renderer dimensions beyond the Phase 1 top-level schema subset."""
+
+        if value is None:
+            return None
+        dimensions = cls._dimension_mapping(value)
+        return {
+            field_name: cls._validated_dimension(field_name, dimensions[field_name])
+            for field_name in ("width", "height")
+        }
 
     async def run(
         self, payload: JsonObject, context: ToolExecutionContext

--- a/tests/test_opal2_api_routes.py
+++ b/tests/test_opal2_api_routes.py
@@ -6,10 +6,12 @@ silently broke route registration for /render and /generate.
 """
 
 import ast
-import importlib.util
+import importlib
 import os
+import re
 
 import pytest
+from fastapi.testclient import TestClient
 
 
 OPAL2_API_PATH = os.path.join(
@@ -36,7 +38,7 @@ def test_opal2_api_render_decorator_correct():
         source = f.read()
     # The malformed pattern was: @app.post(  # comment"/render")
     # This check fails if the broken form is re-introduced.
-    assert '@app.post("/render")' in source, (
+    assert re.search(r'@app\.post\(\s*"/render"(?:\s*,|\s*\))', source), (  # nosec B101 - pytest assertion
         "Opal2 /render decorator is missing or malformed in opal2_api.py"
     )
     assert '# verify_csrf inside"/render"' not in source, (
@@ -67,15 +69,7 @@ def test_opal2_api_routes_registered():
     if a decorator is malformed Python never registers the route, so the
     app.routes list won't contain the path.
     """
-    spec = importlib.util.spec_from_file_location("opal2_api_module", OPAL2_API_PATH)
-    if spec is None or spec.loader is None:
-        pytest.skip("Cannot load opal2_api module via importlib (missing optional deps)")
-
-    try:
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)  # type: ignore[union-attr]
-    except Exception as exc:
-        pytest.skip(f"opal2_api module failed to import (optional deps missing): {exc}")
+    module = importlib.import_module("modules.opal2.api.opal2_api")
 
     app = getattr(module, "app", None)
     assert app is not None, "opal2_api.py must define a FastAPI `app` object"
@@ -89,6 +83,9 @@ def test_opal2_api_routes_registered():
     assert "/generate" in registered_paths, (
         f"/generate not registered in Opal2 app. Registered paths: {sorted(registered_paths)}"
     )
+    assert "/tools" in registered_paths  # nosec B101 - pytest assertion
+    assert "/tools/{tool_id}" in registered_paths  # nosec B101 - pytest assertion
+    assert "/tools/{tool_id}/run" in registered_paths  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -101,10 +98,7 @@ def test_opal2_plugin_system_is_full_implementation():
     verifies that the class loaded by opal2_api.py has the expected interface
     and that the five built-in plugins are registered at instantiation time.
     """
-    try:
-        from modules.opal2.plugin_system import PluginSystem
-    except ImportError as exc:
-        pytest.skip(f"modules.opal2.plugin_system not importable: {exc}")
+    from modules.opal2.plugin_system import PluginSystem
 
     ps = PluginSystem()
 
@@ -133,3 +127,61 @@ def test_opal2_plugin_system_is_full_implementation():
     for name in expected_plugins:
         plugin = ps.get_plugin(name)
         assert plugin is not None, f"get_plugin('{name}') returned None"
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_opal2_compatibility_render_uses_foundry_registry():
+    """The legacy /render implementation must execute the registered glyph tool."""
+
+    module = importlib.import_module("modules.opal2.api.opal2_api")
+    request = module.RenderRequest(
+        glyph_data={
+            "vertices": [[0, 0], [1, 1]],
+            "indices": [0, 1],
+            "dimensions": 2,
+        },
+        renderer_type="webgl",
+        cache_key="opal2-foundry-route-test",
+    )
+
+    result = await module._render_glyph_impl(request)
+
+    assert result["success"] is True  # nosec B101 - pytest assertion
+    assert result["cached"] is False  # nosec B101 - pytest assertion
+    assert result["result"]["format"] == "webgl"  # nosec B101 - pytest assertion
+    assert result["tool_run"]["tool_id"] == "opal2.glyph.render"  # nosec B101 - pytest assertion
+
+
+@pytest.mark.integration
+@pytest.mark.opal2
+def test_opal2_foundry_http_discovery_and_execution():
+    """The standalone API must discover and execute its reference tool."""
+
+    module = importlib.import_module("modules.opal2.api.opal2_api")
+    from src.middleware.fastapi_security import generate_csrf_token
+
+    client = TestClient(module.app)
+    discovery = client.get("/tools")
+    assert discovery.status_code == 200  # nosec B101 - pytest assertion
+    assert discovery.json()["tools"][0]["tool_id"] == "opal2.glyph.render"  # nosec B101 - pytest assertion
+
+    response = client.post(
+        "/tools/opal2.glyph.render/run",
+        headers={"Authorization": f"Bearer {generate_csrf_token('opal2-test')}"},
+        json={
+            "payload": {
+                "glyph_data": {
+                    "vertices": [[0, 0], [1, 1]],
+                    "indices": [0, 1],
+                    "dimensions": 2,
+                },
+                "renderer": "svg",
+            }
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101 - pytest assertion
+    assert response.json()["tool_id"] == "opal2.glyph.render"  # nosec B101 - pytest assertion
+    assert response.json()["output"]["format"] == "svg"  # nosec B101 - pytest assertion

--- a/tests/test_opal2_api_routes.py
+++ b/tests/test_opal2_api_routes.py
@@ -154,6 +154,41 @@ async def test_opal2_compatibility_render_uses_foundry_registry():
     assert result["tool_run"]["tool_id"] == "opal2.glyph.render"  # nosec B101 - pytest assertion
 
 
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_name", ["ToolNotFoundError", "ToolOutputError"])
+async def test_opal2_compatibility_render_handles_registry_failures(
+    monkeypatch, error_name
+):
+    """The compatibility route must convert registry failures into controlled 500s."""
+
+    module = importlib.import_module("modules.opal2.api.opal2_api")
+    error_type = getattr(module, error_name)
+
+    class FailingRegistry:
+        async def run(self, *_args, **_kwargs):
+            raise error_type("forced registry failure")
+
+    async def cache_miss(_cache_key):
+        return None
+
+    monkeypatch.setattr(module, "tool_registry", FailingRegistry())
+    monkeypatch.setattr(module.glyph_cache, "get_async", cache_miss)
+    request = module.RenderRequest(
+        glyph_data={"vertices": [], "indices": [], "dimensions": 2},
+        cache_key=f"opal2-{error_name}-route-test",
+    )
+
+    with pytest.raises(module.HTTPException) as exc_info:
+        await module._render_glyph_impl(request)
+
+    assert exc_info.value.status_code == 500  # nosec B101 - pytest assertion
+    assert (  # nosec B101 - pytest assertion
+        exc_info.value.detail == "glyph render tool execution failed"
+    )
+
+
 @pytest.mark.integration
 @pytest.mark.opal2
 def test_opal2_foundry_http_discovery_and_execution():
@@ -165,11 +200,13 @@ def test_opal2_foundry_http_discovery_and_execution():
     client = TestClient(module.app)
     discovery = client.get("/tools")
     assert discovery.status_code == 200  # nosec B101 - pytest assertion
-    assert discovery.json()["tools"][0]["tool_id"] == "opal2.glyph.render"  # nosec B101 - pytest assertion
+    tool_ids = {tool["tool_id"] for tool in discovery.json()["tools"]}
+    assert "opal2.glyph.render" in tool_ids  # nosec B101 - pytest assertion
 
+    auth_headers = {"Authorization": f"Bearer {generate_csrf_token('opal2-test')}"}
     response = client.post(
         "/tools/opal2.glyph.render/run",
-        headers={"Authorization": f"Bearer {generate_csrf_token('opal2-test')}"},
+        headers=auth_headers,
         json={
             "payload": {
                 "glyph_data": {
@@ -185,3 +222,20 @@ def test_opal2_foundry_http_discovery_and_execution():
     assert response.status_code == 200  # nosec B101 - pytest assertion
     assert response.json()["tool_id"] == "opal2.glyph.render"  # nosec B101 - pytest assertion
     assert response.json()["output"]["format"] == "svg"  # nosec B101 - pytest assertion
+
+    invalid_dimensions = client.post(
+        "/tools/opal2.glyph.render/run",
+        headers=auth_headers,
+        json={
+            "payload": {
+                "glyph_data": {"vertices": [], "indices": [], "dimensions": 2},
+                "renderer": "svg",
+                "dimensions": {"width": 320},
+            }
+        },
+    )
+    assert invalid_dimensions.status_code == 422  # nosec B101 - pytest assertion
+    assert (
+        "dimensions missing required field: height"
+        in invalid_dimensions.json()["detail"]
+    )  # nosec B101 - pytest assertion

--- a/tests/test_opal2_foundry.py
+++ b/tests/test_opal2_foundry.py
@@ -11,6 +11,7 @@ from modules.opal2.tool_contract import (
     ToolExecutionContext,
     ToolInputError,
     ToolManifest,
+    ToolOutputError,
 )
 from modules.opal2.tool_registry import (
     ToolAlreadyRegisteredError,
@@ -46,6 +47,15 @@ class EchoTool(Opal2Tool):
         self, payload: JsonObject, context: ToolExecutionContext
     ) -> JsonObject:
         return {"echo": payload["text"], "policy_profile": context.policy_profile}
+
+
+class NonPortableOutputTool(EchoTool):
+    """Test fixture that violates the foundry's JSON portability guarantee."""
+
+    async def run(
+        self, payload: JsonObject, context: ToolExecutionContext
+    ) -> JsonObject:
+        return {"echo": payload["text"], "policy_profile": object()}
 
 
 @pytest.mark.unit
@@ -108,6 +118,47 @@ async def test_registry_validates_required_input_before_execution():
             "test.echo",
             {"text": "coherence"},
             unsupported_context,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_registry_rejects_non_json_portable_output():
+    registry = ToolRegistry((NonPortableOutputTool(),))
+
+    with pytest.raises(ToolOutputError, match="JSON-serializable"):
+        await registry.run("test.echo", {"text": "coherence"})
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dimensions, expected_error",
+    [
+        ({"width": 320}, "dimensions missing required field: height"),
+        (
+            {"width": "320", "height": 200},
+            "dimensions.width must be an integer",
+        ),
+        (
+            {"width": 99, "height": 200},
+            "dimensions.width must be between 100 and 4096",
+        ),
+    ],
+)
+async def test_glyph_renderer_rejects_invalid_dimensions(dimensions, expected_error):
+    registry = ToolRegistry((GlyphRenderTool(),))
+
+    with pytest.raises(ToolInputError, match=expected_error):
+        await registry.run(
+            GLYPH_RENDER_TOOL_ID,
+            {
+                "glyph_data": {"vertices": [], "indices": [], "dimensions": 2},
+                "renderer": "svg",
+                "dimensions": dimensions,
+            },
         )
 
 

--- a/tests/test_opal2_foundry.py
+++ b/tests/test_opal2_foundry.py
@@ -1,0 +1,141 @@
+"""Contract and execution tests for the OPAL2 tool foundry."""
+
+import json
+
+import pytest
+
+from modules.opal2.tool_contract import (
+    JsonObject,
+    Opal2Tool,
+    ToolContractError,
+    ToolExecutionContext,
+    ToolInputError,
+    ToolManifest,
+)
+from modules.opal2.tool_registry import (
+    ToolAlreadyRegisteredError,
+    ToolNotFoundError,
+    ToolRegistry,
+)
+from modules.opal2.tools import GLYPH_RENDER_TOOL_ID, GlyphRenderTool
+
+
+class EchoTool(Opal2Tool):
+    manifest = ToolManifest(
+        tool_id="test.echo",
+        name="Echo",
+        version="1.0.0",
+        description="Echo a string for registry tests.",
+        capabilities=("echo",),
+        input_schema={
+            "type": "object",
+            "required": ["text"],
+            "additionalProperties": False,
+            "properties": {"text": {"type": "string"}},
+        },
+        output_schema={
+            "type": "object",
+            "required": ["echo", "policy_profile"],
+            "properties": {"echo": {"type": "string"}, "policy_profile": {}},
+        },
+        deterministic=True,
+        policy_profiles=("aurora",),
+    )
+
+    async def run(
+        self, payload: JsonObject, context: ToolExecutionContext
+    ) -> JsonObject:
+        return {"echo": payload["text"], "policy_profile": context.policy_profile}
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_manifest_rejects_nonportable_identifier():
+    with pytest.raises(ToolContractError, match="tool_id"):
+        ToolManifest(
+            tool_id="Aurora Tool",
+            name="Invalid",
+            version="1.0.0",
+            description="Invalid identifier.",
+            capabilities=(),
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_registry_executes_with_portable_provenance():
+    registry = ToolRegistry((EchoTool(),))
+    context = ToolExecutionContext(run_id="opal2-run-test", policy_profile="aurora")
+
+    result = await registry.run("test.echo", {"text": "coherence"}, context)
+
+    assert result.run_id == "opal2-run-test"  # nosec B101 - pytest assertion
+    assert result.output == {  # nosec B101 - pytest assertion
+        "echo": "coherence",
+        "policy_profile": "aurora",
+    }
+    assert result.provenance["runtime"] == "python"  # nosec B101 - pytest assertion
+    assert len(result.provenance["manifest_sha256"]) == 64  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_registry_is_explicit_and_rejects_duplicate_or_missing_tools():
+    registry = ToolRegistry((EchoTool(),))
+    duplicate_tool = EchoTool()
+
+    with pytest.raises(ToolAlreadyRegisteredError):
+        registry.register(duplicate_tool)
+    with pytest.raises(ToolNotFoundError):
+        registry.get("test.missing")
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_registry_validates_required_input_before_execution():
+    registry = ToolRegistry((EchoTool(),))
+
+    with pytest.raises(ToolInputError, match="missing required field: text"):
+        await registry.run("test.echo", {})
+
+    unsupported_context = ToolExecutionContext(policy_profile="unknown")
+    with pytest.raises(ToolInputError, match="does not support policy profile"):
+        await registry.run(
+            "test.echo",
+            {"text": "coherence"},
+            unsupported_context,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_glyph_renderer_is_a_json_portable_reference_tool():
+    registry = ToolRegistry((GlyphRenderTool(),))
+
+    result = await registry.run(
+        GLYPH_RENDER_TOOL_ID,
+        {
+            "glyph_data": {
+                "vertices": [[0, 0], [1, 1]],
+                "indices": [0, 1],
+                "dimensions": 2,
+            },
+            "renderer": "webgl",
+            "dimensions": {"width": 320, "height": 200},
+            "quantum_params": {"coherence_factor": 0.8},
+        },
+    )
+
+    assert result.output["format"] == "webgl"  # nosec B101 - pytest assertion
+    assert result.output["metadata"]["dimensions"] == {  # nosec B101 - pytest assertion
+        "width": 320,
+        "height": 200,
+    }
+    assert (  # nosec B101 - pytest assertion
+        json.loads(json.dumps(result.to_dict()))["tool_id"] == GLYPH_RENDER_TOOL_ID
+    )


### PR DESCRIPTION
## Summary

- define OPAL2 as a portable standalone Tool Foundry and the glyph stack as its first reference tool
- add a neutral manifest, execution context, explicit trusted registry, schema checks, policy-profile validation, and manifest-digest provenance
- expose GET /tools, GET /tools/{tool_id}, and POST /tools/{tool_id}/run while preserving the existing standalone topology
- route the legacy /render implementation through opal2.glyph.render and repair API import, JSON normalization, and static-path startup defects
- replace the route test skip with real package import and HTTP execution coverage

## Boundary

- no mount into the primary Aurora API
- no arbitrary package discovery or remote code loading
- no changes to the legacy OPAL2 staging dashboard
- packaging, signatures, isolated workers, regex reference tool, and Aurora adapter remain later phases

## Validation

- 26 focused OPAL2 tests passed
- ruff checks passed for the implementation and tests
- the active OPAL2 runtime compiled successfully with legacy staging excluded
- all configured pre-commit hooks passed for the changed files
- localhost Uvicorn smoke returned HTTP 200 from /health and /tools