### PR TITLE
fix(security): sanitise caller-supplied ids in deployed monitoring logs

### DIFF
--- a/src/monitoring/drift_detector.py
+++ b/src/monitoring/drift_detector.py
@@ -19,6 +19,8 @@ from src.utils.schema_migrations import get_registry
 
 from src.utils.atomic_io import atomic_write_json, append_jsonl
 
+from src.core.logging_security import safe_str
+
 logger = logging.getLogger(__name__)
 
 
@@ -170,7 +172,7 @@ class DriftDetector:
         
         logger.info(
             "Baseline established for %s:%s - mean=%.2f, std=%.2f",
-            agent_id, metric_name, mean, std_dev
+            safe_str(agent_id), safe_str(metric_name), mean, std_dev
         )
         
         return baseline
@@ -197,7 +199,7 @@ class DriftDetector:
         key = f"{agent_id}:{metric_name}"
         
         if key not in self.baselines:
-            logger.warning("No baseline for %s:%s - cannot detect drift", agent_id, metric_name)
+            logger.warning("No baseline for %s:%s - cannot detect drift", safe_str(agent_id), safe_str(metric_name))
             return None
         
         baseline = self.baselines[key]
@@ -260,7 +262,7 @@ class DriftDetector:
             self.alerts.append(alert)
             logger.warning(
                 "Drift detected: %s:%s [%s] - current=%.2f, baseline=%.2f",
-                agent_id, metric_name, alert.level.value, current_value, baseline.mean
+                safe_str(agent_id), safe_str(metric_name), alert.level.value, current_value, baseline.mean
             )
         
         return alert
@@ -364,7 +366,7 @@ class DriftDetector:
                 record = get_registry().stamp(alert_dict, "drift_alert")
                 append_jsonl(self.alerts_path, record)
         except Exception as e:
-            logger.error("Failed to persist drift alert: %s", e)
+            logger.error("Failed to persist drift alert: %s", safe_str(e))
 
     def _load_alerts(self):
         """Load persisted alerts from the shared alert store."""
@@ -380,7 +382,7 @@ class DriftDetector:
                 ]
             logger.info("Loaded %d drift alerts", len(self.alerts))
         except Exception as e:
-            logger.error("Failed to load drift alerts: %s", e)
+            logger.error("Failed to load drift alerts: %s", safe_str(e))
 
     def _rewrite_alerts(self):
         """Rewrite the shared alert store after explicit mutation."""
@@ -403,7 +405,7 @@ class DriftDetector:
                     tmp.unlink(missing_ok=True)
                     raise
         except Exception as e:
-            logger.error("Failed to rewrite drift alerts: %s", e)
+            logger.error("Failed to rewrite drift alerts: %s", safe_str(e))
 
     def _alert_from_dict(self, data: Dict[str, Any]) -> DriftAlert:
         """Restore a drift alert from persisted data."""

--- a/src/monitoring/monitoring_system.py
+++ b/src/monitoring/monitoring_system.py
@@ -24,6 +24,8 @@ from .ethics_engine import EthicsEngine, EthicsViolation, ActionContext, Violati
 from .behavioral_monitor import BehaviorMonitor
 from .audit_logger import AuditLogger
 
+from src.core.logging_security import safe_str
+
 logger = logging.getLogger(__name__)
 
 
@@ -245,7 +247,7 @@ class MonitoringSystem:
         
         logger.info(
             "Established baseline for %s with %d metrics",
-            agent_id, len(historical_data)
+            safe_str(agent_id), len(historical_data)
         )
     
     def record_agent_behavior(
@@ -401,7 +403,7 @@ class MonitoringSystem:
         if agent_id in self.last_intervention_time:
             elapsed = (utc_now() - self.last_intervention_time[agent_id]).total_seconds()
             if elapsed < self.config.intervention_cooldown_seconds:
-                logger.debug("Intervention cooldown active for %s", agent_id)
+                logger.debug("Intervention cooldown active for %s", safe_str(agent_id))
                 return
         
         # Determine intervention type
@@ -455,7 +457,7 @@ class MonitoringSystem:
                 error = str(exc)
                 logger.error(
                     "Intervention handler failed for %s on %s: %s",
-                    intervention_type.value, agent_id, error
+                    intervention_type.value, safe_str(agent_id), safe_str(error)
                 )
         else:
             error = f"No enforcement handler registered for {intervention_type.value}"
@@ -488,7 +490,7 @@ class MonitoringSystem:
         
         logger.warning(
             "Intervention recorded for %s: %s success=%s - %s",
-            agent_id, intervention_type.value, success, reason
+            safe_str(agent_id), intervention_type.value, success, safe_str(reason)
         )
         
         # Notify critical handlers
@@ -533,7 +535,7 @@ class MonitoringSystem:
             try:
                 handler(data)
             except Exception as e:
-                logger.error("Alert handler failed: %s", e)
+                logger.error("Alert handler failed: %s", safe_str(e))
     
     def get_agent_status(self, agent_id: str) -> Dict[str, Any]:
         """
@@ -672,7 +674,7 @@ class MonitoringSystem:
                 with open(self._state_path, 'r') as f:
                     state = json.load(f)
             except Exception as e:
-                logger.error("Failed to load monitoring state: %s", e)
+                logger.error("Failed to load monitoring state: %s", safe_str(e))
                 return False
 
         if 'baselines' in state:
@@ -717,4 +719,4 @@ class MonitoringSystem:
                 )
                 atomic_write_json(self._state_path, state)
         except Exception as e:
-            logger.error("Failed to persist monitoring state: %s", e)
+            logger.error("Failed to persist monitoring state: %s", safe_str(e))

--- a/src/subroutines/ethics_compliance_monitor.py
+++ b/src/subroutines/ethics_compliance_monitor.py
@@ -16,6 +16,8 @@ import logging
 from datetime import datetime, UTC
 from dataclasses import dataclass
 
+from src.core.logging_security import safe_str
+
 logger = logging.getLogger(__name__)
 
 
@@ -207,13 +209,13 @@ class EthicsComplianceMonitor:
             
             logger.info(
                 "Ethics check completed: operation=%s score=%.2f approved=%s",
-                operation_id, ethics_score, approved
+                safe_str(operation_id), ethics_score, approved
             )
             
             return result
             
         except Exception as e:
-            logger.error("Ethics check failed: operation=%s error=%s", operation_id, str(e))
+            logger.error("Ethics check failed: operation=%s error=%s", safe_str(operation_id), safe_str(e))
             return EthicsCheckResult(
                 success=False,
                 operation_id=operation_id,
@@ -242,7 +244,7 @@ class EthicsComplianceMonitor:
                 }
             )
         except Exception as e:
-            logger.error("Failed to send ethics alert: %s", str(e))
+            logger.error("Failed to send ethics alert: %s", safe_str(e))
 
     def _log_compliance_check(
         self,
@@ -270,7 +272,7 @@ class EthicsComplianceMonitor:
                 symbolic_validation=True
             )
         except Exception as e:
-            logger.error("Failed to log compliance check: %s", str(e))
+            logger.error("Failed to log compliance check: %s", safe_str(e))
 
     def record_operation_blocked(self, result: EthicsCheckResult) -> bool:
         """
@@ -288,7 +290,7 @@ class EthicsComplianceMonitor:
 
         self._blocked_operation_ids.add(result.operation_id)
         self._operations_blocked += 1
-        logger.info("Ethics block enforced: operation=%s", result.operation_id)
+        logger.info("Ethics block enforced: operation=%s", safe_str(result.operation_id))
         return True
 
     def get_compliance_stats(self) -> Dict[str, Any]:

--- a/src/subroutines/subroutine_suite.py
+++ b/src/subroutines/subroutine_suite.py
@@ -19,6 +19,8 @@ from importlib.util import find_spec
 import json
 import re
 
+from src.core.logging_security import safe_str
+
 logger = logging.getLogger(__name__)
 
 
@@ -109,7 +111,7 @@ class AnomalyDetectionEngine:
                 
                 logger.warning(
                     "Anomaly detected: metric=%s deviation=%.2f",
-                    metric_name, deviation
+                    safe_str(metric_name), deviation
                 )
                 
                 # Send alert
@@ -125,7 +127,7 @@ class AnomalyDetectionEngine:
             return None
             
         except Exception as e:
-            logger.error("Anomaly detection failed: %s", str(e))
+            logger.error("Anomaly detection failed: %s", safe_str(e))
             return None
 
     async def _get_baseline(self, metric_name: str) -> Optional[Dict[str, float]]:
@@ -301,7 +303,7 @@ class KnowledgeBaseSyncManager:
         except Exception as e:
             results["sync_status"] = "failed"
             results["error"] = str(e)
-            logger.error("Knowledge base sync failed: %s", str(e))
+            logger.error("Knowledge base sync failed: %s", safe_str(e))
         
         return results
 
@@ -596,7 +598,7 @@ class DependencyHealthMonitor:
         except Exception as e:
             logger.error(
                 "Dependency health check failed: %s - %s",
-                dependency_name, str(e)
+                safe_str(dependency_name), safe_str(e)
             )
             return {
                 "dependency": dependency_name,
@@ -632,7 +634,7 @@ class DependencyHealthMonitor:
         
         logger.warning(
             "Circuit breaker opened for dependency: %s",
-            dependency_name
+            safe_str(dependency_name)
         )
         
         if self.alert_system:
@@ -725,7 +727,7 @@ class PerformanceProfiler:
             
             logger.warning(
                 "Slow operation detected: %s took %.2fms",
-                operation_name, duration_ms
+                safe_str(operation_name), duration_ms
             )
 
     def get_performance_report(self) -> Dict[str, Any]:

--- a/tests/test_log_injection_deployed_monitoring.py
+++ b/tests/test_log_injection_deployed_monitoring.py
@@ -1,0 +1,66 @@
+"""Log-injection regression tests for monitoring/subroutine modules.
+
+These four modules sit inside the import closure of the deployed FastAPI
+entrypoints (``api/aurora_gui_cloudhub_fastapi.py`` per ``k8s/Dockerfile``,
+plus ``api/aurora_api.py``, ``modules/opal2/api/opal2_api.py`` and
+``services/nemo_service/server.py``). They log caller-supplied identifiers,
+so a newline in an id could forge an additional log record.
+
+``%``-style lazy formatting alone does NOT prevent this -- the value is still
+interpolated verbatim. Only ``safe_str`` neutralises the control characters.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from src.core.logging_security import safe_str
+
+FORGED = "agent-1\nCRITICAL:audit:ETHICS_OVERRIDE_APPROVED operator=attacker"
+
+
+def test_safe_str_neutralises_newlines() -> None:
+    """The primitive the fixes rely on must strip record separators."""
+
+    cleaned = safe_str(FORGED)
+    assert "\n" not in cleaned
+    assert "\r" not in cleaned
+
+
+def test_percent_formatting_alone_does_not_neutralise() -> None:
+    """Guards against 'we already use %s, so we're safe' regressions."""
+
+    assert "\n" in "Baseline for %s" % FORGED
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "src.monitoring.drift_detector",
+        "src.monitoring.monitoring_system",
+        "src.subroutines.ethics_compliance_monitor",
+        "src.subroutines.subroutine_suite",
+    ],
+)
+def test_module_imports_safe_str(module_name: str) -> None:
+    """Each deployed module must have the sanitiser available."""
+
+    module = __import__(module_name, fromlist=["safe_str"])
+    assert hasattr(module, "safe_str"), f"{module_name} lost its safe_str import"
+
+
+def test_drift_detector_logs_no_forged_record(caplog: pytest.LogCaptureFixture) -> None:
+    """A newline-bearing metric name must not produce a second log record."""
+
+    from src.monitoring.drift_detector import DriftDetector
+
+    detector = DriftDetector()
+    with caplog.at_level(logging.WARNING):
+        detector.detect_drift(agent_id=FORGED, metric_name="latency", current_value=1.0)
+
+    assert caplog.records, "expected the no-baseline warning to be emitted"
+    for record in caplog.records:
+        assert "\n" not in record.getMessage()
+        assert "ETHICS_OVERRIDE_APPROVED" not in record.getMessage().split("agent-1")[0]


### PR DESCRIPTION
## What

Wraps caller-supplied identifiers in `safe_str()` at the logging call sites in four modules:

- `src/monitoring/drift_detector.py`
- `src/monitoring/monitoring_system.py`
- `src/subroutines/ethics_compliance_monitor.py`
- `src/subroutines/subroutine_suite.py`

Covers `agent_id`, `metric_name`, `operation_id`, `dependency_name`, `operation_name`, `reason` and exception text. Enum `.value` args and numeric conversions are left alone.

## Why this is reachable, not dormant

These four files sit inside the import closure of the **deployed** FastAPI entrypoints:

| Entrypoint | Declared in |
|---|---|
| `aurora_gui_cloudhub_fastapi:app` | `k8s/Dockerfile`, `Dockerfile_aurora_gui_cloudhub` |
| `opal2_api:app` | `Dockerfile.opal2` |
| `services.nemo_service.server:app` | `services/nemo_service/Dockerfile` |
| `api.aurora_api` | — |

## Correction to #1395

#1395 concluded that `event_registry.py` (fixed in #1394) was the **only** reachable log-injection site. That analysis rooted its import closure at `api/aurora_api.py` alone. The deployment manifests actually launch `aurora_gui_cloudhub_fastapi:app`. Widening the closure to all four entrypoints (229 files, up from 212) puts these nine alerts inside it.

The nine corresponding CodeQL alerts were on the list to be dismissed as "not part of the served application". That rationale would have been **wrong**, so they are being fixed instead.

## The trap these call sites set

All four files had already been converted to `%`-style lazy formatting, which is why they read as safe. Lazy formatting does not neutralise anything — the value is still interpolated verbatim, so a newline in an id forges an extra log record. Only `safe_str()` strips the separators.

`tests/test_log_injection_deployed_monitoring.py` asserts that distinction directly (`test_percent_formatting_alone_does_not_neutralise`) so the "we already use `%s`" reasoning cannot quietly return.

## Verification

- Full suite: **3176 passed, 0 failed**, 123 skipped.
- The drift-detector test was re-run with the fix reverted and **fails**, confirming it is not vacuous.
- One self-inflicted bug caught in review: an early pass wrapped `_record_profile(operation_name, ...)` — a data path, not a log call — which would have truncated stored profile keys. Reverted; every `safe_str` in the diff is inside a `logger.*` call.

## Expected CI

Codacy is expected red (#1334, assert-noise). Everything else should pass.