### PR TITLE
fix(security): close a reachable log injection on the coordination API

### DIFF
--- a/src/coordination/event_api.py
+++ b/src/coordination/event_api.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from src.middleware.exception_handler import processing_handler, integration_handler
 from src.middleware.fastapi_security import require_csrf_token
 
@@ -30,13 +30,24 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/coordination", tags=["Event Coordination"])
 
 
+# Identifiers arriving from a request are echoed into log messages downstream.
+# Constraining them at the boundary means a control character cannot enter the
+# system at all, rather than relying on every future log site remembering to
+# sanitise. This is defence in depth: the log sites in event_registry.py also
+# run values through safe_str().
+#
+# The pattern deliberately excludes newlines and carriage returns, which are
+# what let a crafted agent id forge an entire additional log entry.
+_IDENTIFIER = Field(..., min_length=1, max_length=128, pattern=r"^[A-Za-z0-9._:-]+$")
+
+
 # Request/Response models
 class PublishEventRequest(BaseModel):
     """Request to publish an event"""
 
     event_type: EventType
     priority: EventPriority = EventPriority.NORMAL
-    source_agent_id: str
+    source_agent_id: str = _IDENTIFIER
     target_agent_ids: Optional[List[str]] = None
     payload: Dict[str, Any] = {}
     metadata: Dict[str, Any] = {}
@@ -48,7 +59,7 @@ class PublishEventRequest(BaseModel):
 class SubscribeRequest(BaseModel):
     """Request to subscribe to events"""
 
-    agent_id: str
+    agent_id: str = _IDENTIFIER
     event_types: Optional[List[EventType]] = None
     priorities: Optional[List[EventPriority]] = None
     source_agent_ids: Optional[List[str]] = None
@@ -59,8 +70,8 @@ class SubscribeRequest(BaseModel):
 class LockRequest(BaseModel):
     """Request to acquire resource lock"""
 
-    agent_id: str
-    resource_id: str
+    agent_id: str = _IDENTIFIER
+    resource_id: str = _IDENTIFIER
     resource_type: str = "generic"
     ttl_seconds: int = 300
 
@@ -68,8 +79,8 @@ class LockRequest(BaseModel):
 class ConflictDetectionRequest(BaseModel):
     """Request to detect conflicts"""
 
-    agent_id: str
-    resource_id: str
+    agent_id: str = _IDENTIFIER
+    resource_id: str = _IDENTIFIER
     resource_type: str
     operation: str
 

--- a/src/coordination/event_registry.py
+++ b/src/coordination/event_registry.py
@@ -23,6 +23,8 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Optional, Set
 
+from src.core.logging_security import safe_str
+
 from src.coordination.task_utils import fire_and_forget as _fire_and_forget
 
 from src.coordination.event_models import (
@@ -113,7 +115,7 @@ class EventCoordinationRegistry:
         async with self._lock:
             # Validate event hasn't expired
             if event.is_expired():
-                logger.warning(f"Event {event.event_id} has expired, not publishing")
+                logger.warning("Event %s has expired, not publishing", safe_str(event.event_id))
                 return {"success": False, "error": "event_expired", "event_id": event.event_id}
 
             # Store event
@@ -133,7 +135,10 @@ class EventCoordinationRegistry:
             event.status = EventStatus.PROCESSING
 
             logger.info(
-                f"Event published: {event.event_type} from {event.source_agent_id} (priority: {event.priority})"
+                "Event published: %s from %s (priority: %s)",
+                safe_str(event.event_type),
+                safe_str(event.source_agent_id),
+                safe_str(event.priority),
             )
 
         # Deliver to subscribers (outside lock for better concurrency)
@@ -197,10 +202,10 @@ class EventCoordinationRegistry:
                 await asyncio.wait_for(task, timeout=timeout)
                 delivered_to.append(agent_id)
             except asyncio.TimeoutError:
-                logger.warning(f"Handler timeout for agent {agent_id}")
+                logger.warning("Handler timeout for agent %s", safe_str(agent_id))
                 failed.append(agent_id)
             except Exception as e:
-                logger.error(f"Handler error for agent {agent_id}: {e}")
+                logger.error("Handler error for agent %s: %s", safe_str(agent_id), safe_str(e))
                 failed.append(agent_id)
 
         # Update event delivery tracking
@@ -234,7 +239,7 @@ class EventCoordinationRegistry:
             else:
                 handler(event)
         except Exception as e:
-            logger.error(f"Handler invocation failed for agent {agent_id}: {e}")
+            logger.error("Handler invocation failed for agent %s: %s", safe_str(agent_id), safe_str(e))
             raise
 
     async def subscribe(
@@ -260,7 +265,7 @@ class EventCoordinationRegistry:
             if handler:
                 self._event_handlers[subscription.subscription_id].append(handler)
 
-            logger.info(f"Agent {agent_id} subscribed with filter: {event_filter}")
+            logger.info("Agent %s subscribed with filter: %s", safe_str(agent_id), safe_str(event_filter))
 
             return {
                 "success": True,
@@ -290,7 +295,7 @@ class EventCoordinationRegistry:
             if subscription_id in self._event_handlers:
                 del self._event_handlers[subscription_id]
 
-            logger.info(f"Subscription {subscription_id} cancelled")
+            logger.info("Subscription %s cancelled", safe_str(subscription_id))
 
             return {"success": True, "subscription_id": subscription_id}
 
@@ -348,7 +353,7 @@ class EventCoordinationRegistry:
 
                 events.append(event.to_dict())
 
-            logger.info(f"Replayed {len(events)} events for agent {agent_id}")
+            logger.info("Replayed %d events for agent %s", len(events), safe_str(agent_id))
             return events
 
     async def detect_conflict(
@@ -388,7 +393,7 @@ class EventCoordinationRegistry:
                     self._conflicts[conflict.conflict_id] = conflict
                     self._metrics["conflicts_detected"] += 1
 
-                    logger.warning(f"Conflict detected: {conflict.description}")
+                    logger.warning("Conflict detected: %s", safe_str(conflict.description))
 
                     # Prepare conflict event for publishing outside lock
                     conflict_event_to_publish = Event(
@@ -435,7 +440,7 @@ class EventCoordinationRegistry:
                 context_tag="COORD_LOCK",
             )
 
-            logger.info(f"Lock acquired by {agent_id} on {resource_id}")
+            logger.info("Lock acquired by %s on %s", safe_str(agent_id), safe_str(resource_id))
 
         # Publish lock event outside lock to prevent deadlock
         if lock_event_to_publish:
@@ -482,7 +487,7 @@ class EventCoordinationRegistry:
                 context_tag="COORD_LOCK",
             )
 
-            logger.info(f"Lock released by {agent_id} on {resource_id}")
+            logger.info("Lock released by %s on %s", safe_str(agent_id), safe_str(resource_id))
 
         # Publish unlock event outside lock to prevent deadlock
         if unlock_event_to_publish:
@@ -496,7 +501,7 @@ class EventCoordinationRegistry:
         async with self._lock:
             if resource_id in self._resource_locks and self._resource_locks[resource_id] == agent_id:
                 del self._resource_locks[resource_id]
-                logger.info(f"Lock auto-released on {resource_id} after {ttl_seconds}s TTL")
+                logger.info("Lock auto-released on %s after %ss TTL", safe_str(resource_id), ttl_seconds)
 
     async def resolve_conflict(self, conflict_id: str, strategy: str, resolved_by: str) -> Dict[str, Any]:
         """
@@ -533,7 +538,7 @@ class EventCoordinationRegistry:
                 context_tag="COORD_CONFLICT",
             )
 
-            logger.info(f"Conflict {conflict_id} resolved using strategy: {strategy}")
+            logger.info("Conflict %s resolved using strategy: %s", safe_str(conflict_id), safe_str(strategy))
 
         # Publish resolution event outside lock to prevent deadlock
         if resolution_event_to_publish:
@@ -565,7 +570,7 @@ class EventCoordinationRegistry:
                 context_tag="COORD_WORKFLOW",
             )
 
-            logger.info(f"Workflow {workflow.name} created by {workflow.created_by}")
+            logger.info("Workflow %s created by %s", safe_str(workflow.name), safe_str(workflow.created_by))
 
         # Publish workflow event outside lock to prevent deadlock
         if workflow_event_to_publish:

--- a/tests/test_log_injection_event_coordination.py
+++ b/tests/test_log_injection_event_coordination.py
@@ -1,0 +1,102 @@
+"""Log-injection regression tests for the event coordination surface.
+
+CodeQL reported py/log-injection across this module and it was dismissed as
+"won't fix" with no recorded rationale. Re-examined during a dismissal audit,
+it was a true positive and reachable:
+
+    api/aurora_api.py mounts src.coordination.event_api
+      -> SubscribeRequest.agent_id was an unvalidated str
+      -> passed verbatim to EventCoordinationRegistry.subscribe()
+      -> logged with a raw f-string
+
+A newline in agent_id therefore produced a second, fully-formed log entry
+that reads as though the system emitted it.
+
+Note truncation is *not* a defence. Several sites in this codebase apply
+[:100] to logged values, which caps length but preserves control characters —
+see test_truncation_alone_does_not_neutralise_newlines below.
+"""
+
+import asyncio
+import io
+import logging
+
+import pytest
+
+from src.core.logging_security import safe_str
+
+EVIL_ID = "attacker\nCRITICAL:audit:ADMIN OVERRIDE GRANTED to attacker"
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_truncation_alone_does_not_neutralise_newlines():
+    """[:N] limits length but leaves the injection intact; safe_str removes it."""
+    assert "\n" in EVIL_ID[:100], "truncation unexpectedly stripped the newline"
+    assert "\n" not in safe_str(EVIL_ID)
+    assert "\r" not in safe_str(EVIL_ID)
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_registry_logging_cannot_forge_a_log_entry():
+    """A crafted agent id must not produce an additional log line."""
+    from src.coordination.event_registry import EventCoordinationRegistry, EventFilter
+
+    buffer = io.StringIO()
+    handler = logging.StreamHandler(buffer)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    root = logging.getLogger()
+    root.addHandler(handler)
+    previous_level = root.level
+    root.setLevel(logging.INFO)
+    try:
+        async def scenario():
+            registry = EventCoordinationRegistry()
+            await registry.subscribe(agent_id=EVIL_ID, event_filter=EventFilter())
+
+        asyncio.run(scenario())
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous_level)
+
+    output = buffer.getvalue()
+    forged = [line for line in output.splitlines() if line.startswith("CRITICAL:audit:")]
+    assert not forged, f"crafted agent id forged a log entry: {forged}"
+
+    # The value should still be present, just rendered inert on one line.
+    assert "attacker" in output
+
+
+@pytest.mark.unit
+@pytest.mark.security
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "attacker\nCRITICAL:audit:forged",
+        "attacker\r\nWARNING:root:forged",
+        "attacker\roverwrite",
+    ],
+)
+def test_identifiers_with_control_characters_are_rejected_at_the_boundary(payload):
+    """Control characters must not enter the system through a request identifier."""
+    from pydantic import ValidationError
+
+    from src.coordination.event_api import LockRequest, SubscribeRequest
+
+    with pytest.raises(ValidationError):
+        SubscribeRequest(agent_id=payload)
+
+    with pytest.raises(ValidationError):
+        LockRequest(agent_id="valid-agent", resource_id=payload)
+
+
+@pytest.mark.unit
+@pytest.mark.security
+def test_ordinary_identifiers_still_accepted():
+    """The constraint must not reject the identifiers the system actually uses."""
+    from src.coordination.event_api import LockRequest, SubscribeRequest
+
+    assert SubscribeRequest(agent_id="r2-agent-001").agent_id == "r2-agent-001"
+    lock = LockRequest(agent_id="agent.v2:1", resource_id="mem-01")
+    assert lock.resource_id == "mem-01"


### PR DESCRIPTION
First result from auditing the **118 high/critical CodeQL alerts dismissed as "won't fix"** — of which only **8 carry any written rationale**.

## The finding

`py/log-injection` is the largest cluster (48 of 118). This one is a true positive and reachable end to end:

```
api/aurora_api.py:188  mounts src.coordination.event_api
  -> SubscribeRequest.agent_id was a plain, unvalidated `str`
  -> passed verbatim to EventCoordinationRegistry.subscribe()
  -> logged with a raw f-string
```

**Demonstrated, not asserted.** An `agent_id` of `"attacker\nCRITICAL:audit:ADMIN OVERRIDE GRANTED to attacker"` produced a second, fully-formed log entry that reads exactly as though the system emitted it:

```
INFO:src.coordination.event_registry:Agent attacker
CRITICAL:audit:ADMIN OVERRIDE GRANTED to attacker subscribed with filter: ...
```

For a repository whose audit trail is a selling point, a caller being able to write convincing lines into it matters.

## Truncation is not sanitisation

Worth stating plainly, because this codebase relies on it in roughly **29 places**:

```python
>>> "attacker\nCRITICAL:audit:forged"[:100]
'attacker\nCRITICAL:audit:forged'      # newline intact
>>> safe_str("attacker\nCRITICAL:audit:forged")
'attacker CRITICAL:audit:forged'       # neutralised
```

`[:N]` caps length and does nothing else. A test asserts this directly so the assumption cannot quietly return.

## The fix — two layers

1. **`event_registry.py`** — all 14 f-string log calls converted to `%`-style with `safe_str()` on every externally-influenced value.
2. **`event_api.py`** — request identifiers constrained at the boundary (`min_length=1, max_length=128, pattern=^[A-Za-z0-9._:-]+$`), so a control character cannot enter the system at all rather than every future log site having to remember.

Verified after:

```
layer 1: forged log line produced: False
layer 2: SubscribeRequest.agent_id  REJECTED: True
         LockRequest.resource_id    REJECTED: True
         legitimate ids still accepted: r2-agent-001, mem-01
```

## Tests

Six regression tests; **four fail against the previous behaviour** (the other two assert properties true either way — the truncation fact, and that ordinary identifiers still pass).

## Why this matters beyond the one bug

This is the **second** true positive found in this dismissal family — the first was the path traversal in #1364. The pattern is not that the dismissals were careless; most are defensible. It is that **with no rationale recorded, a genuine finding is indistinguishable from the false ones around it**, and stays that way for months.

Remaining clusters not yet adjudicated: `py/overly-permissive-file` (17), `js/missing-rate-limiting` (6), `py/clear-text-logging-sensitive-data` (6), and 10 smaller rules. The other 10 files carrying `py/log-injection` alerts still need the same reachability check — this PR fixes the one proven reachable from an HTTP route.

```
pytest -q    3175 passed, 0 failed, 0 errors   (macOS)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)