### PR TITLE
fix(queue): reconcile decision-gate authority

### DIFF
--- a/.github/workflows/queue-decision-escalation.yml
+++ b/.github/workflows/queue-decision-escalation.yml
@@ -70,6 +70,20 @@ jobs:
               issue = gate.get("github_issue")
               if not issue:
                   continue
+              state_check = subprocess.run(
+                  ["gh", "issue", "view", str(issue), "--json", "state", "--jq", ".state"],
+                  check=False,
+                  capture_output=True,
+                  text=True,
+              )
+              issue_state = state_check.stdout.strip().upper()
+              if state_check.returncode != 0 or issue_state != "OPEN":
+                  detail = issue_state or state_check.stderr.strip() or "UNKNOWN"
+                  print(
+                      f"::warning::skipping {gate['gate_id']}: linked issue "
+                      f"#{issue} is not confirmed open ({detail})"
+                  )
+                  continue
               age = gate.get("days_since_surfaced")
               body = (
                   f"⏰ **Decision-gate escalation** ({gate['gate_id']}, tier {gate['escalation_tier']}): "
@@ -85,6 +99,11 @@ jobs:
               print(f"pinged issue #{issue} for {gate['gate_id']}")
           for item in report["ungated_decisions"]:
               print(f"registry drift (reported in PR body): {item['id']} — {item['title']}")
+          for gate in report.get("integrity_holds", []):
+              print(
+                  f"integrity hold (reported in PR body): {gate['gate_id']} — "
+                  f"{gate.get('integrity_note') or gate['title']}"
+              )
           PY
 
       - name: Open registry-update PR

--- a/ops/work_queue/escalate_gates.py
+++ b/ops/work_queue/escalate_gates.py
@@ -18,6 +18,9 @@ Usage:
 Semantics:
 - A gate escalates when state == "open" and days since
   max(opened, last_surfaced) exceed the threshold (default 3, per #1131).
+- Gates with integrity_status == "reconciliation_required" remain open
+  authority records but are excluded from automated escalation until their
+  stale issue/queue references are reconciled.
 - Bumping last_surfaced (--apply) IS the dedup: a gate will not re-escalate
   until the threshold elapses again. escalation_tier is Aurora's field and
   is never modified here.
@@ -67,6 +70,34 @@ def _today() -> date:
     return datetime.now(timezone.utc).date()
 
 
+def _is_active_open_gate(gate: Dict[str, Any]) -> bool:
+    """Whether a gate may participate in automated escalation and linking."""
+    return (
+        gate.get("state") == "open"
+        and gate.get("integrity_status", "active") == "active"
+    )
+
+
+def find_integrity_holds(registry: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Open gates intentionally suspended from automation pending reconciliation."""
+    holds = []
+    for gate in registry.get("gates", []):
+        if gate.get("state") != "open":
+            continue
+        status = gate.get("integrity_status", "active")
+        if status == "active":
+            continue
+        holds.append({
+            "gate_id": gate.get("gate_id"),
+            "title": gate.get("title"),
+            "integrity_status": status,
+            "integrity_note": gate.get("integrity_note"),
+            "github_issue": gate.get("github_issue"),
+            "queue_item": gate.get("queue_item"),
+        })
+    return holds
+
+
 def find_escalations(
     registry: Dict[str, Any],
     threshold_days: int = DEFAULT_THRESHOLD_DAYS,
@@ -76,7 +107,7 @@ def find_escalations(
     today = today or _today()
     escalations: List[Dict[str, Any]] = []
     for gate in registry.get("gates", []):
-        if gate.get("state") != "open":
+        if not _is_active_open_gate(gate):
             continue
         baseline_candidates = [
             _parse_date(gate.get("opened")),
@@ -106,7 +137,7 @@ def find_escalations(
 
 def _open_gate_refs(registry: Dict[str, Any]) -> tuple[set, set]:
     """(queue_item ids, github issue numbers) referenced by open gates."""
-    open_gates = [g for g in registry.get("gates", []) if g.get("state") == "open"]
+    open_gates = [g for g in registry.get("gates", []) if _is_active_open_gate(g)]
     return (
         {gate.get("queue_item") for gate in open_gates},
         {gate.get("github_issue") for gate in open_gates},
@@ -196,9 +227,10 @@ def main() -> int:
 
     escalations = find_escalations(registry, args.threshold_days)
     drift = find_ungated_decisions(queue, registry)
+    integrity_holds = find_integrity_holds(registry)
 
-    _print_findings(escalations, drift)
-    _write_report(args, escalations, drift)
+    _print_findings(escalations, drift, integrity_holds)
+    _write_report(args, escalations, drift, integrity_holds)
 
     if not escalations and not drift:
         print("No gates past threshold; no registry drift.")
@@ -208,16 +240,30 @@ def main() -> int:
     return 10
 
 
-def _print_findings(escalations: List[Dict[str, Any]], drift: List[Dict[str, Any]]) -> None:
+def _print_findings(
+    escalations: List[Dict[str, Any]],
+    drift: List[Dict[str, Any]],
+    integrity_holds: List[Dict[str, Any]],
+) -> None:
     for item in escalations:
         age = item["days_since_surfaced"]
         print(f"ESCALATE {item['gate_id']} (tier {item['escalation_tier']}, "
               f"{age if age is not None else 'undated'}d, issue #{item['github_issue']}): {item['title']}")
     for item in drift:
         print(f"DRIFT ungated needs-decision item: {item['id']} — {item['title']}")
+    for gate in integrity_holds:
+        print(
+            f"HOLD {gate['gate_id']} ({gate['integrity_status']}): "
+            f"{gate['integrity_note'] or gate['title']}"
+        )
 
 
-def _write_report(args, escalations: List[Dict[str, Any]], drift: List[Dict[str, Any]]) -> None:
+def _write_report(
+    args,
+    escalations: List[Dict[str, Any]],
+    drift: List[Dict[str, Any]],
+    integrity_holds: List[Dict[str, Any]],
+) -> None:
     if not args.json:
         return
     report = {
@@ -225,6 +271,7 @@ def _write_report(args, escalations: List[Dict[str, Any]], drift: List[Dict[str,
         "threshold_days": args.threshold_days,
         "escalations": escalations,
         "ungated_decisions": drift,
+        "integrity_holds": integrity_holds,
     }
     args.json.write_text(json.dumps(report, indent=2) + "\n")
 

--- a/ops/work_queue/escalate_gates.py
+++ b/ops/work_queue/escalate_gates.py
@@ -138,10 +138,15 @@ def find_escalations(
 def _open_gate_refs(registry: Dict[str, Any]) -> tuple[set, set]:
     """(queue_item ids, github issue numbers) referenced by open gates."""
     open_gates = [g for g in registry.get("gates", []) if _is_active_open_gate(g)]
-    return (
-        {gate.get("queue_item") for gate in open_gates},
-        {gate.get("github_issue") for gate in open_gates},
-    )
+    gated_items = {
+        gate["queue_item"] for gate in open_gates
+        if gate.get("queue_item") is not None
+    }
+    gated_issues = {
+        gate["github_issue"] for gate in open_gates
+        if gate.get("github_issue") is not None
+    }
+    return gated_items, gated_issues
 
 
 def _needs_decision(item: Dict[str, Any]) -> Optional[str]:
@@ -159,7 +164,11 @@ def find_ungated_decisions(
         status = _needs_decision(item)
         if status is None:
             continue
-        if item.get("id") in gated_items or item.get("github_issue") in gated_issues:
+        github_issue = item.get("github_issue")
+        if (
+            item.get("id") in gated_items
+            or github_issue is not None and github_issue in gated_issues
+        ):
             continue
         drift.append({
             "id": item.get("id"),
@@ -233,7 +242,13 @@ def main() -> int:
     _write_report(args, escalations, drift, integrity_holds)
 
     if not escalations and not drift:
-        print("No gates past threshold; no registry drift.")
+        if integrity_holds:
+            print(
+                "No gates past threshold; no registry drift; "
+                f"{len(integrity_holds)} integrity hold(s) reported."
+            )
+        else:
+            print("No gates past threshold; no registry drift.")
         return 0
 
     _finalize(args, registry, escalations)

--- a/ops/work_queue/gate_registry.json
+++ b/ops/work_queue/gate_registry.json
@@ -1,8 +1,8 @@
 {
   "registry_authority": "Aurora",
-  "protocol_version": "1.0.0",
-  "description": "Canonical registry of all human-gated decisions in the Aurora work queue. A gate is created when a queue item reaches decision_required state and consumer_fit excludes autonomous agents. Gates persist across sessions and platforms until explicitly resolved. Aurora surfaces all open gates at session open.",
-  "last_updated": "2026-06-22",
+  "protocol_version": "1.1.0",
+  "description": "Canonical registry of all human-gated decisions in the Aurora work queue. A gate is created when a queue item reaches needs-decision or decision_required state and consumer_fit excludes autonomous agents. Gates persist across sessions and platforms until explicitly resolved. An integrity hold suspends automated escalation without resolving the underlying decision.",
+  "last_updated": "2026-07-20",
   "gates": [
     {
       "gate_id": "GATE-001",
@@ -10,6 +10,9 @@
       "github_issue": 841,
       "title": "Pentest vendor selection + pre-condition sign-off",
       "state": "open",
+      "integrity_status": "reconciliation_required",
+      "integrity_checked": "2026-07-20",
+      "integrity_note": "Linked issue #841 is closed as completed, while Q-0003 and Q-0008 are absent from the current queue. Automated escalation is suspended until the operator reconciles the gate with current security-review authority; this does not declare the pentest decision resolved.",
       "decision_owner": "operator",
       "opened": "2026-06-22",
       "last_surfaced": "2026-06-22",
@@ -28,6 +31,64 @@
         "Update NEXT_UP.md to reflect Q-0003 closure"
       ],
       "aurora_notes": "This gate is the critical path to the pentest engagement. The wiring verification sub-task (Q-0003a) is agent-eligible and should not be waiting on the operator. Vendor selection (Q-0003b) is the true human decision. Tier escalation is computed from (today - opened) at each session open.",
+      "closed": null,
+      "resolved_by": null
+    },
+    {
+      "gate_id": "GATE-002",
+      "queue_item": "sim/SENTINEL-phase0",
+      "github_issue": null,
+      "title": "PROJECT SENTINEL Phase 0 governance constitution",
+      "state": "open",
+      "integrity_status": "active",
+      "decision_owner": "Commander Thorne + Sorensen + Sato",
+      "opened": "2026-07-20",
+      "last_surfaced": null,
+      "escalation_tier": 1,
+      "blocks_queue_items": [],
+      "blocks_gates": [],
+      "resolution_criteria": [
+        "Commander Thorne, Sorensen, and Sato governance decision is recorded",
+        "Phase 0 ethics review board constitution is recorded",
+        "The Phase 0 layer-boundary document is drafted or explicitly deferred"
+      ],
+      "resolution_steps": [
+        "Record the governance decision and named decision-makers",
+        "Update queue.json: move sim/SENTINEL-phase0 out of needs-decision",
+        "Update gate_registry.json: set state = resolved, closed = today, resolved_by = operator handle",
+        "Regenerate queue views with sync_queue.py"
+      ],
+      "aurora_notes": "No engineering blocking condition. The decision is governance-only; agents must not constitute the review board or promote the proposal autonomously.",
+      "closed": null,
+      "resolved_by": null
+    },
+    {
+      "gate_id": "GATE-003",
+      "queue_item": "feat/QGIA",
+      "github_issue": null,
+      "title": "QGIA integration routing and crew sign-off",
+      "state": "open",
+      "integrity_status": "active",
+      "decision_owner": "operator / designated crew reviewers",
+      "opened": "2026-07-20",
+      "last_surfaced": null,
+      "escalation_tier": 1,
+      "blocks_queue_items": [],
+      "blocks_gates": [],
+      "resolution_criteria": [
+        "arch/layer-canonization is complete",
+        "ops/QGIA-doctrine-store is complete",
+        "The PAT routing decision is recorded",
+        "Crew sign-off is recorded before any QGIA axiom becomes operationally binding"
+      ],
+      "resolution_steps": [
+        "Record the PAT routing decision and crew reviewers",
+        "Confirm all declared queue dependencies are complete",
+        "Update queue.json: move feat/QGIA out of needs-decision",
+        "Update gate_registry.json: set state = resolved, closed = today, resolved_by = operator handle",
+        "Regenerate queue views with sync_queue.py"
+      ],
+      "aurora_notes": "QGIA remains mediated through L1. This gate does not authorize direct QGIA-to-L2 tasking or promote analytical doctrine into operational canon.",
       "closed": null,
       "resolved_by": null
     }

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from ops.work_queue.escalate_gates import (
     apply_surfacing,
     find_escalations,
+    find_integrity_holds,
     find_ungated_decisions,
 )
 
@@ -73,6 +74,33 @@ def test_resolved_gates_never_escalate():
     assert find_escalations(resolved, threshold_days=3, today=TODAY) == []
 
 
+def test_integrity_hold_suspends_escalation_and_link_authority():
+    held = _registry(
+        integrity_status="reconciliation_required",
+        integrity_note="Linked issue is closed.",
+    )
+    assert find_escalations(held, threshold_days=3, today=TODAY) == []
+    assert find_integrity_holds(held) == [{
+        "gate_id": "GATE-777",
+        "title": "Test gate",
+        "integrity_status": "reconciliation_required",
+        "integrity_note": "Linked issue is closed.",
+        "github_issue": 777,
+        "queue_item": "Q-0777",
+    }]
+
+    queue = {
+        "active": [
+            {
+                "id": "Q-0777",
+                "title": "Still needs a valid gate",
+                "status": "needs-decision",
+            }
+        ]
+    }
+    assert [item["id"] for item in find_ungated_decisions(queue, held)] == ["Q-0777"]
+
+
 def test_undated_open_gate_always_surfaces():
     """Silence must not hide an undated gate."""
     undated = _registry(opened=None, last_surfaced=None)
@@ -115,9 +143,12 @@ def test_live_registry_and_queue_parse_and_report_cleanly():
 
     escalations = find_escalations(registry, threshold_days=3, today=TODAY)
     drift = find_ungated_decisions(queue, registry)
+    holds = find_integrity_holds(registry)
     # No exceptions and structurally sound output is the contract here;
     # actual counts are live data and will change over time.
     for gate in escalations:
         assert gate["gate_id"]
     for item in drift:
         assert item["id"]
+    assert drift == []
+    assert [gate["gate_id"] for gate in holds] == ["GATE-001"]

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -150,5 +150,6 @@ def test_live_registry_and_queue_parse_and_report_cleanly():
         assert gate["gate_id"]
     for item in drift:
         assert item["id"]
-    assert drift == []
-    assert [gate["gate_id"] for gate in holds] == ["GATE-001"]
+    for gate in holds:
+        assert gate["gate_id"]
+        assert gate["integrity_status"] != "active"

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -135,6 +135,22 @@ def test_ungated_needs_decision_items_are_reported_as_drift():
     assert [d["id"] for d in drift] == ["sim/decision-x"]
 
 
+def test_null_gate_refs_do_not_mask_unlinked_decisions():
+    registry = _registry(queue_item="sim/known", github_issue=None)
+    queue = {
+        "active": [
+            {
+                "id": "sim/unlinked",
+                "title": "No issue yet",
+                "status": "needs-decision",
+            }
+        ]
+    }
+
+    drift = find_ungated_decisions(queue, registry)
+    assert [item["id"] for item in drift] == ["sim/unlinked"]
+
+
 def test_live_registry_and_queue_parse_and_report_cleanly():
     """The real files must be consumable by the escalation core."""
     work_queue = Path(__file__).resolve().parent.parent / "ops" / "work_queue"


### PR DESCRIPTION
## Summary

- place stale `GATE-001` on an explicit integrity hold without declaring the pentest decision resolved
- register active gates for `sim/SENTINEL-phase0` and `feat/QGIA`
- exclude integrity-held gates from automated escalation and queue-link authority
- report integrity holds in dry-run/JSON output
- prevent null gate references from masking future ungated decisions
- prevent the workflow from commenting unless a linked GitHub issue is confirmed open

## Evidence

- `GATE-001` links issue #841, which is closed as completed
- its `Q-0003` / `Q-0008` references are absent from the current queue
- the current queue contains two `needs-decision` items with no registry gates
- the 2026-07-20 escalation commented on closed issue #841 and produced #1277

## Authority boundary

- no operator decision is inferred or resolved
- queue rank and item status remain unchanged
- QGIA remains mediated through L1; this change does not authorize direct QGIA-to-L2 tasking
- all changes remain review-gated in this PR

## Validation

- 11 focused gate-escalation test functions passed in the isolated harness
- Python compilation passed
- `gate_registry.json` parsed successfully
- workflow YAML parsed successfully
- live-file dry run reports zero escalations, zero ungated decisions, and one explicit integrity hold

The scratch runtime did not include the `pytest` package, so the repository CI remains the authoritative pytest execution.

## Risk and rollback

The behavioral change is limited to decision-gate automation. Reverting the squash merge commit restores the prior behavior.

Supersedes #1277.