### PR TITLE
feat(queue): decision-gate escalation — final #1131 roadmap item

### DIFF
--- a/.github/workflows/queue-decision-escalation.yml
+++ b/.github/workflows/queue-decision-escalation.yml
@@ -1,0 +1,109 @@
+# queue-decision-escalation.yml
+# Decision-gate escalation for the Aurora work queue — the final roadmap item
+# of issue #1131 ("PAT hails"), implemented per the L1 decision of 2026-07-17
+# as escalation over transports that exist today: GitHub issue-comment pings.
+# Mesh dispatch is operator-run only (the CI mesh store is ephemeral); a real
+# PAT hailing transport remains future work on the mesh terminal surface.
+#
+# Dedup: escalate_gates.py --apply bumps last_surfaced on escalated gates, so
+# a gate cannot re-ping until the threshold elapses again. The bump routes
+# through a PR (never a direct push), same discipline as queue ingestion.
+#
+# Tracked in: https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1131
+
+name: Queue Decision Escalation
+
+on:
+  schedule:
+    - cron: '30 6 * * 1'  # Mondays 06:30 UTC, after the 06:00 ingestion run
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual dispatch (optional)'
+        required: false
+        default: 'Manual escalation run'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  escalate:
+    name: Escalate aged decision gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run escalation check (and bump last_surfaced)
+        id: escalate
+        run: |
+          set +e
+          python ops/work_queue/escalate_gates.py --apply --json /tmp/escalations.json
+          code=$?
+          set -e
+          if [ "$code" = "10" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$code" = "0" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            exit "$code"
+          fi
+
+      - name: Ping linked issues
+        if: steps.escalate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json, subprocess
+          report = json.load(open("/tmp/escalations.json"))
+          for gate in report["escalations"]:
+              issue = gate.get("github_issue")
+              if not issue:
+                  continue
+              age = gate.get("days_since_surfaced")
+              body = (
+                  f"⏰ **Decision-gate escalation** ({gate['gate_id']}, tier {gate['escalation_tier']}): "
+                  f"this gate has awaited an operator decision for "
+                  f"{age if age is not None else 'an unknown number of'} days "
+                  f"(threshold {report['threshold_days']}).\n\n"
+                  f"Blocks: {', '.join(gate.get('blocks_queue_items') or []) or 'none recorded'}. "
+                  f"Owner: {gate.get('decision_owner', 'operator')}.\n\n"
+                  f"_Automated weekly escalation per #1131; last_surfaced has been bumped, "
+                  f"so this will not re-ping before the threshold elapses again._"
+              )
+              subprocess.run(["gh", "issue", "comment", str(issue), "--body", body], check=True)
+              print(f"pinged issue #{issue} for {gate['gate_id']}")
+          for item in report["ungated_decisions"]:
+              print(f"registry drift (reported in PR body): {item['id']} — {item['title']}")
+          PY
+
+      - name: Open registry-update PR
+        if: steps.escalate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="queue/escalation-surfaced-$(date -u +%Y%m%d-%H%M)"
+          git config user.name "aurora-queue-escalation[bot]"
+          git config user.email "aurora-queue-escalation@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add ops/work_queue/gate_registry.json
+          if git diff --cached --quiet; then
+            echo "No registry changes to propose (drift-only run)."
+            exit 0
+          fi
+          git commit -m "aurora(queue): bump last_surfaced on escalated gates (#1131)"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "aurora(queue): record gate escalation surfacing" \
+            --body "$(printf 'Automated last_surfaced bump for gates escalated this run (see #1131 for the design). Linked issues were pinged directly; this PR only records the surfacing so gates do not re-ping inside the threshold window.\n\nEscalation report:\n\n```json\n%s\n```' "$(cat /tmp/escalations.json)")" \
+            --base main --head "$branch"

--- a/.github/workflows/queue-validation.yml
+++ b/.github/workflows/queue-validation.yml
@@ -79,7 +79,7 @@ jobs:
       # conftest fixtures, so it runs standalone.
       - name: Validate queue.json against queue_schema.json
         run: |
-          pytest --noconftest tests/test_work_queue_schema.py tests/test_queue_issue_ingestion.py -q --no-header
+          pytest --noconftest tests/test_work_queue_schema.py tests/test_queue_issue_ingestion.py tests/test_gate_escalation.py -q --no-header
 
       - name: Check generated views are in sync with queue.json
         id: drift_check

--- a/ops/work_queue/escalate_gates.py
+++ b/ops/work_queue/escalate_gates.py
@@ -104,24 +104,29 @@ def find_escalations(
     return escalations
 
 
+def _open_gate_refs(registry: Dict[str, Any]) -> tuple[set, set]:
+    """(queue_item ids, github issue numbers) referenced by open gates."""
+    open_gates = [g for g in registry.get("gates", []) if g.get("state") == "open"]
+    return (
+        {gate.get("queue_item") for gate in open_gates},
+        {gate.get("github_issue") for gate in open_gates},
+    )
+
+
+def _needs_decision(item: Dict[str, Any]) -> Optional[str]:
+    status = item.get("status") or item.get("state")
+    return status if status in ("needs-decision", "decision_required") else None
+
+
 def find_ungated_decisions(
     queue: Dict[str, Any], registry: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
     """needs-decision queue items with no matching open gate (registry drift)."""
-    gated_items = {
-        gate.get("queue_item")
-        for gate in registry.get("gates", [])
-        if gate.get("state") == "open"
-    }
-    gated_issues = {
-        gate.get("github_issue")
-        for gate in registry.get("gates", [])
-        if gate.get("state") == "open"
-    }
+    gated_items, gated_issues = _open_gate_refs(registry)
     drift = []
     for item in queue.get("active", []):
-        status = item.get("status") or item.get("state")
-        if status not in ("needs-decision", "decision_required"):
+        status = _needs_decision(item)
+        if status is None:
             continue
         if item.get("id") in gated_items or item.get("github_issue") in gated_issues:
             continue
@@ -192,6 +197,18 @@ def main() -> int:
     escalations = find_escalations(registry, args.threshold_days)
     drift = find_ungated_decisions(queue, registry)
 
+    _print_findings(escalations, drift)
+    _write_report(args, escalations, drift)
+
+    if not escalations and not drift:
+        print("No gates past threshold; no registry drift.")
+        return 0
+
+    _finalize(args, registry, escalations)
+    return 10
+
+
+def _print_findings(escalations: List[Dict[str, Any]], drift: List[Dict[str, Any]]) -> None:
     for item in escalations:
         age = item["days_since_surfaced"]
         print(f"ESCALATE {item['gate_id']} (tier {item['escalation_tier']}, "
@@ -199,28 +216,28 @@ def main() -> int:
     for item in drift:
         print(f"DRIFT ungated needs-decision item: {item['id']} — {item['title']}")
 
+
+def _write_report(args, escalations: List[Dict[str, Any]], drift: List[Dict[str, Any]]) -> None:
+    if not args.json:
+        return
     report = {
         "generated": _today().isoformat(),
         "threshold_days": args.threshold_days,
         "escalations": escalations,
         "ungated_decisions": drift,
     }
-    if args.json:
-        args.json.write_text(json.dumps(report, indent=2) + "\n")
+    args.json.write_text(json.dumps(report, indent=2) + "\n")
 
-    if not escalations and not drift:
-        print("No gates past threshold; no registry drift.")
-        return 0
 
-    if args.mesh and escalations:
+def _finalize(args, registry: Dict[str, Any], escalations: List[Dict[str, Any]]) -> None:
+    if not escalations:
+        return
+    if args.mesh:
         dispatch_mesh(escalations)
-
-    if args.apply and escalations:
+    if args.apply:
         apply_surfacing(registry, escalations)
         GATE_REGISTRY.write_text(json.dumps(registry, indent=2) + "\n")
         print(f"last_surfaced bumped for {len(escalations)} gate(s).")
-
-    return 10
 
 
 if __name__ == "__main__":

--- a/ops/work_queue/escalate_gates.py
+++ b/ops/work_queue/escalate_gates.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""escalate_gates.py — decision-gate escalation for the Aurora work queue.
+
+Closes the final roadmap item of issue #1131 ("PAT hails"), per the L1
+decision of 2026-07-17: escalation over transports that actually exist —
+GitHub issue-comment pings (driven by the CI workflow) and optional
+mesh-runtime dispatch where a live mesh exists — honestly renamed
+decision-gate escalation. The original PAT-hail wording remains the
+aspiration for when a hailing transport lands (the PAT overlay is
+read-only today; see docs/api/api_surface_inventory.json).
+
+Usage:
+    python ops/work_queue/escalate_gates.py                  # report only
+    python ops/work_queue/escalate_gates.py --apply          # bump last_surfaced
+    python ops/work_queue/escalate_gates.py --json out.json  # machine output
+    python ops/work_queue/escalate_gates.py --mesh           # + mesh dispatch
+
+Semantics:
+- A gate escalates when state == "open" and days since
+  max(opened, last_surfaced) exceed the threshold (default 3, per #1131).
+- Bumping last_surfaced (--apply) IS the dedup: a gate will not re-escalate
+  until the threshold elapses again. escalation_tier is Aurora's field and
+  is never modified here.
+- Queue items in needs-decision state without a matching open gate are
+  reported as registry drift (the gate registry's contract says every
+  decision_required item gets a gate).
+- Mesh dispatch is best-effort and only meaningful where the mesh store
+  lives (operator machine / deployment); in CI the store is ephemeral, so
+  the workflow relies on issue-comment pings instead.
+
+Exit codes: 0 = nothing to escalate, 10 = escalations found (and applied,
+with --apply), 1 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+HERE = Path(__file__).resolve().parent
+GATE_REGISTRY = HERE / "gate_registry.json"
+QUEUE_JSON = HERE / "queue.json"
+
+DEFAULT_THRESHOLD_DAYS = 3
+MESH_ESCALATION_TARGET = "aurora"
+
+
+def _load(path: Path) -> Any:
+    with path.open() as f:
+        return json.load(f)
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def find_escalations(
+    registry: Dict[str, Any],
+    threshold_days: int = DEFAULT_THRESHOLD_DAYS,
+    today: Optional[date] = None,
+) -> List[Dict[str, Any]]:
+    """Open gates whose last surfacing is older than the threshold."""
+    today = today or _today()
+    escalations: List[Dict[str, Any]] = []
+    for gate in registry.get("gates", []):
+        if gate.get("state") != "open":
+            continue
+        baseline_candidates = [
+            _parse_date(gate.get("opened")),
+            _parse_date(gate.get("last_surfaced")),
+        ]
+        baselines = [d for d in baseline_candidates if d is not None]
+        if not baselines:
+            # Undated open gate: always surface — silence must not hide it.
+            age_days = None
+        else:
+            age_days = (today - max(baselines)).days
+            if age_days <= threshold_days:
+                continue
+        escalations.append({
+            "gate_id": gate.get("gate_id"),
+            "title": gate.get("title"),
+            "github_issue": gate.get("github_issue"),
+            "decision_owner": gate.get("decision_owner"),
+            "escalation_tier": gate.get("escalation_tier"),
+            "opened": gate.get("opened"),
+            "last_surfaced": gate.get("last_surfaced"),
+            "days_since_surfaced": age_days,
+            "blocks_queue_items": gate.get("blocks_queue_items", []),
+        })
+    return escalations
+
+
+def find_ungated_decisions(
+    queue: Dict[str, Any], registry: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """needs-decision queue items with no matching open gate (registry drift)."""
+    gated_items = {
+        gate.get("queue_item")
+        for gate in registry.get("gates", [])
+        if gate.get("state") == "open"
+    }
+    gated_issues = {
+        gate.get("github_issue")
+        for gate in registry.get("gates", [])
+        if gate.get("state") == "open"
+    }
+    drift = []
+    for item in queue.get("active", []):
+        status = item.get("status") or item.get("state")
+        if status not in ("needs-decision", "decision_required"):
+            continue
+        if item.get("id") in gated_items or item.get("github_issue") in gated_issues:
+            continue
+        drift.append({
+            "id": item.get("id"),
+            "title": item.get("title"),
+            "github_issue": item.get("github_issue"),
+            "status": status,
+        })
+    return drift
+
+
+def apply_surfacing(
+    registry: Dict[str, Any],
+    escalations: List[Dict[str, Any]],
+    today: Optional[date] = None,
+) -> None:
+    """Bump last_surfaced for escalated gates (the dedup mechanism)."""
+    today_iso = (today or _today()).isoformat()
+    escalated_ids = {e["gate_id"] for e in escalations}
+    for gate in registry.get("gates", []):
+        if gate.get("gate_id") in escalated_ids:
+            gate["last_surfaced"] = today_iso
+    registry["last_updated"] = today_iso
+
+
+def dispatch_mesh(escalations: List[Dict[str, Any]]) -> bool:
+    """Best-effort mesh notification; returns True only on confirmed dispatch."""
+    try:
+        from src.mesh.models import MeshMessageRequest
+        from src.mesh.runtime import MeshRuntime
+
+        runtime = MeshRuntime(HERE.parents[1])
+        summary = "; ".join(
+            f"{e['gate_id']} ({e['title']}, {e['days_since_surfaced'] if e['days_since_surfaced'] is not None else '?'}d)"
+            for e in escalations
+        )
+        import asyncio
+
+        result = asyncio.run(runtime.send_message(MeshMessageRequest(
+            content=f"Decision-gate escalation: {len(escalations)} gate(s) awaiting "
+                    f"operator decision beyond threshold — {summary}",
+            to=MESH_ESCALATION_TARGET,
+            sender_id="queue_escalation",
+            sender_name="Queue Escalation",
+            type="direct",
+        )))
+        return bool(result.get("success"))
+    except Exception as exc:
+        print(f"mesh dispatch unavailable ({exc}) — relying on issue pings", file=sys.stderr)
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--threshold-days", type=int, default=DEFAULT_THRESHOLD_DAYS)
+    parser.add_argument("--apply", action="store_true",
+                        help="Bump last_surfaced on escalated gates (writes registry)")
+    parser.add_argument("--json", type=Path, default=None,
+                        help="Write machine-readable escalation report to this path")
+    parser.add_argument("--mesh", action="store_true",
+                        help="Also attempt mesh-runtime dispatch (best-effort)")
+    args = parser.parse_args()
+
+    registry = _load(GATE_REGISTRY)
+    queue = _load(QUEUE_JSON)
+
+    escalations = find_escalations(registry, args.threshold_days)
+    drift = find_ungated_decisions(queue, registry)
+
+    for item in escalations:
+        age = item["days_since_surfaced"]
+        print(f"ESCALATE {item['gate_id']} (tier {item['escalation_tier']}, "
+              f"{age if age is not None else 'undated'}d, issue #{item['github_issue']}): {item['title']}")
+    for item in drift:
+        print(f"DRIFT ungated needs-decision item: {item['id']} — {item['title']}")
+
+    report = {
+        "generated": _today().isoformat(),
+        "threshold_days": args.threshold_days,
+        "escalations": escalations,
+        "ungated_decisions": drift,
+    }
+    if args.json:
+        args.json.write_text(json.dumps(report, indent=2) + "\n")
+
+    if not escalations and not drift:
+        print("No gates past threshold; no registry drift.")
+        return 0
+
+    if args.mesh and escalations:
+        dispatch_mesh(escalations)
+
+    if args.apply and escalations:
+        apply_surfacing(registry, escalations)
+        GATE_REGISTRY.write_text(json.dumps(registry, indent=2) + "\n")
+        print(f"last_surfaced bumped for {len(escalations)} gate(s).")
+
+    return 10
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -1,0 +1,123 @@
+"""
+Tests for ops/work_queue/escalate_gates.py — the final #1131 roadmap item
+(decision-gate escalation, per the 2026-07-17 L1 decision).
+
+Pure-function coverage, stdlib only, so queue-validation.yml can run this
+with --noconftest alongside the other work-queue suites: aging math and
+threshold boundary, the last_surfaced dedup contract, undated-gate
+surfacing, ungated needs-decision drift detection, and apply semantics
+(escalation_tier is Aurora's field and must never change here).
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+
+from ops.work_queue.escalate_gates import (
+    apply_surfacing,
+    find_escalations,
+    find_ungated_decisions,
+)
+
+TODAY = date(2026, 7, 18)
+
+
+def _registry(**gate_overrides):
+    gate = {
+        "gate_id": "GATE-777",
+        "queue_item": "Q-0777",
+        "github_issue": 777,
+        "title": "Test gate",
+        "state": "open",
+        "decision_owner": "operator",
+        "opened": "2026-07-01",
+        "last_surfaced": "2026-07-01",
+        "escalation_tier": 1,
+        "blocks_queue_items": ["Q-0778"],
+    }
+    gate.update(gate_overrides)
+    return {"registry_authority": "Aurora", "last_updated": "2026-07-01", "gates": [gate]}
+
+
+def test_aged_open_gate_escalates():
+    escalations = find_escalations(_registry(), threshold_days=3, today=TODAY)
+    assert len(escalations) == 1
+    gate = escalations[0]
+    assert gate["gate_id"] == "GATE-777"
+    assert gate["days_since_surfaced"] == 17
+    assert gate["github_issue"] == 777
+
+
+def test_threshold_boundary_is_strictly_greater_than():
+    # Surfaced exactly threshold days ago -> NOT escalated (age == threshold)
+    at_threshold = _registry(last_surfaced="2026-07-15")
+    assert find_escalations(at_threshold, threshold_days=3, today=TODAY) == []
+    # One day older -> escalated
+    past_threshold = _registry(last_surfaced="2026-07-14")
+    assert len(find_escalations(past_threshold, threshold_days=3, today=TODAY)) == 1
+
+
+def test_recently_surfaced_gate_is_deduped():
+    fresh = _registry(last_surfaced="2026-07-17")
+    assert find_escalations(fresh, threshold_days=3, today=TODAY) == []
+
+
+def test_last_surfaced_wins_over_opened():
+    """An old gate re-surfaced recently must not re-escalate."""
+    resurfaced = _registry(opened="2026-06-01", last_surfaced="2026-07-16")
+    assert find_escalations(resurfaced, threshold_days=3, today=TODAY) == []
+
+
+def test_resolved_gates_never_escalate():
+    resolved = _registry(state="resolved")
+    assert find_escalations(resolved, threshold_days=3, today=TODAY) == []
+
+
+def test_undated_open_gate_always_surfaces():
+    """Silence must not hide an undated gate."""
+    undated = _registry(opened=None, last_surfaced=None)
+    escalations = find_escalations(undated, threshold_days=3, today=TODAY)
+    assert len(escalations) == 1
+    assert escalations[0]["days_since_surfaced"] is None
+
+
+def test_apply_bumps_last_surfaced_but_never_tier():
+    registry = _registry()
+    escalations = find_escalations(registry, threshold_days=3, today=TODAY)
+    apply_surfacing(registry, escalations, today=TODAY)
+
+    gate = registry["gates"][0]
+    assert gate["last_surfaced"] == "2026-07-18"
+    assert gate["escalation_tier"] == 1, "escalation_tier is Aurora's field"
+    assert registry["last_updated"] == "2026-07-18"
+    # Post-bump, the same gate no longer escalates: dedup holds
+    assert find_escalations(registry, threshold_days=3, today=TODAY) == []
+
+
+def test_ungated_needs_decision_items_are_reported_as_drift():
+    queue = {
+        "active": [
+            {"id": "sim/decision-x", "title": "Needs a call", "status": "needs-decision"},
+            {"id": "Q-0777-linked", "title": "Gated", "status": "needs-decision",
+             "github_issue": 777},
+            {"id": "ops/normal", "title": "Just open", "status": "open"},
+        ]
+    }
+    drift = find_ungated_decisions(queue, _registry())
+    assert [d["id"] for d in drift] == ["sim/decision-x"]
+
+
+def test_live_registry_and_queue_parse_and_report_cleanly():
+    """The real files must be consumable by the escalation core."""
+    work_queue = Path(__file__).resolve().parent.parent / "ops" / "work_queue"
+    registry = json.loads((work_queue / "gate_registry.json").read_text())
+    queue = json.loads((work_queue / "queue.json").read_text())
+
+    escalations = find_escalations(registry, threshold_days=3, today=TODAY)
+    drift = find_ungated_decisions(queue, registry)
+    # No exceptions and structurally sound output is the contract here;
+    # actual counts are live data and will change over time.
+    for gate in escalations:
+        assert gate["gate_id"]
+    for item in drift:
+        assert item["id"]


### PR DESCRIPTION
## What

The last #1131 roadmap item ("PAT hails"), implemented per the L1 decision recorded there (2026-07-17, option a): **decision-gate escalation over transports that exist today** — GitHub issue-comment pings from the weekly workflow, plus best-effort mesh dispatch for operator-run contexts. Honest naming: the PAT overlay is read-only (its inventory entry disclaims hailing), so "PAT hails" stays an aspiration until that transport exists.

## Design as built

- **Aging keys off `gate_registry.json`** — gates carry `opened`/`last_surfaced`/`escalation_tier`. A gate escalates when open and > 3 days past max(opened, last_surfaced).
- **`last_surfaced` bump = the dedup.** After an escalation run (`--apply`), the gate cannot re-ping until the threshold elapses again. No comment-history archaeology.
- **`escalation_tier` is Aurora's field** — never modified here; a test locks that in.
- **Registry-drift detection**: `needs-decision` queue items with no matching open gate are reported (the registry's own contract says every decision_required item gets a gate).
- **PR-only state changes**: the workflow pings issues directly, but the `last_surfaced` bump routes through a PR gated by `queue-validation.yml` — identical discipline to the ingestion workflow.
- **Undated open gates always surface** — silence must not hide them.

## Verification

- 9 new tests (threshold boundary is strictly-greater-than, dedup round-trip, resurfaced-gate behavior, resolved/undated gates, tier immutability, drift detection, live-file consumption) — added to `queue-validation.yml`'s blocking step; combined work-queue suite: **22 passed**.
- Workflow YAML validated.
- **Live dry-run finds real work**: GATE-001 (pentest vendor selection + pre-condition sign-off, #841) is **26 days** past surfacing at tier 1, and `sim/SENTINEL-phase0` + `feat/QGIA` are ungated needs-decision drift. The first scheduled run (Monday 06:30 UTC) will ping #841 and propose the surfacing bump.

## #1131 status after this merges

All five roadmap items complete — the issue can close as fully delivered.

Refs #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)