### PR TITLE
fix: repair the reviewer's first ninety seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,14 +209,12 @@ Aurora CloudBank 2.1.0 delivers substantial new capabilities with **5 major modu
 
 Aurora CloudBank 2.0.0 represents a **major milestone**: the platform has evolved from experimental research to a **production-grade enterprise system**. This release includes comprehensive platform enhancements, zero HIGH vulnerabilities, and complete documentation overhaul.
 
-### 🏆 Sprint Achievements (Days 1-3, Nov 10-15)
+### Scope of this release (Nov 10-15)
 
-- **24,145 lines deployed** across 6 merged PRs
-- **100% goal achievement** (12 issues closed, 6 PRs merged) - completed **2 days early**
-- **Zero HIGH vulnerabilities** (6 HIGH vulnerabilities fixed during sprint)
-- **Zero open PRs/issues** at sprint completion
-- **109 test files** with comprehensive coverage
-- **48,347 lines** of production Python code
+- 6 HIGH-severity vulnerabilities identified and fixed
+- 12 issues closed across 6 merged PRs
+- PR and issue backlog cleared at release
+- 109 test files covering the platform surface
 
 ### Added
 
@@ -346,8 +344,12 @@ Aurora CloudBank 2.0.0 represents a **major milestone**: the platform has evolve
 
 ### Contributors
 
-Special commendation to the **Days 1-3 Sprint Team** for achieving 100% goal completion 2 days early:
-- **GitHub Copilot Agents** - 24,145 lines of code
+> Contributors below include engineering contributors alongside in-universe
+> operational roles, per the Orion Station operations protocol documented in
+> [`.aurora/README.md`](.aurora/README.md). This is a deliberate convention,
+> not a transcription error.
+
+- **GitHub Copilot Agents** - Implementation across the sprint PRs
 - **Claude Sonnet 4.5** - Documentation and planning
 - **OPS Rodriguez** - Sprint coordination and tactical execution
 - **CI/CD Teams** - Pipeline optimization and automated testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,47 +1,34 @@
-# Contributing to Aurora CloudBank Symbolic# Contributing to Aurora Reflective Autonomy System
+# Contributing to Aurora CloudBank Symbolic
 
-Thank you for your interest in contributing to Aurora! This guide will help you get started and understand our development workflow.Thank you for your interest in contributing!
+Thank you for your interest in contributing to Aurora! This guide will help you
+get started and understand our development workflow.
 
-## 🚀 Quick Start## How to Contribute
+## 🚀 Quick Start
 
-### Prerequisites- Fork the repository
+### Prerequisites
 
-- **Python 3.11+** (3.12 recommended)- Create a new branch for your feature or fix
-
-- **Git** with GPG signing configured (optional but recommended)- Write clear, well-documented code
-
-- **VS Code** with Dev Containers extension (recommended for consistent environment)- Add or update tests as needed
-
-- Submit a pull request with a clear description
+- **Python 3.11+** (3.12 recommended)
+- **Git** with GPG signing configured (optional but recommended)
+- **VS Code** with Dev Containers extension (recommended for a consistent environment)
 
 ### Setup
 
-## Code Style
-
 1. **Fork and clone the repository**
-
-   ```bash- Follow PEP8 for Python code
-
-   git clone https://github.com/YOUR_USERNAME/aurora-cloudbank-symbolic.git- Use descriptive commit messages
-
-   cd aurora-cloudbank-symbolic
-
-   ```## Reporting Issues
-
-
-
-2. **Install dependencies**- Use GitHub Issues to report bugs or request features
-
    ```bash
+   git clone https://github.com/YOUR_USERNAME/aurora-cloudbank-symbolic.git
+   cd aurora-cloudbank-symbolic
+   ```
 
-   # Option A: Dev Container (recommended)## Code of Conduct
-
+2. **Install dependencies**
+   ```bash
+   # Option A: Dev Container (recommended)
    # Open in VS Code and select "Reopen in Container"
 
-   - Be respectful and collaborative
-
    # Option B: Local setup
-   pip3 install -r requirements.txt
+   pip install -r requirements.txt
+
+   # Optional extras (quantum backends, MCP connector, telemetry)
+   pip install -r requirements-optional.txt
    ```
 
 3. **Verify setup**
@@ -232,14 +219,14 @@ pytest -m field_state             # Field state tests only
 
 ### Manual Testing
 ```bash
-# Start Aurora API server
-python aurora_api.py
+# Start the Aurora API server
+make serve-dev            # or: python api/aurora_api.py
 
-# Run CLI
-python aurora_cli.py --help
+# Run the live 4-step onboarding demo against it (second terminal)
+make demo
 
-# Test specific module
-python -c "from modules.field_state_manager import FieldStateManager; print('✅ Import success')"
+# Test a specific module imports cleanly
+python -c "from modules.field_state_manager.field_state_manager import FieldStateManager; print('✅ Import success')"
 ```
 
 ## 📚 Documentation
@@ -255,7 +242,7 @@ python -c "from modules.field_state_manager import FieldStateManager; print('✅
 - `README.md` - Overview and quick start
 - `CONTRIBUTING.md` - This file
 - `docs/LOCAL_TESTING_GUIDE.md` - Testing workflow
-- `docs/CI_WORKFLOW_FIX.md` - CI strategy
+- `docs/archive/CI_WORKFLOW_FIX.md` - CI strategy
 - `ops/work_queue/README.md` - Work queue authority model and `aurora(queue):` convention
 
 ## 🎯 Aurora-Specific Guidelines
@@ -348,7 +335,7 @@ Contributors are recognized in several ways:
 
 - [Geometric Ethics Architecture](docs/GEOMETRIC_ETHICS_ARCHITECTURE.md)
 - [Local Testing Guide](docs/LOCAL_TESTING_GUIDE.md)
-- [CI Workflow Strategy](docs/CI_WORKFLOW_FIX.md)
+- [CI Workflow Strategy](docs/archive/CI_WORKFLOW_FIX.md)
 - [Aurora Documentation](https://auo959.github.io/aurora-cloudbank-symbolic)
 - [Work Queue Guide](ops/work_queue/QUEUE_GUIDE.md)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Aurora CloudBank Symbolic
 
+[![CI](https://github.com/AUo959/aurora-cloudbank-symbolic/actions/workflows/aurora-ci-minimal.yml/badge.svg?branch=main)](https://github.com/AUo959/aurora-cloudbank-symbolic/actions/workflows/aurora-ci-minimal.yml)
+[![CodeQL](https://github.com/AUo959/aurora-cloudbank-symbolic/actions/workflows/codeql-unified.yml/badge.svg?branch=main)](https://github.com/AUo959/aurora-cloudbank-symbolic/actions/workflows/codeql-unified.yml)
 [![Python](https://img.shields.io/badge/python-3.11+-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.128+-green)](https://fastapi.tiangolo.com/)
-[![Pydantic](https://img.shields.io/badge/Pydantic-v2-orange)](https://docs.pydantic.dev/)
 
 A quantum-symbolic computing platform for enterprise AI. Combines hierarchical memory management, quantum circuit simulation, multi-model AI orchestration, geometric ethics enforcement, and production observability in a single FastAPI application.
 
@@ -80,7 +80,7 @@ aurora-cloudbank-symbolic/
 │   ├── synergy/           # Component registry and dependency graph
 │   ├── integrations/      # ChatGPT and Gemini agent integrations
 │   └── core/              # DLP tracking, request envelope, time utilities
-├── tests/                 # 253 test files (pytest)
+├── tests/                 # 293 test files (pytest)
 ├── docs/                  # Reference documentation
 ├── scripts/               # Development and maintenance automation
 └── cli/                   # Command-line tools
@@ -147,7 +147,7 @@ All modules follow a consistent layout: `__init__.py`, `core.py`, `api.py`, `mod
 
 ## API
 
-The server exposes ~339 HTTP routes across 30+ routers. All routes return JSON.
+The server exposes 301 operations across 293 paths and 30 routers. All routes return JSON.
 
 **Access the interactive docs:**
 
@@ -159,14 +159,30 @@ The server exposes ~339 HTTP routes across 30+ routers. All routes return JSON.
 
 | Group | Prefix | Description |
 |---|---|---|
-| AuMemManager | `/aumem/` | Memory CRUD, semantic retrieval, quantum vector creation, metrics |
-| Quantum Simulator | `/api/quantum/` | Scenario execution, backend selection, result retrieval |
-| Synergy | `/api/synergy/` | Component registry, dependency graph, health |
-| Monitoring | `/api/monitoring/` | Drift alerts, ethics compliance, audit logs |
-| R2 Telemetry | `/api/telemetry/` | Trace export, Prometheus metrics |
-| Auth | `/api/auth/` | JWT token issuance and refresh |
-| GUMAS | `/api/gumas/` | Ethics alignment enforcement |
+| AuMemManager | `/memory/` | Memory CRUD, semantic retrieval, quantum vector creation, metrics |
+| Quantum Simulator | `/simulate/` | Scenario execution, backend selection, result retrieval, forecasting |
+| Synergy | `/synergy/` | Component registry, dependency graph, health |
+| Monitoring | `/monitoring/` | Drift alerts, baselines, behavioural checks |
+| Insight Ledger | `/ledger/` | Audit entries, chain verification, export |
+| R2 Telemetry | `/r2-telemetry/` | Trace export, Prometheus metrics |
+| GUMAS | `/gumas/` | Ethics alignment enforcement |
 | Sensors | `/api/sensors/` | System sensor array |
+| Subroutines | `/subroutines/` | Registration and sandboxed execution |
+
+**State-changing requests need a CSRF token.** Fetch one from
+`GET /api/csrf-token` and send it back as the `X-CSRF-Token` header:
+
+```bash
+TOKEN=$(curl -s localhost:8000/api/csrf-token | jq -r .csrf_token)
+curl -X POST localhost:8000/memory/create \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $TOKEN" -H "Authorization: Bearer $TOKEN" \
+  -d '{"content":"hello","memory_type":"agent","owner":"you"}'
+```
+
+The `/api/auth/` router registers only when authentication users are
+configured (`AURORA_AUTH_USERS_JSON` or `AURORA_AUTH_USERS_FILE`); a default
+local run starts without it and logs the reason.
 
 **CloudHub GUI routes:**
 
@@ -175,6 +191,22 @@ The server exposes ~339 HTTP routes across 30+ routers. All routes return JSON.
 - `/legacy/vsa` — Retired Quantum VSA playground notice
 
 See [`docs/reference/API_CATALOG.md`](docs/reference/API_CATALOG.md) for the full route listing.
+
+### MCP connector
+
+Aurora's live state is also exposed over the [Model Context Protocol](https://modelcontextprotocol.io),
+so any MCP-capable host (Claude Desktop, Claude Code, and others) can read it
+directly. Five read-only tools: `aurora_get_state`, `aurora_get_agents`,
+`aurora_get_drift`, `aurora_get_ethics_log`, `aurora_get_capsules`.
+
+```bash
+pip install -r requirements-optional.txt   # provides the mcp SDK
+python -m connector.server                 # stdio transport
+```
+
+Elevated operations are gated behind an HMAC-signed, expiring Pilot seal.
+Setup, transport options, and a ready `claude_desktop_config.json` block are in
+[`connector/README.md`](connector/README.md).
 
 ---
 

--- a/api/aurora_api.py
+++ b/api/aurora_api.py
@@ -9,6 +9,7 @@ Enhanced with Claude Sonnet 4 capabilities and ChatGPT Agent Mode integration.
 import asyncio
 import logging
 import os
+import secrets
 import time
 from contextlib import asynccontextmanager
 
@@ -1267,6 +1268,47 @@ def health_check_api(request: Request):
 
 
 # ================================
+# CSRF Token Issuance
+# ================================
+
+@app.get("/api/csrf-token")
+@limiter.limit("60/minute")
+def issue_csrf_token(request: Request):
+    """
+    Issue a CSRF token for use with state-changing requests.
+
+    GlobalCsrfMiddleware rejects any unsafe-method request to a non-allowlisted
+    path that does not carry a valid X-CSRF-Token header. This endpoint is the
+    issuance half of that contract — it is itself on the middleware allowlist
+    (see src/middleware/csrf_middleware.py::_CSRF_ALLOWLIST).
+
+    The token is a stateless HMAC over ``session_id.timestamp`` keyed by
+    CSRF_SECRET_KEY, valid for CSRF_TOKEN_EXPIRY_SECONDS. Callers that already
+    hold a session identifier may pass it as ``session_id`` so the token is
+    bound to that session; otherwise a random one is generated.
+
+    Note on threat model: because the token is not bound to a cookie or
+    authenticated session by default, it defends against blind cross-origin
+    submission but is only as strong as the CORS policy in front of it. Keep
+    ALLOWED_CORS_ORIGINS restrictive in any deployment that relies on it.
+
+    DLP: csrf_token_issuance
+    """
+    from src.middleware.fastapi_security import (
+        CSRF_TOKEN_EXPIRY_SECONDS,
+        generate_csrf_token,
+    )
+
+    session_id = request.query_params.get("session_id") or secrets.token_urlsafe(16)
+    return {
+        "csrf_token": generate_csrf_token(session_id),
+        "session_id": session_id,
+        "header": "X-CSRF-Token",
+        "expires_in_seconds": CSRF_TOKEN_EXPIRY_SECONDS,
+    }
+
+
+# ================================
 # Telemetry and Observability Endpoints
 # ================================
 
@@ -1736,7 +1778,8 @@ class HandshakeRequest(BaseModel):
 @app.post("/api/thread-bridge/handshake", dependencies=[Depends(security), Depends(verify_csrf_token)])
 @limiter.limit("10/minute")
 async def thread_bridge_handshake_endpoint(
-    request: HandshakeRequest,
+    payload: HandshakeRequest,
+    request: Request,
     token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
@@ -1754,7 +1797,7 @@ async def thread_bridge_handshake_endpoint(
 
     try:
         bridge = get_bridge_instance()
-        result = bridge.handshake(request.thread_id)
+        result = bridge.handshake(payload.thread_id)
 
         if not result.get("success"):
             return JSONResponse(
@@ -1788,7 +1831,8 @@ class ValidateRequest(BaseModel):
 @app.post("/api/thread-bridge/validate", dependencies=[Depends(security), Depends(verify_csrf_token)])
 @limiter.limit("30/minute")
 async def thread_bridge_validate_endpoint(
-    request: ValidateRequest,
+    payload: ValidateRequest,
+    request: Request,
     token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
@@ -1805,7 +1849,7 @@ async def thread_bridge_validate_endpoint(
 
     try:
         bridge = get_bridge_instance()
-        validation = bridge.validate_continuity(request.source, request.target)
+        validation = bridge.validate_continuity(payload.source, payload.target)
 
         return {
             "success": True,
@@ -1862,7 +1906,8 @@ class TransferRequest(BaseModel):
 @app.post("/api/thread-bridge/transfer", dependencies=[Depends(security), Depends(verify_csrf_token)])
 @limiter.limit("10/minute")
 async def thread_bridge_transfer_endpoint(
-    request: TransferRequest,
+    payload: TransferRequest,
+    request: Request,
     token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
@@ -1881,9 +1926,9 @@ async def thread_bridge_transfer_endpoint(
     try:
         bridge = get_bridge_instance()
         result = bridge.transfer_context(
-            source=request.source,
-            target=request.target,
-            context_data=request.context_data
+            source=payload.source,
+            target=payload.target,
+            context_data=payload.context_data
         )
 
         if not result.get("success"):
@@ -2266,7 +2311,8 @@ async def v2_trigger_election(request: Request, token: HTTPAuthorizationCredenti
 @app.post("/api/v2/repos/register", dependencies=[Depends(security), Depends(verify_csrf_token)])
 @limiter.limit("20/minute")
 async def v2_register_repository(
-    request: RepositoryRegisterRequest,
+    payload: RepositoryRegisterRequest,
+    request: Request,
     token: HTTPAuthorizationCredentials = Depends(security)
 ):
     """
@@ -2284,9 +2330,9 @@ async def v2_register_repository(
     try:
         synchronizer = get_repository_synchronizer()
         repo_info = await synchronizer.register_repository(
-            repo_id=request.repo_id,
-            repo_path=request.repo_path,
-            branch=request.branch
+            repo_id=payload.repo_id,
+            repo_path=payload.repo_path,
+            branch=payload.branch
         )
 
         return {

--- a/connector/README.md
+++ b/connector/README.md
@@ -1,7 +1,8 @@
 # Aurora Cloudbank MCP Connector
 
-> Version: 0.1.0 (scaffold)  
+> Version: 0.1.0  
 > Status: ✅ v0.1.0 — all five read-only tools wired to live Aurora API endpoints  
+> Install: `pip install -r requirements-optional.txt` (provides the `mcp` SDK)  
 > Protocol: [Model Context Protocol (MCP)](https://modelcontextprotocol.io)  
 > Transport: stdio (default) | SSE (HTTP streaming)
 

--- a/modules/aumemmanager/api_integration.py
+++ b/modules/aumemmanager/api_integration.py
@@ -6,10 +6,13 @@ FastAPI endpoints for hierarchical memory management with quantum-symbolic capab
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
+import logging
 import time
 
 from modules.aumemmanager import HierarchicalMemoryManager, MemoryType
 from src.middleware.fastapi_security import limiter, require_csrf_token
+
+logger = logging.getLogger(__name__)
 
 # Global memory manager instance (in production, this would be properly managed)
 memory_manager = HierarchicalMemoryManager(max_active_memories=1000)
@@ -93,24 +96,24 @@ class SystemMetricsResponse(BaseModel):
 
 @router.post("/create", response_model=Dict[str, str], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 @limiter.limit("60/minute")  # Memory write - rate limited per IP
-async def create_memory(request: MemoryCreateRequest, http_request: Request):
+async def create_memory(payload: MemoryCreateRequest, request: Request):
     """Create a new memory item with quantum-symbolic capabilities"""
     try:
         # Convert string memory type to enum
         try:
-            memory_type = MemoryType(request.memory_type.lower())
+            memory_type = MemoryType(payload.memory_type.lower())
         except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid memory type: {request.memory_type}")
+            raise HTTPException(status_code=400, detail=f"Invalid memory type: {payload.memory_type}")
 
         memory_id = memory_manager.add_memory(
-            content=request.content,
+            content=payload.content,
             memory_type=memory_type,
-            owner=request.owner,
-            importance=request.importance,
-            tags=request.tags,
-            quantum_properties=request.quantum_properties,
-            aurora_anchors=request.aurora_anchors,
-            cultural_score=request.cultural_score,
+            owner=payload.owner,
+            importance=payload.importance,
+            tags=payload.tags,
+            quantum_properties=payload.quantum_properties,
+            aurora_anchors=payload.aurora_anchors,
+            cultural_score=payload.cultural_score,
         )
 
         return {
@@ -119,7 +122,10 @@ async def create_memory(request: MemoryCreateRequest, http_request: Request):
             "message": f"Memory created successfully with ID: {memory_id}",
         }
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -176,21 +182,24 @@ async def retrieve_memories(request: MemoryRetrievalRequest):
 
         return response_memories
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/quantum/create_vector", response_model=Dict[str, Any], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 @limiter.limit("60/minute")  # Memory write - rate limited per IP
-async def create_quantum_vector(request: QuantumVectorRequest, http_request: Request):
+async def create_quantum_vector(payload: QuantumVectorRequest, request: Request):
     """Create a quantum-symbolic vector for memory management"""
     try:
         qv = memory_manager.flight_controller.create_quantum_vector(
-            vector_id=request.vector_id,
-            magnitude=request.magnitude,
-            phase=request.phase,
-            aurora_anchors=request.aurora_anchors,
-            dlp_classification=request.dlp_classification,
+            vector_id=payload.vector_id,
+            magnitude=payload.magnitude,
+            phase=payload.phase,
+            aurora_anchors=payload.aurora_anchors,
+            dlp_classification=payload.dlp_classification,
         )
 
         return {
@@ -202,7 +211,10 @@ async def create_quantum_vector(request: QuantumVectorRequest, http_request: Req
             "status": "created",
         }
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -223,30 +235,36 @@ async def entangle_vectors(vector1_id: str, vector2_id: str, request: Request):
         else:
             raise HTTPException(status_code=404, detail="One or both vectors not found")
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/quantum/trajectory", response_model=Dict[str, Any], dependencies=SENSITIVE_MEMORY_DEPENDENCIES)
 @limiter.limit("60/minute")  # Memory write - rate limited per IP
-async def compute_trajectory(request: TrajectoryRequest, http_request: Request):
+async def compute_trajectory(payload: TrajectoryRequest, request: Request):
     """Compute quantum vector trajectory using flight control"""
     try:
-        target_state = {"magnitude": request.target_magnitude, "phase": request.target_phase}
+        target_state = {"magnitude": payload.target_magnitude, "phase": payload.target_phase}
 
         trajectory = memory_manager.flight_controller.compute_trajectory(
-            vector_id=request.vector_id, target_state=target_state, trajectory_type=request.trajectory_type
+            vector_id=payload.vector_id, target_state=target_state, trajectory_type=payload.trajectory_type
         )
 
         return {
-            "vector_id": request.vector_id,
-            "trajectory_type": request.trajectory_type,
+            "vector_id": payload.vector_id,
+            "trajectory_type": payload.trajectory_type,
             "waypoints": len(trajectory),
             "trajectory": trajectory,
             "status": "computed",
         }
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -268,7 +286,10 @@ async def get_system_metrics():
             quantum_network_density=metrics.get("quantum_network_density", 0.0),
         )
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -285,7 +306,10 @@ async def batch_process_lifecycle():
             "message": "Batch lifecycle processing completed successfully",
         }
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -307,7 +331,10 @@ async def compress_memories(
             "results": results,
         }
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -318,7 +345,10 @@ async def export_system_state():
         state = memory_manager.export_state()
         return {"status": "exported", "export_timestamp": state["export_timestamp"], "system_state": state}
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -329,7 +359,10 @@ async def get_quantum_network_analysis():
         analysis = memory_manager.flight_controller.get_entanglement_network_analysis()
         return {"status": "analyzed", "timestamp": time.time(), "network_analysis": analysis}
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in aumemmanager route")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/modules/qgia/README.md
+++ b/modules/qgia/README.md
@@ -68,7 +68,7 @@ No `networkx` dependency — trust graph uses adjacency dicts.
 ## Related Documents
 
 - [QGIA L1 Node Registration](../../docs/architecture/QGIA_L1_NODE_REGISTRATION.md)
-- [Analyst Orientation Guide](../../docs/philosophy/07_ANALYST_ORIENTATION.md)
+- [Analyst Orientation Guide](../../docs/archive/philosophy/07_ANALYST_ORIENTATION.md)
 - [QGIA Canon Staff Registry](../../docs/architecture/QGIA_CANON_STAFF_REGISTRY.md)
 
 ## Parameter Reference

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -83,3 +83,11 @@ kombu>=5.3.0                        # Messaging library
 opentelemetry-api>=1.42.1           # OpenTelemetry API
 opentelemetry-sdk>=1.42.1           # OpenTelemetry SDK
 sentry-sdk>=2.65.0                  # Error tracking
+
+# ===================================================================
+# MCP CONNECTOR (Optional)
+# ===================================================================
+# Required by connector/server.py to expose Aurora state over the Model
+# Context Protocol. Without it the connector and tests/connector are
+# unavailable; the core API is unaffected. See connector/README.md.
+mcp>=1.28.1                         # Model Context Protocol SDK

--- a/scripts/aurora_onboard.py
+++ b/scripts/aurora_onboard.py
@@ -422,6 +422,24 @@ def main(
     args = build_parser().parse_args(argv)
     output = stream or sys.stdout
     root = repo_root or Path(__file__).resolve().parents[1]
+
+    # No terminal attached (piped, redirected, CI, container) means the
+    # interactive prompts can never be answered. Degrade to the same path as
+    # --skip-interactive rather than failing on EOF, so `make onboard` in a
+    # non-tty context still produces a useful report. Only applies when reading
+    # from real stdin — an injected input_fn supplies its own answers.
+    if (
+        not args.skip_interactive
+        and not args.agent
+        and input_fn is input
+        and not sys.stdin.isatty()
+    ):
+        args.skip_interactive = True
+        print(
+            "ℹ️  No interactive terminal detected — running in non-interactive mode "
+            "(equivalent to --skip-interactive).",
+            file=output,
+        )
     started = time.perf_counter()
     app = AuroraOnboarding(root=root, stream=output, input_fn=input_fn)
     try:

--- a/tests/connector/conftest.py
+++ b/tests/connector/conftest.py
@@ -1,0 +1,52 @@
+"""Shared fixtures and guards for the MCP connector test package.
+
+Several tests here construct a live ``CloudbankBridge``, which fails closed
+without ``AURORA_CONNECTOR_TOKEN`` (see #824) and then issues real HTTP
+requests to ``AURORA_API_BASE_URL``. They are integration tests despite
+carrying ``@pytest.mark.unit``.
+
+Rather than let them fail on every developer machine — and leak partially
+initialised connector state into unrelated tests that run after them — they
+are skipped unless the connector environment is actually configured.
+
+To run them:
+
+    export AURORA_CONNECTOR_TOKEN=<token>
+    export AURORA_API_BASE_URL=http://localhost:8000   # optional, this is the default
+    make serve-dev                                     # in another terminal
+    pytest tests/connector
+"""
+
+import os
+
+import pytest
+
+# Modules whose tests reach a live bridge. Everything else in this package
+# (seal HMAC, schema validation of declared inputs, server dispatch and error
+# mapping) is genuinely offline and always runs.
+_REQUIRES_LIVE_BRIDGE = {
+    "test_tools.py",
+    "test_bridge_headers.py",
+    "test_transport.py",
+    "test_schema_validation.py",
+}
+
+_SKIP_REASON = (
+    "connector integration tests need AURORA_CONNECTOR_TOKEN and a running "
+    "Aurora API; see tests/connector/conftest.py"
+)
+
+
+def _connector_env_configured() -> bool:
+    return bool(os.getenv("AURORA_CONNECTOR_TOKEN"))
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip live-bridge tests unless the connector environment is configured."""
+    if _connector_env_configured():
+        return
+
+    skip_marker = pytest.mark.skip(reason=_SKIP_REASON)
+    for item in items:
+        if item.path.name in _REQUIRES_LIVE_BRIDGE:
+            item.add_marker(skip_marker)

--- a/tests/connector/test_auth_token.py
+++ b/tests/connector/test_auth_token.py
@@ -40,7 +40,7 @@ def seal_secret(monkeypatch):
 @pytest.mark.security
 def test_generated_seal_has_four_colon_separated_fields(seal_secret):
     seal = generate_pilot_seal("operator-1", scope="read")
-    assert len(seal.split(":")) == 4
+    assert len(seal.split(":")) == 4  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -59,15 +59,15 @@ def test_generate_requires_configured_secret(monkeypatch):
 @pytest.mark.unit
 @pytest.mark.security
 def test_freshly_generated_seal_validates(seal_secret):
-    assert is_valid_pilot_seal(generate_pilot_seal("operator-1")) is True
+    assert is_valid_pilot_seal(generate_pilot_seal("operator-1")) is True  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
 @pytest.mark.security
 def test_seal_expiring_in_the_future_is_accepted(seal_secret):
     seal = generate_pilot_seal("operator-1", exp_seconds=60)
-    assert int(seal.split(":")[2]) > time.time()
-    assert is_valid_pilot_seal(seal) is True
+    assert int(seal.split(":")[2]) > time.time()  # nosec B101 - pytest assertion
+    assert is_valid_pilot_seal(seal) is True  # nosec B101 - pytest assertion
 
 
 # ---------------------------------------------------------------------------
@@ -80,7 +80,7 @@ def test_seal_expiring_in_the_future_is_accepted(seal_secret):
 def test_seal_is_rejected_without_configured_secret(seal_secret, monkeypatch):
     seal = generate_pilot_seal("operator-1")
     monkeypatch.delenv("AURORA_PILOT_SEAL_SECRET", raising=False)
-    assert is_valid_pilot_seal(seal) is False
+    assert is_valid_pilot_seal(seal) is False  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -88,7 +88,7 @@ def test_seal_is_rejected_without_configured_secret(seal_secret, monkeypatch):
 def test_seal_signed_with_a_different_secret_is_rejected(seal_secret, monkeypatch):
     seal = generate_pilot_seal("operator-1")
     monkeypatch.setenv("AURORA_PILOT_SEAL_SECRET", "a-different-secret")
-    assert is_valid_pilot_seal(seal) is False
+    assert is_valid_pilot_seal(seal) is False  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -98,7 +98,7 @@ def test_tampered_scope_is_rejected(seal_secret):
     operator_id, _scope, exp, mac = generate_pilot_seal(
         "operator-1", scope="read"
     ).split(":")
-    assert is_valid_pilot_seal(f"{operator_id}:write:{exp}:{mac}") is False
+    assert is_valid_pilot_seal(f"{operator_id}:write:{exp}:{mac}") is False  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -107,20 +107,20 @@ def test_extended_expiry_is_rejected(seal_secret):
     """Pushing out the expiry must break the HMAC."""
     operator_id, scope, exp, mac = generate_pilot_seal("operator-1").split(":")
     forged_exp = int(exp) + 86_400
-    assert is_valid_pilot_seal(f"{operator_id}:{scope}:{forged_exp}:{mac}") is False
+    assert is_valid_pilot_seal(f"{operator_id}:{scope}:{forged_exp}:{mac}") is False  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
 @pytest.mark.security
 def test_expired_seal_is_rejected(seal_secret):
     seal = generate_pilot_seal("operator-1", exp_seconds=-1)
-    assert is_valid_pilot_seal(seal) is False
+    assert is_valid_pilot_seal(seal) is False  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
 @pytest.mark.security
 def test_non_integer_expiry_is_rejected(seal_secret):
-    assert is_valid_pilot_seal("operator-1:read:not-a-number:deadbeef") is False
+    assert is_valid_pilot_seal("operator-1:read:not-a-number:deadbeef") is False  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -136,14 +136,14 @@ def test_non_integer_expiry_is_rejected(seal_secret):
     ],
 )
 def test_malformed_seals_are_rejected(seal_secret, seal):
-    assert is_valid_pilot_seal(seal) is False
+    assert is_valid_pilot_seal(seal) is False  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
 @pytest.mark.security
 def test_v0_1_substring_seal_is_rejected(seal_secret):
     """The pre-#822 substring seal must no longer validate."""
-    assert is_valid_pilot_seal("AURORA-PILOT-SEAL-VERIFIED") is False
+    assert is_valid_pilot_seal("AURORA-PILOT-SEAL-VERIFIED") is False  # nosec B101 - pytest assertion
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +160,7 @@ def test_validate_environment_exits_on_missing_token(monkeypatch):
     with pytest.raises(SystemExit) as exc_info:
         validate_environment()
 
-    assert exc_info.value.code == 1
+    assert exc_info.value.code == 1  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -172,7 +172,7 @@ def test_validate_environment_exits_on_missing_base_url(monkeypatch):
     with pytest.raises(SystemExit) as exc_info:
         validate_environment()
 
-    assert exc_info.value.code == 1
+    assert exc_info.value.code == 1  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit

--- a/tests/connector/test_auth_token.py
+++ b/tests/connector/test_auth_token.py
@@ -1,68 +1,149 @@
 """
 Tests for connector/auth/token.py
-Covers: is_valid_pilot_seal, validate_environment (missing vars, all vars present).
+
+Covers the v0.2+ HMAC Pilot seal (generate_pilot_seal / is_valid_pilot_seal)
+and validate_environment.
+
+These tests previously asserted the v0.1 substring-matching seal, which the
+#822 hardening pass deliberately removed. Seals are now
+``{operator_id}:{scope}:{exp_unix}:{hmac_hex}``, signed with
+AURORA_PILOT_SEAL_SECRET and rejected once expired.
 """
 
-import os
-import sys
+import time
 
 import pytest
 
 from connector.auth.token import (
-    PILOT_SEAL_SIGNATURE,
     REQUIRED_ENV_VARS,
+    generate_pilot_seal,
     is_valid_pilot_seal,
     validate_environment,
 )
 
+SECRET = "test-pilot-seal-secret-not-for-production"
+
+
+@pytest.fixture
+def seal_secret(monkeypatch):
+    """Configure the signing secret for seal generation and validation."""
+    monkeypatch.setenv("AURORA_PILOT_SEAL_SECRET", SECRET)
+    return SECRET
+
 
 # ---------------------------------------------------------------------------
-# is_valid_pilot_seal
+# generate_pilot_seal
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_valid_pilot_seal_exact_match():
-    """Exact PILOT_SEAL_SIGNATURE string must return True."""
-    assert is_valid_pilot_seal(PILOT_SEAL_SIGNATURE) is True
+def test_generated_seal_has_four_colon_separated_fields(seal_secret):
+    seal = generate_pilot_seal("operator-1", scope="read")
+    assert len(seal.split(":")) == 4
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_valid_pilot_seal_case_insensitive():
-    """Seal validation is case-insensitive; uppercased seal must still pass."""
-    assert is_valid_pilot_seal(PILOT_SEAL_SIGNATURE.upper()) is True
+def test_generate_requires_configured_secret(monkeypatch):
+    monkeypatch.delenv("AURORA_PILOT_SEAL_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        generate_pilot_seal("operator-1")
+
+
+# ---------------------------------------------------------------------------
+# is_valid_pilot_seal — acceptance
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_valid_pilot_seal_embedded_in_longer_string():
-    """Seal signature embedded inside a longer string must still validate."""
-    wrapped = f"PREFIX {PILOT_SEAL_SIGNATURE} SUFFIX"
-    assert is_valid_pilot_seal(wrapped) is True
+def test_freshly_generated_seal_validates(seal_secret):
+    assert is_valid_pilot_seal(generate_pilot_seal("operator-1")) is True
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_invalid_pilot_seal_wrong_string():
-    """A completely wrong seal string must return False."""
-    assert is_valid_pilot_seal("wrong-seal-value") is False
+def test_seal_expiring_in_the_future_is_accepted(seal_secret):
+    seal = generate_pilot_seal("operator-1", exp_seconds=60)
+    assert int(seal.split(":")[2]) > time.time()
+    assert is_valid_pilot_seal(seal) is True
+
+
+# ---------------------------------------------------------------------------
+# is_valid_pilot_seal — rejection
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_invalid_pilot_seal_empty_string():
-    """An empty seal must return False."""
-    assert is_valid_pilot_seal("") is False
+def test_seal_is_rejected_without_configured_secret(seal_secret, monkeypatch):
+    seal = generate_pilot_seal("operator-1")
+    monkeypatch.delenv("AURORA_PILOT_SEAL_SECRET", raising=False)
+    assert is_valid_pilot_seal(seal) is False
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_invalid_pilot_seal_partial_match():
-    """A partial / truncated seal must return False."""
-    partial = PILOT_SEAL_SIGNATURE[:10]
-    assert is_valid_pilot_seal(partial) is False
+def test_seal_signed_with_a_different_secret_is_rejected(seal_secret, monkeypatch):
+    seal = generate_pilot_seal("operator-1")
+    monkeypatch.setenv("AURORA_PILOT_SEAL_SECRET", "a-different-secret")
+    assert is_valid_pilot_seal(seal) is False
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_tampered_scope_is_rejected(seal_secret):
+    """Escalating scope in a validly-signed seal must break the HMAC."""
+    operator_id, _scope, exp, mac = generate_pilot_seal(
+        "operator-1", scope="read"
+    ).split(":")
+    assert is_valid_pilot_seal(f"{operator_id}:write:{exp}:{mac}") is False
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_extended_expiry_is_rejected(seal_secret):
+    """Pushing out the expiry must break the HMAC."""
+    operator_id, scope, exp, mac = generate_pilot_seal("operator-1").split(":")
+    forged_exp = int(exp) + 86_400
+    assert is_valid_pilot_seal(f"{operator_id}:{scope}:{forged_exp}:{mac}") is False
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_expired_seal_is_rejected(seal_secret):
+    seal = generate_pilot_seal("operator-1", exp_seconds=-1)
+    assert is_valid_pilot_seal(seal) is False
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_non_integer_expiry_is_rejected(seal_secret):
+    assert is_valid_pilot_seal("operator-1:read:not-a-number:deadbeef") is False
+
+
+@pytest.mark.unit
+@pytest.mark.security
+@pytest.mark.parametrize(
+    "seal",
+    [
+        "",
+        "wrong-seal-value",
+        "operator-1:read",
+        "operator-1:read:123",
+        "operator-1:read:123:mac:extra",
+    ],
+)
+def test_malformed_seals_are_rejected(seal_secret, seal):
+    assert is_valid_pilot_seal(seal) is False
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_v0_1_substring_seal_is_rejected(seal_secret):
+    """The pre-#822 substring seal must no longer validate."""
+    assert is_valid_pilot_seal("AURORA-PILOT-SEAL-VERIFIED") is False
 
 
 # ---------------------------------------------------------------------------
@@ -73,8 +154,6 @@ def test_invalid_pilot_seal_partial_match():
 @pytest.mark.unit
 @pytest.mark.security
 def test_validate_environment_exits_on_missing_token(monkeypatch):
-    """validate_environment() must call sys.exit(1) when AURORA_CONNECTOR_TOKEN is absent."""
-    # Remove all required env vars
     for var in REQUIRED_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
 
@@ -87,7 +166,6 @@ def test_validate_environment_exits_on_missing_token(monkeypatch):
 @pytest.mark.unit
 @pytest.mark.security
 def test_validate_environment_exits_on_missing_base_url(monkeypatch):
-    """validate_environment() must call sys.exit(1) when AURORA_API_BASE_URL is absent."""
     monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", "test-token-123")
     monkeypatch.delenv("AURORA_API_BASE_URL", raising=False)
 
@@ -100,38 +178,29 @@ def test_validate_environment_exits_on_missing_base_url(monkeypatch):
 @pytest.mark.unit
 @pytest.mark.security
 def test_validate_environment_passes_with_required_vars(monkeypatch):
-    """validate_environment() must not raise or exit when all required vars are set."""
     monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", "test-token-abc")
     monkeypatch.setenv("AURORA_API_BASE_URL", "http://localhost:8000")
-    # Remove optional pilot seal so we don't accidentally trigger its branch
     monkeypatch.delenv("AURORA_PILOT_SEAL", raising=False)
 
-    # Must not raise SystemExit
     validate_environment()
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_validate_environment_accepts_valid_pilot_seal(monkeypatch):
-    """validate_environment() must accept a valid pilot seal without exiting."""
+def test_validate_environment_accepts_valid_pilot_seal(seal_secret, monkeypatch):
     monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", "test-token-abc")
     monkeypatch.setenv("AURORA_API_BASE_URL", "http://localhost:8000")
-    monkeypatch.setenv("AURORA_PILOT_SEAL", PILOT_SEAL_SIGNATURE)
+    monkeypatch.setenv("AURORA_PILOT_SEAL", generate_pilot_seal("operator-1"))
 
-    # Must not raise
     validate_environment()
 
 
 @pytest.mark.unit
 @pytest.mark.security
-def test_validate_environment_accepts_invalid_pilot_seal_with_warning(monkeypatch):
-    """
-    validate_environment() must not exit for an invalid pilot seal —
-    it only logs a warning. Exit is reserved for missing required vars.
-    """
+def test_validate_environment_tolerates_invalid_pilot_seal(seal_secret, monkeypatch):
+    """An invalid seal degrades to read-only rather than exiting."""
     monkeypatch.setenv("AURORA_CONNECTOR_TOKEN", "test-token-abc")
     monkeypatch.setenv("AURORA_API_BASE_URL", "http://localhost:8000")
-    monkeypatch.setenv("AURORA_PILOT_SEAL", "bad-seal-value")
+    monkeypatch.setenv("AURORA_PILOT_SEAL", "not-a-valid-seal")
 
-    # Must not raise
     validate_environment()

--- a/tests/connector/test_tools.py
+++ b/tests/connector/test_tools.py
@@ -404,7 +404,7 @@ async def test_get_capsules_total_verified_matches_payload():
     tool = GetCapsulesTool()
     result = await tool.run({})
     data = json.loads(result)
-    assert data["total_verified"] == len(data["capsules"])
+    assert data["total_verified"] == len(data["capsules"])  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit
@@ -414,7 +414,7 @@ async def test_get_capsules_default_returns_all_capsules():
     tool = GetCapsulesTool()
     result = await tool.run({})
     data = json.loads(result)
-    assert len(data["capsules"]) == data["total_verified"]
+    assert len(data["capsules"]) == data["total_verified"]  # nosec B101 - pytest assertion
 
 
 @pytest.mark.unit

--- a/tests/connector/test_tools.py
+++ b/tests/connector/test_tools.py
@@ -23,7 +23,7 @@ from connector.tools.get_state import GetStateTool
 from connector.tools.get_agents import GetAgentsTool
 from connector.tools.get_drift import GetDriftTool, DRIFT_THRESHOLDS
 from connector.tools.get_ethics import GetEthicsLogTool
-from connector.tools.get_capsules import GetCapsulesTool, TOTAL_VERIFIED_CAPSULES
+from connector.tools.get_capsules import GetCapsulesTool
 
 
 # ---------------------------------------------------------------------------
@@ -394,22 +394,27 @@ async def test_get_capsules_default_returns_valid_json():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_capsules_total_verified_matches_constant():
-    """total_verified in response must equal TOTAL_VERIFIED_CAPSULES constant."""
+async def test_get_capsules_total_verified_matches_payload():
+    """total_verified must agree with the number of capsules returned.
+
+    Was asserted against a hardcoded TOTAL_VERIFIED_CAPSULES constant from the
+    v0.1 stub; the tool now counts what it actually loaded (#828), so the
+    meaningful invariant is internal consistency of the response.
+    """
     tool = GetCapsulesTool()
     result = await tool.run({})
     data = json.loads(result)
-    assert data["total_verified"] == TOTAL_VERIFIED_CAPSULES
+    assert data["total_verified"] == len(data["capsules"])
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_capsules_default_returns_all_capsules():
-    """run({}) with no filter must return all verified capsules."""
+    """run({}) with no filter must return every capsule it counted."""
     tool = GetCapsulesTool()
     result = await tool.run({})
     data = json.loads(result)
-    assert len(data["capsules"]) == TOTAL_VERIFIED_CAPSULES
+    assert len(data["capsules"]) == data["total_verified"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Everything here is on the path a first-time reader walks: clone, read the
README, run the demo, open CONTRIBUTING. Each item was found by actually
walking it, and each fix was verified by walking it again.

## The significant one — 111 endpoints were unreachable

`GlobalCsrfMiddleware` allowlists `/api/csrf-token` as *"the token issuance
endpoint itself"*, but that route was never registered on the primary app.
`generate_csrf_token` was only reachable from the CloudHub GUI's template
context, so **no HTTP client could obtain a CSRF token** and all 111 mutating
operations returned 403 to every external caller. The onboarding demo failed
2 of 4 steps on exactly this — memory-write and ethics-evaluation, the two
most interesting things it demonstrates.

Registers `GET /api/csrf-token`. Verified: no token → 403, malformed → 403,
issued token → reaches the handler. Enforcement is unchanged.

Provenance: #784 made enforcement global; issuance never shipped alongside it.

## Also fixed

**7 rate-limited handlers were broken at call time.** Their Pydantic body
parameter was named `request`, which SlowAPI resolves as the Starlette
`Request` — it found a `BaseModel` and raised on every call. Renamed to
`payload` across `api/aurora_api.py` and `modules/aumemmanager/`.

**Intentional 4xx were reported as 500.** Every route in `api_integration.py`
wrapped its body in `except Exception` with no `HTTPException` guard, so a
bad `memory_type` returned a server error. Now 400, and the swallowed
exception is logged rather than discarded.

**`tests/connector` could not be collected at all** — two imports referenced
constants removed by the #822/#828 hardening. The seal tests asserted the
*old* substring-matching behaviour that #822 deliberately removed as a
security fix; rewritten against the HMAC contract, now asserting that forged
scope, extended expiry, wrong secret and expired seals all fail. 21 tests.

**`aurora_onboard.py` died on EOF without a tty** — the first command the
README gives a new engineer. Now degrades to `--skip-interactive`. Exit code
was already correct; this was a bad experience, not a silent failure.

**Every endpoint prefix in the README was wrong** except `/api/sensors/`.
`/aumem/` → `/memory/`, `/api/gumas/` → `/gumas/`, and four more. Re-derived
from the running app's OpenAPI schema. Adds a CSRF example verified to run
verbatim.

**The MCP connector is surfaced.** Five read-only tools, wired to live
endpoints since #828 and hardened through #822–#829 — previously findable
only by opening `connector/`. Declares the `mcp` SDK in
`requirements-optional.txt` (it was only in the lock file, so a fresh clone
could not run it) and drops a "(scaffold)" label that contradicted the line
beneath it.

**`CONTRIBUTING.md` opened with two interleaved drafts** — line 1 rendered as
`# Contributing to Aurora CloudBank Symbolic# Contributing to Aurora
Reflective Autonomy System`. Header repaired; everything from "Development
Workflow" onward was already fine and is untouched. Stale paths corrected.

**CHANGELOG velocity metrics replaced with outcomes.** "24,145 lines
deployed", "100% goal achievement… 2 days early". The in-universe contributor
credits are kept, with a one-line note pointing at `.aurora/README.md` so an
outside reader can tell it is a documented convention.

## Test results

Full suite, clean clone, Python 3.12, `requirements.txt` only:

| | baseline | this branch |
|---|---|---|
| passed | 2,979 | **3,008** |
| failed | 45 | **36** |
| errors | 34 | **27** |

**No regressions** — every failure on this branch already existed on `main`.

One ordering bug surfaced and is fixed here: restoring connector collection
exposed 27 integration tests marked `@pytest.mark.unit` that build a live
`CloudbankBridge`. They failed without credentials *and* leaked state —
running them before `test_dlp_auto_tracker.py` broke
`test_full_request_lifecycle`. A package conftest now skips them with the
reason and the command to run them properly.

## Not addressed

- `docs/archive/philosophy/` stays put. The #1139 audit ruled explicitly that
  "its archive location is preserved"; that is the owner's call, not a
  drive-by move. The broken link *to* it from `modules/qgia/README.md` is
  fixed.
- `simulation/` untouched — owned by #1234.
- The 27 remaining errors are unchanged pre-existing environment issues
  (hardcoded `/var/lib/nemo_snapshots`, absent Redis, unconfigured auth).

Repo settings applied separately: homepage repointed from a 404ing Vercel URL
to the live Pages site, template flag cleared, 12 topics added.