### PR TITLE
feat(opal2): add regex workshop and portable tool packages

### DIFF
--- a/docs/architecture/OPAL2_FOUNDRY_ARCHITECTURE.md
+++ b/docs/architecture/OPAL2_FOUNDRY_ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # OPAL2 Tool Foundry Architecture
 
-**Status:** Phase 1 implementation baseline
+**Status:** Phase 2 implementation baseline
 
 **Runtime topology:** standalone service
 
 **Reference implementation:** `modules/opal2/`
 
-**Primary reference tool:** `opal2.glyph.render`
+**Reference tools:** `opal2.glyph.render`, `opal2.regex.workshop`
 
 ## Definition
 
@@ -15,10 +15,11 @@ registering, validating, executing, and eventually packaging modular tools.
 Aurora is the first platform integration profile, not a dependency of the
 portable foundry contract.
 
-The symbolic glyph and rendering stack is the first reference tool produced by
-the foundry. It is not the complete definition of OPAL2.
+The symbolic glyph stack and deterministic regex workshop are the first two
+reference tools produced by the foundry. Together they prove that OPAL2's
+contract is not specific to rendering.
 
-## Phase 1 boundary
+## Current implementation boundary
 
 Phase 1 establishes a small executable spine:
 
@@ -31,8 +32,17 @@ Phase 1 establishes a small executable spine:
 - compatibility routing from the existing `/render` endpoint through the
   foundry registry.
 
-Phase 1 does **not** claim that packaging, remote installation, multi-tenant
-isolation, or general third-party loading is complete.
+Phase 2 proves generality and begins the portability boundary:
+
+- `opal2.regex.workshop` generates bounded curated patterns and checks sample
+  expectations without executing arbitrary user-provided regex;
+- `.opaltool` specification 0.1 exports deterministic archives containing the
+  tool manifest, schemas, implementation artifact, fixtures, and digests;
+- package verification is inspect-only and never extracts, imports, or executes
+  package code.
+
+This baseline does **not** claim that signatures, package activation, remote
+installation, multi-tenant isolation, or third-party loading are complete.
 
 ## Runtime topology
 
@@ -51,7 +61,7 @@ OPAL2 standalone API
         +-- execution + provenance
         |
         v
-reference tools (glyph renderer today; regex and others later)
+reference tools (glyph renderer + regex workshop)
         |
         +-- neutral consumer
         `-- Aurora adapter / policy profile
@@ -93,14 +103,15 @@ not scan arbitrary directories or import user-supplied code. The older OPAL2
 plugin loader remains a visualization compatibility surface and is not the
 portable foundry installation mechanism.
 
-Remote or third-party packages must not be enabled until OPAL2 has:
+`.opaltool` 0.1 now provides the versioned package manifest and digest checks.
+Remote or third-party packages must not be enabled until OPAL2 additionally
+has:
 
-1. a versioned package manifest;
-2. digest and signature verification;
-3. dependency and SBOM validation;
-4. an isolated subprocess, container, or WASM execution boundary;
-5. capability and resource-limit enforcement;
-6. clean-room conformance tests.
+1. asymmetric publisher-signature verification;
+2. dependency and SBOM validation;
+3. an isolated subprocess, container, or WASM execution boundary;
+4. capability and resource-limit enforcement;
+5. clean-room conformance tests and revocation provenance.
 
 ## Standalone API
 
@@ -135,23 +146,28 @@ Focused validation:
 
 ```bash
 python -m compileall -q -x 'modules/opal2/staging' modules/opal2
-python -m pytest tests/test_opal2_foundry.py tests/test_opal2_api_routes.py -q
+python -m pytest \
+  tests/test_opal2_foundry.py \
+  tests/test_opal2_api_routes.py \
+  tests/test_opal2_regex_workshop.py \
+  tests/test_opal2_tool_package.py -q
 ```
 
 ## Planned convergence
 
 ### Phase 2: prove generality
 
-- Add an SDK/scaffold for authoring tools.
-- Restore a narrowly specified regex-generation tool as the first non-renderer
-  reference implementation.
-- Add full input/output conformance fixtures.
-- Introduce an Aurora adapter rather than direct runtime imports.
+- **Implemented:** narrowly specified regex generation and sample conformance as
+  the first non-renderer tool.
+- **Implemented:** deterministic inspect-only `.opaltool` 0.1 export with a
+  packaged regex fixture.
+- **Deferred:** authoring scaffold and full schema-conformance harness.
+- **Deferred:** Aurora adapter rather than direct runtime imports.
 
 ### Phase 3: prove portability
 
-- Define a signed `.opaltool` archive containing the manifest, schemas,
-  implementation artifact, fixtures, digest, and SBOM.
+- Promote `.opaltool` to a signed format with dependency lock, SBOM, publisher
+  identity, and revocation provenance.
 - Export and import the same tool in a clean neutral environment and a clean
   Aurora environment.
 - Require matching fixture output and provenance digests.
@@ -166,13 +182,18 @@ python -m pytest tests/test_opal2_foundry.py tests/test_opal2_api_routes.py -q
 
 ## Public proof flow
 
-The target public demonstration is:
+The target public demonstration is now split into implemented and deferred
+proofs:
 
-1. scaffold a regex tool;
-2. run its conformance fixtures;
-3. export one signed package;
-4. execute the same package in neutral OPAL2 and through the Aurora adapter;
-5. visualize its run and provenance through `opal2.glyph.render`.
+1. **Implemented:** run the regex tool through the neutral registry and HTTP
+   API;
+2. **Implemented:** export and integrity-verify a deterministic inspect-only
+   package carrying its fixture;
+3. **Deferred:** scaffold the same tool from an authoring SDK;
+4. **Deferred:** sign and execute the package in isolated neutral OPAL2 and
+   through the Aurora adapter;
+5. **Deferred:** visualize its run and provenance through
+   `opal2.glyph.render`.
 
 That flow proves that OPAL2 is a tool foundry rather than a renderer with a new
 name.

--- a/docs/architecture/OPAL2_TOOL_PACKAGE_SPEC.md
+++ b/docs/architecture/OPAL2_TOOL_PACKAGE_SPEC.md
@@ -1,0 +1,94 @@
+# OPAL2 Tool Package Specification
+
+**Format:** `.opaltool`
+
+**Specification version:** `0.1`
+
+**Activation status:** inspect-only
+
+## Purpose
+
+An `.opaltool` file is the portable transport artifact produced by the OPAL2
+foundry. Version 0.1 proves deterministic export, schema carriage, bounded
+inspection, and content-integrity verification. It does not grant execution
+trust and it is not a remote plugin installer.
+
+## Archive layout
+
+The artifact is a reproducible ZIP archive with sorted members, fixed metadata,
+and canonical JSON:
+
+```text
+opaltool.json
+schemas/input.schema.json
+schemas/output.schema.json
+src/<implementation files>
+fixtures/<optional conformance fixtures>
+```
+
+`opaltool.json` declares:
+
+- format and specification version;
+- the complete portable `ToolManifest`;
+- the descriptive `module:object` entrypoint;
+- the required OPAL2 core API;
+- activation state;
+- SHA-256 and byte length for every payload member.
+
+The archive SHA-256 returned by the verifier is a transport receipt. File
+digests detect corruption or mutation, but they do not prove publisher
+identity: an attacker capable of replacing a package can replace unsigned
+digests too.
+
+## Safety boundary
+
+The version 0.1 verifier:
+
+- never extracts package members;
+- never imports or executes implementation code;
+- rejects absolute paths, traversal, backslashes, duplicate members, and
+  symlinks;
+- enforces file-count and uncompressed-size limits;
+- rejects undeclared members and missing payloads;
+- verifies every declared SHA-256 and schema copy;
+- requires `activation: inspect-only`.
+
+Package activation remains deferred until OPAL2 has publisher signatures,
+dependency and SBOM policy, isolated workers, capability limits, and clean-room
+conformance. The legacy dynamic plugin loader is not an activation mechanism
+for `.opaltool` files.
+
+## Reference export
+
+The first package-enabled tool is `opal2.regex.workshop`:
+
+```python
+from modules.opal2.tool_package import export_builtin_tool
+
+receipt = export_builtin_tool(
+    "opal2.regex.workshop",
+    "/tmp/opal2-regex-workshop.opaltool",
+)
+print(receipt.to_dict())
+```
+
+The same artifact can be verified without loading its source:
+
+```python
+from modules.opal2.tool_package import verify_opaltool_package
+
+receipt = verify_opaltool_package("/tmp/opal2-regex-workshop.opaltool")
+assert receipt.package_manifest["activation"] == "inspect-only"
+```
+
+## Deferred version 1.0 requirements
+
+Before the format can be called installable or generally trustworthy, version
+1.0 must add:
+
+1. publisher identity and an asymmetric signature envelope;
+2. dependency lock and SBOM members;
+3. fixture digests and a conformance result contract;
+4. a neutral OPAL2 core distribution;
+5. isolated activation with CPU, memory, time, network, and filesystem limits;
+6. revocation and registry provenance.

--- a/modules/opal2/README.md
+++ b/modules/opal2/README.md
@@ -8,14 +8,17 @@
 ## Current implementation status
 
 Phase 1 provides a portable tool manifest, explicit trusted-tool registry,
-execution provenance, and the `opal2.glyph.render` reference tool. The
-standalone API exposes tool discovery and execution under `/tools` while
-preserving the existing `/generate`, `/render`, cache, plugin, and WebSocket
-routes.
+execution provenance, and the `opal2.glyph.render` reference tool. Phase 2 adds
+the deterministic `opal2.regex.workshop` tool and the first `.opaltool`
+transport format. The standalone API exposes tool discovery and execution
+under `/tools` while preserving the existing `/generate`, `/render`, cache,
+plugin, and WebSocket routes.
 
-Packaging, remote installation, isolated workers, the Aurora adapter, and the
-regex reference tool remain planned work. The legacy dynamic plugin loader is
-not a trusted package-installation boundary.
+`.opaltool` version 0.1 supports deterministic export and integrity inspection
+only. Package activation, publisher signatures, isolated workers, and the
+Aurora adapter remain planned work. The legacy dynamic plugin loader is not a
+trusted package-installation boundary. See
+[OPAL2 Tool Package Specification](../../docs/architecture/OPAL2_TOOL_PACKAGE_SPEC.md).
 
 ## Glyph visualization reference tool
 

--- a/modules/opal2/api/opal2_api.py
+++ b/modules/opal2/api/opal2_api.py
@@ -17,7 +17,7 @@ To run Opal2 alongside the main Aurora API, start it as a separate process
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Optional
 
@@ -41,15 +41,19 @@ from modules.opal2.tool_contract import (
     json_ready,
 )
 from modules.opal2.tool_registry import ToolNotFoundError, ToolRegistry
-from modules.opal2.tools import GLYPH_RENDER_TOOL_ID, GlyphRenderTool
+from modules.opal2.tools import (
+    GLYPH_RENDER_TOOL_ID,
+    GlyphRenderTool,
+    RegexWorkshopTool,
+)
 
 security = HTTPBearer()
 logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="OPAL2 Tool Foundry",
-    description="Portable tool registry and runtime with symbolic visualization reference tools",
-    version="2.1.0",
+    description="Portable tool registry and runtime with regex and symbolic visualization reference tools",
+    version="2.2.0",
 )
 
 glyph_core = GlyphCore()
@@ -57,9 +61,17 @@ glyph_cache = GlyphCache()
 quantum_renderer = QuantumRenderer()
 plugin_system = PluginSystem()
 symbolic_core = SymbolicCore()
-tool_registry = ToolRegistry((GlyphRenderTool(quantum_renderer),))
+tool_registry = ToolRegistry((GlyphRenderTool(quantum_renderer), RegexWorkshopTool()))
 
 active_connections: List[WebSocket] = []
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_now_iso() -> str:
+    return _utc_now().isoformat()
 
 
 class RenderRequest(BaseModel):
@@ -98,7 +110,7 @@ class WebSocketMessage(BaseModel):
 
     type: str = Field(..., description="Message type")
     data: Dict[str, Any] = Field(..., description="Message data")
-    timestamp: datetime = Field(default_factory=datetime.now)
+    timestamp: datetime = Field(default_factory=_utc_now)
 
 
 class ToolRunRequest(BaseModel):
@@ -115,9 +127,9 @@ async def root() -> Dict[str, Any]:
 
     return {
         "system": "OPAL2 Tool Foundry",
-        "version": "2.1.0",
+        "version": "2.2.0",
         "status": "operational",
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": _utc_now_iso(),
         "components": {
             "glyph_core": "active",
             "quantum_renderer": "active",
@@ -146,7 +158,7 @@ async def health_check() -> Dict[str, Any]:
         return {
             "healthy": False,
             "components": {},
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_now_iso(),
             "error": "internal error",
         }
 
@@ -154,7 +166,7 @@ async def health_check() -> Dict[str, Any]:
     return {
         "healthy": all_healthy,
         "components": health_status,
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": _utc_now_iso(),
     }
 
 
@@ -270,9 +282,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             message = json.loads(await websocket.receive_text())
             if message.get("type") == "ping":
                 await websocket.send_text(
-                    json.dumps(
-                        {"type": "pong", "timestamp": datetime.now().isoformat()}
-                    )
+                    json.dumps({"type": "pong", "timestamp": _utc_now_iso()})
                 )
             elif message.get("type") == "subscribe":
                 await websocket.send_text(
@@ -280,7 +290,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                         {
                             "type": "subscribed",
                             "channel": message.get("channel"),
-                            "timestamp": datetime.now().isoformat(),
+                            "timestamp": _utc_now_iso(),
                         }
                     )
                 )

--- a/modules/opal2/tool_package.py
+++ b/modules/opal2/tool_package.py
@@ -1,0 +1,468 @@
+"""Deterministic, inspect-only packaging for portable OPAL2 tool artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile, ZipInfo
+
+from .tool_contract import JsonObject, Opal2Tool, ToolManifest
+
+PACKAGE_FORMAT = "opaltool"
+PACKAGE_SPEC_VERSION = "0.1"
+CORE_API = "opal2.core.v1"
+PACKAGE_MANIFEST_PATH = "opaltool.json"
+INPUT_SCHEMA_PATH = "schemas/input.schema.json"
+OUTPUT_SCHEMA_PATH = "schemas/output.schema.json"
+REQUIRED_SCHEMA_PATHS = frozenset({INPUT_SCHEMA_PATH, OUTPUT_SCHEMA_PATH})
+MAX_PACKAGE_FILES = 64
+MAX_PACKAGE_BYTES = 5 * 1024 * 1024
+
+
+class ToolPackageError(ValueError):
+    """Raised when an OPAL2 package cannot be built or verified safely."""
+
+
+@dataclass(frozen=True)
+class VerifiedToolPackage:
+    """Verified metadata for an inert OPAL2 package artifact."""
+
+    path: Path
+    package_manifest: Mapping[str, Any]
+    tool_manifest: ToolManifest
+    archive_sha256: str
+
+    def to_dict(self) -> JsonObject:
+        """Return the verification receipt as JSON-compatible data."""
+
+        return {
+            "path": str(self.path),
+            "format": self.package_manifest["format"],
+            "spec_version": self.package_manifest["spec_version"],
+            "tool_id": self.tool_manifest.tool_id,
+            "tool_version": self.tool_manifest.version,
+            "entrypoint": self.package_manifest["entrypoint"],
+            "activation": self.package_manifest["activation"],
+            "archive_sha256": self.archive_sha256,
+            "verified_files": len(self.package_manifest["integrity"]["files"]),
+        }
+
+
+def build_opaltool_package(
+    tool: Opal2Tool,
+    destination: str | Path,
+    *,
+    entrypoint: str,
+    implementation_files: Mapping[str, bytes | str],
+    fixture_files: Mapping[str, Mapping[str, Any]] | None = None,
+) -> VerifiedToolPackage:
+    """Build a reproducible package without granting it execution trust."""
+
+    package_path = _validated_destination(destination, entrypoint)
+    payloads = _prepare_payloads(tool, implementation_files, fixture_files or {})
+    integrity = {
+        name: {"sha256": _sha256(data), "size": len(data)}
+        for name, data in sorted(payloads.items())
+    }
+    package_manifest = {
+        "format": PACKAGE_FORMAT,
+        "spec_version": PACKAGE_SPEC_VERSION,
+        "core_api": CORE_API,
+        "entrypoint": entrypoint,
+        "activation": "inspect-only",
+        "tool": tool.manifest.to_dict(),
+        "integrity": {"algorithm": "sha256", "files": integrity},
+    }
+    members = {PACKAGE_MANIFEST_PATH: _json_bytes(package_manifest), **payloads}
+    _validate_package_limits(members)
+
+    package_path.parent.mkdir(parents=True, exist_ok=True)
+    with ZipFile(package_path, "x", compression=ZIP_DEFLATED) as archive:
+        for name, data in sorted(members.items()):
+            archive.writestr(_zip_info(name), data)
+    return verify_opaltool_package(package_path)
+
+
+def _validated_destination(destination: str | Path, entrypoint: str) -> Path:
+    package_path = Path(destination)
+    if package_path.exists():
+        raise ToolPackageError(
+            f"refusing to overwrite existing package: {package_path}"
+        )
+    if package_path.suffix != ".opaltool":
+        raise ToolPackageError("package destination must use the .opaltool suffix")
+    _validate_entrypoint(entrypoint)
+    return package_path
+
+
+def _validate_package_limits(members: Mapping[str, bytes]) -> None:
+    if len(members) > MAX_PACKAGE_FILES:
+        raise ToolPackageError(f"package exceeds the file limit of {MAX_PACKAGE_FILES}")
+    if sum(len(data) for data in members.values()) > MAX_PACKAGE_BYTES:
+        raise ToolPackageError(
+            f"package exceeds the size limit of {MAX_PACKAGE_BYTES} bytes"
+        )
+
+
+def verify_opaltool_package(path: str | Path) -> VerifiedToolPackage:
+    """Verify archive structure and digests without extracting or importing code."""
+
+    package_path = Path(path)
+    if package_path.suffix != ".opaltool":
+        raise ToolPackageError("package path must use the .opaltool suffix")
+    try:
+        with ZipFile(package_path) as archive:
+            members = _read_members(archive)
+    except (BadZipFile, OSError, RuntimeError) as exc:
+        raise ToolPackageError(f"invalid OPAL2 package: {exc}") from exc
+
+    try:
+        package_manifest = json.loads(members[PACKAGE_MANIFEST_PATH])
+    except KeyError as exc:
+        raise ToolPackageError(f"package is missing {PACKAGE_MANIFEST_PATH}") from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ToolPackageError("package manifest is not valid UTF-8 JSON") from exc
+    if not isinstance(package_manifest, Mapping):
+        raise ToolPackageError("package manifest must be an object")
+
+    tool_manifest = _validate_package_manifest(package_manifest, members)
+    return VerifiedToolPackage(
+        path=package_path,
+        package_manifest=dict(package_manifest),
+        tool_manifest=tool_manifest,
+        archive_sha256=_hash_file(package_path),
+    )
+
+
+def export_builtin_tool(tool_id: str, destination: str | Path) -> VerifiedToolPackage:
+    """Export an explicitly allowlisted built-in tool as an inert package."""
+
+    from .tools.regex_workshop import REGEX_WORKSHOP_TOOL_ID, RegexWorkshopTool
+
+    if tool_id != REGEX_WORKSHOP_TOOL_ID:
+        raise ToolPackageError(f"built-in tool is not package-enabled: {tool_id}")
+    source_path = Path(__file__).parent / "tools" / "regex_workshop.py"
+    return build_opaltool_package(
+        RegexWorkshopTool(),
+        destination,
+        entrypoint="modules.opal2.tools.regex_workshop:RegexWorkshopTool",
+        implementation_files={"src/regex_workshop.py": source_path.read_bytes()},
+        fixture_files={
+            "fixtures/basic.json": {
+                "input": {
+                    "template": "exact",
+                    "value": "station[808]",
+                    "samples": [
+                        {"text": "station[808]", "expected_match": True},
+                        {"text": "station808", "expected_match": False},
+                    ],
+                },
+                "expected": {
+                    "pattern": r"\Astation\[808\]\Z",
+                    "all_expectations_met": True,
+                },
+            }
+        },
+    )
+
+
+def _prepare_payloads(
+    tool: Opal2Tool,
+    implementation_files: Mapping[str, bytes | str],
+    fixture_files: Mapping[str, Mapping[str, Any]],
+) -> dict[str, bytes]:
+    if not implementation_files:
+        raise ToolPackageError("package requires at least one implementation file")
+    payloads = {
+        INPUT_SCHEMA_PATH: _json_bytes(tool.manifest.input_schema),
+        OUTPUT_SCHEMA_PATH: _json_bytes(tool.manifest.output_schema),
+    }
+    for name, content in implementation_files.items():
+        _validate_member_name(name, required_prefix="src/")
+        payloads[name] = (
+            content.encode("utf-8") if isinstance(content, str) else content
+        )
+    for name, fixture in fixture_files.items():
+        _validate_member_name(name, required_prefix="fixtures/")
+        payloads[name] = _json_bytes(fixture)
+    return payloads
+
+
+def _read_members(archive: ZipFile) -> dict[str, bytes]:
+    infos = archive.infolist()
+    if len(infos) > MAX_PACKAGE_FILES:
+        raise ToolPackageError(f"package exceeds the file limit of {MAX_PACKAGE_FILES}")
+
+    members: dict[str, bytes] = {}
+    total_size = 0
+    for info in infos:
+        if info.filename in members:
+            raise ToolPackageError(
+                f"package contains duplicate member: {info.filename}"
+            )
+        data = _read_member(archive, info)
+        total_size += len(data)
+        if total_size > MAX_PACKAGE_BYTES:
+            raise ToolPackageError(
+                f"package exceeds the size limit of {MAX_PACKAGE_BYTES} bytes"
+            )
+        members[info.filename] = data
+    return members
+
+
+def _read_member(archive: ZipFile, info: ZipInfo) -> bytes:
+    _validate_member_name(info.filename)
+    file_mode = info.external_attr >> 16
+    if stat.S_IFMT(file_mode) == stat.S_IFLNK:
+        raise ToolPackageError(f"package member must not be a symlink: {info.filename}")
+    with archive.open(info) as member_file:
+        data = member_file.read(MAX_PACKAGE_BYTES + 1)
+    if len(data) > MAX_PACKAGE_BYTES:
+        raise ToolPackageError(
+            f"package exceeds the size limit of {MAX_PACKAGE_BYTES} bytes"
+        )
+    return data
+
+
+def _validate_package_manifest(
+    package: Mapping[str, Any], members: Mapping[str, bytes]
+) -> ToolManifest:
+    _validate_package_header(package)
+    tool_manifest = _tool_manifest_from_mapping(package.get("tool"))
+    declared_files = _declared_integrity_files(package, members)
+    _verify_declared_files(declared_files, members)
+    input_schema, output_schema = _load_packaged_schemas(members)
+    if (
+        input_schema != tool_manifest.input_schema
+        or output_schema != tool_manifest.output_schema
+    ):
+        raise ToolPackageError("packaged schemas do not match the tool manifest")
+    return tool_manifest
+
+
+def _validate_package_header(package: Mapping[str, Any]) -> None:
+    if package.get("format") != PACKAGE_FORMAT:
+        raise ToolPackageError(f"unsupported package format: {package.get('format')}")
+    if package.get("spec_version") != PACKAGE_SPEC_VERSION:
+        raise ToolPackageError(
+            f"unsupported package spec version: {package.get('spec_version')}"
+        )
+    if package.get("core_api") != CORE_API:
+        raise ToolPackageError(f"unsupported core API: {package.get('core_api')}")
+    if package.get("activation") != "inspect-only":
+        raise ToolPackageError("package activation must remain inspect-only")
+    _validate_entrypoint(package.get("entrypoint"))
+
+
+def _declared_integrity_files(
+    package: Mapping[str, Any], members: Mapping[str, bytes]
+) -> Mapping[str, Any]:
+    integrity = package.get("integrity")
+    if not isinstance(integrity, Mapping) or integrity.get("algorithm") != "sha256":
+        raise ToolPackageError("package integrity algorithm must be sha256")
+    declared_files = integrity.get("files")
+    if not isinstance(declared_files, Mapping):
+        raise ToolPackageError("package integrity files must be an object")
+    if set(members) != {PACKAGE_MANIFEST_PATH, *declared_files}:
+        raise ToolPackageError("package contents do not match the integrity manifest")
+    if not REQUIRED_SCHEMA_PATHS.issubset(declared_files):
+        raise ToolPackageError("package is missing required schema members")
+    _validate_payload_layout(declared_files)
+    return declared_files
+
+
+def _validate_payload_layout(declared_files: Mapping[str, Any]) -> None:
+    if not any(name.startswith("src/") for name in declared_files):
+        raise ToolPackageError("package requires at least one implementation member")
+    unsupported = [
+        name for name in declared_files if not _is_supported_payload_name(name)
+    ]
+    if unsupported:
+        raise ToolPackageError(f"unsupported package payload: {min(unsupported)}")
+
+
+def _is_supported_payload_name(name: str) -> bool:
+    return (
+        name in REQUIRED_SCHEMA_PATHS
+        or name.startswith("src/")
+        or name.startswith("fixtures/")
+    )
+
+
+def _verify_declared_files(
+    declared_files: Mapping[str, Any], members: Mapping[str, bytes]
+) -> None:
+    for name, receipt in declared_files.items():
+        _validate_member_name(name)
+        if not isinstance(receipt, Mapping):
+            raise ToolPackageError(f"integrity receipt must be an object: {name}")
+        data = members[name]
+        if receipt.get("size") != len(data) or receipt.get("sha256") != _sha256(data):
+            raise ToolPackageError(f"package integrity verification failed: {name}")
+
+
+def _load_packaged_schemas(
+    members: Mapping[str, bytes],
+) -> tuple[Any, Any]:
+    try:
+        input_schema = json.loads(members[INPUT_SCHEMA_PATH])
+        output_schema = json.loads(members[OUTPUT_SCHEMA_PATH])
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ToolPackageError("packaged schemas must be valid UTF-8 JSON") from exc
+    return input_schema, output_schema
+
+
+def _tool_manifest_from_mapping(value: Any) -> ToolManifest:
+    if not isinstance(value, Mapping):
+        raise ToolPackageError("tool manifest must be an object")
+
+    tool_id = _manifest_string(value, "tool_id")
+    name = _manifest_string(value, "name")
+    version = _manifest_string(value, "version")
+    description = _manifest_string(value, "description")
+    capabilities = _manifest_string_tuple(value, "capabilities")
+    input_schema = _manifest_mapping(value, "input_schema")
+    output_schema = _manifest_mapping(value, "output_schema")
+    runtime = _manifest_optional_string(value, "runtime", "python")
+    deterministic = _manifest_bool(value, "deterministic", False)
+    side_effects = _manifest_string_tuple(value, "side_effects", ())
+    policy_profiles = _manifest_string_tuple(value, "policy_profiles", ())
+    export_targets = _manifest_string_tuple(value, "export_targets", ("python",))
+
+    try:
+        return ToolManifest(
+            tool_id=tool_id,
+            name=name,
+            version=version,
+            description=description,
+            capabilities=capabilities,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            runtime=runtime,
+            deterministic=deterministic,
+            side_effects=side_effects,
+            policy_profiles=policy_profiles,
+            export_targets=export_targets,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ToolPackageError(f"invalid tool manifest: {exc}") from exc
+
+
+def _manifest_string(value: Mapping[str, Any], field_name: str) -> str:
+    field_value = value.get(field_name)
+    if not isinstance(field_value, str):
+        raise ToolPackageError(f"tool manifest field '{field_name}' must be a string")
+    return field_value
+
+
+def _manifest_optional_string(
+    value: Mapping[str, Any], field_name: str, default: str
+) -> str:
+    field_value = value.get(field_name, default)
+    if not isinstance(field_value, str):
+        raise ToolPackageError(f"tool manifest field '{field_name}' must be a string")
+    return field_value
+
+
+def _manifest_string_tuple(
+    value: Mapping[str, Any],
+    field_name: str,
+    default: tuple[str, ...] | None = None,
+) -> tuple[str, ...]:
+    if field_name not in value:
+        if default is None:
+            raise ToolPackageError(f"tool manifest is missing field: {field_name}")
+        return default
+    field_value = value[field_name]
+    if not isinstance(field_value, list) or any(
+        not isinstance(item, str) for item in field_value
+    ):
+        raise ToolPackageError(
+            f"tool manifest field '{field_name}' must be an array of strings"
+        )
+    return tuple(field_value)
+
+
+def _manifest_mapping(value: Mapping[str, Any], field_name: str) -> Mapping[str, Any]:
+    field_value = value.get(field_name)
+    if not isinstance(field_value, Mapping):
+        raise ToolPackageError(f"tool manifest field '{field_name}' must be an object")
+    return field_value
+
+
+def _manifest_bool(value: Mapping[str, Any], field_name: str, default: bool) -> bool:
+    field_value = value.get(field_name, default)
+    if not isinstance(field_value, bool):
+        raise ToolPackageError(f"tool manifest field '{field_name}' must be a boolean")
+    return field_value
+
+
+def _validate_entrypoint(value: Any) -> None:
+    if not isinstance(value, str) or value.count(":") != 1:
+        raise ToolPackageError("entrypoint must use module:object syntax")
+    module_name, object_name = value.split(":", 1)
+    if (
+        not module_name
+        or not object_name
+        or not all(part.isidentifier() for part in module_name.split("."))
+    ):
+        raise ToolPackageError("entrypoint must use module:object syntax")
+    if not object_name.isidentifier():
+        raise ToolPackageError("entrypoint object must be a valid identifier")
+
+
+def _validate_member_name(name: Any, *, required_prefix: str | None = None) -> None:
+    if not isinstance(name, str):
+        raise ToolPackageError(f"unsafe package member name: {name}")
+    if _has_unsafe_member_text(name) or _has_unsafe_member_path(name):
+        raise ToolPackageError(f"unsafe package member name: {name}")
+    if required_prefix and not name.startswith(required_prefix):
+        raise ToolPackageError(
+            f"package member must be under {required_prefix}: {name}"
+        )
+
+
+def _has_unsafe_member_text(name: str) -> bool:
+    return not name or "\\" in name or "\x00" in name
+
+
+def _has_unsafe_member_path(name: str) -> bool:
+    path = PurePosixPath(name)
+    return (
+        path.is_absolute()
+        or path.as_posix() != name
+        or name.endswith("/")
+        or not path.parts
+        or ".." in path.parts
+    )
+
+
+def _zip_info(name: str) -> ZipInfo:
+    info = ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.compress_type = ZIP_DEFLATED
+    info.create_system = 3
+    info.external_attr = 0o100644 << 16
+    return info
+
+
+def _json_bytes(value: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as package_file:
+        for chunk in iter(lambda: package_file.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/modules/opal2/tools/__init__.py
+++ b/modules/opal2/tools/__init__.py
@@ -1,5 +1,11 @@
 """Built-in reference tools shipped with the OPAL2 foundry."""
 
 from .glyph_render import GLYPH_RENDER_TOOL_ID, GlyphRenderTool
+from .regex_workshop import REGEX_WORKSHOP_TOOL_ID, RegexWorkshopTool
 
-__all__ = ["GLYPH_RENDER_TOOL_ID", "GlyphRenderTool"]
+__all__ = [
+    "GLYPH_RENDER_TOOL_ID",
+    "REGEX_WORKSHOP_TOOL_ID",
+    "GlyphRenderTool",
+    "RegexWorkshopTool",
+]

--- a/modules/opal2/tools/regex_workshop.py
+++ b/modules/opal2/tools/regex_workshop.py
@@ -60,9 +60,29 @@ class RegexWorkshopTool(Opal2Tool):
             "additionalProperties": False,
             "properties": {
                 "template": {"type": "string", "enum": _TEMPLATES},
-                "value": {"type": "string"},
-                "flags": {"type": "array"},
-                "samples": {"type": "array"},
+                "value": {"type": "string", "maxLength": MAX_LITERAL_LENGTH},
+                "flags": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": sorted(_FLAG_VALUES)},
+                    "maxItems": len(_FLAG_VALUES),
+                    "uniqueItems": True,
+                },
+                "samples": {
+                    "type": "array",
+                    "maxItems": MAX_SAMPLES,
+                    "items": {
+                        "type": "object",
+                        "required": ["text"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "text": {
+                                "type": "string",
+                                "maxLength": MAX_SAMPLE_LENGTH,
+                            },
+                            "expected_match": {"type": ["boolean", "null"]},
+                        },
+                    },
+                },
             },
         },
         output_schema={
@@ -80,11 +100,53 @@ class RegexWorkshopTool(Opal2Tool):
             "properties": {
                 "pattern": {"type": "string"},
                 "template": {"type": "string"},
-                "flags": {"type": "array"},
-                "samples": {"type": "array"},
-                "expectations_evaluated": {"type": "integer"},
+                "flags": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": sorted(_FLAG_VALUES)},
+                    "maxItems": len(_FLAG_VALUES),
+                    "uniqueItems": True,
+                },
+                "samples": {
+                    "type": "array",
+                    "maxItems": MAX_SAMPLES,
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "text",
+                            "matched",
+                            "match",
+                            "span",
+                            "groups",
+                            "expected_match",
+                            "expectation_met",
+                        ],
+                        "additionalProperties": False,
+                        "properties": {
+                            "text": {"type": "string"},
+                            "matched": {"type": "boolean"},
+                            "match": {"type": ["string", "null"]},
+                            "span": {
+                                "type": ["array", "null"],
+                                "items": {"type": "integer"},
+                                "minItems": 2,
+                                "maxItems": 2,
+                            },
+                            "groups": {
+                                "type": "array",
+                                "items": {"type": ["string", "null"]},
+                            },
+                            "expected_match": {"type": ["boolean", "null"]},
+                            "expectation_met": {"type": ["boolean", "null"]},
+                        },
+                    },
+                },
+                "expectations_evaluated": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_SAMPLES,
+                },
                 "all_expectations_met": {"type": "boolean"},
-                "warnings": {"type": "array"},
+                "warnings": {"type": "array", "items": {"type": "string"}},
             },
         },
         runtime="python",

--- a/modules/opal2/tools/regex_workshop.py
+++ b/modules/opal2/tools/regex_workshop.py
@@ -1,0 +1,215 @@
+"""Deterministic regex composition and sample-testing reference tool."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from ..tool_contract import (
+    JsonObject,
+    Opal2Tool,
+    ToolExecutionContext,
+    ToolInputError,
+    ToolManifest,
+)
+
+REGEX_WORKSHOP_TOOL_ID = "opal2.regex.workshop"
+MAX_LITERAL_LENGTH = 1_024
+MAX_SAMPLES = 100
+MAX_SAMPLE_LENGTH = 10_000
+
+_FLAG_VALUES: dict[str, re.RegexFlag] = {
+    "ignore_case": re.IGNORECASE,
+    "multiline": re.MULTILINE,
+    "dotall": re.DOTALL,
+}
+_FIXED_PATTERNS = {
+    "integer": r"\A[+-]?\d+\Z",
+    "decimal": r"\A[+-]?(?:\d+(?:\.\d*)?|\.\d+)\Z",
+    "email": (
+        r"\A[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+        r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+        r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+\Z"
+    ),
+    "uuid": (
+        r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-"
+        r"[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\Z"
+    ),
+    "iso_date": r"\A\d{4}-\d{2}-\d{2}\Z",
+}
+_LITERAL_TEMPLATES = {"exact", "contains", "starts_with", "ends_with", "word"}
+_TEMPLATES = sorted(_FIXED_PATTERNS.keys() | _LITERAL_TEMPLATES)
+
+
+class RegexWorkshopTool(Opal2Tool):
+    """Build safe regex templates and evaluate bounded conformance samples."""
+
+    manifest = ToolManifest(
+        tool_id=REGEX_WORKSHOP_TOOL_ID,
+        name="OPAL2 Regex Workshop",
+        version="1.0.0",
+        description=(
+            "Compose deterministic regular expressions from curated templates "
+            "and evaluate bounded sample expectations."
+        ),
+        capabilities=("regex-generation", "pattern-testing", "input-validation"),
+        input_schema={
+            "type": "object",
+            "required": ["template"],
+            "additionalProperties": False,
+            "properties": {
+                "template": {"type": "string", "enum": _TEMPLATES},
+                "value": {"type": "string"},
+                "flags": {"type": "array"},
+                "samples": {"type": "array"},
+            },
+        },
+        output_schema={
+            "type": "object",
+            "required": [
+                "pattern",
+                "template",
+                "flags",
+                "samples",
+                "expectations_evaluated",
+                "all_expectations_met",
+                "warnings",
+            ],
+            "additionalProperties": False,
+            "properties": {
+                "pattern": {"type": "string"},
+                "template": {"type": "string"},
+                "flags": {"type": "array"},
+                "samples": {"type": "array"},
+                "expectations_evaluated": {"type": "integer"},
+                "all_expectations_met": {"type": "boolean"},
+                "warnings": {"type": "array"},
+            },
+        },
+        runtime="python",
+        deterministic=True,
+        side_effects=(),
+        policy_profiles=("aurora",),
+        export_targets=("python", "opaltool", "oci"),
+    )
+
+    async def run(
+        self, payload: JsonObject, context: ToolExecutionContext
+    ) -> JsonObject:
+        del context  # Policy selection is recorded by the registry execution envelope.
+        template = payload["template"]
+        pattern = _build_pattern(template, payload.get("value"))
+        flag_names, flag_value = _validated_flags(payload.get("flags", []))
+        samples = _validated_samples(payload.get("samples", []))
+        compiled = re.compile(pattern, flag_value)
+
+        results = [
+            _evaluate_sample(compiled, text, expected) for text, expected in samples
+        ]
+        evaluated = sum(item["expected_match"] is not None for item in results)
+        all_met = all(
+            item["expectation_met"] is not False
+            for item in results
+            if item["expected_match"] is not None
+        )
+        warnings = []
+        if template == "iso_date":
+            warnings.append(
+                "iso_date validates lexical shape only, not calendar validity"
+            )
+
+        return {
+            "pattern": pattern,
+            "template": template,
+            "flags": list(flag_names),
+            "samples": results,
+            "expectations_evaluated": evaluated,
+            "all_expectations_met": all_met,
+            "warnings": warnings,
+        }
+
+
+def _build_pattern(template: str, value: Any) -> str:
+    if template in _FIXED_PATTERNS:
+        if value is not None:
+            raise ToolInputError(f"template '{template}' does not accept value")
+        return _FIXED_PATTERNS[template]
+
+    if not isinstance(value, str):
+        raise ToolInputError(f"template '{template}' requires a string value")
+    if len(value) > MAX_LITERAL_LENGTH:
+        raise ToolInputError(f"value exceeds {MAX_LITERAL_LENGTH} characters")
+
+    escaped = re.escape(value)
+    return {
+        "exact": rf"\A{escaped}\Z",
+        "contains": escaped,
+        "starts_with": rf"\A{escaped}",
+        "ends_with": rf"{escaped}\Z",
+        "word": rf"\b{escaped}\b",
+    }[template]
+
+
+def _validated_flags(value: Any) -> tuple[tuple[str, ...], re.RegexFlag]:
+    if not isinstance(value, (list, tuple)):
+        raise ToolInputError("flags must be an array")
+    if any(not isinstance(flag_name, str) for flag_name in value):
+        raise ToolInputError("flags must contain only strings")
+    if len(value) != len(set(value)):
+        raise ToolInputError("flags must not contain duplicates")
+
+    combined = re.NOFLAG
+    for flag_name in value:
+        if flag_name not in _FLAG_VALUES:
+            raise ToolInputError(
+                f"unsupported flag: {flag_name}; expected one of {sorted(_FLAG_VALUES)}"
+            )
+        combined |= _FLAG_VALUES[flag_name]
+    return tuple(value), combined
+
+
+def _validated_samples(value: Any) -> list[tuple[str, bool | None]]:
+    if not isinstance(value, (list, tuple)):
+        raise ToolInputError("samples must be an array")
+    if len(value) > MAX_SAMPLES:
+        raise ToolInputError(f"samples exceeds the limit of {MAX_SAMPLES}")
+
+    return [_validated_sample(index, sample) for index, sample in enumerate(value)]
+
+
+def _validated_sample(index: int, sample: Any) -> tuple[str, bool | None]:
+    if not isinstance(sample, Mapping):
+        raise ToolInputError(f"samples[{index}] must be an object")
+    unexpected = set(sample) - {"text", "expected_match"}
+    if unexpected:
+        raise ToolInputError(
+            f"samples[{index}] contains unexpected field: {min(unexpected)}"
+        )
+    text = sample.get("text")
+    expected = sample.get("expected_match")
+    if not isinstance(text, str):
+        raise ToolInputError(f"samples[{index}].text must be a string")
+    if len(text) > MAX_SAMPLE_LENGTH:
+        raise ToolInputError(
+            f"samples[{index}].text exceeds {MAX_SAMPLE_LENGTH} characters"
+        )
+    if expected is not None and not isinstance(expected, bool):
+        raise ToolInputError(f"samples[{index}].expected_match must be a boolean")
+    return text, expected
+
+
+def _evaluate_sample(
+    compiled: re.Pattern[str], text: str, expected: bool | None
+) -> JsonObject:
+    match = compiled.search(text)
+    matched = match is not None
+    return {
+        "text": text,
+        "matched": matched,
+        "match": match.group(0) if match else None,
+        "span": list(match.span()) if match else None,
+        "groups": list(match.groups()) if match else [],
+        "expected_match": expected,
+        "expectation_met": matched == expected if expected is not None else None,
+    }

--- a/tests/test_opal2_api_routes.py
+++ b/tests/test_opal2_api_routes.py
@@ -198,10 +198,14 @@ def test_opal2_foundry_http_discovery_and_execution():
     from src.middleware.fastapi_security import generate_csrf_token
 
     client = TestClient(module.app)
+    root_response = client.get("/")
+    assert root_response.status_code == 200  # nosec B101 - pytest assertion
+    assert root_response.json()["timestamp"].endswith("+00:00")  # nosec B101 - pytest assertion
     discovery = client.get("/tools")
     assert discovery.status_code == 200  # nosec B101 - pytest assertion
     tool_ids = {tool["tool_id"] for tool in discovery.json()["tools"]}
     assert "opal2.glyph.render" in tool_ids  # nosec B101 - pytest assertion
+    assert "opal2.regex.workshop" in tool_ids  # nosec B101 - pytest assertion
 
     auth_headers = {"Authorization": f"Bearer {generate_csrf_token('opal2-test')}"}
     response = client.post(
@@ -222,6 +226,24 @@ def test_opal2_foundry_http_discovery_and_execution():
     assert response.status_code == 200  # nosec B101 - pytest assertion
     assert response.json()["tool_id"] == "opal2.glyph.render"  # nosec B101 - pytest assertion
     assert response.json()["output"]["format"] == "svg"  # nosec B101 - pytest assertion
+
+    regex_response = client.post(
+        "/tools/opal2.regex.workshop/run",
+        headers=auth_headers,
+        json={
+            "payload": {
+                "template": "word",
+                "value": "anchor",
+                "samples": [
+                    {"text": "stable anchor", "expected_match": True},
+                    {"text": "anchored", "expected_match": False},
+                ],
+            }
+        },
+    )
+    assert regex_response.status_code == 200  # nosec B101 - pytest assertion
+    assert regex_response.json()["tool_id"] == "opal2.regex.workshop"  # nosec B101 - pytest assertion
+    assert regex_response.json()["output"]["all_expectations_met"] is True  # nosec B101 - pytest assertion
 
     invalid_dimensions = client.post(
         "/tools/opal2.glyph.render/run",

--- a/tests/test_opal2_regex_workshop.py
+++ b/tests/test_opal2_regex_workshop.py
@@ -1,6 +1,7 @@
 """Conformance tests for the neutral OPAL2 regex workshop tool."""
 
 import pytest
+from jsonschema import Draft7Validator, ValidationError
 
 from modules.opal2.tool_contract import ToolExecutionContext, ToolInputError
 from modules.opal2.tool_registry import ToolRegistry
@@ -15,25 +16,50 @@ from modules.opal2.tools.regex_workshop import (
 @pytest.mark.opal2
 @pytest.mark.asyncio
 async def test_regex_workshop_builds_escaped_literal_pattern():
-    registry = ToolRegistry((RegexWorkshopTool(),))
+    tool = RegexWorkshopTool()
+    registry = ToolRegistry((tool,))
+    payload = {
+        "template": "exact",
+        "value": "station[808]",
+        "flags": ["ignore_case"],
+        "samples": [
+            {"text": "STATION[808]", "expected_match": True},
+            {"text": "station808", "expected_match": False},
+        ],
+    }
 
     result = await registry.run(
         REGEX_WORKSHOP_TOOL_ID,
-        {
-            "template": "exact",
-            "value": "station[808]",
-            "flags": ["ignore_case"],
-            "samples": [
-                {"text": "STATION[808]", "expected_match": True},
-                {"text": "station808", "expected_match": False},
-            ],
-        },
+        payload,
     )
+
+    Draft7Validator(tool.manifest.input_schema).validate(payload)
+    Draft7Validator(tool.manifest.output_schema).validate(result.output)
 
     assert result.output["pattern"] == r"\Astation\[808\]\Z"  # nosec B101 - pytest assertion
     assert result.output["all_expectations_met"] is True  # nosec B101 - pytest assertion
     assert result.output["expectations_evaluated"] == 2  # nosec B101 - pytest assertion
     assert result.provenance["runtime"] == "python"  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_regex_workshop_manifest_rejects_malformed_collection_items():
+    manifest = RegexWorkshopTool.manifest
+    Draft7Validator.check_schema(manifest.input_schema)
+    Draft7Validator.check_schema(manifest.output_schema)
+    validator = Draft7Validator(manifest.input_schema)
+
+    with pytest.raises(ValidationError):
+        validator.validate({"template": "integer", "flags": [1]})
+    with pytest.raises(ValidationError):
+        validator.validate({"template": "integer", "flags": ["dotall", "dotall"]})
+    with pytest.raises(ValidationError):
+        validator.validate({"template": "integer", "samples": [{"text": 42}]})
+    with pytest.raises(ValidationError):
+        validator.validate(
+            {"template": "integer", "samples": [{"text": "42", "extra": True}]}
+        )
 
 
 @pytest.mark.unit

--- a/tests/test_opal2_regex_workshop.py
+++ b/tests/test_opal2_regex_workshop.py
@@ -1,0 +1,154 @@
+"""Conformance tests for the neutral OPAL2 regex workshop tool."""
+
+import pytest
+
+from modules.opal2.tool_contract import ToolExecutionContext, ToolInputError
+from modules.opal2.tool_registry import ToolRegistry
+from modules.opal2.tools.regex_workshop import (
+    MAX_SAMPLE_LENGTH,
+    REGEX_WORKSHOP_TOOL_ID,
+    RegexWorkshopTool,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_regex_workshop_builds_escaped_literal_pattern():
+    registry = ToolRegistry((RegexWorkshopTool(),))
+
+    result = await registry.run(
+        REGEX_WORKSHOP_TOOL_ID,
+        {
+            "template": "exact",
+            "value": "station[808]",
+            "flags": ["ignore_case"],
+            "samples": [
+                {"text": "STATION[808]", "expected_match": True},
+                {"text": "station808", "expected_match": False},
+            ],
+        },
+    )
+
+    assert result.output["pattern"] == r"\Astation\[808\]\Z"  # nosec B101 - pytest assertion
+    assert result.output["all_expectations_met"] is True  # nosec B101 - pytest assertion
+    assert result.output["expectations_evaluated"] == 2  # nosec B101 - pytest assertion
+    assert result.provenance["runtime"] == "python"  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template, matching, rejected",
+    [
+        ("integer", "+42", "4.2"),
+        ("decimal", "-4.2", "4.2.1"),
+        ("email", "crew@example.org", "crew@example"),
+        ("uuid", "123e4567-e89b-12d3-a456-426614174000", "not-a-uuid"),
+        ("iso_date", "2026-07-18", "07/18/2026"),
+    ],
+)
+async def test_regex_workshop_fixed_templates(template, matching, rejected):
+    registry = ToolRegistry((RegexWorkshopTool(),))
+
+    result = await registry.run(
+        REGEX_WORKSHOP_TOOL_ID,
+        {
+            "template": template,
+            "samples": [
+                {"text": matching, "expected_match": True},
+                {"text": rejected, "expected_match": False},
+            ],
+        },
+    )
+
+    assert result.output["all_expectations_met"] is True  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload, expected_error",
+    [
+        ({"template": "exact"}, "requires a string value"),
+        ({"template": "integer", "value": "42"}, "does not accept value"),
+        (
+            {"template": "contains", "value": "x", "flags": ["ascii"]},
+            "unsupported flag",
+        ),
+        (
+            {"template": "contains", "value": "x", "flags": [{}]},
+            "only strings",
+        ),
+        (
+            {
+                "template": "contains",
+                "value": "x",
+                "samples": [{"text": "x" * (MAX_SAMPLE_LENGTH + 1)}],
+            },
+            "exceeds",
+        ),
+    ],
+)
+async def test_regex_workshop_rejects_unbounded_or_ambiguous_input(
+    payload, expected_error
+):
+    registry = ToolRegistry((RegexWorkshopTool(),))
+
+    with pytest.raises(ToolInputError, match=expected_error):
+        await registry.run(REGEX_WORKSHOP_TOOL_ID, payload)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_regex_workshop_supports_aurora_as_optional_profile():
+    registry = ToolRegistry((RegexWorkshopTool(),))
+
+    result = await registry.run(
+        REGEX_WORKSHOP_TOOL_ID,
+        {"template": "word", "value": "anchor"},
+        ToolExecutionContext(policy_profile="aurora"),
+    )
+
+    assert result.output["pattern"] == r"\banchor\b"  # nosec B101 - pytest assertion
+    assert result.provenance["policy_profile"] == "aurora"  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_regex_workshop_multiline_cannot_weaken_document_anchors():
+    registry = ToolRegistry((RegexWorkshopTool(),))
+
+    result = await registry.run(
+        REGEX_WORKSHOP_TOOL_ID,
+        {
+            "template": "integer",
+            "flags": ["multiline"],
+            "samples": [{"text": "prefix\n42", "expected_match": False}],
+        },
+    )
+
+    assert result.output["all_expectations_met"] is True  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.asyncio
+async def test_regex_workshop_accepts_contract_compatible_tuple_arrays():
+    registry = ToolRegistry((RegexWorkshopTool(),))
+
+    result = await registry.run(
+        REGEX_WORKSHOP_TOOL_ID,
+        {
+            "template": "exact",
+            "value": "anchor",
+            "flags": ("ignore_case",),
+            "samples": ({"text": "ANCHOR", "expected_match": True},),
+        },
+    )
+
+    assert result.output["all_expectations_met"] is True  # nosec B101 - pytest assertion

--- a/tests/test_opal2_tool_package.py
+++ b/tests/test_opal2_tool_package.py
@@ -1,0 +1,210 @@
+"""Tests for deterministic, inert OPAL2 package artifacts."""
+
+import hashlib
+import json
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+
+from modules.opal2.tool_package import (
+    PACKAGE_MANIFEST_PATH,
+    ToolPackageError,
+    build_opaltool_package,
+    export_builtin_tool,
+    verify_opaltool_package,
+)
+from modules.opal2.tools.regex_workshop import (
+    REGEX_WORKSHOP_TOOL_ID,
+    RegexWorkshopTool,
+)
+
+
+def _read_package_members(package_path):
+    with ZipFile(package_path) as archive:
+        return {name: archive.read(name) for name in archive.namelist()}
+
+
+def _write_package_members(package_path, members):
+    package_path.unlink()
+    with ZipFile(package_path, "w", compression=ZIP_DEFLATED) as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+
+
+def _replace_package_manifest(members, package):
+    members[PACKAGE_MANIFEST_PATH] = json.dumps(package, sort_keys=True).encode()
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_builtin_regex_package_is_reproducible_and_verifiable(tmp_path):
+    first = tmp_path / "regex-first.opaltool"
+    second = tmp_path / "regex-second.opaltool"
+
+    first_receipt = export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, first)
+    second_receipt = export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, second)
+
+    assert first.read_bytes() == second.read_bytes()  # nosec B101 - pytest assertion
+    assert first_receipt.archive_sha256 == second_receipt.archive_sha256  # nosec B101 - pytest assertion
+    assert first_receipt.tool_manifest.tool_id == REGEX_WORKSHOP_TOOL_ID  # nosec B101 - pytest assertion
+    assert first_receipt.package_manifest["activation"] == "inspect-only"  # nosec B101 - pytest assertion
+    assert first_receipt.to_dict()["verified_files"] == 4  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_package_contains_manifest_schemas_and_implementation(tmp_path):
+    package_path = tmp_path / "regex.opaltool"
+    export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, package_path)
+
+    with ZipFile(package_path) as archive:
+        names = set(archive.namelist())
+        package = json.loads(archive.read(PACKAGE_MANIFEST_PATH))
+
+    assert names == {  # nosec B101 - pytest assertion
+        PACKAGE_MANIFEST_PATH,
+        "schemas/input.schema.json",
+        "schemas/output.schema.json",
+        "src/regex_workshop.py",
+        "fixtures/basic.json",
+    }
+    assert package["format"] == "opaltool"  # nosec B101 - pytest assertion
+    assert package["core_api"] == "opal2.core.v1"  # nosec B101 - pytest assertion
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_package_verifier_rejects_tampered_payload(tmp_path):
+    package_path = tmp_path / "tampered.opaltool"
+    export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, package_path)
+
+    members = _read_package_members(package_path)
+    members["src/regex_workshop.py"] = b"tampered"
+    _write_package_members(package_path, members)
+
+    with pytest.raises(ToolPackageError, match="integrity verification failed"):
+        verify_opaltool_package(package_path)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_package_verifier_rejects_path_traversal(tmp_path):
+    package_path = tmp_path / "unsafe.opaltool"
+    with ZipFile(package_path, "w") as archive:
+        archive.writestr("../escape.py", "pass")
+
+    with pytest.raises(ToolPackageError, match="unsafe package member"):
+        verify_opaltool_package(package_path)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_package_verifier_rejects_normalized_member_alias(tmp_path):
+    package_path = tmp_path / "normalized-alias.opaltool"
+    with ZipFile(package_path, "w") as archive:
+        archive.writestr("src//tool.py", "pass")
+
+    with pytest.raises(ToolPackageError, match="unsafe package member"):
+        verify_opaltool_package(package_path)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_package_builder_requires_explicit_new_destination(tmp_path):
+    package_path = tmp_path / "existing.opaltool"
+    package_path.write_bytes(b"existing")
+    tool = RegexWorkshopTool()
+
+    with pytest.raises(ToolPackageError, match="refusing to overwrite"):
+        build_opaltool_package(
+            tool,
+            package_path,
+            entrypoint="modules.opal2.tools.regex_workshop:RegexWorkshopTool",
+            implementation_files={"src/regex_workshop.py": "pass"},
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.parametrize(
+    "field_name, field_value, expected_error",
+    [
+        ("core_api", "opal2.core.v99", "unsupported core API"),
+        ("activation", "execute", "activation must remain inspect-only"),
+    ],
+)
+def test_package_verifier_rejects_incompatible_header(
+    tmp_path, field_name, field_value, expected_error
+):
+    package_path = tmp_path / "incompatible.opaltool"
+    export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, package_path)
+    members = _read_package_members(package_path)
+    package = json.loads(members[PACKAGE_MANIFEST_PATH])
+    package[field_name] = field_value
+    _replace_package_manifest(members, package)
+    _write_package_members(package_path, members)
+
+    with pytest.raises(ToolPackageError, match=expected_error):
+        verify_opaltool_package(package_path)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+@pytest.mark.parametrize(
+    "field_name, field_value, expected_error",
+    [
+        ("capabilities", "regex-generation", "array of strings"),
+        ("side_effects", ["network", 42], "array of strings"),
+        ("deterministic", "yes", "must be a boolean"),
+        ("runtime", ["python"], "must be a string"),
+    ],
+)
+def test_package_verifier_rejects_malformed_tool_manifest(
+    tmp_path, field_name, field_value, expected_error
+):
+    package_path = tmp_path / "malformed-manifest.opaltool"
+    export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, package_path)
+    members = _read_package_members(package_path)
+    package = json.loads(members[PACKAGE_MANIFEST_PATH])
+    package["tool"][field_name] = field_value
+    _replace_package_manifest(members, package)
+    _write_package_members(package_path, members)
+
+    with pytest.raises(ToolPackageError, match=expected_error):
+        verify_opaltool_package(package_path)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_package_verifier_requires_implementation_payload(tmp_path):
+    package_path = tmp_path / "missing-implementation.opaltool"
+    export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, package_path)
+    members = _read_package_members(package_path)
+    package = json.loads(members[PACKAGE_MANIFEST_PATH])
+    members.pop("src/regex_workshop.py")
+    package["integrity"]["files"].pop("src/regex_workshop.py")
+    _replace_package_manifest(members, package)
+    _write_package_members(package_path, members)
+
+    with pytest.raises(ToolPackageError, match="implementation member"):
+        verify_opaltool_package(package_path)
+
+
+@pytest.mark.unit
+@pytest.mark.opal2
+def test_package_verifier_rejects_undeclared_payload_class(tmp_path):
+    package_path = tmp_path / "unsupported-payload.opaltool"
+    export_builtin_tool(REGEX_WORKSHOP_TOOL_ID, package_path)
+    members = _read_package_members(package_path)
+    package = json.loads(members[PACKAGE_MANIFEST_PATH])
+    unsupported_data = b"not part of the package contract"
+    members["docs/note.txt"] = unsupported_data
+    package["integrity"]["files"]["docs/note.txt"] = {
+        "sha256": hashlib.sha256(unsupported_data).hexdigest(),
+        "size": len(unsupported_data),
+    }
+    _replace_package_manifest(members, package)
+    _write_package_members(package_path, members)
+
+    with pytest.raises(ToolPackageError, match="unsupported package payload"):
+        verify_opaltool_package(package_path)


### PR DESCRIPTION
## Summary
- add the deterministic opal2.regex.workshop reference tool and register it with the standalone API
- define reproducible .opaltool specification 0.1 archives carrying manifests, schemas, source, fixtures, and SHA-256 receipts
- verify packages without extraction, import, or execution
- document the implemented Phase 2 boundary and the remaining signature, isolation, adapter, and clean-room work

## Stack
This PR is intentionally based on the Phase 1 branch from #1272. Merge #1272 first; this branch can then be rebased or retargeted to main without expanding the Phase 1 review.

## Safety boundary
- arbitrary user-provided regex is not executed; only curated templates and escaped literals are supported
- sample count and text length are bounded
- packages remain activation: inspect-only
- package verifier rejects traversal, normalized aliases, duplicate members, symlinks, undeclared files, oversized content, schema drift, and digest mismatch

## Validation
- 50 focused OPAL2 tests passed
- targeted Ruff, formatting, Bandit, and isolated mypy passed
- pre-commit and flake8 passed for all changed files
- active OPAL2 compilation passed with the legacy staging directory excluded
- real Uvicorn discovery and authenticated regex execution passed
- independent package export and verification produced matching archive SHA-256 receipts