### PR TITLE
fix: close CodeQL public review alerts

### DIFF
--- a/api/aurora_gui_cloudhub_fastapi.py
+++ b/api/aurora_gui_cloudhub_fastapi.py
@@ -891,13 +891,13 @@ def mcp_bridge_health_check():
         capsule_summary = _get_capsule_summary(capsules)
 
         return _build_response(mcp_data, sec, functions_count, mesh_sync_active, capsule_summary)
-    except Exception as e:  # pragma: no cover - defensive fallback
-        logger.error("MCP health check failed: %s", str(e))
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        logger.error("MCP health check failed (%s)", type(exc).__name__)
         return JSONResponse(
             status_code=503,
             content={
                 "status": "unhealthy",
-                "error": str(e),
+                "error": "internal error",
                 "kubernetes": {"ready": False, "live": True},
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             },

--- a/modules/aumemmanager/api_integration.py
+++ b/modules/aumemmanager/api_integration.py
@@ -379,5 +379,6 @@ async def health_check():
             "quantum_vectors": metrics.get("quantum_vectors", 0),
             "system_uptime": time.time() - metrics.get("last_cleanup", time.time()),
         }
-    except Exception as e:
-        return {"status": "unhealthy", "error": str(e), "timestamp": time.time()}
+    except Exception as exc:
+        logger.error("AuMemManager health probe failed (%s)", type(exc).__name__)
+        return {"status": "unhealthy", "error": "internal error", "timestamp": time.time()}

--- a/modules/opal2/api/opal2_api.py
+++ b/modules/opal2/api/opal2_api.py
@@ -402,7 +402,8 @@ async def test_glyph_core() -> Dict[str, Any]:
         result = await glyph_core.test_generation()
         return {"healthy": bool(result.get("success")), "test_result": result}
     except Exception as exc:  # pragma: no cover - defensive path
-        return {"healthy": False, "error": str(exc)}
+        logger.error("Glyph core health probe failed (%s)", type(exc).__name__)
+        return {"healthy": False, "error": "internal error"}
 
 
 async def test_quantum_renderer() -> Dict[str, Any]:
@@ -410,7 +411,8 @@ async def test_quantum_renderer() -> Dict[str, Any]:
         result = await quantum_renderer.test_render()
         return {"healthy": bool(result.get("success")), "test_result": result}
     except Exception as exc:  # pragma: no cover - defensive path
-        return {"healthy": False, "error": str(exc)}
+        logger.error("Quantum renderer health probe failed (%s)", type(exc).__name__)
+        return {"healthy": False, "error": "internal error"}
 
 
 async def test_plugin_system() -> Dict[str, Any]:
@@ -418,7 +420,8 @@ async def test_plugin_system() -> Dict[str, Any]:
         plugin_count = len(plugin_system.list_plugins())
         return {"healthy": True, "plugin_count": plugin_count}
     except Exception as exc:  # pragma: no cover - defensive path
-        return {"healthy": False, "error": str(exc)}
+        logger.error("Plugin system health probe failed (%s)", type(exc).__name__)
+        return {"healthy": False, "error": "internal error"}
 
 
 async def test_cache_system() -> Dict[str, Any]:
@@ -426,7 +429,8 @@ async def test_cache_system() -> Dict[str, Any]:
         stats = await glyph_cache.get_stats()
         return {"healthy": True, "stats": stats}
     except Exception as exc:  # pragma: no cover - defensive path
-        return {"healthy": False, "error": str(exc)}
+        logger.error("Cache system health probe failed (%s)", type(exc).__name__)
+        return {"healthy": False, "error": "internal error"}
 
 
 def test_tool_registry() -> Dict[str, Any]:
@@ -434,7 +438,8 @@ def test_tool_registry() -> Dict[str, Any]:
         tools = tool_registry.list_manifests()
         return {"healthy": bool(tools), "tool_count": len(tools)}
     except Exception as exc:  # pragma: no cover - defensive path
-        return {"healthy": False, "error": str(exc)}
+        logger.error("Tool registry health probe failed (%s)", type(exc).__name__)
+        return {"healthy": False, "error": "internal error"}
 
 
 def _verify_token(token: HTTPAuthorizationCredentials | None) -> None:

--- a/src/improvement/engine.py
+++ b/src/improvement/engine.py
@@ -18,7 +18,7 @@ from typing import List, Dict, Optional, Any, Set
 from enum import Enum
 from pathlib import Path
 
-from src.core.logging_security import safe_str, safe_path, safe_error
+from src.core.logging_security import safe_path, safe_str
 
 logger = logging.getLogger(__name__)
 
@@ -315,7 +315,7 @@ class CodeImprovementEngine:
     def register_pattern(self, pattern: ImprovementPattern):
         """Register custom improvement pattern"""
         self._patterns.append(pattern)
-        logger.info("Registered improvement pattern: %s", safe_str(pattern.name))
+        logger.info("Registered improvement pattern type: %s", type(pattern).__name__)
     
     def analyze_file(self, file_path: Path) -> List[ImprovementSuggestion]:
         """
@@ -330,7 +330,7 @@ class CodeImprovementEngine:
         try:
             content = file_path.read_text()
         except Exception as e:
-            logger.error("Failed to read file %s: %s", safe_path(file_path), safe_error(e))
+            logger.error("Failed to read analysis file (%s)", type(e).__name__)
             return []
         
         suggestions = []
@@ -339,7 +339,11 @@ class CodeImprovementEngine:
                 pattern_suggestions = pattern.detect(str(file_path), content)
                 suggestions.extend(pattern_suggestions)
             except Exception as e:
-                logger.error("Pattern %s failed on %s: %s", safe_str(pattern.name), safe_path(file_path), safe_error(e))
+                logger.error(
+                    "Improvement pattern %s failed while analyzing a file (%s)",
+                    type(pattern).__name__,
+                    type(e).__name__,
+                )
         
         return suggestions
     
@@ -395,7 +399,7 @@ class CodeImprovementEngine:
                     results[str(resolved)] = suggestions
 
 
-        logger.info("Analyzed directory %s: found improvements in %d files", safe_path(directory), len(results))
+        logger.info("Directory analysis found improvements in %d files", len(results))
         return results
     
     def filter_suggestions(

--- a/src/mesh/terminals.py
+++ b/src/mesh/terminals.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 from .manifests import normalize_lookup
 from .models import AgentManifest
-
-
-PERSONNEL_ATTENTION_TAG_RE = re.compile(r"^\{\{@[^{}]+:::.+\}\}$")
 
 
 class PersonnelAttentionTagError(ValueError):
@@ -22,7 +18,19 @@ class PersonnelAttentionTagError(ValueError):
 def is_personnel_attention_tag(value: str) -> bool:
     """Return true for EVA/HUD Personnel Attention Tag syntax."""
 
-    return bool(PERSONNEL_ATTENTION_TAG_RE.match(value.strip()))
+    candidate = value.strip()
+    if not candidate.startswith("{{@") or not candidate.endswith("}}"):
+        return False
+
+    label, separator, message = candidate[3:-2].partition(":::")
+    return bool(
+        separator
+        and label
+        and message
+        and "{" not in label
+        and "}" not in label
+        and "\n" not in message
+    )
 
 
 @dataclass

--- a/tests/test_codeql_security_regressions.py
+++ b/tests/test_codeql_security_regressions.py
@@ -1,0 +1,133 @@
+"""Regression coverage for the public-review CodeQL backlog."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+import pytest
+
+
+def test_improvement_engine_logs_do_not_expose_request_data(tmp_path, caplog) -> None:
+    """Analysis failures retain an error class without logging request-derived data."""
+
+    from src.improvement.engine import (
+        CodeImprovementEngine,
+        ImprovementCategory,
+        ImprovementPattern,
+        ImprovementSeverity,
+    )
+
+    class FailingPattern(ImprovementPattern):
+        def __init__(self) -> None:
+            super().__init__(
+                "customer-secret-pattern",
+                ImprovementCategory.SECURITY,
+                ImprovementSeverity.HIGH,
+            )
+
+        def detect(self, file_path, content):
+            raise RuntimeError("customer-secret-pattern-detail")
+
+    engine = CodeImprovementEngine()
+    engine.register_pattern(FailingPattern())
+    secret_directory = tmp_path / "customer-secret-directory"
+    secret_directory.mkdir()
+    secret_file = secret_directory / "customer-secret-file.py"
+    secret_file.write_text("max_items = 9999\n")
+
+    with caplog.at_level(logging.INFO, logger="src.improvement.engine"):
+        engine.analyze_file(tmp_path / "missing-customer-secret-file.py")
+        engine.analyze_file(secret_file)
+        engine.analyze_directory(secret_directory)
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "customer-secret" not in messages
+    assert "FileNotFoundError" in messages
+    assert "RuntimeError" in messages
+
+
+def test_personnel_attention_tag_rejection_is_linear_for_long_input() -> None:
+    """A rejected, attacker-controlled terminal id must not trigger regex backtracking."""
+
+    from src.mesh.terminals import is_personnel_attention_tag
+
+    adversarial_terminal_id = "{{@" + ("z:::" * 20_000) + "!"
+    started = time.perf_counter()
+    assert is_personnel_attention_tag(adversarial_terminal_id) is False
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.2
+
+
+@pytest.mark.asyncio
+async def test_opal2_health_response_hides_probe_exception(monkeypatch, caplog) -> None:
+    """Opal2 health output exposes status, not internal exception details."""
+
+    from modules.opal2.api import opal2_api
+
+    async def healthy_probe():
+        return {"healthy": True}
+
+    def failing_registry_probe():
+        raise RuntimeError("opal2-customer-secret")
+
+    monkeypatch.setattr(opal2_api, "test_glyph_core", healthy_probe)
+    monkeypatch.setattr(opal2_api, "test_quantum_renderer", healthy_probe)
+    monkeypatch.setattr(opal2_api, "test_plugin_system", healthy_probe)
+    monkeypatch.setattr(opal2_api, "test_cache_system", healthy_probe)
+    monkeypatch.setattr(opal2_api.tool_registry, "list_manifests", failing_registry_probe)
+
+    with caplog.at_level(logging.ERROR, logger=opal2_api.__name__):
+        result = await opal2_api.health_check()
+
+    assert result["components"]["tool_registry"] == {
+        "healthy": False,
+        "error": "internal error",
+    }
+    assert "opal2-customer-secret" not in json.dumps(result)
+    assert "opal2-customer-secret" not in caplog.text
+    assert "RuntimeError" in caplog.text
+
+
+def test_cloudhub_health_response_hides_config_exception(monkeypatch, caplog) -> None:
+    """CloudHub health failures return a stable public error contract."""
+
+    from api import aurora_gui_cloudhub_fastapi as cloudhub
+
+    def failing_config_load():
+        raise RuntimeError("cloudhub-customer-secret")
+
+    monkeypatch.setattr(cloudhub, "get_mcp_bridge_core", failing_config_load)
+
+    with caplog.at_level(logging.ERROR, logger=cloudhub.__name__):
+        response = cloudhub.mcp_bridge_health_check()
+
+    payload = json.loads(response.body)
+    assert payload["status"] == "unhealthy"
+    assert payload["error"] == "internal error"
+    assert "cloudhub-customer-secret" not in response.body.decode()
+    assert "cloudhub-customer-secret" not in caplog.text
+    assert "RuntimeError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_aumem_health_response_hides_metrics_exception(monkeypatch, caplog) -> None:
+    """AuMemManager health failures do not reflect exception messages."""
+
+    from modules.aumemmanager import api_integration
+
+    def failing_metrics_load():
+        raise RuntimeError("aumem-customer-secret")
+
+    monkeypatch.setattr(api_integration.memory_manager, "get_metrics", failing_metrics_load)
+
+    with caplog.at_level(logging.ERROR, logger=api_integration.__name__):
+        result = await api_integration.health_check()
+
+    assert result["status"] == "unhealthy"
+    assert result["error"] == "internal error"
+    assert "aumem-customer-secret" not in json.dumps(result)
+    assert "aumem-customer-secret" not in caplog.text
+    assert "RuntimeError" in caplog.text

--- a/tests/test_codeql_security_regressions.py
+++ b/tests/test_codeql_security_regressions.py
@@ -43,9 +43,9 @@ def test_improvement_engine_logs_do_not_expose_request_data(tmp_path, caplog) ->
         engine.analyze_directory(secret_directory)
 
     messages = "\n".join(record.getMessage() for record in caplog.records)
-    assert "customer-secret" not in messages
-    assert "FileNotFoundError" in messages
-    assert "RuntimeError" in messages
+    assert "customer-secret" not in messages  # nosec B101 - pytest assertion
+    assert "FileNotFoundError" in messages  # nosec B101 - pytest assertion
+    assert "RuntimeError" in messages  # nosec B101 - pytest assertion
 
 
 def test_personnel_attention_tag_rejection_is_linear_for_long_input() -> None:
@@ -55,10 +55,10 @@ def test_personnel_attention_tag_rejection_is_linear_for_long_input() -> None:
 
     adversarial_terminal_id = "{{@" + ("z:::" * 20_000) + "!"
     started = time.perf_counter()
-    assert is_personnel_attention_tag(adversarial_terminal_id) is False
+    assert is_personnel_attention_tag(adversarial_terminal_id) is False  # nosec B101 - pytest assertion
     elapsed = time.perf_counter() - started
 
-    assert elapsed < 0.2
+    assert elapsed < 0.2  # nosec B101 - pytest assertion
 
 
 @pytest.mark.asyncio
@@ -77,18 +77,20 @@ async def test_opal2_health_response_hides_probe_exception(monkeypatch, caplog) 
     monkeypatch.setattr(opal2_api, "test_quantum_renderer", healthy_probe)
     monkeypatch.setattr(opal2_api, "test_plugin_system", healthy_probe)
     monkeypatch.setattr(opal2_api, "test_cache_system", healthy_probe)
-    monkeypatch.setattr(opal2_api.tool_registry, "list_manifests", failing_registry_probe)
+    monkeypatch.setattr(
+        opal2_api.tool_registry, "list_manifests", failing_registry_probe
+    )
 
     with caplog.at_level(logging.ERROR, logger=opal2_api.__name__):
         result = await opal2_api.health_check()
 
-    assert result["components"]["tool_registry"] == {
+    assert result["components"]["tool_registry"] == {  # nosec B101 - pytest assertion
         "healthy": False,
         "error": "internal error",
     }
-    assert "opal2-customer-secret" not in json.dumps(result)
-    assert "opal2-customer-secret" not in caplog.text
-    assert "RuntimeError" in caplog.text
+    assert "opal2-customer-secret" not in json.dumps(result)  # nosec B101 - pytest assertion
+    assert "opal2-customer-secret" not in caplog.text  # nosec B101 - pytest assertion
+    assert "RuntimeError" in caplog.text  # nosec B101 - pytest assertion
 
 
 def test_cloudhub_health_response_hides_config_exception(monkeypatch, caplog) -> None:
@@ -105,15 +107,17 @@ def test_cloudhub_health_response_hides_config_exception(monkeypatch, caplog) ->
         response = cloudhub.mcp_bridge_health_check()
 
     payload = json.loads(response.body)
-    assert payload["status"] == "unhealthy"
-    assert payload["error"] == "internal error"
-    assert "cloudhub-customer-secret" not in response.body.decode()
-    assert "cloudhub-customer-secret" not in caplog.text
-    assert "RuntimeError" in caplog.text
+    assert payload["status"] == "unhealthy"  # nosec B101 - pytest assertion
+    assert payload["error"] == "internal error"  # nosec B101 - pytest assertion
+    assert "cloudhub-customer-secret" not in response.body.decode()  # nosec B101 - pytest assertion
+    assert "cloudhub-customer-secret" not in caplog.text  # nosec B101 - pytest assertion
+    assert "RuntimeError" in caplog.text  # nosec B101 - pytest assertion
 
 
 @pytest.mark.asyncio
-async def test_aumem_health_response_hides_metrics_exception(monkeypatch, caplog) -> None:
+async def test_aumem_health_response_hides_metrics_exception(
+    monkeypatch, caplog
+) -> None:
     """AuMemManager health failures do not reflect exception messages."""
 
     from modules.aumemmanager import api_integration
@@ -121,13 +125,15 @@ async def test_aumem_health_response_hides_metrics_exception(monkeypatch, caplog
     def failing_metrics_load():
         raise RuntimeError("aumem-customer-secret")
 
-    monkeypatch.setattr(api_integration.memory_manager, "get_metrics", failing_metrics_load)
+    monkeypatch.setattr(
+        api_integration.memory_manager, "get_metrics", failing_metrics_load
+    )
 
     with caplog.at_level(logging.ERROR, logger=api_integration.__name__):
         result = await api_integration.health_check()
 
-    assert result["status"] == "unhealthy"
-    assert result["error"] == "internal error"
-    assert "aumem-customer-secret" not in json.dumps(result)
-    assert "aumem-customer-secret" not in caplog.text
-    assert "RuntimeError" in caplog.text
+    assert result["status"] == "unhealthy"  # nosec B101 - pytest assertion
+    assert result["error"] == "internal error"  # nosec B101 - pytest assertion
+    assert "aumem-customer-secret" not in json.dumps(result)  # nosec B101 - pytest assertion
+    assert "aumem-customer-secret" not in caplog.text  # nosec B101 - pytest assertion
+    assert "RuntimeError" in caplog.text  # nosec B101 - pytest assertion


### PR DESCRIPTION
## Summary

Closes CloudBank's seven open CodeQL findings that currently gate a clean public-security review:

- stop request-derived paths and exception messages from reaching improvement-engine logs
- replace the polynomial Personnel Attention Tag regex with an equivalent linear parser
- keep Opal2, CloudHub, and AuMemManager health contracts while returning generic public error details

## Security invariant

Untrusted request data and internal exception messages must not be reflected through logs or public health responses. Attacker-controlled terminal identifiers must be parsed in linear time.

## Validation

- reproduced the vulnerable logging disclosures and ~0.43s polynomial parse on a crafted input before the patch
- `81 passed` across the new regressions plus existing improvement, mesh, Opal2, CloudHub, and AuMemManager suites
- `23 passed` for safe HTTP error and logging-security suites
- Python compile checks and `git diff --check` pass
- focused Ruff scan reports one pre-existing E741 at `src/improvement/engine.py:270`; no changed-line lint finding

## GitHub alerts

Targets CodeQL alerts #909, #908, #907, #890, #888, #883, and #882. Alert closure and green CI remain the merge gate.