### PR TITLE
docs: make CanonRec authority explicit

### DIFF
--- a/ARCHITECTURE_QUICKMAP.md
+++ b/ARCHITECTURE_QUICKMAP.md
@@ -2,7 +2,20 @@
 
 ## What this is
 
-Aurora CloudBank Symbolic is the code and canon repository for Aurora, the simulation director of the Orion Station institutional simulation, plus the runtime services that support ethics-governed simulation, symbolic memory, QGIA signal intake, and auditable operations. The repository has one ontological layer model—L1 station operations, L2 simulation/research environments, and L3 conceptual frameworks—and a separate three-step Triplex consent protocol. Treat those two uses of “layer” as distinct.
+Aurora CloudBank Symbolic is Aurora's runtime and checked-in canon-mirror repository, plus the services that support ethics-governed simulation, symbolic memory, QGIA signal intake, and auditable operations. CanonRec is the authority repository; the Aurora root workspace propagates selected CanonRec and L1-ledger payloads into CloudBank and verifies the combined integration surface. The repository has one ontological layer model—L1 station operations, L2 simulation/research environments, and L3 conceptual frameworks—and a separate three-step Triplex consent protocol. Treat those two uses of “layer” as distinct.
+
+## Authority flow
+
+```text
+CanonRec authority
+  -> Aurora root propagation and integration gates
+    -> CloudBank runtime mirrors
+```
+
+CloudBank can boot without a CanonRec checkout because the runtime mirrors are
+versioned here. Authoritative canon review and the full L1 integration suite do
+require CanonRec. The exact source revision and mirror hash are recorded in
+[`docs/CANON_PROVENANCE.md`](./docs/CANON_PROVENANCE.md).
 
 ## Layer architecture → code map
 
@@ -62,3 +75,4 @@ QGIA supplies real-world analytical signals. L1 crew and relay systems interpret
 - Symbolic memory → `modules/aumemmanager/`, `modules/symbolic_core/`
 - `src/` orientation and polyglot boundary → [`src/README.md`](./src/README.md)
 - Canon authority map → [`CANON_INDEX.md`](./CANON_INDEX.md)
+- Cross-repository source revision and mirror hashes → [`docs/CANON_PROVENANCE.md`](./docs/CANON_PROVENANCE.md)

--- a/CANON_INDEX.md
+++ b/CANON_INDEX.md
@@ -8,6 +8,23 @@ This applies even if you believe you already know the answer.
 
 ---
 
+## Authority Boundary
+
+CanonRec is the cross-repository authority source. This index maps the
+CloudBank documents and runtime mirrors that consume or present that canon; it
+does not make CloudBank the sole authority repository.
+
+| Topic | Governing Document |
+| --- | --- |
+| CanonRec source revision, mirror hashes, and sync boundary | `docs/CANON_PROVENANCE.md` |
+| Machine-readable provenance receipt | `config/canon_provenance.json` |
+| CloudBank runtime canon consistency gate | `tests/test_canon_consistency.py` |
+
+The staff-registry authority remains explicitly unreconciled between CanonRec
+and CloudBank. Do not resolve that conflict from this index alone.
+
+---
+
 ## Architecture & Layers
 
 | Topic | Authoritative Document |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ A FastAPI platform for keeping machine-generated knowledge coherent over long
 horizons: hierarchical memory, provenance-tracked state, geometric ethics
 enforcement, drift detection, and production observability.
 
-It is also the code and canon repository for Aurora, the simulation director of
-the Orion Station institutional simulation. That is not decoration on the
-engineering — it is what the engineering is for. Keeping a large,
+It is also the runtime and checked-in canon-mirror repository for Aurora, the
+simulation director of the Orion Station institutional simulation. CanonRec is
+the authority repository; CloudBank carries reviewable runtime copies that are
+propagated and checked by the Aurora root workspace. That is not decoration on
+the engineering — it is what the engineering is for. Keeping a large,
 LLM-generated corpus internally consistent across sessions, model changes, and
 contributors is the problem this system exists to solve, and the simulation is
 the corpus it solves it against: large enough that conflicts are non-trivial,
@@ -34,6 +36,8 @@ and both are load-bearing.
 >
 > **Looking for a specific document?** [`docs/index.md`](./docs/index.md) maps every documentation directory and states what authority each one carries.
 >
+> **Reviewing canon provenance?** [`docs/CANON_PROVENANCE.md`](./docs/CANON_PROVENANCE.md) identifies the CanonRec source revision, mirrored payload hash, and the surfaces that still require reconciliation.
+>
 > **New AI agent or Copilot session?** Start with [`AGENTS.md`](./AGENTS.md) (bootstrap protocol and rules) and [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) (machine-readable concept map).
 
 ---
@@ -42,6 +46,7 @@ and both are load-bearing.
 
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
+- [Canon authority and provenance](#canon-authority-and-provenance)
 - [Modules](#modules)
 - [API](#api)
 - [Configuration](#configuration)
@@ -73,7 +78,8 @@ pip install -r requirements.txt
 
 # Configure environment
 cp .env.example .env
-# Edit .env — set AURORA_SECRET_KEY, JWT_SECRET_KEY, CSRF_SECRET_KEY, WS_AUTH_SECRET
+# Edit .env — set AURORA_SECRET_KEY, JWT_SECRET_KEY, CSRF_SECRET_KEY,
+# WS_AUTH_SECRET, and MONITORING_SIGNING_KEY
 # (generate with: openssl rand -hex 32)
 
 # Start the server
@@ -117,6 +123,37 @@ All modules follow a consistent layout: `__init__.py`, `core.py`, `api.py`, `mod
 - **Pydantic V2**: All request/response models use Pydantic V2 (`model_config`, `ConfigDict`). V1 patterns (`class Config`, `max_items`) are not used.
 - **DLP tracking**: Every persistent operation carries a `context_tag` and generates a SHA-256 symbolic hash for audit trail continuity.
 - **Async throughout**: All I/O-bound operations use `async def`. Blocking calls are isolated.
+
+---
+
+## Canon authority and provenance
+
+CloudBank is self-contained for application startup, but it is not the sole
+authority for Aurora canon.
+
+```text
+AUo959/CanonRec (authority)
+  -> Aurora root canon_sync.py + integration CI
+    -> CloudBank config/canonical_validation.yaml and managed persona memories
+      -> runtime consistency gates
+```
+
+The current canonical-validation mirror is tied to CanonRec revision
+`c1f25e57a99ed98f8df6ed8eb2a93ba94bd2aa14`; its source and destination
+SHA-256 are recorded in [`config/canon_provenance.json`](./config/canon_provenance.json).
+`tests/test_canon_provenance.py` fails if the checked-in mirror changes without
+an accompanying provenance update.
+
+A CanonRec checkout is therefore:
+
+- **not required** to start the base FastAPI application from this repository;
+- **required** to review or change authoritative canon;
+- **required** by the Aurora root's complete L1 integration/simulation suite.
+
+The CanonRec and CloudBank staff registries currently differ and are not yet a
+managed sync payload. Neither should be described as the sole machine-readable
+staff SSOT until that authority decision is reconciled. See
+[`docs/CANON_PROVENANCE.md`](./docs/CANON_PROVENANCE.md).
 
 ---
 
@@ -243,6 +280,7 @@ Copy `.env.example` to `.env` and set the required values:
 | `JWT_SECRET_KEY` | Yes | 64-hex JWT signing key |
 | `CSRF_SECRET_KEY` | Yes | 64-hex CSRF HMAC key |
 | `WS_AUTH_SECRET` | Yes | 64-hex WebSocket token HMAC key |
+| `MONITORING_SIGNING_KEY` | For monitoring routes | HMAC key for the monitoring audit chain; without it the monitoring dashboard router is skipped |
 | `ALLOWED_CORS_ORIGINS` | No | Comma-separated allowed origins (default: localhost) |
 | `RATE_LIMIT_ENABLED` | No | Enable rate limiting (default: `true`) |
 | `REDIS_URL` | No | Redis URL for distributed rate limiting |

--- a/config/canon_provenance.json
+++ b/config/canon_provenance.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "authority": {
+    "repository": "https://github.com/AUo959/CanonRec",
+    "revision": "c1f25e57a99ed98f8df6ed8eb2a93ba94bd2aa14",
+    "source_path": "canon/L3/canonical_validation.yaml",
+    "source_sha256": "c0604d68b3d2a0e8d35336caa4e8275ca0d19409a43f23d6f65e43dbf04c7cd6"
+  },
+  "cloudbank_mirror": {
+    "path": "config/canonical_validation.yaml",
+    "sha256": "c0604d68b3d2a0e8d35336caa4e8275ca0d19409a43f23d6f65e43dbf04c7cd6",
+    "requires_canonrec_checkout_at_runtime": false
+  },
+  "propagation": {
+    "control_plane_repository": "AUo959/Aurora_ORIONCORE_Directory_Main",
+    "command": "python3 tools/canon_sync.py --check",
+    "verified_at": "2026-07-29"
+  },
+  "unreconciled_surfaces": [
+    {
+      "name": "orion_station_staff_registry",
+      "status": "owner_authority_decision_required",
+      "canonrec_path": "canon/L1/station/ORION_STATION_CANONICAL_STAFF_REGISTRY.json",
+      "canonrec_sha256": "4cc8bf4f808f68e1c4e3e505d32c15bf7c92959fd09a9d419e6c6254e848542d",
+      "cloudbank_path": "ORION_STATION_CANONICAL_STAFF_REGISTRY.json",
+      "cloudbank_sha256": "0a5c6eff0ab8f45a07257e8e99e4f96fdd4e94b7253be9210d2275f4969348ca"
+    }
+  ]
+}

--- a/docs/CANON_PROVENANCE.md
+++ b/docs/CANON_PROVENANCE.md
@@ -1,0 +1,79 @@
+# Canon provenance and repository boundary
+
+## Authority chain
+
+CanonRec is the authority repository for Aurora / ORIONCORE canon. CloudBank is
+the runtime repository and carries checked-in mirrors so that a standalone
+application checkout remains reproducible.
+
+```text
+AUo959/CanonRec
+  canon/L3/canonical_validation.yaml
+       |
+       | Aurora root tools/canon_sync.py
+       v
+AUo959/aurora-cloudbank-symbolic
+  config/canonical_validation.yaml
+       |
+       v
+  runtime and tests/test_canon_consistency.py
+```
+
+The Aurora root also generates managed files under `config/mesh/memory/` from
+its newest L1 entity ledger. Those generated memories are a separate payload
+family; they are not direct copies of CanonRec files.
+
+## Current verified snapshot
+
+| Field | Value |
+| --- | --- |
+| CanonRec repository | `https://github.com/AUo959/CanonRec` |
+| CanonRec revision | `c1f25e57a99ed98f8df6ed8eb2a93ba94bd2aa14` |
+| Source path | `canon/L3/canonical_validation.yaml` |
+| CloudBank mirror | `config/canonical_validation.yaml` |
+| Source and mirror SHA-256 | `c0604d68b3d2a0e8d35336caa4e8275ca0d19409a43f23d6f65e43dbf04c7cd6` |
+| Verified | 2026-07-29 |
+
+The machine-readable form is `config/canon_provenance.json`. Its CloudBank
+hashes are enforced by `tests/test_canon_provenance.py`. The cross-repository
+source/destination comparison is enforced from the Aurora root workspace.
+
+## Runtime requirement
+
+A CanonRec checkout is not a package, import, mount, or startup dependency for
+the base CloudBank FastAPI application. The checked-in mirror is sufficient for
+startup and local consistency tests.
+
+CanonRec is required when:
+
+- authoritative canon is reviewed, promoted, or reconciled;
+- a mirror is refreshed;
+- the Aurora root runs its complete CloudBank + CanonRec L1 integration suite;
+- a reviewer needs to trace a CloudBank canon claim to its authority source.
+
+## Unreconciled staff registry
+
+The following files are materially different and are not currently part of the
+managed propagation contract:
+
+- CanonRec: `canon/L1/station/ORION_STATION_CANONICAL_STAFF_REGISTRY.json`
+- CloudBank: `ORION_STATION_CANONICAL_STAFF_REGISTRY.json`
+
+Their current hashes are recorded in `config/canon_provenance.json`. The
+CloudBank file identifies itself as a reconstructed registry, while the
+CanonRec file is an older v2.4.1 manifest. Selecting one, or defining a
+deterministic merge, requires an owner authority decision. Until then, neither
+file should be presented as the sole machine-readable staff SSOT.
+
+## Refresh procedure
+
+From the canonical Aurora root workspace:
+
+```bash
+python3 tools/canon_sync.py --check
+```
+
+When CanonRec legitimately changes, use the root propagation workflow to stage
+the CloudBank update, refresh `config/canon_provenance.json`, run the CloudBank
+canon/provenance tests, and carry the result through normal branch and CI
+review. Do not copy authority files manually without updating provenance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,16 @@ This directory contains reference documentation for developers working with Auro
 
 ---
 
+## Canon authority and provenance
+
+| Document | Description |
+| --- | --- |
+| [CANON_PROVENANCE.md](CANON_PROVENANCE.md) | CanonRec authority revision, CloudBank mirror hash, runtime dependency boundary, and unreconciled staff-registry surface |
+| [`../CANON_INDEX.md`](../CANON_INDEX.md) | Topic-to-document authority routing inside CloudBank |
+| [`../config/canon_provenance.json`](../config/canon_provenance.json) | Machine-readable provenance receipt enforced by tests |
+
+---
+
 ## Setup and Development
 
 | Document | Description |

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -90,4 +90,4 @@ sentry-sdk>=2.65.0                  # Error tracking
 # Required by connector/server.py to expose Aurora state over the Model
 # Context Protocol. Without it the connector and tests/connector are
 # unavailable; the core API is unaffected. See connector/README.md.
-mcp>=1.28.1                         # Model Context Protocol SDK
+mcp>=1.28.1,<2.0.0                  # Model Context Protocol SDK (v1 API)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,4 +14,4 @@ flake8>=6.1.0
 # Connector test support
 # Runtime use remains optional, but tests/connector and test_mcp_connector_wired
 # import the MCP SDK during collection.
-mcp>=1.28.1
+mcp>=1.28.1,<2.0.0

--- a/tests/test_canon_provenance.py
+++ b/tests/test_canon_provenance.py
@@ -1,0 +1,59 @@
+"""Machine-checkable provenance for CloudBank's CanonRec mirror."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROVENANCE_PATH = PROJECT_ROOT / "config" / "canon_provenance.json"
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_provenance() -> dict:
+    return json.loads(PROVENANCE_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.critical
+def test_canonrec_authority_receipt_is_specific() -> None:
+    receipt = load_provenance()
+    authority = receipt["authority"]
+
+    assert receipt["schema_version"] == 1
+    assert authority["repository"] == "https://github.com/AUo959/CanonRec"
+    assert re.fullmatch(r"[0-9a-f]{40}", authority["revision"])
+    assert authority["source_path"] == "canon/L3/canonical_validation.yaml"
+    assert re.fullmatch(r"[0-9a-f]{64}", authority["source_sha256"])
+
+
+@pytest.mark.critical
+def test_checked_in_canon_mirror_matches_provenance_hash() -> None:
+    receipt = load_provenance()
+    mirror = receipt["cloudbank_mirror"]
+    mirror_path = PROJECT_ROOT / mirror["path"]
+
+    assert mirror_path.is_file()
+    assert sha256_file(mirror_path) == mirror["sha256"]
+    assert mirror["sha256"] == receipt["authority"]["source_sha256"]
+    assert mirror["requires_canonrec_checkout_at_runtime"] is False
+
+
+@pytest.mark.critical
+def test_unreconciled_staff_registry_drift_is_explicit() -> None:
+    receipt = load_provenance()
+    staff = next(
+        item
+        for item in receipt["unreconciled_surfaces"]
+        if item["name"] == "orion_station_staff_registry"
+    )
+
+    assert staff["status"] == "owner_authority_decision_required"
+    assert sha256_file(PROJECT_ROOT / staff["cloudbank_path"]) == staff["cloudbank_sha256"]
+    assert staff["canonrec_sha256"] != staff["cloudbank_sha256"]

--- a/tests/test_canon_provenance.py
+++ b/tests/test_canon_provenance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
+import unittest
 from pathlib import Path
 
 import pytest
@@ -22,38 +22,38 @@ def load_provenance() -> dict:
 
 
 @pytest.mark.critical
-def test_canonrec_authority_receipt_is_specific() -> None:
-    receipt = load_provenance()
-    authority = receipt["authority"]
+class TestCanonProvenance(unittest.TestCase):
+    def test_canonrec_authority_receipt_is_specific(self) -> None:
+        receipt = load_provenance()
+        authority = receipt["authority"]
 
-    assert receipt["schema_version"] == 1
-    assert authority["repository"] == "https://github.com/AUo959/CanonRec"
-    assert re.fullmatch(r"[0-9a-f]{40}", authority["revision"])
-    assert authority["source_path"] == "canon/L3/canonical_validation.yaml"
-    assert re.fullmatch(r"[0-9a-f]{64}", authority["source_sha256"])
+        self.assertEqual(receipt["schema_version"], 1)
+        self.assertEqual(authority["repository"], "https://github.com/AUo959/CanonRec")
+        self.assertRegex(authority["revision"], r"\A[0-9a-f]{40}\Z")
+        self.assertEqual(authority["source_path"], "canon/L3/canonical_validation.yaml")
+        self.assertRegex(authority["source_sha256"], r"\A[0-9a-f]{64}\Z")
 
+    def test_checked_in_canon_mirror_matches_provenance_hash(self) -> None:
+        receipt = load_provenance()
+        mirror = receipt["cloudbank_mirror"]
+        mirror_path = PROJECT_ROOT / mirror["path"]
 
-@pytest.mark.critical
-def test_checked_in_canon_mirror_matches_provenance_hash() -> None:
-    receipt = load_provenance()
-    mirror = receipt["cloudbank_mirror"]
-    mirror_path = PROJECT_ROOT / mirror["path"]
+        self.assertTrue(mirror_path.is_file())
+        self.assertEqual(sha256_file(mirror_path), mirror["sha256"])
+        self.assertEqual(mirror["sha256"], receipt["authority"]["source_sha256"])
+        self.assertFalse(mirror["requires_canonrec_checkout_at_runtime"])
 
-    assert mirror_path.is_file()
-    assert sha256_file(mirror_path) == mirror["sha256"]
-    assert mirror["sha256"] == receipt["authority"]["source_sha256"]
-    assert mirror["requires_canonrec_checkout_at_runtime"] is False
+    def test_unreconciled_staff_registry_drift_is_explicit(self) -> None:
+        receipt = load_provenance()
+        staff = next(
+            item
+            for item in receipt["unreconciled_surfaces"]
+            if item["name"] == "orion_station_staff_registry"
+        )
 
-
-@pytest.mark.critical
-def test_unreconciled_staff_registry_drift_is_explicit() -> None:
-    receipt = load_provenance()
-    staff = next(
-        item
-        for item in receipt["unreconciled_surfaces"]
-        if item["name"] == "orion_station_staff_registry"
-    )
-
-    assert staff["status"] == "owner_authority_decision_required"
-    assert sha256_file(PROJECT_ROOT / staff["cloudbank_path"]) == staff["cloudbank_sha256"]
-    assert staff["canonrec_sha256"] != staff["cloudbank_sha256"]
+        self.assertEqual(staff["status"], "owner_authority_decision_required")
+        self.assertEqual(
+            sha256_file(PROJECT_ROOT / staff["cloudbank_path"]),
+            staff["cloudbank_sha256"],
+        )
+        self.assertNotEqual(staff["canonrec_sha256"], staff["cloudbank_sha256"])


### PR DESCRIPTION
## Summary
- state the CanonRec -> root propagation -> CloudBank runtime-mirror authority chain
- add a machine-readable provenance receipt with CanonRec revision and SHA-256
- add critical tests that bind the checked-in mirror and staff-registry drift to that receipt
- document that CanonRec is required for authority and full integration, but not base API startup
- add the monitoring signing key to the startup configuration guidance
- keep connector/test installs on the tested MCP v1 API until the connector is migrated to MCP v2

## Validation
- 44 focused canon, provenance, naming, onboarding, and mesh tests passed
- `ruff check tests/test_canon_provenance.py` passed
- Python 3.11 and 3.12 dependency-validation jobs passed with `mcp>=1.28.1,<2.0.0`
- JSON validation and `git diff --check` passed

## CI evidence for the MCP ceiling
The base commit's last green full-suite job installed MCP 1.28.1. During this PR, the open-ended `mcp>=1.28.1` constraint began resolving to MCP 2.0.0; six connector-server tests then failed because the v1 `Server.list_tools` API is absent. The ceiling is an explicit compatibility contract, not a claim that MCP v2 should never be adopted.

## Explicit unresolved boundary
The CanonRec and CloudBank staff registries remain materially different. This change records that drift without choosing or inventing an authority resolution.
