### PR TITLE
fix(ci): repair four post-merge workflow failures

### DIFF
--- a/.github/workflows/aurora-release.yml
+++ b/.github/workflows/aurora-release.yml
@@ -1,10 +1,8 @@
 name: Aurora Release Pipeline
 
 permissions:
-  contents: write         # Write releases and tags
-  actions: read          # Read workflow status
-  checks: write          # Write check results
-  security-events: write # Write security events
+  contents: write  # Write releases and tags
+  actions: read    # Read workflow status
 
 'on':
   push:
@@ -16,9 +14,6 @@ permissions:
         description: Release version
         required: true
         default: v1.0.0
-permissions:
-  contents: write
-  actions: read
 jobs:
   create-release:
     name: "\U0001F4E6 Create Release"

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -158,7 +158,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: spdx-json
           output-file: sbom.spdx.json
       

--- a/.github/workflows/sonarcloud-issue-reporter.yml
+++ b/.github/workflows/sonarcloud-issue-reporter.yml
@@ -25,45 +25,6 @@ jobs:
         run: |
           echo "number=${{ github.event.check_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
 
-      - name: Fetch SonarCloud violations
-        id: sonar
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PROJECT_KEY: AUo959_aurora-cloudbank-symbolic
-        run: |
-          RESPONSE=$(curl -sf -u "${SONAR_TOKEN}:" \
-            "https://sonarcloud.io/api/issues/search?componentKeys=${PROJECT_KEY}&pullRequest=${PR_NUMBER}&types=BUG,VULNERABILITY&resolved=false&severities=BLOCKER,CRITICAL,MAJOR&ps=50" \
-            2>/dev/null || echo '{"issues":[]}')
-
-          python3 - <<'PYEOF'
-          import json, os, sys
-
-          data = json.loads(os.environ.get('SONAR_RESPONSE', '{}'))
-          issues = data.get('issues', [])
-
-          if not issues:
-              body = '### ✅ SonarCloud: No open BUG/VULNERABILITY issues in new code\n'
-              body += '_The quality gate failure may be caused by a rating threshold rather than individual issues._'
-          else:
-              lines = [f'### ⚠️ SonarCloud Violations ({len(issues)} open)', '']
-              for iss in issues:
-                  component = iss.get('component', '').split(':')[-1]
-                  line = iss.get('line', '?')
-                  rule = iss.get('rule', '')
-                  severity = iss.get('severity', '')
-                  msg = iss.get('message', '')
-                  lines.append(f'- **{severity}** `{component}` line {line} `[{rule}]` {msg}')
-              body = '\n'.join(lines)
-
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write('body<<BODYEOF\n')
-              f.write(body + '\n')
-              f.write('BODYEOF\n')
-          PYEOF
-        env:
-          SONAR_RESPONSE: ${{ steps.sonar.outputs.response }}
-
       - name: Fetch SonarCloud violations (curl + python)
         id: fetch
         env:
@@ -75,37 +36,43 @@ jobs:
             "https://sonarcloud.io/api/issues/search?componentKeys=${PROJECT_KEY}&pullRequest=${PR_NUMBER}&types=BUG,VULNERABILITY&resolved=false&severities=BLOCKER,CRITICAL,MAJOR&ps=50" \
             || echo '{"issues":[]}')
 
-          BODY=$(echo "$RESPONSE" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-issues = data.get('issues', [])
-if not issues:
-    print('### SonarCloud: No open BUG/VULNERABILITY issues returned')
-    print('')
-    print('The quality gate may be failing on a rating metric rather than a specific issue.')
-    print('Check the SonarCloud dashboard directly for details.')
-else:
-    print(f'### ⚠️ SonarCloud Violations ({len(issues)} open)')
-    print('')
-    for iss in issues:
-        component = iss.get('component', '').split(':')[-1]
-        line = iss.get('line', '?')
-        rule = iss.get('rule', '')
-        severity = iss.get('severity', '')
-        msg = iss.get('message', '')
-        print(f'- **{severity}** \`{component}\` line {line} \`[{rule}]\` {msg}')
-")
+          SONAR_RESPONSE="$RESPONSE" python3 <<'PYEOF'
+          import json
+          import os
 
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo "$BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          data = json.loads(os.environ["SONAR_RESPONSE"])
+          issues = data.get("issues", [])
+          if not issues:
+              lines = [
+                  "### SonarCloud: No open BUG/VULNERABILITY issues returned",
+                  "",
+                  "The quality gate may be failing on a rating metric rather than a specific issue.",
+                  "Check the SonarCloud dashboard directly for details.",
+              ]
+          else:
+              lines = [f"### ⚠️ SonarCloud Violations ({len(issues)} open)", ""]
+              for issue in issues:
+                  component = issue.get("component", "").split(":")[-1]
+                  line = issue.get("line", "?")
+                  rule = issue.get("rule", "")
+                  severity = issue.get("severity", "")
+                  message = issue.get("message", "")
+                  lines.append(f"- **{severity}** `{component}` line {line} `[{rule}]` {message}")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write("body<<EOF\n")
+              output.write("\n".join(lines) + "\n")
+              output.write("EOF\n")
+          PYEOF
 
       - name: Post violations comment
         uses: actions/github-script@v7
+        env:
+          SONAR_REPORT_BODY: ${{ steps.fetch.outputs.body }}
         with:
           script: |
             const prNumber = parseInt('${{ steps.pr.outputs.number }}');
-            const body = `## 🔍 SonarCloud Violation Report\n\n${{ steps.fetch.outputs.body }}\n\n_Auto-fetched after quality gate failure. Fix these specific violations to get the gate to pass._`;
+            const body = `## 🔍 SonarCloud Violation Report\n\n${process.env.SONAR_REPORT_BODY}\n\n_Auto-fetched after quality gate failure. Fix these specific violations to get the gate to pass._`;
 
             // Delete previous reports from this workflow to avoid clutter
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/synergy_dashboard.yml
+++ b/.github/workflows/synergy_dashboard.yml
@@ -218,23 +218,7 @@ jobs:
           print("Dashboard generated successfully")
           EOF
           
-      - name: Commit and push dashboard
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/dashboards/synergy_dashboard.md
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "Auto-update: Synergy Dashboard Module (Issue #260)"
-            # Extract branch name and push explicitly to avoid detached HEAD issues
-            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-            git push origin HEAD:"${BRANCH_NAME}"
-          fi
-      
-      - name: Upload dashboard artifact (for PRs)
-        if: github.event_name == 'pull_request'
+      - name: Upload dashboard artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: synergy-dashboard


### PR DESCRIPTION
## Summary

- publish the generated Synergy dashboard as a workflow artifact instead of committing directly to protected `main`
- generate the SBOM from the first exact image tag emitted and pushed by Docker metadata
- make the release workflow loadable by consolidating its duplicate top-level `permissions` mapping
- make the Sonar reporter loadable and executable by removing the duplicate broken fetch step, fixing the embedded Python block, and passing report text through the environment

## Failure evidence

- Synergy Dashboard Module: run `29887259558` failed with `GH006` while pushing its generated commit to protected `main`
- Kubernetes CI/CD Pipeline: run `29887259571` pushed lowercase short-SHA tags but passed Syft an uppercase full-SHA tag
- Aurora release: run `29887259115` created no jobs
- Sonar reporter: run `29887258725` created no jobs

## Validation

- `actionlint` passes for the dashboard, release, and Sonar workflows
- targeted `actionlint` passes for the Kubernetes workflow after excluding its pre-existing unrelated `needs.test` notification-context diagnostic
- mocked SonarCloud response validation passes for both issue and empty-result cases
- `git diff --check`
- diff scope guard confirms only the four issue-tracked workflow files changed

Closes #1305
