### PR TITLE
test: run the 51 Node tests in CI, and stop racing the mesh pipeline

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,73 @@
+---
+name: Node Tests
+# The root package.json has run 51 Node tests under `npm run test:node` (plus
+# `npm run test:web`) and NO workflow has ever invoked either one — the same gap
+# frontend/ had before .github/workflows/frontend-ci.yml. 51 passing tests that
+# CI never runs are not a gate; they are documentation that happens to execute.
+#
+# #1362 reported both commands as broken. Re-checked on 2026-08-02: both exit 0
+# from a clean clone once dependencies are installed. The original report came
+# from an environment without node_modules, so `express` and friends could not
+# resolve. The stale part of that issue is the failure; the real and still-open
+# part is that nothing runs them.
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tests/node/**'
+      - 'tests/web/**'
+      - 'src/**/*.js'
+      - 'middleware/**/*.js'
+      - '.github/workflows/node-tests.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tests/node/**'
+      - 'tests/web/**'
+      - 'src/**/*.js'
+      - 'middleware/**/*.js'
+      - '.github/workflows/node-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  node-tests:
+    name: "Node and web tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v5.0.0
+        with:
+          node-version: '22'          # package.json engines: node 22.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      # --ignore-scripts: the root postinstall is only an echo, and skipping
+      # lifecycle scripts keeps a compromised transitive dependency from
+      # executing at install time. Verified both suites pass without them.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Blocking. 51 tests across the bridge, mesh, command-node, PAS and
+      # session-flow surfaces.
+      - name: Node tests
+        run: npm run test:node
+
+      # Blocking, but thin: tests/web/test-web-components.js is a single test.
+      # It is wired here so the command cannot rot unnoticed the way it did
+      # before; broadening the web coverage is tracked separately on #1362.
+      - name: Web component tests
+        run: npm run test:web

--- a/tests/test_mesh_router_v1.py
+++ b/tests/test_mesh_router_v1.py
@@ -73,8 +73,19 @@ def test_alias_resolution_and_live_fallback(tmp_path: Path) -> None:
         result = await runtime.send_message(
             MeshMessageRequest(to="Alex Thorne", content="Need a routing decision before the next checkpoint.")
         )
-        await asyncio.sleep(0.08)
-        history = runtime.get_channel_history("private:captain:alex")["events"]
+        # Poll for the terminal event rather than sleeping a fixed interval.
+        # The six events below are emitted asynchronously, so a fixed wait races
+        # the pipeline: on a loaded runner only the first four had landed, which
+        # failed an unrelated PR (#1367, a one-line model-identifier change).
+        # Waiting on the condition keeps the assertion strict while removing the
+        # dependency on how fast the runner happens to be.
+        history = []
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            history = runtime.get_channel_history("private:captain:alex")["events"]
+            if any(event["event_type"] == "agent_reply" for event in history):
+                break
+            await asyncio.sleep(0.01)
         return result, history
 
     result, history = asyncio.run(scenario())


### PR DESCRIPTION
Closes #1391. Addresses the substantive half of #1362.

## #1362 — 51 Node tests, and nothing in CI runs them

The root `package.json` has run 51 tests under `npm run test:node` (plus `npm run test:web`), and **no workflow has ever invoked either command.** This is the same gap `frontend/` had before `frontend-ci.yml`: 51 passing tests that CI never runs aren't a gate, they're documentation that happens to execute.

Adds `.github/workflows/node-tests.yml`, running both as blocking steps on the paths that can affect them.

### The issue's premise is stale — worth saying plainly

#1362 reports both commands as broken: `crypto_refactored.js` missing, `tests/web` absent. Re-checked on 2026-08-02:

- `tests/web/` **exists**
- nothing references `crypto_refactored` anywhere
- `npm run test:node` → **exit 0, 51 passed**
- `npm run test:web` → **exit 0, 1 passed**

The original report came from an environment with no `node_modules`, so `express` and friends couldn't resolve. **The failure was stale; the missing CI coverage was not** — which is the part actually worth fixing.

Two of #1362's acceptance criteria remain open, so I've left it open: broadening `test:web` beyond its single test, and deciding whether the intent behind the original `crypto.test.js` needs restoring rather than just noting its absence.

## #1391 — a fixed sleep racing an async pipeline

`test_alias_resolution_and_live_fallback` waited a fixed **80 ms**, then asserted six asynchronously-emitted events had arrived. On a loaded runner only four had landed, failing an unrelated PR (#1367 — a one-line model-identifier change).

Replaced with a poll for the terminal `agent_reply` event under a 10 s deadline. **The assertion is unchanged and just as strict**; only the dependency on runner speed is removed. The same file already used this pattern in `test_broadcast_routes_to_all_channel_agents`.

### Proof it fixes the race rather than merely passing

I could never reproduce the original flake (0/10 isolated, 0/8 under load), so "12 runs pass" would have proved nothing — it passed before too. Instead I drove the manifest typing delay up until the reply lands outside the old window:

| `delay_ms` | old (fixed 80 ms) | new (poll) |
|---|---|---|
| 5 | PASS — 6 events | PASS — 6 events |
| 60 | PASS — 6 events | PASS — 6 events |
| **200** | **FAIL — 3 events** | **PASS — 6 events** |

That is the actual failure mode, reproduced and fixed.

## Verification

- Full suite: **3182 passed, 0 failed**, 123 skipped.
- Target test: 12/12 consecutive runs.
- `npm ci --ignore-scripts` verified sufficient — the root `postinstall` is only an `echo`, and skipping lifecycle scripts stops a compromised transitive dependency executing at install time.

## Incidental finding, not fixed here

`diagnostics.json` is **tracked**, and `npm run test:node` mutates it (`commandCount`, `lastCommandAt`). Running the Node suite therefore dirties the working tree, and once this workflow runs in CI that will show up on every PR touching those paths. It should probably be untracked or written to a temp path — worth its own issue rather than smuggling a behavioural change into this one.