### PR TITLE
fix: replace retired and fabricated Claude model IDs in AIModel enum

### DIFF
--- a/modules/ai_core/__init__.py
+++ b/modules/ai_core/__init__.py
@@ -2,7 +2,7 @@
 AI Core Module for Aurora CloudBank Symbolic
 
 Unified AI integration supporting multiple models:
-- Claude 3.5 Sonnet, 4.5 Opus (Anthropic)
+- Claude Opus 5, Claude Sonnet 5 (Anthropic)
 - GPT-4, GPT-4o, GPT-5, GPT-5 Codex (OpenAI)
 
 Features:

--- a/modules/ai_core/claude_integration_hub.py
+++ b/modules/ai_core/claude_integration_hub.py
@@ -1,7 +1,7 @@
 """
 Enhanced Claude Integration Hub for Aurora CloudBank Symbolic
 
-Supports Claude 3.5 Sonnet and 4.5 Opus with intelligent fallback
+Supports Claude Opus 5 and Claude Sonnet 5 with intelligent fallback
 Maintains backward compatibility with existing Sonnet 4 integration
 """
 
@@ -26,27 +26,28 @@ logger = logging.getLogger(__name__)
 class ClaudeConfig:
     """Configuration for Claude model integration"""
 
-    # Model selection
-    preferred_model: str = "claude-4-5-opus-20250115"  # Default to 4.5 Opus
-    fallback_model: str = "claude-3-5-sonnet-20241022"  # Fallback to 3.5 Sonnet
+    # Model selection (IDs verified against the Anthropic catalog on 2026-07-25;
+    # these take no date suffix)
+    preferred_model: str = "claude-opus-5"  # Default to Opus 5
+    fallback_model: str = "claude-sonnet-5"  # Fallback to Sonnet 5
     enable_gpt_fallback: bool = True
     gpt_fallback_model: str = "gpt-4o"
 
     # Performance settings
-    max_tokens: int = 16384  # 4.5 Opus supports up to 16k
+    max_tokens: int = 16384  # conservative default; Opus 5 supports up to 128k
     temperature: float = 0.7
     top_p: float = 0.9
-    context_window: int = 500_000  # 4.5 Opus: 500K, 3.5 Sonnet: 200K
+    context_window: int = 1_000_000  # Opus 5 and Sonnet 5: 1M
 
     # Safety and ethics
     safety_level: str = "high"
     ethics_protocol: str = "Picard_Delta_3"
 
     # Feature flags
-    enable_code_execution: bool = True  # 4.5 Opus feature
+    enable_code_execution: bool = True  # supported by Opus 5 and Sonnet 5
     enable_vision: bool = True
     enable_function_calling: bool = True
-    preserve_legacy_behavior: bool = True  # Maintain 3.5 compatibility
+    preserve_legacy_behavior: bool = True  # Maintain legacy Sonnet 4 hub compatibility
 
     # DLP and tracking
     dlp_tracking: bool = True
@@ -55,13 +56,13 @@ class ClaudeConfig:
 
 class ClaudeIntegrationHub:
     """
-    Enhanced Claude integration supporting 3.5 Sonnet and 4.5 Opus
+    Enhanced Claude integration supporting Claude Opus 5 and Claude Sonnet 5
 
     Key features:
     - Automatic model selection based on availability
-    - Intelligent fallback chain: 4.5 Opus → 3.5 Sonnet → GPT-4o
+    - Intelligent fallback chain: Opus 5 → Sonnet 5 → GPT-4o
     - Context window optimization
-    - Code execution support (4.5 Opus)
+    - Code execution support
     - Backward compatible with existing sonnet4_integration_hub
     """
 
@@ -81,8 +82,8 @@ class ClaudeIntegrationHub:
         claude_cfg = self.config.get("claude", {})
 
         return ClaudeConfig(
-            preferred_model=claude_cfg.get("preferred_model", "claude-4-5-opus-20250115"),
-            fallback_model=claude_cfg.get("fallback_model", "claude-3-5-sonnet-20241022"),
+            preferred_model=claude_cfg.get("preferred_model", "claude-opus-5"),
+            fallback_model=claude_cfg.get("fallback_model", "claude-sonnet-5"),
             enable_gpt_fallback=claude_cfg.get("enable_gpt_fallback", True),
             gpt_fallback_model=claude_cfg.get("gpt_fallback_model", "gpt-4o"),
             max_tokens=claude_cfg.get("max_tokens", 16384),
@@ -103,26 +104,26 @@ class ClaudeIntegrationHub:
         try:
             available = self._unified_ai.get_available_models()
 
-            # Check for Claude 4.5 Opus
-            if AIModel and AIModel.CLAUDE_45_OPUS in available:
-                logger.info("✅ Claude 4.5 Opus available")
-                self.claude_45_available = True
+            # Check for Claude Opus 5
+            if AIModel and AIModel.CLAUDE_OPUS_5 in available:
+                logger.info("✅ Claude Opus 5 available")
+                self.claude_opus_available = True
             else:
-                logger.info("⏳ Claude 4.5 Opus not yet available, will use 3.5 Sonnet")
-                self.claude_45_available = False
+                logger.info("⏳ Claude Opus 5 not available, will use Sonnet 5")
+                self.claude_opus_available = False
 
-            # Check for Claude 3.5 Sonnet
-            if AIModel and AIModel.CLAUDE_35_SONNET in available:
-                logger.info("✅ Claude 3.5 Sonnet available")
-                self.claude_35_available = True
+            # Check for Claude Sonnet 5
+            if AIModel and AIModel.CLAUDE_SONNET_5 in available:
+                logger.info("✅ Claude Sonnet 5 available")
+                self.claude_sonnet_available = True
             else:
-                logger.warning("⚠️  Claude 3.5 Sonnet not available")
-                self.claude_35_available = False
+                logger.warning("⚠️  Claude Sonnet 5 not available")
+                self.claude_sonnet_available = False
 
         except Exception as e:
             logger.error(f"Error checking model availability: {e}")
-            self.claude_45_available = False
-            self.claude_35_available = True  # Assume 3.5 works
+            self.claude_opus_available = False
+            self.claude_sonnet_available = True  # Assume Sonnet 5 works
 
     async def execute_request(
         self,
@@ -185,26 +186,26 @@ class ClaudeIntegrationHub:
 
         chain = []
 
-        # For reasoning tasks, prefer 4.5 Opus
+        # For reasoning tasks, prefer Opus 5
         if task_type in ["reasoning", "mathematical"]:
-            if self.claude_45_available:
-                chain.append(AIModel.CLAUDE_45_OPUS)
-            if self.claude_35_available:
-                chain.append(AIModel.CLAUDE_35_SONNET)
+            if self.claude_opus_available:
+                chain.append(AIModel.CLAUDE_OPUS_5)
+            if self.claude_sonnet_available:
+                chain.append(AIModel.CLAUDE_SONNET_5)
 
-        # For code generation, prefer 4.5 Opus (better code execution)
+        # For code generation, prefer Opus 5 (stronger code generation)
         elif task_type == "code_generation":
-            if self.claude_45_available:
-                chain.append(AIModel.CLAUDE_45_OPUS)
-            if self.claude_35_available:
-                chain.append(AIModel.CLAUDE_35_SONNET)
+            if self.claude_opus_available:
+                chain.append(AIModel.CLAUDE_OPUS_5)
+            if self.claude_sonnet_available:
+                chain.append(AIModel.CLAUDE_SONNET_5)
 
         # For general tasks, use availability order
         else:
-            if self.claude_35_available:
-                chain.append(AIModel.CLAUDE_35_SONNET)
-            if self.claude_45_available:
-                chain.append(AIModel.CLAUDE_45_OPUS)
+            if self.claude_sonnet_available:
+                chain.append(AIModel.CLAUDE_SONNET_5)
+            if self.claude_opus_available:
+                chain.append(AIModel.CLAUDE_OPUS_5)
 
         # Add GPT fallback if enabled
         if self.claude_config.enable_gpt_fallback:
@@ -247,7 +248,11 @@ class ClaudeIntegrationHub:
 
     async def enable_claude_45(self) -> Dict[str, bool]:
         """
-        Enable Claude 4.5 Opus (when available)
+        Enable the top-tier Claude model (Opus 5).
+
+        The ``_45`` in the name is legacy: it predates the catalog
+        reconciliation and is kept because the ``/enable-claude-45`` API route
+        and the ``get_global_status()`` response keys are public surface.
 
         Returns:
             Status dictionary
@@ -256,16 +261,16 @@ class ClaudeIntegrationHub:
             return {"error": "Unified AI not available", "enabled": False}
 
         try:
-            self._unified_ai.enable_model(AIModel.CLAUDE_45_OPUS)
-            self.claude_45_available = True
+            self._unified_ai.enable_model(AIModel.CLAUDE_OPUS_5)
+            self.claude_opus_available = True
 
-            logger.info("🚀 Claude 4.5 Opus enabled!")
+            logger.info("🚀 Claude Opus 5 enabled!")
 
             return {
                 "enabled": True,
-                "model": "claude-4-5-opus-20250115",
-                "context_window": 500_000,
-                "max_tokens": 16384,
+                "model": AIModel.CLAUDE_OPUS_5.value,
+                "context_window": 1_000_000,
+                "max_tokens": 128_000,
                 "features": {
                     "code_execution": True,
                     "vision": True,
@@ -275,7 +280,7 @@ class ClaudeIntegrationHub:
             }
 
         except Exception as e:
-            logger.error(f"Failed to enable Claude 4.5: {e}")
+            logger.error(f"Failed to enable Claude Opus 5: {e}")
             return {"error": str(e), "enabled": False}
 
     def get_global_status(self) -> Dict[str, Any]:
@@ -286,8 +291,10 @@ class ClaudeIntegrationHub:
             Status dictionary with model availability and configuration
         """
         return {
-            "claude_35_sonnet_available": self.claude_35_available,
-            "claude_45_opus_available": self.claude_45_available,
+            # Key names are legacy public surface; the values now track
+            # Claude Sonnet 5 and Claude Opus 5 respectively.
+            "claude_35_sonnet_available": self.claude_sonnet_available,
+            "claude_45_opus_available": self.claude_opus_available,
             "preferred_model": self.claude_config.preferred_model,
             "fallback_model": self.claude_config.fallback_model,
             "gpt_fallback_enabled": self.claude_config.enable_gpt_fallback,

--- a/modules/ai_core/unified_ai_interface.py
+++ b/modules/ai_core/unified_ai_interface.py
@@ -2,7 +2,7 @@
 Unified AI Interface for Aurora CloudBank Symbolic
 
 Multi-model AI abstraction layer supporting:
-- Claude 3.5 Sonnet, 4.5 Opus
+- Claude Opus 5, Claude Sonnet 5
 - GPT-4, GPT-4o, GPT-5 (Codex)
 - Intelligent fallback chains
 - Runtime model selection
@@ -30,7 +30,7 @@ class AIProvider(Enum):
 class AIModel(Enum):
     """Supported AI models with version tracking.
 
-    Catalog reconciliation: 2026-06-02.
+    Catalog reconciliation: 2026-07-25 (Anthropic entries).
 
     Identifiers tagged "UNVERIFIED placeholder" below are aspirational and are
     NOT confirmed against the provider's live catalog. They are gated by
@@ -38,11 +38,21 @@ class AIModel(Enum):
     through the public interface (see ``select_optimal_model``). Promote one to
     a live identifier only after confirming it against the provider catalog and
     flipping its ``available`` flag in the same change.
+
+    A "Verified live" tag means the identifier was checked against the
+    provider's own catalog on the reconciliation date above — not that it was
+    once believed correct. The previous Claude entries violated that rule: a
+    retired identifier (``claude-3-5-sonnet-20241022``, retired 2025-10-28)
+    carried the tag while being the only selectable Anthropic model, and the
+    gated entry (``claude-4-5-opus-20250115``) named a release that never
+    existed in any form. Both were replaced against the current Anthropic
+    catalog. Anthropic IDs below take no date suffix — they are complete as
+    written.
     """
 
-    # Claude family
-    CLAUDE_35_SONNET = "claude-3-5-sonnet-20241022"  # Verified live
-    CLAUDE_45_OPUS = "claude-4-5-opus-20250115"  # UNVERIFIED placeholder (available=False)
+    # Claude family — verified against the Anthropic catalog on 2026-07-25
+    CLAUDE_OPUS_5 = "claude-opus-5"  # Verified live
+    CLAUDE_SONNET_5 = "claude-sonnet-5"  # Verified live
 
     # GPT family
     GPT_4 = "gpt-4"  # Verified live
@@ -121,33 +131,33 @@ class UnifiedAIInterface:
 
     # Model capabilities registry
     CAPABILITIES: Dict[AIModel, ModelCapabilities] = {
-        AIModel.CLAUDE_35_SONNET: ModelCapabilities(
-            model=AIModel.CLAUDE_35_SONNET,
+        AIModel.CLAUDE_OPUS_5: ModelCapabilities(
+            model=AIModel.CLAUDE_OPUS_5,
             provider=AIProvider.ANTHROPIC,
-            context_window=200_000,
-            max_output_tokens=8192,
-            supports_function_calling=True,
-            supports_vision=True,
-            reasoning_strength=9,
-            code_generation_strength=8,
-            mathematical_strength=9,
-            cost_per_1k_tokens=0.003,
-            latency_avg_ms=800,
-        ),
-        AIModel.CLAUDE_45_OPUS: ModelCapabilities(
-            model=AIModel.CLAUDE_45_OPUS,
-            provider=AIProvider.ANTHROPIC,
-            context_window=500_000,
-            max_output_tokens=16384,
+            context_window=1_000_000,
+            max_output_tokens=128_000,
             supports_function_calling=True,
             supports_vision=True,
             supports_code_execution=True,
             reasoning_strength=10,
-            code_generation_strength=9,
+            code_generation_strength=10,
             mathematical_strength=10,
-            cost_per_1k_tokens=0.015,  # Expected pricing
+            cost_per_1k_tokens=0.005,  # $5 / 1M input tokens
             latency_avg_ms=1200,
-            available=False,  # Not yet released
+        ),
+        AIModel.CLAUDE_SONNET_5: ModelCapabilities(
+            model=AIModel.CLAUDE_SONNET_5,
+            provider=AIProvider.ANTHROPIC,
+            context_window=1_000_000,
+            max_output_tokens=128_000,
+            supports_function_calling=True,
+            supports_vision=True,
+            supports_code_execution=True,
+            reasoning_strength=9,
+            code_generation_strength=9,
+            mathematical_strength=9,
+            cost_per_1k_tokens=0.003,  # $3 / 1M input tokens
+            latency_avg_ms=800,
         ),
         AIModel.GPT_4: ModelCapabilities(
             model=AIModel.GPT_4,
@@ -209,29 +219,29 @@ class UnifiedAIInterface:
     # Default fallback chains for different task types
     FALLBACK_CHAINS = {
         "reasoning": [
-            AIModel.CLAUDE_45_OPUS,
+            AIModel.CLAUDE_OPUS_5,
             AIModel.GPT_5,
-            AIModel.CLAUDE_35_SONNET,
+            AIModel.CLAUDE_SONNET_5,
             AIModel.GPT_4O,
         ],
         "code_generation": [
             AIModel.GPT_5_CODEX,
             AIModel.GPT_5,
-            AIModel.CLAUDE_45_OPUS,
-            AIModel.CLAUDE_35_SONNET,
+            AIModel.CLAUDE_OPUS_5,
+            AIModel.CLAUDE_SONNET_5,
             AIModel.GPT_4O,
         ],
         "mathematical": [
-            AIModel.CLAUDE_45_OPUS,
-            AIModel.CLAUDE_35_SONNET,
+            AIModel.CLAUDE_OPUS_5,
+            AIModel.CLAUDE_SONNET_5,
             AIModel.GPT_5,
             AIModel.GPT_4,
         ],
         "general": [
             AIModel.GPT_4O,
-            AIModel.CLAUDE_35_SONNET,
+            AIModel.CLAUDE_SONNET_5,
             AIModel.GPT_5,
-            AIModel.CLAUDE_45_OPUS,
+            AIModel.CLAUDE_OPUS_5,
         ],
     }
 
@@ -542,7 +552,7 @@ class UnifiedAIInterface:
         return [model for model, caps in self.CAPABILITIES.items() if caps.available]
 
     def enable_model(self, model: AIModel):
-        """Enable a model (e.g., when Claude 4.5 or GPT-5 become available)"""
+        """Enable a model (e.g., when a gated placeholder like GPT-5 becomes available)"""
         if model in self.CAPABILITIES:
             self.CAPABILITIES[model].available = True
             logger.info(f"✅ Model {model.value} enabled")

--- a/tests/test_unified_ai_interface.py
+++ b/tests/test_unified_ai_interface.py
@@ -19,6 +19,23 @@ from modules.ai_core.unified_ai_interface import (
 )
 
 
+@pytest.fixture(autouse=True)
+def restore_model_availability():
+    """Restore the shipped ``available`` flags after every test.
+
+    ``UnifiedAIInterface.CAPABILITIES`` is a class attribute, so every instance
+    (including the module-level ``unified_ai`` singleton) shares one dict.
+    Tests that flip availability would otherwise leak into later tests and make
+    assertions about shipped defaults order-dependent.
+    """
+    original = {
+        model: caps.available for model, caps in UnifiedAIInterface.CAPABILITIES.items()
+    }
+    yield
+    for model, available in original.items():
+        UnifiedAIInterface.CAPABILITIES[model].available = available
+
+
 @pytest.mark.unit
 @pytest.mark.ai
 class TestUnifiedAIInterface:
@@ -29,8 +46,8 @@ class TestUnifiedAIInterface:
         interface = UnifiedAIInterface()
 
         assert len(interface.CAPABILITIES) > 0
-        assert AIModel.CLAUDE_35_SONNET in interface.CAPABILITIES
-        assert AIModel.CLAUDE_45_OPUS in interface.CAPABILITIES
+        assert AIModel.CLAUDE_SONNET_5 in interface.CAPABILITIES
+        assert AIModel.CLAUDE_OPUS_5 in interface.CAPABILITIES
         assert AIModel.GPT_4O in interface.CAPABILITIES
         assert AIModel.GPT_5 in interface.CAPABILITIES
         assert AIModel.GPT_5_CODEX in interface.CAPABILITIES
@@ -104,9 +121,9 @@ class TestUnifiedAIInterface:
         selected_code = await interface.select_optimal_model(request, "code_generation")
         assert selected_code == AIModel.GPT_5_CODEX  # First in code gen chain
 
-        # For reasoning, should prefer Claude 4.5 Opus
+        # For reasoning, should prefer Claude Opus 5
         selected_reasoning = await interface.select_optimal_model(request, "reasoning")
-        assert selected_reasoning == AIModel.CLAUDE_45_OPUS  # First in reasoning chain
+        assert selected_reasoning == AIModel.CLAUDE_OPUS_5  # First in reasoning chain
 
     def test_get_available_models(self):
         """Test getting list of available models"""
@@ -114,13 +131,13 @@ class TestUnifiedAIInterface:
 
         # Set some models as available
         interface.CAPABILITIES[AIModel.GPT_4O].available = True
-        interface.CAPABILITIES[AIModel.CLAUDE_35_SONNET].available = True
+        interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5].available = True
         interface.CAPABILITIES[AIModel.GPT_5].available = False
 
         available = interface.get_available_models()
 
         assert AIModel.GPT_4O in available
-        assert AIModel.CLAUDE_35_SONNET in available
+        assert AIModel.CLAUDE_SONNET_5 in available
         assert AIModel.GPT_5 not in available
 
     def test_enable_disable_models(self):
@@ -139,11 +156,55 @@ class TestUnifiedAIInterface:
         """Aspirational placeholder IDs must ship gated (available=False)."""
         interface = UnifiedAIInterface()
 
-        for model in (AIModel.CLAUDE_45_OPUS, AIModel.GPT_5, AIModel.GPT_5_CODEX):
+        for model in (AIModel.GPT_5, AIModel.GPT_5_CODEX):
             assert interface.CAPABILITIES[model].available is False, (
                 f"{model.value} is an unverified placeholder and must default to "
                 "available=False"
             )
+
+    def test_claude_models_are_current_catalog_ids(self):
+        """Claude entries must carry live, date-suffix-free catalog IDs and be
+        selectable — the retired 3.5 Sonnet ID and the fabricated 4.5 Opus ID
+        must not reappear."""
+        interface = UnifiedAIInterface()
+
+        retired_or_fabricated = {
+            "claude-3-5-sonnet-20241022",  # retired 2025-10-28, returns 404
+            "claude-4-5-opus-20250115",  # never existed in any form
+        }
+
+        claude_models = [
+            model
+            for model, caps in interface.CAPABILITIES.items()
+            if caps.provider is AIProvider.ANTHROPIC
+        ]
+        assert claude_models, "at least one Anthropic model must be registered"
+
+        for model in claude_models:
+            assert model.value not in retired_or_fabricated, (
+                f"{model.value} is a retired or fabricated identifier"
+            )
+            assert interface.CAPABILITIES[model].available is True, (
+                f"{model.value} is verified live and must be selectable"
+            )
+
+        assert AIModel.CLAUDE_OPUS_5.value == "claude-opus-5"
+        assert AIModel.CLAUDE_SONNET_5.value == "claude-sonnet-5"
+
+    def test_claude_capability_profiles_match_catalog(self):
+        """Context window, output ceiling, and cost must match the published
+        Anthropic catalog rather than carrying over the previous entries."""
+        interface = UnifiedAIInterface()
+
+        opus = interface.CAPABILITIES[AIModel.CLAUDE_OPUS_5]
+        assert opus.context_window == 1_000_000
+        assert opus.max_output_tokens == 128_000
+        assert opus.cost_per_1k_tokens == 0.005
+
+        sonnet = interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5]
+        assert sonnet.context_window == 1_000_000
+        assert sonnet.max_output_tokens == 128_000
+        assert sonnet.cost_per_1k_tokens == 0.003
 
     @pytest.mark.asyncio
     async def test_unavailable_model_cannot_be_selected(self):
@@ -200,15 +261,15 @@ class TestAIRequestResponse:
             system_prompt="system context",
             max_tokens=8192,
             temperature=0.5,
-            model_preference=AIModel.CLAUDE_45_OPUS,
-            fallback_chain=[AIModel.CLAUDE_35_SONNET, AIModel.GPT_4O],
+            model_preference=AIModel.CLAUDE_OPUS_5,
+            fallback_chain=[AIModel.CLAUDE_SONNET_5, AIModel.GPT_4O],
             context_tag="custom_tag",
         )
 
         assert request.system_prompt == "system context"
         assert request.max_tokens == 8192
         assert request.temperature == 0.5
-        assert request.model_preference == AIModel.CLAUDE_45_OPUS
+        assert request.model_preference == AIModel.CLAUDE_OPUS_5
         assert len(request.fallback_chain) == 2
         assert request.context_tag == "custom_tag"
 
@@ -249,8 +310,8 @@ class TestModelIntegration:
         request = AIRequest(
             prompt="test",
             fallback_chain=[
-                AIModel.CLAUDE_45_OPUS,
-                AIModel.CLAUDE_35_SONNET,
+                AIModel.CLAUDE_OPUS_5,
+                AIModel.CLAUDE_SONNET_5,
                 AIModel.GPT_4O,
             ],
         )
@@ -301,13 +362,13 @@ class TestAIIntegrationErrorHandling:
             mock_call.side_effect = asyncio.TimeoutError("Request timeout")
 
             # Should handle timeout gracefully
-            interface.CAPABILITIES[AIModel.CLAUDE_35_SONNET].available = True
+            interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5].available = True
 
             try:
                 # Timeout should be caught and handled
                 result = await interface._execute_anthropic(
                     AIRequest(prompt="test"),
-                    AIModel.CLAUDE_35_SONNET
+                    AIModel.CLAUDE_SONNET_5
                 )
                 # If it returns, should indicate failure
                 if result is not None:
@@ -353,7 +414,7 @@ class TestAIIntegrationErrorHandling:
         with patch.object(interface, '_execute_anthropic', new_callable=AsyncMock) as mock_call:
             error_response = AIResponse(
                 content="",
-                model_used=AIModel.CLAUDE_35_SONNET,
+                model_used=AIModel.CLAUDE_SONNET_5,
                 provider=AIProvider.ANTHROPIC,
                 tokens_used=0,
                 latency_ms=50,
@@ -364,7 +425,7 @@ class TestAIIntegrationErrorHandling:
 
             result = await interface._execute_anthropic(
                 AIRequest(prompt="test"),
-                AIModel.CLAUDE_35_SONNET
+                AIModel.CLAUDE_SONNET_5
             )
 
             assert result.success is False
@@ -407,11 +468,11 @@ class TestAIIntegrationErrorHandling:
             # Return invalid response structure
             mock_call.return_value = None
 
-            interface.CAPABILITIES[AIModel.CLAUDE_35_SONNET].available = True
+            interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5].available = True
 
             result = await interface._execute_anthropic(
                 AIRequest(prompt="test"),
-                AIModel.CLAUDE_35_SONNET
+                AIModel.CLAUDE_SONNET_5
             )
 
             # Should handle None response gracefully
@@ -423,19 +484,19 @@ class TestAIIntegrationErrorHandling:
         interface = UnifiedAIInterface()
 
         # Set primary model as unavailable, backup as available
-        interface.CAPABILITIES[AIModel.CLAUDE_45_OPUS].available = False
-        interface.CAPABILITIES[AIModel.CLAUDE_35_SONNET].available = True
+        interface.CAPABILITIES[AIModel.CLAUDE_OPUS_5].available = False
+        interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5].available = True
 
         request = AIRequest(
             prompt="test",
-            model_preference=AIModel.CLAUDE_45_OPUS,
-            fallback_chain=[AIModel.CLAUDE_35_SONNET]
+            model_preference=AIModel.CLAUDE_OPUS_5,
+            fallback_chain=[AIModel.CLAUDE_SONNET_5]
         )
 
         selected = await interface.select_optimal_model(request, "general")
 
         # Should select from fallback chain
-        assert selected == AIModel.CLAUDE_35_SONNET
+        assert selected == AIModel.CLAUDE_SONNET_5
 
     @pytest.mark.asyncio
     async def test_all_models_unavailable(self):
@@ -496,7 +557,7 @@ class TestAIIntegrationErrorHandling:
         with patch.object(interface, '_execute_anthropic', new_callable=AsyncMock) as mock_call:
             error_response = AIResponse(
                 content="",
-                model_used=AIModel.CLAUDE_35_SONNET,
+                model_used=AIModel.CLAUDE_SONNET_5,
                 provider=AIProvider.ANTHROPIC,
                 tokens_used=0,
                 latency_ms=100,
@@ -509,7 +570,7 @@ class TestAIIntegrationErrorHandling:
             for _ in range(3):
                 result = await interface._execute_anthropic(
                     AIRequest(prompt="test"),
-                    AIModel.CLAUDE_35_SONNET
+                    AIModel.CLAUDE_SONNET_5
                 )
                 assert result.success is False
 
@@ -575,20 +636,20 @@ class TestAIIntegrationErrorHandling:
         with patch.object(interface, '_execute_anthropic', new_callable=AsyncMock) as mock_call:
             mock_call.return_value = AIResponse(
                 content="test response",
-                model_used=AIModel.CLAUDE_35_SONNET,
+                model_used=AIModel.CLAUDE_SONNET_5,
                 provider=AIProvider.ANTHROPIC,
                 tokens_used=50,
                 latency_ms=200,
                 success=True
             )
 
-            interface.CAPABILITIES[AIModel.CLAUDE_35_SONNET].available = True
+            interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5].available = True
 
             # Fire multiple requests concurrently
             requests = [
                 interface._execute_anthropic(
                     AIRequest(prompt=f"test {i}"),
-                    AIModel.CLAUDE_35_SONNET
+                    AIModel.CLAUDE_SONNET_5
                 )
                 for i in range(5)
             ]
@@ -640,22 +701,22 @@ class TestAIIntegrationResilience:
         interface = UnifiedAIInterface()
 
         # Set up fallback chain
-        interface.CAPABILITIES[AIModel.CLAUDE_45_OPUS].available = False
-        interface.CAPABILITIES[AIModel.CLAUDE_35_SONNET].available = True
+        interface.CAPABILITIES[AIModel.CLAUDE_OPUS_5].available = False
+        interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5].available = True
         interface.CAPABILITIES[AIModel.GPT_4O].available = True
 
         request = AIRequest(
             prompt="test",
-            model_preference=AIModel.CLAUDE_45_OPUS,
+            model_preference=AIModel.CLAUDE_OPUS_5,
             fallback_chain=[
-                AIModel.CLAUDE_35_SONNET,
+                AIModel.CLAUDE_SONNET_5,
                 AIModel.GPT_4O
             ]
         )
 
         # Should successfully select from fallback
         selected = await interface.select_optimal_model(request, "general")
-        assert selected in [AIModel.CLAUDE_35_SONNET, AIModel.GPT_4O]
+        assert selected in [AIModel.CLAUDE_SONNET_5, AIModel.GPT_4O]
 
     @pytest.mark.asyncio
     async def test_model_recovery_after_failure(self):


### PR DESCRIPTION
Both Claude entries in the `AIModel` enum were wrong, and one carried a false `# Verified live` comment.

| Before | After |
|---|---|
| `CLAUDE_35_SONNET = "claude-3-5-sonnet-20241022"  # Verified live` | `CLAUDE_OPUS_5 = "claude-opus-5"  # Verified live` |
| `CLAUDE_45_OPUS = "claude-4-5-opus-20250115"  # UNVERIFIED placeholder` | `CLAUDE_SONNET_5 = "claude-sonnet-5"  # Verified live` |

**`claude-3-5-sonnet-20241022` was retired on 2025-10-28 and returns 404.** It was tagged `# Verified live` and was the only Anthropic entry with `available=True` — so it was the only model `select_optimal_model()` could ever pick. Every Anthropic call routed through this interface failed against the live API, then silently fell back to GPT-4o (`execute_request` catches the exception, writes `logger.error`, and continues).

**`claude-4-5-opus-20250115` never existed in any form.** Correctly gated `available=False`, so inert rather than harmful, but it should not remain as a fabricated identifier.

Both replaced against the current Anthropic catalog. These IDs take **no date suffix** — they are complete as written.

## Notes on the approach

**Opus 5 takes the top-tier slot**, not a positional swap — it leads the reasoning and mathematical fallback chains, so "prefer the strongest model for reasoning" stays true.

**Both ship `available=True`.** They're real, verified IDs; gating them would recreate the no-selectable-model problem in reverse.

**Capabilities were stale on all three fields**, not just the IDs — Opus 5 is now `1_000_000 / 128_000 / 0.005`, Sonnet 5 `1_000_000 / 128_000 / 0.003`.

**The enum docstring's promotion rule was sound and is kept.** What it lacked was a definition of the tag it governs, so `# Verified live` now explicitly means *checked against the provider catalog on the reconciliation date* — not *once believed correct* — plus a record of how the previous entries violated the rule.

**GPT entries deliberately untouched.** No authoritative source at hand for OpenAI's catalog, and `GPT_5` / `GPT_5_CODEX` are already gated `available=False`.

## Two things worth reviewer attention

**1. A third file was in scope by necessity.** `modules/ai_core/claude_integration_hub.py` referenced both enum members in 9 places — the rename would have broken it with an `AttributeError` at import. Beyond those references I also updated its config defaults, which held the *same* two bad IDs (`preferred_model = "claude-4-5-opus-20250115"`), and renamed its internal availability attributes for accuracy.

`enable_claude_45()`, the `/enable-claude-45` route, and the `get_global_status()` response keys are **left intact** — they're public surface, and renaming them is a separate decision. Both are commented as legacy naming. Easy to revert to the minimal 9-line fix if preferred.

**2. A pre-existing test bug was masking itself.** `test_aspirational_models_default_unavailable` fails on the **unmodified baseline** too — verified via `git stash`. `UnifiedAIInterface.CAPABILITIES` is a *class* attribute, so one dict is shared by every instance including the module-level `unified_ai` singleton; an earlier test setting all models available permanently flips `GPT_5` to `True` for every later instance.

Fixed test-side with an autouse fixture that restores the flags. **Production semantics unchanged** — making `CAPABILITIES` per-instance would alter cross-consumer `enable_model` behaviour and deserves a deliberate call. Tracked in #1329.

## Test plan

```
pytest tests/test_unified_ai_interface.py -q
```

**34 passed, 1 skipped.** The skip is `aiohttp` not installed (pre-existing).

Two regression tests added: one denylisting both bad IDs and asserting every Anthropic entry resolves and is selectable, one pinning the capability numbers against the catalog.

Also checked: `tests/test_orchestrator_wiring.py` has 3 failures that are **identical on baseline** — pre-existing and unrelated to this change.

## Follow-up

#1329 covers the process gap that allowed this — a catalog validator against `GET /v1/models`, dated verification fields, and an alert so an enabled-but-404ing model can't silently degrade again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
