### PR TITLE
fix(ci): stop Codacy failing every PR that adds a test (#1334)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,40 @@
+---
+# Codacy Cloud configuration.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# The Codacy GitHub App gate is configured with a zero-new-issues threshold
+# while bandit's B101 ("use of assert") is enabled for test files. pytest
+# expresses every assertion with `assert`, so *any* pull request that adds a
+# test failed the gate by construction -- see issue #1334. On PR #1327, 13 of
+# the 17 reported "new issues" were `use of assert` in test files.
+#
+# The effect was worse than the cause: every merged PR carried a red check,
+# which trains reviewers to ignore the signal entirely, and it penalised adding
+# coverage. Three PRs (#1394, #1396, #1398) were merged over this red check.
+#
+# THIS IS A MITIGATION, NOT THE CORRECT FIX
+# -----------------------------------------
+# The correct fix is to disable the B101 pattern for test paths in the Codacy
+# dashboard, which keeps every other tool reporting on test code. That setting
+# is server-side and cannot be expressed in this repository -- both in-repo
+# Codacy workflows (.github/workflows/codacy.yml, codacy-analysis.yml) are
+# disabled with `if: false`, so the gate is driven entirely by the Codacy App.
+#
+# Excluding the paths below is the only lever available in-repo. The trade-off
+# is real and is stated plainly: Codacy no longer reports ANY finding in test
+# code, not just the inapplicable assert one. That is judged acceptable because
+# test code is not shipped -- it sits outside the import closure of all four
+# deployed entrypoints (see docs/CODEQL_TRIAGE.md) -- and because CodeQL,
+# SonarCloud and GitGuardian still analyse these paths.
+#
+# When the dashboard pattern is fixed, DELETE this file so test code is covered
+# again. Track that on #1334.
+
+exclude_paths:
+  - 'tests/**'
+  - '**/tests/**'
+  - '**/test_*.py'
+  - '**/*_test.py'
+  - 'conftest.py'
+  - '**/conftest.py'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,7 +152,7 @@ on each one's limits.
 |---|---|---|
 | CodeQL | every PR | Alerts dismissed as "won't fix" do not reappear. Query all states, not just `open`, before concluding a branch is clean. Every high/critical dismissal is adjudicated in [docs/CODEQL_TRIAGE.md](docs/CODEQL_TRIAGE.md). |
 | SonarCloud | every PR | Quality gate is scoped to changed lines, not the whole tree. |
-| Codacy | every PR | Currently fails any PR that adds pytest tests — see the tracking issue on the zero-new-issues threshold. |
+| Codacy | every PR | Test paths are excluded via `.codacy.yml`, so Codacy reports nothing about test code at all. This works around a zero-new-issues threshold that failed any PR adding a pytest `assert` (#1334); the correct dashboard-side fix would restore coverage of tests. |
 | GitGuardian | every PR | Detects committed secrets; says nothing about secrets supplied at runtime. |
 | Security-marked tests | `pytest -m security` | Covers path containment, CSRF, PII redaction, ledger tamper detection. Not exhaustive. |
 | Dependabot | continuous | Opens PRs; merging them is not automatic, and the `frontend/` package has no build gate verifying them. |


### PR DESCRIPTION
Closes #1334 (as far as the repository can).

## The problem

The Codacy gate uses a **zero-new-issues** threshold while bandit's `B101` ("use of assert") is enabled for test files. pytest expresses every assertion with `assert`, so **any PR that adds a test fails by construction**. On #1327, 13 of the 17 reported "new issues" were `use of assert` in test files.

The effect is worse than the cause. Every merged PR carries a red check, which trains reviewers to ignore the signal — and it penalises adding coverage, which is exactly backwards. #1394, #1396 and #1398 were all merged over this red check today.

## Why the correct fix isn't in this PR

The right fix is to disable the `B101` pattern for test paths **in the Codacy dashboard**, keeping every other tool reporting on test code.

That is server-side and cannot be expressed here. Both in-repo Codacy workflows are disabled:

- `.github/workflows/codacy.yml` — `if: false`
- `.github/workflows/codacy-analysis.yml` — `if: false`

So the `Codacy Static Code Analysis` check comes entirely from the Codacy GitHub App. `.codacy/codacy.yaml` is only the CLI runtime/tool list and has no bearing on the gate.

## What this PR does

Adds a root `.codacy.yml` excluding test paths — the only lever available in-repo.

## The trade-off, stated rather than hidden

**Codacy will now report nothing about test code at all**, not just the inapplicable assert finding. That is judged acceptable because:

- Test code is not shipped — it sits outside the import closure of all four deployed entrypoints (`docs/CODEQL_TRIAGE.md`).
- CodeQL, SonarCloud and GitGuardian still analyse these paths.

Both the file and `SECURITY.md` say this outright, including the instruction to **delete `.codacy.yml` once the dashboard pattern is fixed** so test coverage returns. `SECURITY.md` previously described the old broken behaviour; it now describes what actually runs.

## Verification

This PR is the test: it adds no pytest asserts, so if Codacy still fails, the exclusion is not being honoured and the dashboard fix is the only path. I'll report which.