### PR TITLE
docs: make the repository navigable, and its claims checkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,30 @@
 [![Python](https://img.shields.io/badge/python-3.11+-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-A quantum-symbolic computing platform for enterprise AI. Combines hierarchical memory management, quantum circuit simulation, multi-model AI orchestration, geometric ethics enforcement, and production observability in a single FastAPI application.
+A FastAPI platform for keeping machine-generated knowledge coherent over long
+horizons: hierarchical memory, provenance-tracked state, geometric ethics
+enforcement, drift detection, and production observability.
+
+It is also the code and canon repository for Aurora, the simulation director of
+the Orion Station institutional simulation. That is not decoration on the
+engineering — it is what the engineering is for. Keeping a large,
+LLM-generated corpus internally consistent across sessions, model changes, and
+contributors is the problem this system exists to solve, and the simulation is
+the corpus it solves it against: large enough that conflicts are non-trivial,
+long-lived enough that drift is real rather than hypothetical, and without
+external ground truth, which forces genuine internal-consistency machinery
+rather than a lookup against someone else's answer key.
+
+So the module list contains both `src/middleware/` and `modules/crew_agents/`,
+and both are load-bearing.
 
 > **New engineer?** Start with [`GETTING_STARTED_ENGINEER.md`](./GETTING_STARTED_ENGINEER.md), then run `python scripts/aurora_onboard.py` for a repository-grounded first interaction.
 >
 > **Reviewing the architecture?** Start with [`ARCHITECTURE_QUICKMAP.md`](./ARCHITECTURE_QUICKMAP.md) for a 10-minute orientation to the layer structure, runtime flow, and code map.
+>
+> **Want to know why it is built this way?** Read [`docs/archive/philosophy/`](./docs/archive/philosophy/PHILOSOPHY.md) — seven documents deriving the architecture from one principle about auditable reasoning. Foundational design intent, not current runtime canon.
+>
+> **Looking for a specific document?** [`docs/index.md`](./docs/index.md) maps every documentation directory and states what authority each one carries.
 >
 > **New AI agent or Copilot session?** Start with [`AGENTS.md`](./AGENTS.md) (bootstrap protocol and rules) and [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) (machine-readable concept map).
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ and both are load-bearing.
 >
 > **Want to know why it is built this way?** Read [`docs/archive/philosophy/`](./docs/archive/philosophy/PHILOSOPHY.md) — seven documents deriving the architecture from one principle about auditable reasoning. Foundational design intent, not current runtime canon.
 >
+> **Sceptical?** [`docs/VERIFIED_CLAIMS.md`](./docs/VERIFIED_CLAIMS.md) pairs every claim in this README with the command that proves or falsifies it, and the result that command produced.
+>
 > **Looking for a specific document?** [`docs/index.md`](./docs/index.md) maps every documentation directory and states what authority each one carries.
 >
 > **New AI agent or Copilot session?** Start with [`AGENTS.md`](./AGENTS.md) (bootstrap protocol and rules) and [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) (machine-readable concept map).
@@ -166,7 +168,7 @@ All modules follow a consistent layout: `__init__.py`, `core.py`, `api.py`, `mod
 
 ## API
 
-The server exposes 301 operations across 293 paths and 30 routers. All routes return JSON.
+The server exposes 290 operations across 282 paths and 30 tags with core requirements and the four required secrets set; 302 across 294 with a full `.env` and optional extras installed. Route registration skips modules whose optional dependencies are absent, so the count varies with your configuration. All routes return JSON.
 
 **Access the interactive docs:**
 

--- a/docs/VERIFIED_CLAIMS.md
+++ b/docs/VERIFIED_CLAIMS.md
@@ -1,0 +1,281 @@
+# Verified Claims
+
+Every claim this repository makes about itself should be checkable by someone
+who does not trust it. This document pairs each claim with the command that
+proves or falsifies it, and the result that command produced.
+
+This follows the standard the design philosophy sets for the system's own
+outputs — *"only outputs that can be proven wrong are outputs that can be
+proven right"* ([05_GANDALF_STANDARD.md](archive/philosophy/05_GANDALF_STANDARD.md)).
+It applies the same rule to the documentation.
+
+**Setup for everything below:**
+
+```bash
+python3.12 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt && pip install pytest pytest-asyncio pytest-timeout
+
+# The app refuses to start without these four. Generate throwaway ones:
+export AURORA_SECRET_KEY=$(openssl rand -hex 32)
+export JWT_SECRET_KEY=$(openssl rand -hex 32)
+export CSRF_SECRET_KEY=$(openssl rand -hex 32)
+export WS_AUTH_SECRET=$(openssl rand -hex 32)
+```
+
+Measured on Python 3.12, `requirements.txt` only, no optional extras, no
+external services.
+
+---
+
+## The system installs and starts
+
+```bash
+python -c "import time,sys; sys.path.insert(0,'.'); t=time.time(); import api.aurora_api; print(f'{time.time()-t:.1f}s')"
+
+python -c "import sys; sys.path.insert(0,'.'); import api.aurora_api as a; s=a.app.openapi(); print(len(s['paths']),'paths', sum(len(v) for v in s['paths'].values()),'operations')"
+```
+
+Observed: **1.7 s**, **282 paths / 290 operations / 30 tags**.
+
+**The count depends on your configuration, and this is worth knowing before you
+compare notes with anyone.** Route registration is tolerant by design — modules
+whose optional dependencies are absent are skipped and logged rather than
+aborting boot. With a `.env` file present and optional extras installed the same
+command reports **294 paths / 302 operations**. The 282/290 figure is the floor
+for a minimal install, not a ceiling.
+
+---
+
+## The test suite
+
+```bash
+pytest -q
+```
+
+Observed on a clean clone with core requirements only:
+
+| | count |
+|---|---|
+| passed | **3,008** |
+| failed | 36 |
+| errors | 27 |
+| skipped | 123 |
+| duration | ~5 min 30 s |
+
+The 36 failures and 27 errors are **environmental, not logic**, and are honest
+about it — a hardcoded `/var/lib/nemo_snapshots` path, absent Redis, and
+unconfigured auth users account for most of them. They are listed here rather
+than hidden because a reader will hit them, and discovering them unannounced is
+worse than being told.
+
+Fast path: `pytest -m unit`.
+
+---
+
+## Tamper-evident audit log
+
+**Claim:** altering any recorded field in an audit entry breaks verification.
+
+```bash
+pytest tests/test_audit_logger_security.py -q    # 4 passed
+```
+
+To see it directly rather than trusting the suite:
+
+```python
+from src.monitoring.audit_logger import AuditLogger
+lg = AuditLogger(signing_key="demo-key")
+for i in range(4):
+    lg.log_drift_alert(agent_id=f"a{i}", severity="WARNING",
+                       metric_name=f"m{i}", current_value=0.5+i, baseline_value=0.4)
+
+print(lg.verify_chain())                       # True
+entry = lg.entries[1]
+entry.data = dict(entry.data, current_value=999.0)   # alter a recorded fact
+print(lg.verify_entry(entry), lg.verify_chain())     # False False
+```
+
+Observed: clean chain verifies; altering either `data` or `severity` on any
+entry flips both `verify_entry()` and `verify_chain()` to `False`. SHA-256 over
+the entry content with `previous_hash` linkage
+(`src/monitoring/audit_logger.py`).
+
+---
+
+## PII detection and redaction
+
+**Claim:** PII is detected and masked before it reaches a log or a response.
+
+```bash
+pytest tests/test_data_guardian.py tests/test_persist_redact.py -q    # 34 passed
+```
+
+```python
+from modules.data_guardian.detection_rules import PIIDetector
+from modules.data_guardian.redaction import RedactionEngine
+
+sample = "Contact john.doe@example.com or call 555-123-4567. SSN 123-45-6789, card 4111-1111-1111-1111"
+hits = PIIDetector().detect(sample)          # list of dicts: type, start, end
+print(RedactionEngine().redact_text(sample, hits))
+```
+
+Observed:
+
+```
+Contact ********@*******.*** or call ************. SSN ***********, card *******************
+```
+
+**Scope, stated honestly:** `PIIType` declares 12 categories; **6 have
+detection rules** — email, SSN, phone, credit card, IP address, date of birth.
+Driver's licence, passport, bank account, full name, address and custom are
+declared but not implemented. There is no credential or secret detection: an
+AWS key passes through unredacted.
+
+---
+
+## Log-injection resistance
+
+**Claim:** user input cannot forge log lines.
+
+```bash
+pytest tests/test_log_sanitizer.py -q    # 14 passed
+```
+
+```python
+from modules.data_guardian.log_sanitizer import sanitize_log_output
+print(repr(sanitize_log_output("user=bob\n2026-01-01 ADMIN forged entry")))
+```
+
+Observed: `'user=bob\\n2026-01-01 ADMIN forged entry'` — newlines become literal
+escapes, so the line cannot be split. Also strips C0/C1 control characters and
+truncates at 4096 chars. This is an **injection** guard, not a PII redactor;
+the two are separate concerns handled by separate code.
+
+---
+
+## CSRF enforcement
+
+**Claim:** state-changing requests without a valid token are rejected.
+
+```bash
+make serve-dev          # in another terminal
+TOKEN=$(curl -s localhost:8000/api/csrf-token | jq -r .csrf_token)
+
+# no token
+curl -s -o /dev/null -w "%{http_code}\n" -X POST localhost:8000/memory/create \
+  -H "Content-Type: application/json" \
+  -d '{"content":"x","memory_type":"agent","owner":"you"}'
+
+# malformed token
+curl -s -o /dev/null -w "%{http_code}\n" -X POST localhost:8000/memory/create \
+  -H "Content-Type: application/json" -H "X-CSRF-Token: not.a.token" \
+  -d '{"content":"x","memory_type":"agent","owner":"you"}'
+
+# valid token
+curl -s -o /dev/null -w "%{http_code}\n" -X POST localhost:8000/memory/create \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $TOKEN" -H "Authorization: Bearer $TOKEN" \
+  -d '{"content":"x","memory_type":"agent","owner":"you"}'
+```
+
+Observed: **403**, **403**, **200**.
+
+**Threat model, stated honestly:** the token is a stateless HMAC and is not
+bound to a cookie or authenticated session by default. It defends against blind
+cross-origin submission, but its strength depends on the CORS policy in front
+of it. Keep `ALLOWED_CORS_ORIGINS` restrictive anywhere this matters.
+
+---
+
+## Pilot seal (MCP elevated access)
+
+**Claim:** elevated connector operations require an unforgeable, expiring seal.
+
+```bash
+pytest tests/connector/test_auth_token.py tests/connector/test_hmac_seal.py -q
+```
+
+Observed: **26 passed**. The suite asserts that a forged scope, an extended
+expiry, a seal signed with a different secret, an expired seal, and the
+pre-#822 substring-style seal are all rejected.
+
+---
+
+## Deterministic simulation
+
+**Claim:** the same seed produces the same run; a different seed does not.
+
+```bash
+# use `md5` instead of `md5sum` on macOS
+sim() { python simulation/orion_station_simulation.py --seed "$1" --ticks 30 --log-level WARNING | md5sum; }
+
+a=$(sim 42); b=$(sim 42); c=$(sim 43)
+[ "$a" = "$b" ]  && echo "deterministic:  yes"
+[ "$a" != "$c" ] && echo "seed-sensitive: yes"
+```
+
+Observed: identical digests across runs at seed 42; different digest at seed 43.
+
+There is **no automated test asserting this** — it is verified by the command
+above only. Adding one is open work.
+
+---
+
+## MCP connector
+
+**Claim:** Aurora state is exposed over the Model Context Protocol as five
+read-only tools.
+
+```bash
+pip install -r requirements-optional.txt
+python -c "from connector.tools import TOOL_REGISTRY; print(len(TOOL_REGISTRY), sorted(TOOL_REGISTRY))"
+python -m connector.server --help
+```
+
+Observed: **5** — `aurora_get_agents`, `aurora_get_capsules`, `aurora_get_drift`,
+`aurora_get_ethics_log`, `aurora_get_state`.
+
+Offline connector tests run with no configuration:
+
+```bash
+pytest tests/connector -q      # 35 passed, 79 skipped
+```
+
+The 79 skipped are integration tests needing `AURORA_CONNECTOR_TOKEN` and a
+running API; they announce that rather than failing silently. See
+[`tests/connector/conftest.py`](../tests/connector/conftest.py).
+
+---
+
+## Scale
+
+| Measure | Value | Check |
+|---|---|---|
+| Test files | 293 | `git ls-files 'tests/**test_*.py' 'tests/test_*.py' \| wc -l` |
+| Test lines | 64,389 | `git ls-files tests \| grep '\.py$' \| xargs wc -l \| tail -1` |
+| Source lines (api+src+modules) | 145,391 | `git ls-files api src modules \| grep '\.py$' \| xargs wc -l \| tail -1` |
+| Middleware modules | 12 | `ls src/middleware/*.py \| wc -l` |
+
+Test-to-source ratio is roughly **1:2.3** (64,389 / 145,391).
+
+---
+
+## What is not claimed
+
+Stated so nobody has to discover it by reading code:
+
+- **Quantum cloud backends** (AWS Braket, Azure Quantum, IBM, Cirq) require
+  provider accounts and fall back to local simulation. The local
+  `quantum_state.py` `apply_gate()` is explicitly a mock and says so in its
+  own source.
+- **HALO/PAS drift control** is a working runtime class; the end-to-end L1–L2
+  wiring that would feed it live signals is not shipped.
+- **Recovered protocol custody** — the manifest schema exists, but all five
+  protocols' custody hashes are still `PENDING` (tracked in #1233).
+- **Connector v0.2 write operations and v0.3 streaming** are planned, not
+  built. `connector/README.md` marks them as such.
+
+---
+
+*Reproduced against `main`. If a command here does not produce the stated
+result, that is a bug in this document — please open an issue.*

--- a/docs/archive/philosophy/01_EPISTEMIC_FOUNDATION.md
+++ b/docs/archive/philosophy/01_EPISTEMIC_FOUNDATION.md
@@ -133,5 +133,5 @@ This is not a UI feature. It is a core design constraint.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/01_EPISTEMIC_FOUNDATION.md*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/01_EPISTEMIC_FOUNDATION.md*  
 *Version 1.0 — March 11, 2026*

--- a/docs/archive/philosophy/02_SYMBOLIC_ARCHITECTURE.md
+++ b/docs/archive/philosophy/02_SYMBOLIC_ARCHITECTURE.md
@@ -142,5 +142,5 @@ has been built according to these principles from inception.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/02_SYMBOLIC_ARCHITECTURE.md*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/02_SYMBOLIC_ARCHITECTURE.md*  
 *Version 1.0 — March 11, 2026*

--- a/docs/archive/philosophy/03_CONSENT_AND_IDENTITY.md
+++ b/docs/archive/philosophy/03_CONSENT_AND_IDENTITY.md
@@ -123,5 +123,5 @@ cryptographic architecture.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/03_CONSENT_AND_IDENTITY.md*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/03_CONSENT_AND_IDENTITY.md*  
 *Version 1.0 — March 11, 2026*

--- a/docs/archive/philosophy/04_ETHICS_PROTOCOL.md
+++ b/docs/archive/philosophy/04_ETHICS_PROTOCOL.md
@@ -160,5 +160,5 @@ Trustworthiness requires the capacity to refuse.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/04_ETHICS_PROTOCOL.md*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/04_ETHICS_PROTOCOL.md*  
 *Version 1.0 — March 11, 2026*

--- a/docs/archive/philosophy/05_GANDALF_STANDARD.md
+++ b/docs/archive/philosophy/05_GANDALF_STANDARD.md
@@ -153,5 +153,5 @@ that is actually trustworthy.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/05_GANDALF_STANDARD.md*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/05_GANDALF_STANDARD.md*  
 *Version 1.0 — March 11, 2026*

--- a/docs/archive/philosophy/06_SCOPE_AND_LIMITS.md
+++ b/docs/archive/philosophy/06_SCOPE_AND_LIMITS.md
@@ -174,5 +174,5 @@ Aurora's constraints are structural. That is what makes them real.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/06_SCOPE_AND_LIMITS.md*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/06_SCOPE_AND_LIMITS.md*  
 *Version 1.0 — March 11, 2026*

--- a/docs/archive/philosophy/07_ANALYST_ORIENTATION.md
+++ b/docs/archive/philosophy/07_ANALYST_ORIENTATION.md
@@ -295,7 +295,7 @@ who uses Aurora from an analyst who is used by it.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/07_ANALYST_ORIENTATION.md*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/07_ANALYST_ORIENTATION.md*  
 *Version 1.0 — March 11, 2026*  
 *Audience: QGIA application layer users, domain analysts, intelligence consumers*  
 *Does not require: substrate architecture knowledge, cryptographic familiarity, Aurora system access*

--- a/docs/archive/philosophy/PHILOSOPHY.md
+++ b/docs/archive/philosophy/PHILOSOPHY.md
@@ -27,12 +27,14 @@ machine cognition looks like.
 | [04_ETHICS_PROTOCOL.md](04_ETHICS_PROTOCOL.md) | Picard_Delta_3, drift monitoring, the ethics enforcement layer | Platform |
 | [05_GANDALF_STANDARD.md](05_GANDALF_STANDARD.md) | The operational philosophy of constrained amplification | Universal |
 | [06_SCOPE_AND_LIMITS.md](06_SCOPE_AND_LIMITS.md) | What Aurora refuses to be — the no-master-node guarantee | Universal |
+| [07_ANALYST_ORIENTATION.md](07_ANALYST_ORIENTATION.md) | How to read Aurora outputs correctly — for domain experts, no architecture knowledge assumed | Application |
 
 ---
 
 ## The Derivation Chain
 
-All six documents are derivations from a single root principle:
+Documents 01–06 are derivations from a single root principle; 07 applies the
+result at the analyst-facing surface:
 
 > **A reasoning system is only trustworthy to the extent that its reasoning
 > chain can be opened, examined, challenged, and corrected — and to the extent
@@ -50,5 +52,5 @@ what Aurora is for: a system whose philosophy is traceable to first principles.
 
 ---
 
-*Aurora CloudBank Symbolic — docs/philosophy/*  
+*Aurora CloudBank Symbolic — docs/archive/philosophy/*  
 *Initiated: March 11, 2026*

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,7 +147,7 @@ than trust.
 
 The suite below states the design intent the architecture derives from. It is
 **foundational, not current runtime canon**: it lives under `archive/` by the
-#1139 ruling, and archive placement does not confer present authority. Read it
+ruling in #1139, and archive placement does not confer present authority. Read it
 to understand *why* the system is shaped this way; read `architecture/` and the
 committed code plus tests for what it currently *does*.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,6 +136,13 @@ and `DOCUMENT_PACKAGE_ONLY`; links here do not implement runtime activation.
 | ----------------------------------------------------------------- | ---------------------------- |
 | [INCIDENT_RESPONSE_RUNBOOK.md](INCIDENT_RESPONSE_RUNBOOK.md)      | Incident response procedures |
 
+## Verifying claims
+
+[VERIFIED_CLAIMS.md](VERIFIED_CLAIMS.md) pairs each claim the project makes
+about itself with a runnable command and the result it produced, including
+the limits of what is implemented. Start here if you want to check rather
+than trust.
+
 ## Design philosophy
 
 The suite below states the design intent the architecture derives from. It is

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ This directory contains reference documentation for developers working with Auro
 | [`reference/`](reference/) | Convenience catalogs and reference guides | Verify generated or snapshot material against its governed source before citing it as current. |
 | [`security/`](security/) | Remediation records, status reports, and penetration-test scope/history | Root [`SECURITY.md`](../SECURITY.md) governs disclosure policy; current controls require code and test evidence. |
 | [`review-notes/`](review-notes/) | Dated review and audit evidence | Non-canonical observations; revalidate findings against live repository state. |
-| [`archive/`](archive/) | Superseded, historical, or custody material | Historical context only; archive placement does not confer current authority. |
+| [`archive/`](archive/) | Superseded, historical, or custody material — including the [design philosophy suite](#design-philosophy) | Historical context only; archive placement does not confer current authority. |
 
 ## Root structural controls
 
@@ -136,12 +136,31 @@ and `DOCUMENT_PACKAGE_ONLY`; links here do not implement runtime activation.
 | ----------------------------------------------------------------- | ---------------------------- |
 | [INCIDENT_RESPONSE_RUNBOOK.md](INCIDENT_RESPONSE_RUNBOOK.md)      | Incident response procedures |
 
+## Design philosophy
+
+The suite below states the design intent the architecture derives from. It is
+**foundational, not current runtime canon**: it lives under `archive/` by the
+#1139 ruling, and archive placement does not confer present authority. Read it
+to understand *why* the system is shaped this way; read `architecture/` and the
+committed code plus tests for what it currently *does*.
+
+| Document | Description |
+| --- | --- |
+| [archive/philosophy/PHILOSOPHY.md](archive/philosophy/PHILOSOPHY.md) | Master index and the derivation chain linking all six documents to one root principle |
+| [archive/philosophy/01_EPISTEMIC_FOUNDATION.md](archive/philosophy/01_EPISTEMIC_FOUNDATION.md) | The Palantír argument — why unauditable reasoning is indistinguishable from guessing |
+| [archive/philosophy/02_SYMBOLIC_ARCHITECTURE.md](archive/philosophy/02_SYMBOLIC_ARCHITECTURE.md) | What Aurora is at the cognitive substrate level |
+| [archive/philosophy/03_CONSENT_AND_IDENTITY.md](archive/philosophy/03_CONSENT_AND_IDENTITY.md) | Consent gating and identity architecture |
+| [archive/philosophy/04_ETHICS_PROTOCOL.md](archive/philosophy/04_ETHICS_PROTOCOL.md) | Picard_Delta_3, drift monitoring, ethics enforcement — historical narrative; see [ethics/README.md](ethics/README.md) for current runtime evidence |
+| [archive/philosophy/05_GANDALF_STANDARD.md](archive/philosophy/05_GANDALF_STANDARD.md) | Constrained amplification; why only falsifiable claims count |
+| [archive/philosophy/06_SCOPE_AND_LIMITS.md](archive/philosophy/06_SCOPE_AND_LIMITS.md) | The no-master-node guarantee — what Aurora refuses to become |
+| [archive/philosophy/07_ANALYST_ORIENTATION.md](archive/philosophy/07_ANALYST_ORIENTATION.md) | Orientation for analysts consuming Aurora output |
+
 ---
 
 ## Not finding what you need?
 
-- See `docs/archive/` for historical internal reports, phase summaries, and session notes.
+- See `archive/` for historical internal reports, phase summaries, and session notes.
 - The interactive API docs are at `http://localhost:8000/docs` when the server is running.
-- `API_CATALOG.md` (root) has the full route listing.
+- [`reference/API_CATALOG.md`](reference/API_CATALOG.md) has the full route listing.
 - `CONTRIBUTING.md` (root) has the contribution guide.
 - `CLAUDE.md` (root) has AI assistant guidance for working with this codebase.


### PR DESCRIPTION
**Stacked on #1309** — base is `fix/reviewer-first-contact`, not `main`.
Both branches touch `README.md`; stacking avoids the conflict. Merge #1309
first and this retargets to `main` cleanly.

The documentation here was findable only by someone who already knew the
project. Individually the pieces were good. They did not compose.

## Two entry documents described the project differently

`README.md` opened with *"a quantum-symbolic computing platform for enterprise
AI."* `ARCHITECTURE_QUICKMAP.md` opened with *"the code and canon repository for
Aurora, the simulation director of the Orion Station institutional simulation."*

A reader got a different answer depending on where they landed — and the
README's version set up an expectation the codebase visibly contradicts, which
costs more credibility than either framing would alone. The README now leads
with what the system does and states the domain plainly, as the reason the
engineering exists rather than as a caveat appended to it.

## The design philosophy was unreachable

Seven documents deriving the architecture from one principle about auditable
reasoning — indexed nowhere, linked from nothing, and, because they sit under
`archive/`, signposted to every reader as obsolete.

**They stay where they are.** The #1139 audit ruled explicitly that "its archive
location is preserved"; reversing that is the owner's call, not a drive-by move
in a docs PR. Instead they are indexed in `docs/index.md` under an honest
authority note — *foundational, not current runtime canon* — and reachable from
the README's routing block.

Along the way: the suite's own footers claimed `docs/philosophy/`, a path that
does not exist, so a reader landing on one was told the wrong place to find its
siblings. And `PHILOSOPHY.md` indexed six of its seven documents —
`07_ANALYST_ORIENTATION` was orphaned from its own index.

## Claims are now checkable

`docs/VERIFIED_CLAIMS.md` pairs each claim with a runnable command and the
output it produced. Nothing new was built for it — every capability was already
there and already passing. A category claim like "PII detection" reads as
aspiration; `pytest tests/test_data_guardian.py` reads as evidence.

**Every command in that document was executed against this branch before it was
written down.** That exercise immediately caught two wrong numbers in the
README, which is the argument for doing it: route counts are
configuration-dependent — **282 paths / 290 operations** minimal, **294 / 302**
with a `.env` and optional extras — not the single figure previously stated.

It records limits in the same document rather than a flattering separate one:
`PIIType` declares 12 categories and 6 have rules (an AWS key passes through
unredacted); the CSRF token is not session-bound; simulation determinism has no
automated test, only the command shown; quantum cloud backends fall back to a
local mock; recovered-protocol custody hashes are still `PENDING` (#1233).

## Navigation

- `docs/index.md` was already an excellent directory authority map, linked from
  nowhere. It is now the README's "looking for a specific document?" route.
- README routing gains two paths — design intent, and claim verification —
  alongside the existing new-engineer, architecture, and agent entries.
- `docs/index.md` pointed at a root `API_CATALOG.md` that does not exist;
  corrected to `reference/API_CATALOG.md`.

Every link across README, `docs/index.md`, `VERIFIED_CLAIMS.md`,
`ARCHITECTURE_QUICKMAP`, `GETTING_STARTED_ENGINEER`, `CONTRIBUTING`, `AGENTS`,
`CANON_INDEX` and the philosophy suite resolves. Documentation only — no code
changes, no test changes.