### PR TITLE
security: close the two ledger path-root hardening gaps (#1337)

### DIFF
--- a/modules/insight_ledger/ledger_core.py
+++ b/modules/insight_ledger/ledger_core.py
@@ -11,7 +11,7 @@ import json
 import os
 from datetime import datetime, timezone
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from threading import Lock
 from typing import Any, Dict, List, Optional
 
@@ -26,6 +26,57 @@ try:
 except ImportError:
     SecureStorage = None  # type: ignore
     CRYPTOGRAPHY_AVAILABLE = False
+
+
+def resolve_export_root(env_value: str) -> Path:
+    """
+    Resolve and validate the ledger export root.
+
+    ``AURORA_LEDGER_EXPORT_PATH`` is operator configuration, not request data,
+    but a misconfigured value silently weakens the containment boundary that
+    :func:`validate_safe_path` enforces against it. Pointing it at the
+    filesystem root makes *every* path "contained"; pointing it at a file makes
+    the failure surface as a confusing ``mkdir`` error much later. Both are
+    rejected here, at the point of configuration, with a message naming the
+    variable. See #1337.
+
+    Args:
+        env_value: Raw ``AURORA_LEDGER_EXPORT_PATH`` value; empty means default.
+
+    Returns:
+        An existing, validated export root directory.
+
+    Raises:
+        ValueError: If the configured root is the filesystem root or is not a
+            directory.
+    """
+    if env_value:
+        export_root = Path(env_value)
+        # Validate against the *resolved* form, but return the path as given.
+        # validate_safe_path() matches a caller-supplied absolute path against
+        # both spellings of the root, and on macOS the unresolved spelling is
+        # the one callers hold: tempfile hands back /var/folders/... while
+        # resolve() yields /private/var/folders/.... Resolving here would throw
+        # the as-given spelling away and reject a caller passing back the very
+        # path it was just handed — the exact macOS regression fixed earlier in
+        # validate_safe_path, and caught here by test_export_ledger.
+        probe = export_root.resolve()
+        # A root of "/" (or "C:\\") makes the containment check vacuous: every
+        # absolute path on that volume is lexically "inside" it.
+        if probe == Path(probe.anchor):
+            raise ValueError(
+                "AURORA_LEDGER_EXPORT_PATH must not be the filesystem root "
+                f"({probe}); containment would be vacuous."
+            )
+        if probe.exists() and not probe.is_dir():
+            raise ValueError(
+                f"AURORA_LEDGER_EXPORT_PATH must be a directory, got: {probe}"
+            )
+    else:
+        export_root = Path.cwd() / "data" / "exports"
+
+    export_root.mkdir(parents=True, exist_ok=True)
+    return export_root
 
 
 def validate_safe_path(user_path: str, safe_root: Path, allow_create: bool = False) -> Path:
@@ -57,7 +108,25 @@ def validate_safe_path(user_path: str, safe_root: Path, allow_create: bool = Fal
     safe_root = safe_root.resolve()
     safe_root_str = str(safe_root)
 
-    if requested.is_absolute():
+    # Windows drive-relative input (``C:foo``) carries a drive but is NOT
+    # absolute, so ``Path.is_absolute()`` alone routes it down the relative
+    # branch.  That branch joins with safe_root before resolving — and joining
+    # an anchored path *discards* the left operand:
+    #
+    #     PureWindowsPath("D:/ledger") / "C:foo"  ->  PureWindowsPath("C:foo")
+    #
+    # which silently leaves the containment root.  Treat anything carrying a
+    # drive or a root as path-rooted so it goes through the lexical
+    # ``relative_to`` barrier below and fails closed instead.
+    #
+    # The check runs through PureWindowsPath on *every* platform so the
+    # behaviour is identical on Linux CI and on Windows; otherwise this would
+    # only be exercised on a Windows runner, and no CI job runs on Windows for
+    # the Python suite.  See #1337.
+    windows_view = PureWindowsPath(user_path)
+    is_path_rooted = bool(requested.is_absolute() or windows_view.drive or windows_view.root)
+
+    if is_path_rooted:
         # Do not call .resolve() directly on caller-supplied absolute paths.
         # relative_to() is a pure string operation: it raises ValueError when
         # the path is not lexically under safe_root (no filesystem access).
@@ -655,8 +724,7 @@ class InsightLedger:
         # validate_safe_path has no temp-directory exemption: point the root at
         # the directory the export belongs in, rather than exempting it.
         _export_env = os.environ.get("AURORA_LEDGER_EXPORT_PATH", "")
-        export_root = Path(_export_env) if _export_env else Path.cwd() / "data" / "exports"
-        export_root.mkdir(parents=True, exist_ok=True)
+        export_root = resolve_export_root(_export_env)
 
         # Validate output path is safe
         validated_path = validate_safe_path(output_path, export_root, allow_create=True)

--- a/tests/test_ledger_windows_path_roots.py
+++ b/tests/test_ledger_windows_path_roots.py
@@ -1,0 +1,111 @@
+"""Regression tests for ledger path-root hardening (#1337).
+
+Both cases here are Windows-shaped, but every assertion runs on every platform.
+No CI job runs the Python suite on Windows, so a test guarded by
+``sys.platform == "win32"`` would never execute and would prove nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PureWindowsPath
+
+import pytest
+
+from modules.insight_ledger.ledger_core import resolve_export_root, validate_safe_path
+
+
+# --------------------------------------------------------------------------
+# Drive-relative input must fail closed
+# --------------------------------------------------------------------------
+
+DRIVE_RELATIVE = [
+    "C:foo",             # drive, no root -- is_absolute() is False on Windows
+    "C:ledger.json",
+    "D:nested/export.json",
+    "c:lowercase.json",
+]
+
+
+def test_drive_relative_is_not_absolute_on_windows() -> None:
+    """The premise: these carry a drive but are not absolute.
+
+    If this ever stops holding, the guard below is testing nothing.
+    """
+    for raw in DRIVE_RELATIVE:
+        candidate = PureWindowsPath(raw)
+        assert candidate.drive, f"{raw} should carry a drive"
+        assert not candidate.is_absolute(), f"{raw} should not be absolute"
+
+
+def test_joining_drive_relative_discards_the_root() -> None:
+    """Why this matters: an anchored right operand drops the containment root."""
+    joined = PureWindowsPath("D:/ledger/exports") / "C:foo"
+    assert joined == PureWindowsPath("C:foo")
+    assert "ledger" not in str(joined)
+
+
+@pytest.mark.security
+@pytest.mark.parametrize("raw", DRIVE_RELATIVE)
+def test_drive_relative_paths_are_rejected(tmp_path: Path, raw: str) -> None:
+    """Drive-bearing input must be refused rather than joined and resolved."""
+    with pytest.raises(ValueError, match="outside allowed directory"):
+        validate_safe_path(raw, tmp_path, allow_create=True)
+
+
+@pytest.mark.security
+def test_windows_root_relative_is_rejected(tmp_path: Path) -> None:
+    r"""``\foo`` is root-relative on Windows: root but no drive."""
+    with pytest.raises(ValueError, match="outside allowed directory"):
+        validate_safe_path(r"\ledger.json", tmp_path, allow_create=True)
+
+
+def test_ordinary_relative_paths_still_work(tmp_path: Path) -> None:
+    """The guard must not reject legitimate relative export names."""
+    result = validate_safe_path("export.json", tmp_path, allow_create=True)
+    assert result == (tmp_path.resolve() / "export.json")
+
+    nested = validate_safe_path("sub/export.json", tmp_path, allow_create=True)
+    assert nested == (tmp_path.resolve() / "sub" / "export.json")
+
+
+def test_traversal_still_rejected(tmp_path: Path) -> None:
+    """Pre-existing containment behaviour is unchanged."""
+    with pytest.raises(ValueError, match="Parent directory references not allowed"):
+        validate_safe_path("../escape.json", tmp_path, allow_create=True)
+
+
+# --------------------------------------------------------------------------
+# Export-root misconfiguration must fail loudly
+# --------------------------------------------------------------------------
+
+@pytest.mark.security
+def test_export_root_rejects_filesystem_root() -> None:
+    """A root of "/" would make containment vacuous."""
+    anchor = Path(Path.cwd().anchor)
+    with pytest.raises(ValueError, match="must not be the filesystem root"):
+        resolve_export_root(str(anchor))
+
+
+@pytest.mark.security
+def test_export_root_rejects_non_directory(tmp_path: Path) -> None:
+    """Pointing the root at a file should fail with a message naming the var."""
+    target = tmp_path / "not-a-dir"
+    target.write_text("x")
+    with pytest.raises(ValueError, match="AURORA_LEDGER_EXPORT_PATH must be a directory"):
+        resolve_export_root(str(target))
+
+
+def test_export_root_creates_and_returns_directory(tmp_path: Path) -> None:
+    """A valid configured root is created if absent and returned resolved."""
+    target = tmp_path / "exports" / "nested"
+    result = resolve_export_root(str(target))
+    assert result == target.resolve()
+    assert result.is_dir()
+
+
+def test_export_root_default_when_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty value falls back to <cwd>/data/exports."""
+    monkeypatch.chdir(tmp_path)
+    result = resolve_export_root("")
+    assert result == (tmp_path / "data" / "exports").resolve()
+    assert result.is_dir()


### PR DESCRIPTION
Closes #1337.

## 1. Windows drive-relative input bypassed the containment root

`C:foo` carries a drive but is **not absolute**, so `Path.is_absolute()` alone routed it down the *relative* branch — which joins with `safe_root` before resolving. Joining an anchored right operand discards the left one:

```python
PureWindowsPath("D:/ledger/exports") / "C:foo"   ->   PureWindowsPath("C:foo")
```

The containment root is silently gone. `validate_safe_path` now treats anything carrying a drive **or** a root as path-rooted, so it goes through the lexical `relative_to` barrier and fails closed.

Detection runs through `PureWindowsPath` on **every** platform, so behaviour is identical on Linux CI and on Windows. A test guarded on `sys.platform == "win32"` would never execute — no CI job runs the Python suite on Windows.

## 2. `AURORA_LEDGER_EXPORT_PATH` misconfiguration failed quietly

New `resolve_export_root()` rejects:

- **the filesystem root** — containment against `/` is vacuous, since every absolute path on the volume is lexically "inside" it;
- **a non-directory target** — previously this sailed through to a confusing `mkdir` error much later.

Both messages name the variable.

## A regression I introduced and caught

The first version of `resolve_export_root()` returned `Path(env).resolve()`. That broke `test_export_ledger` on macOS, and the reason is worth recording because it is a trap this file has fallen into before:

```
ValueError: Path outside allowed directory: /var/folders/.../export.json
```

`resolve()` throws away the *as-given* spelling, and `validate_safe_path` needs it — `tempfile` hands callers `/var/folders/...` while `resolve()` yields `/private/var/folders/...`, so a caller passing back the very path it was just handed got rejected. It now validates against a resolved *probe* but returns the path as given.

This is the same macOS spelling trap already documented inside `validate_safe_path`; the existing suite caught it immediately.

## Tests

`tests/test_ledger_windows_path_roots.py` — **13 tests, all platform-independent.**

They assert not just the outcome but the *premise* and the *mechanism*:

- `test_drive_relative_is_not_absolute_on_windows` — these inputs really do carry a drive and really aren't absolute. If that ever stops holding, the guard is testing nothing and this test says so.
- `test_joining_drive_relative_discards_the_root` — pins the actual escape mechanism.

Plus regression cover that ordinary relative paths (`export.json`, `sub/export.json`) and `..` rejection are unchanged.

**Confirmed non-vacuous:** reverting the guard fails 5 of the 13.

## Verification

Full suite: **3195 passed, 0 failed**, 123 skipped.

## Not claimed

Neither gap is remotely reachable — #1336 already removed caller-selected paths from the public Improvement and Ledger export HTTP surfaces. These are internal/operator-configuration hardening, exactly as #1337 framed them.