### PR TITLE
fix: green on macOS, close a path traversal, and gate the frontend

### DIFF
--- a/.github/workflows/cross-platform-paths.yml
+++ b/.github/workflows/cross-platform-paths.yml
@@ -1,0 +1,75 @@
+---
+name: Cross-Platform Path Checks
+# Every other workflow is ubuntu-latest. That is why three path-handling bugs
+# reached main unchallenged: a "/tmp/" prefix test that never matched macOS's
+# /var/folders temp dir, a Windows drive-relative case, and a validator that
+# compared an unresolved caller path against a resolved root — the last of which
+# failed 11 tests and errored 25 more on macOS while staying green on Linux,
+# because /tmp needs no resolution there.
+#
+# This job runs the path- and security-sensitive tests on macOS and Windows.
+# It is deliberately narrow: the point is to catch platform assumptions early,
+# not to duplicate the full suite on three operating systems.
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'modules/insight_ledger/**'
+      - 'src/improvement/**'
+      - 'src/utils/**'
+      - 'tests/test_insight_ledger*.py'
+      - 'tests/test_improvement_api.py'
+      - 'tests/modules/test_insight_ledger_security.py'
+      - '.github/workflows/cross-platform-paths.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'modules/insight_ledger/**'
+      - 'src/improvement/**'
+      - 'src/utils/**'
+      - 'tests/test_insight_ledger*.py'
+      - 'tests/test_improvement_api.py'
+      - 'tests/modules/test_insight_ledger_security.py'
+      - '.github/workflows/cross-platform-paths.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  paths:
+    name: "Path checks (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # Fail closed: these are the surfaces where platform assumptions bite.
+      - name: Path, ledger and improvement tests
+        run: |
+          pytest -q --tb=short \
+            tests/test_insight_ledger.py \
+            tests/test_insight_ledger_integration.py \
+            tests/modules/test_insight_ledger_security.py \
+            tests/test_improvement_api.py
+
+      - name: Security-marked tests
+        run: pytest -q -m security --tb=short

--- a/.github/workflows/cross-platform-paths.yml
+++ b/.github/workflows/cross-platform-paths.yml
@@ -57,19 +57,29 @@ jobs:
         with:
           python-version: '3.12'
 
+      # requirements-test.txt carries pytest and its plugins; requirements.txt
+      # alone leaves the runner without a pytest to invoke.
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-test.txt
 
+      # `shell: bash` on every step below: the Windows default is PowerShell,
+      # which does not accept backslash line-continuations and reported the
+      # whole invocation as an unrecognised cmdlet. `python -m pytest` rather
+      # than bare `pytest` so the run does not depend on the console script
+      # landing on PATH, which differs between the runners.
+      #
       # Fail closed: these are the surfaces where platform assumptions bite.
       - name: Path, ledger and improvement tests
+        shell: bash
         run: |
-          pytest -q --tb=short \
+          python -m pytest -q --tb=short \
             tests/test_insight_ledger.py \
             tests/test_insight_ledger_integration.py \
             tests/modules/test_insight_ledger_security.py \
             tests/test_improvement_api.py
 
       - name: Security-marked tests
-        run: pytest -q -m security --tb=short
+        shell: bash
+        run: python -m pytest -q -m security --tb=short

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,81 @@
+---
+name: Frontend CI
+# frontend/ is a full Vite/React application with its own package.json, and
+# until now no workflow referenced it — zero of 58 jobs. Dependabot merged into
+# it continuously (#1318 alone carried 39 updates) with nothing verifying the
+# result, so the app had been unbuildable for some time without anyone noticing:
+# Tailwind's PostCSS plugin had moved packages, Vite 8 no longer accepted the
+# object form of manualChunks, the v3 @tailwind directives no longer loaded the
+# theme config, and 15 TypeScript errors had accumulated.
+#
+# type-check and build are blocking, because they now pass and they are what
+# catches the next unverified dependency bump. Lint is advisory only because
+# ESLint is not wired to the TypeScript parser and reports parse errors on every
+# .ts/.tsx file — a config defect tracked in #1340, not a code defect.
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: frontend
+
+jobs:
+  frontend:
+    name: "Frontend build and type-check"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v5.0.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # `npm ci` runs the "prepare" script, which invokes husky; husky exits
+      # non-zero when it cannot find .git relative to the working directory.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Blocking: this is the gate that catches a dependency bump breaking the
+      # type surface.
+      - name: Type-check
+        run: npm run type-check
+
+      # Blocking: catches PostCSS/bundler/config breakage that type-check cannot
+      # see, which is exactly how the Tailwind and Vite majors slipped through.
+      - name: Build
+        run: npm run build
+
+      # Advisory: ESLint currently parses .ts/.tsx with the default parser and
+      # reports "The keyword 'interface' is reserved" and "Unexpected token <"
+      # across the codebase. That is the lint setup, not the source. Tracked in
+      # #1340; promote this to blocking once the baseline is truthful.
+      - name: Lint (advisory; tracked in #1340)
+        continue-on-error: true
+        run: npm run lint
+
+      # Blocking, but currently vacuous: no *.test.* or *.spec.* files exist yet.
+      # --passWithNoTests keeps it green until they do, at which point this step
+      # starts enforcing them without needing to be edited.
+      - name: Unit tests
+        run: npx vitest run --passWithNoTests

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -77,5 +77,9 @@ jobs:
       # Blocking, but currently vacuous: no *.test.* or *.spec.* files exist yet.
       # --passWithNoTests keeps it green until they do, at which point this step
       # starts enforcing them without needing to be edited.
+      #
+      # --no-install so npx can only run the vitest already pinned by
+      # package-lock.json; without it npx will silently fetch and execute an
+      # unpinned release when the local one is missing.
       - name: Unit tests
-        run: npx vitest run --passWithNoTests
+        run: npx --no-install vitest run --passWithNoTests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,28 @@
 
 ## Security Overview
 
-Aurora CloudBank implements enterprise-grade security measures to protect user data, 
-system integrity, and ensure secure operations across all components.
+Aurora CloudBank applies defence-in-depth to protect user data and system
+integrity: CSRF enforcement on every state-changing route, PII scrubbing before
+logging, a hash-linked tamper-evident audit ledger, and path containment on
+every filesystem-touching surface.
 
-**Security Score: 100/100 (Outstanding)**
+**This project has not been independently audited, and carries no security
+score.** Any number here would be self-assigned, and a self-assigned score is
+the kind of claim this repository tries not to make — see
+[`docs/VERIFIED_CLAIMS.md`](docs/VERIFIED_CLAIMS.md) for the standard: every
+claim shows the command that produces it.
+
+What can be said with evidence:
+
+- **114 security-marked tests** cover path containment, CSRF, PII redaction, and
+  ledger tamper detection. Run them with `pytest -m security -q`
+  (114 passed, 4 skipped, ~2 s on the machine this was measured on).
+- Static analysis runs on every PR (CodeQL, SonarCloud, Codacy, GitGuardian).
+- Known open security work is tracked in public issues rather than closed
+  silently — see the `security:` prefixed issues.
+
+Known-open findings are listed in the issue tracker, not summarised here, so
+that this file cannot drift away from them.
 
 ## 🛡️ Security Framework
 
@@ -123,22 +141,36 @@ python security_monitoring_system.py
 curl http://localhost:8000/security/status
 ```
 
-## 📊 Security Metrics
+## 📊 What runs, and what it does not tell you
 
-| Metric | Target | Current |
-|--------|--------|---------|
-| Vulnerability Response Time | < 24h | ✅ Achieved |
-| Security Scan Coverage | 100% | ✅ Achieved |
-| Dependency Security | 100% | ✅ Achieved |
-| Code Security Score | 95+ | ✅ 100/100 |
-| Monitoring Coverage | 100% | ✅ Achieved |
+This table previously reported five metrics as "✅ Achieved", including a
+self-assigned 100/100 code security score. None of those figures were measured,
+so they have been replaced with the checks that actually run and an honest note
+on each one's limits.
 
-## 🏆 Security Certifications
+| Check | Runs on | What it does *not* cover |
+|---|---|---|
+| CodeQL | every PR | Alerts dismissed as "won't fix" do not reappear. Query all states, not just `open`, before concluding a branch is clean. |
+| SonarCloud | every PR | Quality gate is scoped to changed lines, not the whole tree. |
+| Codacy | every PR | Currently fails any PR that adds pytest tests — see the tracking issue on the zero-new-issues threshold. |
+| GitGuardian | every PR | Detects committed secrets; says nothing about secrets supplied at runtime. |
+| Security-marked tests | `pytest -m security` | Covers path containment, CSRF, PII redaction, ledger tamper detection. Not exhaustive. |
+| Dependabot | continuous | Opens PRs; merging them is not automatic, and the `frontend/` package has no build gate verifying them. |
 
-- **OWASP Compliance**: Following OWASP Top 10 guidelines
-- **Security by Design**: Built-in security architecture
-- **Zero Trust**: Implemented zero trust principles
-- **Enterprise Ready**: Production-grade security measures
+**No CI job runs on macOS or Windows.** Every workflow is `ubuntu-latest`, so
+platform-specific defects reach `main` unchallenged — three have, all in path
+handling.
+
+## 🏆 Design principles
+
+These are the principles the architecture is built to, **not certifications** —
+nothing here has been certified or independently assessed:
+
+- **OWASP Top 10**: used as a design reference
+- **Security by design**: security considered at architecture level, not bolted on
+- **Zero trust**: verify at each boundary rather than trusting callers
+- **Defence in depth**: containment enforced at more than one layer, so a single
+  missed check is not sufficient on its own
 
 ## 📋 Security Checklist
 

--- a/docs/VERIFIED_CLAIMS.md
+++ b/docs/VERIFIED_CLAIMS.md
@@ -52,21 +52,39 @@ for a minimal install, not a ceiling.
 pytest -q
 ```
 
-Observed on a clean clone with core requirements only:
+Observed on a clean clone with core requirements only, on macOS (Darwin 25.5.0,
+CPython 3.12.13):
 
 | | count |
 |---|---|
-| passed | **3,008** |
-| failed | 36 |
-| errors | 27 |
+| passed | **3,146** |
+| failed | 0 |
+| errors | 0 |
 | skipped | 123 |
-| duration | ~5 min 30 s |
+| xfailed | 9 |
+| xpassed | 2 |
+| duration | ~5 min 50 s |
 
-The 36 failures and 27 errors are **environmental, not logic**, and are honest
-about it — a hardcoded `/var/lib/nemo_snapshots` path, absent Redis, and
-unconfigured auth users account for most of them. They are listed here rather
-than hidden because a reader will hit them, and discovering them unannounced is
-worse than being told.
+An earlier revision of this page recorded 3,008 passed with 36 failures and 27
+errors, described as environmental rather than logic. That was accurate when
+written and is no longer: the causes were fixed rather than explained away — a
+hardcoded `/var/lib/nemo_snapshots` snapshot path, a module-level auth-users
+build that stopped `/api/auth/` registering at all, a missing CSRF-token
+issuance endpoint, an async Redis client constructed without a liveness check,
+and a path validator that compared an unresolved caller path against a resolved
+root and so rejected every macOS temp directory.
+
+The 123 skips are honest skips — optional dependencies (`aiohttp`, `z3`,
+`pytest-benchmark`), connector integration tests that need a running API and a
+token, and one Cryptography-availability branch that cannot be exercised while
+Cryptography is installed. Each states its reason in the skip message.
+
+The 2 xpassed entries are tests marked environment-specific that happen to pass
+here; they are left marked because they depend on a working `.venv/bin/pip` and
+a devcontainer, neither of which is guaranteed.
+
+> Re-measure before citing. This table is a reading taken on one machine, not a
+> guarantee. `pytest -q` prints the same summary line in about six minutes.
 
 Fast path: `pytest -m unit`.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,6 +58,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.62.0",
+        "@tailwindcss/postcss": "^4.3.3",
         "@tanstack/react-query-devtools": "^5.101.4",
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^16.3.2",
@@ -101,6 +102,19 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -2937,6 +2951,289 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -6312,6 +6609,20 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
@@ -6951,6 +7262,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7410,6 +7728,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jotai": {
@@ -10007,6 +10335,20 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/three": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",
+    "@tailwindcss/postcss": "^4.3.3",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^16.3.2",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,11 @@
+// Tailwind v4 moved its PostCSS plugin out of the `tailwindcss` package and
+// into `@tailwindcss/postcss`. Naming `tailwindcss` here failed the build with
+// "It looks like you're trying to use `tailwindcss` directly as a PostCSS
+// plugin". The v4 bump arrived via dependabot; nothing in CI built the
+// frontend, so the breakage stayed invisible until someone ran the build by hand.
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };

--- a/frontend/src/components/Editor/EditorToolbar.tsx
+++ b/frontend/src/components/Editor/EditorToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/lib/utils';
-import { Play, Save, Share2, GitFork, RefreshCw } from 'lucide-react';
+import { Play, Save, Share2, GitFork } from 'lucide-react';
 import { ReactNode } from 'react';
 
 interface EditorToolbarProps {

--- a/frontend/src/lib/api/aurora.ts
+++ b/frontend/src/lib/api/aurora.ts
@@ -63,9 +63,11 @@ export const auroraAPI = {
     chat: (message: AgentMessage) =>
       apiClient.post<AgentResponse>('/api/agent/chat', message),
 
-    stream: (message: AgentMessage) =>
-      // For streaming, we'll use EventSource in a separate hook
-      `/api/agent/stream`,
+    // Returns the endpoint only; the caller opens an EventSource against it.
+    // The message is not sent from here, so the parameter is deliberately
+    // unused and underscore-prefixed to say so — it keeps the signature
+    // symmetrical with chat() above for callers that pass the same object.
+    stream: (_message: AgentMessage) => `/api/agent/stream`,
   },
 
   // ===== Compliance =====

--- a/frontend/src/pages/AgentConsole/index.tsx
+++ b/frontend/src/pages/AgentConsole/index.tsx
@@ -181,7 +181,7 @@ export default function AgentConsole() {
 
   const sendMessage = useMutation({
     mutationFn: (message: AgentMessage) => auroraAPI.agent.chat(message),
-    onSuccess: (data: AgentResponse, variables) => {
+    onSuccess: (data: AgentResponse) => {
       const assistantMessage: Message = {
         id: Date.now().toString(),
         role: 'assistant',

--- a/frontend/src/pages/Dashboard/index.tsx
+++ b/frontend/src/pages/Dashboard/index.tsx
@@ -141,8 +141,6 @@ export default function Dashboard() {
   const {
     data: memoryMetrics,
     isError: memoryError,
-    isStale: memoryStale,
-    dataUpdatedAt: memoryUpdatedAt,
     refetch: refetchMemory,
   } = useQuery({
     queryKey: ['memory-metrics'],

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,6 +1,19 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+/* Tailwind v4 entry point.
+ *
+ * The package has been on v4 for a while, but this file still used the v3
+ * `@tailwind base/components/utilities` directives, and v4 stopped reading
+ * `tailwind.config.ts` implicitly. The build therefore failed with "Cannot
+ * apply unknown utility class `border-border`" — every theme token defined in
+ * that config was invisible. Nothing in CI built the frontend, so it went
+ * unnoticed.
+ *
+ * `@config` is v4's supported bridge to a v3-style config. It keeps the whole
+ * existing theme — colours, fonts, keyframes, animations — working unchanged,
+ * rather than hand-porting 171 lines into `@theme` and risking silent visual
+ * drift. Porting to `@theme` remains available later as a deliberate change.
+ */
+@import "tailwindcss";
+@config "../../tailwind.config.ts";
 
 @layer base {
   :root {

--- a/frontend/src/types/playground.ts
+++ b/frontend/src/types/playground.ts
@@ -1,6 +1,86 @@
 export type PlaygroundLanguage = 'python' | 'javascript';
 export type PlaygroundTheme = 'light' | 'dark';
 
+// ---------------------------------------------------------------------------
+// Playground API contract
+//
+// src/services/playground.ts imported these seven types, but they were never
+// defined here — 7 of the 15 TypeScript errors that made `npm run build` fail.
+// Each mirrors the Pydantic model of the same name in src/playground/models.py,
+// which is the authoritative contract; field names are the wire names (snake
+// case) rather than camelCase for that reason. PlaygroundLanguage already
+// matches the backend's ExecutionLanguage enum exactly.
+// ---------------------------------------------------------------------------
+
+/** POST /playground/session */
+export interface SessionCreateRequest {
+  language: PlaygroundLanguage;
+  /** Optional starter snippet. */
+  seed_code?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SessionCreateResponse {
+  session_id: string;
+  /** Unix timestamp (seconds). */
+  expires_at: number;
+}
+
+/** POST /playground/execute */
+export interface ExecuteRequest {
+  /** Existing session identifier; omitted to start a new one. */
+  session_id?: string | null;
+  code: string;
+  language: PlaygroundLanguage;
+  stdin?: string | null;
+}
+
+export interface ExecutionResult {
+  task_id: string;
+  session_id: string;
+  status: string;
+  output: string;
+  errors: string[];
+  /** Unix timestamps (seconds). */
+  started_at: number;
+  completed_at?: number | null;
+  duration_ms?: number | null;
+  /** Present when PII redaction rewrote the output. */
+  redacted_output?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+/** Returned by POST /playground/execute and GET /playground/results/{id}. */
+export interface ExecutionStatusResponse {
+  task_id: string;
+  session_id: string;
+  status: string;
+  /** Absent while the task is still queued or running. */
+  result?: ExecutionResult | null;
+}
+
+/** POST /playground/share */
+export interface ShareRequest {
+  session_id: string;
+  code: string;
+  language: PlaygroundLanguage;
+}
+
+export interface ShareResponse {
+  short_code: string;
+  session_id: string;
+  url: string;
+  embed_html: string;
+}
+
+/** Frames pushed over GET /playground/ws/{session_id}. */
+export interface StreamMessage {
+  event: string;
+  session_id: string;
+  task_id?: string | null;
+  payload?: Record<string, unknown>;
+}
+
 export interface PlaygroundExample {
   id: string;
   title: string;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="vite/client" />
+
+// Vite's ambient types were never referenced, so `import.meta.env` was unknown
+// to tsc — 3 of the 15 TypeScript errors that made `npm run build` fail. The
+// triple-slash directive above supplies the built-in members (DEV, PROD, MODE,
+// BASE_URL, SSR).
+//
+// The interface below declares this project's own VITE_-prefixed variables, so
+// a typo in one is a compile error rather than a silent `undefined` at runtime.
+// Keep it in step with .env.example.
+
+interface ImportMetaEnv {
+  /** Base URL of the Aurora API. Falls back to http://localhost:8000. */
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -57,7 +57,7 @@ export default defineConfig({
             'chart-vendor': ['recharts', 'd3'],
           };
 
-          const normalised = id.replace(/\\/g, '/');
+          const normalised = id.replaceAll('\\', '/');
           for (const [chunk, packages] of Object.entries(groups)) {
             if (packages.some((pkg) => normalised.includes(`/node_modules/${pkg}/`))) {
               return chunk;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -35,16 +35,35 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-          'three-vendor': ['three', '@react-three/fiber', '@react-three/drei'],
-          'ui-vendor': [
-            '@radix-ui/react-dialog',
-            '@radix-ui/react-dropdown-menu',
-            '@radix-ui/react-select',
-            '@radix-ui/react-tabs',
-          ],
-          'chart-vendor': ['recharts', 'd3'],
+        // Vite 8 / Rollup 4 dropped the object form of manualChunks — it now
+        // warns "Invalid type: Expected Function but received Object" and
+        // silently stops chunking. Same grouping, expressed as the function
+        // form: match on the module id rather than declaring package lists.
+        //
+        // Matching is on `/node_modules/<name>/` so a package cannot be caught
+        // by a substring of an unrelated dependency's path.
+        manualChunks(id: string) {
+          if (!id.includes('node_modules')) return undefined;
+
+          const groups: Record<string, string[]> = {
+            'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+            'three-vendor': ['three', '@react-three/fiber', '@react-three/drei'],
+            'ui-vendor': [
+              '@radix-ui/react-dialog',
+              '@radix-ui/react-dropdown-menu',
+              '@radix-ui/react-select',
+              '@radix-ui/react-tabs',
+            ],
+            'chart-vendor': ['recharts', 'd3'],
+          };
+
+          const normalised = id.replace(/\\/g, '/');
+          for (const [chunk, packages] of Object.entries(groups)) {
+            if (packages.some((pkg) => normalised.includes(`/node_modules/${pkg}/`))) {
+              return chunk;
+            }
+          }
+          return undefined;
         },
       },
     },

--- a/modules/insight_ledger/ledger_core.py
+++ b/modules/insight_ledger/ledger_core.py
@@ -53,6 +53,7 @@ def validate_safe_path(user_path: str, safe_root: Path, allow_create: bool = Fal
     directory those paths live in — containment rather than exemption.
     """
     requested = Path(user_path)
+    safe_root_as_given = safe_root
     safe_root = safe_root.resolve()
     safe_root_str = str(safe_root)
 
@@ -62,9 +63,28 @@ def validate_safe_path(user_path: str, safe_root: Path, allow_create: bool = Fal
         # the path is not lexically under safe_root (no filesystem access).
         # We then reconstruct from the trusted safe_root prefix so that
         # .resolve() is never called on unvalidated user data.
-        try:
-            rel = requested.relative_to(safe_root)
-        except ValueError:
+        #
+        # Try both spellings of the root, because relative_to() is lexical and
+        # the two can be disjoint strings for the same directory. On macOS
+        # /var is a symlink to /private/var, and tempfile/env values are handed
+        # back unresolved: safe_root.resolve() is /private/var/folders/... while
+        # the caller holds /var/folders/.... Matching only the resolved spelling
+        # rejected a caller passing back the very path it had just been given,
+        # which failed 11 tests and errored 25 more on macOS while staying green
+        # on Linux, where /tmp needs no resolution. The same applies to any
+        # symlinked mount or home directory.
+        #
+        # Both candidates are trusted configuration, not request data, and the
+        # reconstruction below still happens against the *resolved* root — so
+        # the containment barrier is unchanged, only the spelling is forgiving.
+        rel = None
+        for candidate in (safe_root, safe_root_as_given):
+            try:
+                rel = requested.relative_to(candidate)
+                break
+            except ValueError:
+                continue
+        if rel is None:
             raise ValueError(f"Path outside allowed directory: {user_path}")
         full_path = (safe_root / rel).resolve()
     else:

--- a/src/improvement/api.py
+++ b/src/improvement/api.py
@@ -35,6 +35,44 @@ def _safe_root() -> Path:
     return root
 
 
+def _validate_file_patterns(file_patterns: Optional[List[str]]) -> None:
+    """Reject glob patterns that would walk outside the analysis directory.
+
+    ``directory`` is resolved through trusted enumeration, but the pattern was
+    passed to ``Path.rglob()`` unchecked — and rglob honours ``..``. So
+    ``{"directory": "proj", "file_patterns": ["../*.py"]}`` read proj's
+    siblings, and ``../../*.py`` escaped the configured root entirely, with the
+    matched absolute paths echoed back in the response.
+
+    Absolute patterns already raise NotImplementedError inside pathlib, but are
+    rejected here too so the caller gets a 400 rather than a 500.
+    """
+    for pattern in file_patterns or []:
+        candidate = PurePath(pattern)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "File patterns must stay within the analyzed directory: "
+                    "absolute patterns and '..' are not allowed."
+                ),
+            )
+
+
+def _root_spellings(safe_root: Path) -> tuple[PurePath, ...]:
+    """Every string form that names the analysis root.
+
+    ``relative_to`` compares lexically, so a root reached through a symlinked
+    prefix needs both its resolved and its as-configured spelling. Returns the
+    resolved form first; the configured form is added only when it differs.
+    """
+    spellings = [PurePath(str(safe_root))]
+    override = os.environ.get("AURORA_IMPROVEMENT_ROOT", "")
+    if override and str(PurePath(override)) != str(safe_root):
+        spellings.append(PurePath(override))
+    return tuple(spellings)
+
+
 def _request_parts(user_path: str, safe_root: Path) -> tuple[str, ...]:
     """Convert a request value to lexical root-relative lookup components.
 
@@ -43,16 +81,30 @@ def _request_parts(user_path: str, safe_root: Path) -> tuple[str, ...]:
     filesystem path.
     """
     requested = PurePath(user_path)
-    root_key = PurePath(str(safe_root))
 
     if requested.is_absolute():
-        try:
-            requested = requested.relative_to(root_key)
-        except ValueError as exc:
+        # relative_to() is lexical, so the root has to be tried in every
+        # spelling that names it. _safe_root() resolves, but callers hold the
+        # unresolved form: on macOS /var is a symlink to /private/var, so a
+        # request carrying the path it was just given (/var/folders/...) is
+        # lexically disjoint from the resolved root (/private/var/folders/...)
+        # and was refused with 403. Linux never showed it, because /tmp needs
+        # no resolution. Any symlinked mount or home directory behaves the same.
+        #
+        # These candidates are trusted configuration, never request data, and
+        # every returned path still comes from trusted iterdir() enumeration
+        # below — so this widens the accepted spelling, not the boundary.
+        for root_key in _root_spellings(safe_root):
+            try:
+                requested = requested.relative_to(root_key)
+                break
+            except ValueError:
+                continue
+        else:
             raise HTTPException(
                 status_code=403,
                 detail="Access to this path is not allowed.",
-            ) from exc
+            )
     elif ".." in requested.parts:
         raise HTTPException(
             status_code=400,
@@ -205,6 +257,8 @@ async def analyze_directory(request: AnalyzeDirectoryRequest):
 
     if not full_path.is_dir():
         raise HTTPException(status_code=400, detail=f"Not a directory: {request.directory}")
+
+    _validate_file_patterns(request.file_patterns)
 
     results = engine.analyze_directory(full_path, request.file_patterns)
 

--- a/src/improvement/api.py
+++ b/src/improvement/api.py
@@ -269,7 +269,15 @@ async def analyze_file(request: AnalyzeFileRequest):
     return [suggestion.to_dict() for suggestion in suggestions]
 
 
-@router.post("/analyze-directory", response_model=AnalysisReportResponse)
+@router.post(
+    "/analyze-directory",
+    response_model=AnalysisReportResponse,
+    responses={
+        400: {"description": "Not a directory, or a file pattern that is rooted, drive-qualified, or contains '..'"},
+        403: {"description": "Path resolves outside the analysis root"},
+        404: {"description": "Directory not found beneath the analysis root"},
+    },
+)
 async def analyze_directory(request: AnalyzeDirectoryRequest):
     """Analyze a trusted, root-enumerated directory."""
     engine = get_improvement_engine()

--- a/src/improvement/api.py
+++ b/src/improvement/api.py
@@ -6,7 +6,7 @@ Provides REST API for code analysis and improvement suggestions.
 
 import os
 from enum import Enum
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
@@ -44,17 +44,37 @@ def _validate_file_patterns(file_patterns: Optional[List[str]]) -> None:
     siblings, and ``../../*.py`` escaped the configured root entirely, with the
     matched absolute paths echoed back in the response.
 
-    Absolute patterns already raise NotImplementedError inside pathlib, but are
+    Rooted patterns already raise NotImplementedError inside pathlib, but are
     rejected here too so the caller gets a 400 rather than a 500.
+
+    The check runs through PureWindowsPath on every platform because
+    ``is_absolute()`` alone is not sufficient and its answer is
+    platform-dependent:
+
+    ==========================  ===========  ==========  =====
+    pattern                     posix_abs    win_abs     caught by
+    ==========================  ===========  ==========  =====
+    ``/etc/*.conf``             True         **False**   root
+    ``C:foo/*.py``              False        **False**   drive
+    ``C:/x/*.py``               False        True        drive/root
+    ``\\\\srv\\share\\*.py``    False        True        drive
+    ``../*.py``                 False        False       ``..``
+    ==========================  ===========  ==========  =====
+
+    ``/etc/*.conf`` is the case that matters: on Windows it has no drive, so
+    ``is_absolute()`` is False and it slipped through to rglob(), which raised
+    NotImplementedError and turned a 400 into a 500. ``C:foo`` is the
+    drive-relative form tracked in #1337. PureWindowsPath also treats ``\\`` as
+    a separator, so ``..\\..\\x`` is caught on Linux too.
     """
     for pattern in file_patterns or []:
-        candidate = PurePath(pattern)
-        if candidate.is_absolute() or ".." in candidate.parts:
+        candidate = PureWindowsPath(pattern)
+        if candidate.drive or candidate.root or ".." in candidate.parts:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     "File patterns must stay within the analyzed directory: "
-                    "absolute patterns and '..' are not allowed."
+                    "rooted, drive-qualified and '..' patterns are not allowed."
                 ),
             )
 

--- a/src/improvement/engine.py
+++ b/src/improvement/engine.py
@@ -360,16 +360,37 @@ class CodeImprovementEngine:
         """
         if file_patterns is None:
             file_patterns = ["*.py"]
-        
+
         results = {}
-        
+
+        # rglob() honours ".." inside a pattern, so a caller-supplied pattern
+        # can walk back out of `directory`: "../*.py" reaches its siblings and
+        # "../../*.py" escapes further still. Callers are expected to reject
+        # such patterns up front, but this method takes them as an argument and
+        # cannot assume that happened — so every match is confirmed to resolve
+        # inside `directory` before it is read. Absolute patterns raise
+        # NotImplementedError inside pathlib and never get this far.
+        directory_resolved = directory.resolve()
+
         for pattern in file_patterns:
             for file_path in directory.rglob(pattern):
-                if file_path.is_file():
-                    suggestions = self.analyze_file(file_path)
-                    if suggestions:
-                        results[str(file_path)] = suggestions
-        
+                if not file_path.is_file():
+                    continue
+
+                resolved = file_path.resolve()
+                if directory_resolved not in resolved.parents:
+                    logger.warning(
+                        "Skipping %s: pattern %r escaped the analysis directory",
+                        safe_path(resolved),
+                        pattern,
+                    )
+                    continue
+
+                suggestions = self.analyze_file(resolved)
+                if suggestions:
+                    results[str(resolved)] = suggestions
+
+
         logger.info("Analyzed directory %s: found improvements in %d files", safe_path(directory), len(results))
         return results
     

--- a/src/improvement/engine.py
+++ b/src/improvement/engine.py
@@ -379,10 +379,14 @@ class CodeImprovementEngine:
 
                 resolved = file_path.resolve()
                 if directory_resolved not in resolved.parents:
+                    # `pattern` is caller-controlled, so it goes through
+                    # safe_str() like every other untrusted value logged here —
+                    # a raw %r would let a crafted pattern inject newlines and
+                    # forge log entries.
                     logger.warning(
-                        "Skipping %s: pattern %r escaped the analysis directory",
+                        "Skipping %s: pattern %s escaped the analysis directory",
                         safe_path(resolved),
-                        pattern,
+                        safe_str(pattern),
                     )
                     continue
 

--- a/src/middleware/dlp_auto_tracker.py
+++ b/src/middleware/dlp_auto_tracker.py
@@ -11,9 +11,28 @@ import logging
 logger = logging.getLogger(__name__)
 
 import time
+import uuid
 from typing import Callable, Optional, Set
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+
+def _unique_suffix() -> str:
+    """Return a collision-resistant suffix for a DLP correlation tag.
+
+    Tag IDs were built from ``int(time.time() * 1000)`` alone, so any two
+    requests handled inside the same millisecond received identical tags. That
+    is a correlation ID joining a request to its audit records: colliding tags
+    can attribute two requests to one audit entry, and can attach a response to
+    the wrong request via ``add_dependency``. It also made
+    tests/test_dlp_auto_tracker.py intermittently fail — 2 failures in 12
+    isolated runs — which is the same defect seen from the outside.
+
+    The millisecond prefix is kept because it makes tags sort chronologically,
+    which is useful when reading an audit trail; uniqueness comes from the
+    random suffix rather than from the clock.
+    """
+    return f"{int(time.time() * 1000)}_{uuid.uuid4().hex[:12]}"
 
 # Import with graceful fallback
 try:
@@ -122,7 +141,7 @@ class DLPAutoTrackingMiddleware(BaseHTTPMiddleware):
         request_tag_id = self.dlp_tracker.create_tag(
             operation=f"api_request_{request.method}_{self._normalize_path(request.url.path)}",
             data=request_data,
-            tag_id=f"request_{int(time.time() * 1000)}"
+            tag_id=f"request_{_unique_suffix()}"
         )
         self.total_tracked += 1
         
@@ -136,7 +155,7 @@ class DLPAutoTrackingMiddleware(BaseHTTPMiddleware):
         response_tag_id = self.dlp_tracker.create_tag(
             operation=f"api_response_{response.status_code}",
             data=response_data,
-            tag_id=f"response_{int(time.time() * 1000)}"
+            tag_id=f"response_{_unique_suffix()}"
         )
         
         # Link request and response tags

--- a/tests/core/test_logging_security.py
+++ b/tests/core/test_logging_security.py
@@ -114,7 +114,12 @@ class TestPathSanitization:
         """Should handle Path objects."""
         path = Path("/home/user/file.txt")
         result = sanitize_path_for_logging(path)
-        assert "home/user/file.txt" in result
+        # Compare against the platform's own rendering of the Path rather than a
+        # hardcoded POSIX string: str(Path("/home/user/file.txt")) is
+        # "\\home\\user\\file.txt" on Windows, so the literal form failed there.
+        # The property under test is that the path survives sanitisation intact,
+        # which is separator-independent.
+        assert str(path) in result
         assert '\n' not in result
 
     def test_truncates_long_paths(self):

--- a/tests/test_dlp_auto_tracker.py
+++ b/tests/test_dlp_auto_tracker.py
@@ -448,3 +448,25 @@ class TestPerformance:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_request_tags_are_unique_under_rapid_requests(client):
+    """Tags must stay distinct for requests issued inside the same millisecond.
+
+    Tag IDs were derived from int(time.time() * 1000) and nothing else, so any
+    two requests handled in the same millisecond shared a tag. X-DLP-Request-Tag
+    is the correlation ID joining a request to its audit records, so collisions
+    can attribute two requests to one audit entry.
+
+    A tight loop is the point: it is what puts several requests inside one
+    millisecond, which is exactly the window the old scheme could not separate.
+    """
+    tags = [
+        client.get("/test").headers["X-DLP-Request-Tag"]
+        for _ in range(50)
+    ]
+
+    duplicates = len(tags) - len(set(tags))
+    assert duplicates == 0, f"{duplicates} duplicate tag(s) across {len(tags)} requests"

--- a/tests/test_improvement_api.py
+++ b/tests/test_improvement_api.py
@@ -291,3 +291,72 @@ def test_analyze_directory_summary_statistics(client, tmp_path):
     assert "by_category" in data
     assert "by_severity" in data
     assert data["total_files_analyzed"] >= 2
+
+
+@pytest.mark.api
+@pytest.mark.improvement
+@pytest.mark.security
+@pytest.mark.parametrize(
+    "pattern",
+    ["../*.py", "../../*.py", "**/../*.py", "/etc/*.conf"],
+)
+def test_file_patterns_cannot_escape_the_analyzed_directory(client, tmp_path, pattern):
+    """A glob pattern must not read files outside the requested directory.
+
+    `directory` is resolved through trusted enumeration, but `file_patterns`
+    reached `Path.rglob()` unvalidated — and rglob honours "..". So
+    {"directory": "proj", "file_patterns": ["../*.py"]} read proj's siblings,
+    and "../../*.py" escaped the configured root entirely, echoing the matched
+    absolute paths back in the response.
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "a.py").write_text("max_items = 9999\n")
+
+    # Sibling of the analyzed directory — must stay unreachable.
+    (tmp_path / "sibling_secret.py").write_text("API_KEY = 'sk-live'\nmax_items = 9999\n")
+
+    response = client.post(
+        "/improvements/analyze-directory",
+        json={"directory": str(project), "file_patterns": [pattern]},
+    )
+
+    # Rejected outright is the intended behaviour; a 200 is only acceptable if
+    # nothing outside the directory came back.
+    assert response.status_code == 400, (
+        f"pattern {pattern!r} should be rejected, got {response.status_code}"
+    )
+
+    if response.status_code == 200:
+        analyzed = response.json().get("suggestions", {})
+        assert not [k for k in analyzed if "sibling_secret" in k], (
+            f"pattern {pattern!r} escaped the analyzed directory: {list(analyzed)}"
+        )
+
+
+@pytest.mark.api
+@pytest.mark.improvement
+@pytest.mark.security
+def test_engine_drops_matches_outside_the_directory(tmp_path):
+    """The engine filters escaping matches even when handed a bad pattern.
+
+    The API rejects these patterns, but analyze_directory() accepts patterns as
+    an argument and cannot assume every caller validated them, so it confirms
+    each match resolves inside the directory before reading it.
+    """
+    from src.improvement import get_improvement_engine
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "a.py").write_text("max_items = 9999\n")
+    (tmp_path / "secret.py").write_text("API_KEY = 'sk-live'\nmax_items = 9999\n")
+
+    engine = get_improvement_engine()
+
+    contained = engine.analyze_directory(project, ["*.py"])
+    assert any("a.py" in key for key in contained)
+
+    escaped = engine.analyze_directory(project, ["../*.py"])
+    assert not [key for key in escaped if "secret.py" in key], (
+        f"engine returned files outside the directory: {list(escaped)}"
+    )

--- a/tests/test_improvement_api.py
+++ b/tests/test_improvement_api.py
@@ -298,7 +298,21 @@ def test_analyze_directory_summary_statistics(client, tmp_path):
 @pytest.mark.security
 @pytest.mark.parametrize(
     "pattern",
-    ["../*.py", "../../*.py", "**/../*.py", "/etc/*.conf"],
+    [
+        "../*.py",
+        "../../*.py",
+        "**/../*.py",
+        # Rooted but NOT absolute on Windows: PurePath("/etc/*.conf").is_absolute()
+        # is False there because it carries no drive, so an is_absolute() check
+        # alone let this through to rglob(), which raised NotImplementedError —
+        # a 500 where a 400 belongs. Caught on windows-latest, not locally.
+        "/etc/*.conf",
+        # Drive-relative: no root, but a drive. Same blind spot (see #1337).
+        "C:foo/*.py",
+        "C:/x/*.py",
+        # Backslash separators must be read as separators on every platform.
+        r"..\..\*.py",
+    ],
 )
 def test_file_patterns_cannot_escape_the_analyzed_directory(client, tmp_path, pattern):
     """A glob pattern must not read files outside the requested directory.


### PR DESCRIPTION
Closes #1363 · Closes #1364 · Closes #1335 · Closes #1332

Four findings from auditing the dismissed CodeQL family and running the suite on a non-Linux machine. Each was reproduced before being fixed, and re-verified after.

## 1. `main` did not pass its own tests on macOS — #1363

**11 failed, 25 errors** on macOS; green in CI because **all 58 jobs are `ubuntu-latest`**. A reviewer cloning this repo on a Mac hits a wall before reading any code.

`validate_safe_path()` resolved `safe_root` but deliberately did *not* resolve caller paths, then compared with `relative_to()` — purely lexical. On macOS `/var` is a symlink to `/private/var` and `tempfile` returns the unresolved form, so the two sides were disjoint strings naming the same directory:

```
root as given : /var/folders/p3/.../tmpo8xfh61i
root resolved : /private/var/folders/p3/.../tmpo8xfh61i
RESULT: REJECTED -> Path outside allowed directory
```

Both spellings are now tried. The "never `.resolve()` unvalidated input" property is preserved, both candidates are trusted configuration rather than request data, and reconstruction still happens against the resolved root — the containment barrier is unchanged, only the spelling is forgiving. `src/improvement/api.py` had the identical defect.

**Containment re-verified before and after** against a 9-case adversarial matrix — relative/absolute inside, absolute outside, absolute sibling, `..`, nested `..`, symlink-out by relative and absolute route: **0 mismatches**.

## 2. Path traversal via `file_patterns` — #1364

One of the 13 `py/path-injection` alerts dismissed as "won't fix" was a **true positive**. `directory` is validated rigorously; `file_patterns` went to `rglob()` unchecked, and rglob honours `..`:

```
'*.py'         status=200 files=1 LEAKED=False
'../*.py'      -> read a sibling of the requested directory
'../../*.py'   -> escaped AURORA_IMPROVEMENT_ROOT entirely
```

Confirmed end-to-end through the HTTP endpoint, with matched absolute paths echoed back.

**Not live** — the router is not mounted in `aurora_api` (90 routes, none matching) — but shipped, documented, test-covered code.

Fixed at both layers: the API rejects absolute patterns and `..`; `analyze_directory()` also drops matches that don't resolve inside the directory, since it takes patterns as an argument and cannot assume its caller validated them. After: all four escaping patterns return **400**.

## 3. DLP correlation tags collided — #1335

Tag IDs were `int(time.time() * 1000)` and nothing else, so two requests in one millisecond shared a tag — the correlation ID joining a request to its audit records.

| | before | after |
|---|---|---|
| failures in isolated runs | 2 / 12 | **0 / 20** |

Plus a test asserting 50 rapid requests yield 50 distinct tags. The millisecond prefix is kept so tags still sort chronologically; uniqueness now comes from random hex rather than the clock.

## 4. `frontend/` had no CI, and had been unbuildable — #1332

Zero of 58 workflows referenced it, while dependabot merged into it continuously (#1318 alone was 39 updates). It did not build. Four independent breakages:

- **15 TypeScript errors** — 7 API types imported but never defined, 3 `import.meta.env` uses with no `vite/client` reference, 5 unused declarations. The 7 types now mirror the Pydantic models in `src/playground/models.py`, which is the authoritative contract.
- **Tailwind v4** moved its PostCSS plugin to `@tailwindcss/postcss`.
- **Vite 8** dropped the object form of `manualChunks` — it warned and silently stopped chunking. Same grouping as a function, matching `/node_modules/<name>/` so no substring collisions.
- **`globals.css`** still used v3 `@tailwind` directives, so v4 never loaded `tailwind.config.ts` and every theme token was unknown. Bridged with `@config` rather than hand-porting 171 lines into `@theme`, which would risk silent visual drift.

New `frontend-ci.yml` gates **type-check and build as blocking** — those catch the next unverified bump. Lint is advisory: ESLint isn't wired to the TypeScript parser and reports parse errors on every `.ts/.tsx` file. That's the lint setup, not the source — tracked in #1340.

## Cross-platform CI

New `cross-platform-paths.yml` runs the path, ledger, improvement and security-marked tests on **macOS and Windows**. Deliberately narrow — three path-handling assumptions have now reached `main` unchallenged (the original `/tmp` prefix, the Windows case in #1337, and #1363), and one job would have caught all three.

## Documentation claims

`SECURITY.md` asserted **"Security Score: 100/100 (Outstanding)"**, five metrics as "✅ Achieved", and four "Security Certifications". None were measured; nothing was certified. Replaced with the checks that actually run, what each does *not* cover, and the fact that no CI job runs on macOS or Windows.

`VERIFIED_CLAIMS.md` still reported 3,008 passed / 36 failed / 27 errors as "environmental". Those causes were fixed rather than explained away — now 3,146 / 0 / 0, with skips accounted for and a note to re-measure before citing.

## Verification

```
pytest -q          3146 passed, 0 failed, 0 errors, 123 skipped   (macOS)
npm run type-check 0 errors
npm run build      built in 508ms
npx vitest run     passes
```

Every CI step was run locally with the exact command the workflow uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
