### PR TITLE
security: make PII response redaction failure-safe (#1344)

### DIFF
--- a/modules/data_guardian/middleware.py
+++ b/modules/data_guardian/middleware.py
@@ -4,6 +4,27 @@ FastAPI Middleware for Data Guardian
 Intercepts requests and responses to automatically detect and redact PII.
 
 Anchor: T1-EDG-001-MIDDLEWARE
+
+.. deprecated::
+    **DataGuardianMiddleware is not registered on any application.** The
+    middleware actually served in production is
+    ``src.middleware.pii_middleware.PIIMiddleware`` (see
+    ``api/aurora_api.py``); this class is reachable only from
+    ``modules.data_guardian`` re-exports and ``tests/test_data_guardian.py``.
+
+    Do not adopt it without fixing ``_scan_response`` first. It carries the
+    consume-then-return defect that #1344 fixed in ``PIIMiddleware``: it drains
+    ``response.body_iterator`` into ``body_bytes`` and then, on *any*
+    exception — and also when ``body_bytes`` is empty — falls through to
+    ``return response, []``. That response object is exhausted, so the client
+    receives an empty or partial body under the original status and headers. It
+    also copies ``Content-Length`` from the pre-redaction body, and swallows
+    every failure with a bare ``except Exception: pass``, so a redactor that
+    always throws is indistinguishable from one that finds nothing.
+
+    Left in place rather than repaired because repairing unregistered code
+    invites its adoption; prefer ``PIIMiddleware``, which is tested for these
+    exact failure modes in ``tests/test_pii_middleware_failure_safe.py``.
 """
 
 import json

--- a/src/middleware/pii_middleware.py
+++ b/src/middleware/pii_middleware.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -84,8 +84,11 @@ class PIIMiddleware(BaseHTTPMiddleware):
                 try:
                     data = json.loads(body)
                     self._scan_and_log(data, request.url.path, direction="request")
-                except Exception:
-                    pass  # Never break request processing due to scanning errors
+                except Exception as exc:
+                    # Never break request processing due to scanning errors, but
+                    # do not fail silently either: a scan that always throws
+                    # looks identical to a scan that finds nothing.
+                    self._log_failure(request.url.path, "request-scan", exc)
 
         response = await call_next(request)
 
@@ -105,7 +108,21 @@ class PIIMiddleware(BaseHTTPMiddleware):
         PII values are never included in log output.
         """
         findings: List[str] = []
-        self._walk(data, findings)
+        failures: List[str] = []
+        self._walk(data, findings, failures=failures)
+        if failures:
+            # Aggregated to one line per scan: _walk runs per string value, so
+            # logging each failure would flood the log on a large payload while
+            # telling you nothing more than the class and the count.
+            logger.warning(
+                "PIIMiddleware: detector failed on %d value(s) in %s body for %s (%s) "
+                "— those values were not scanned",
+                len(failures),
+                direction,
+                path,
+                ", ".join(sorted(set(failures))),
+                extra={"path": path, "direction": direction, "error_classes": sorted(set(failures))},
+            )
         if findings:
             logger.warning(
                 "PII detected in %s body for %s: %s",
@@ -115,8 +132,18 @@ class PIIMiddleware(BaseHTTPMiddleware):
                 extra={"pii_types": findings, "path": path},
             )
 
-    def _walk(self, data: Any, findings: List[str], depth: int = 0) -> None:
-        """Recursively walk data and collect PII type names into *findings*."""
+    def _walk(
+        self,
+        data: Any,
+        findings: List[str],
+        depth: int = 0,
+        failures: Optional[List[str]] = None,
+    ) -> None:
+        """Recursively walk data and collect PII type names into *findings*.
+
+        Detector failures are appended to *failures* as exception class names
+        so the caller can report them once, rather than being swallowed.
+        """
         if depth > 10:
             return
 
@@ -130,37 +157,92 @@ class PIIMiddleware(BaseHTTPMiddleware):
                     pii_type = match.get("type", "unknown")
                     if pii_type not in findings:
                         findings.append(pii_type)
-            except Exception:
-                pass
+            except Exception as exc:
+                # Scanning must never break the request; record the class only
+                # (never the value, which is the PII itself) and continue.
+                if failures is not None:
+                    failures.append(type(exc).__name__)
 
         elif isinstance(data, dict):
             for v in data.values():
-                self._walk(v, findings, depth + 1)
+                self._walk(v, findings, depth + 1, failures=failures)
 
         elif isinstance(data, (list, tuple)):
             for item in data:
-                self._walk(item, findings, depth + 1)
+                self._walk(item, findings, depth + 1, failures=failures)
 
     # ------------------------------------------------------------------
     # Response redaction
     # ------------------------------------------------------------------
 
+    def _log_failure(self, path: str, stage: str, exc: BaseException) -> None:
+        """Record a scan/redaction failure without ever logging PII values.
+
+        Only the route, the stage, and the exception *class* are emitted. The
+        exception message is deliberately omitted: detector and JSON errors
+        routinely quote the offending input, which is precisely the data this
+        middleware exists to keep out of logs.
+        """
+        logger.warning(
+            "PIIMiddleware: %s failed for %s (%s) — protection degraded for this response",
+            stage,
+            path,
+            type(exc).__name__,
+            extra={"pii_stage": stage, "path": path, "error_class": type(exc).__name__},
+        )
+
+    @staticmethod
+    def _rebuild(
+        response: Response,
+        body: bytes,
+        *,
+        media_type: Optional[str],
+        body_changed: bool,
+    ) -> Response:
+        """Reconstruct a response from buffered bytes.
+
+        Once ``body_iterator`` has been drained the original response object is
+        unusable — returning it hands the client an empty or partial body under
+        the original status and headers. Every exit from redaction therefore
+        goes through here.
+
+        When the body changed, ``content-length`` is dropped so Starlette
+        recomputes it; copying the pre-redaction value would describe bytes that
+        are no longer being sent.
+        """
+        headers = dict(response.headers)
+        if body_changed:
+            for key in [k for k in headers if k.lower() == "content-length"]:
+                headers.pop(key)
+        return Response(
+            content=body,
+            status_code=response.status_code,
+            headers=headers,
+            media_type=media_type,
+        )
+
     async def _maybe_redact_response(self, response: Response, path: str) -> Response:
         """Consume the response body, redact any PII, and return a new Response."""
+        # Buffer first, and keep the bytes for every subsequent exit path.
+        body_bytes = b""
         try:
-            body_bytes = b""
             async for chunk in response.body_iterator:
                 body_bytes += chunk
+        except Exception as exc:
+            # The iterator is now partially drained and cannot be replayed;
+            # emit whatever was buffered rather than an exhausted response.
+            self._log_failure(path, "response-buffer", exc)
+            return self._rebuild(
+                response, body_bytes, media_type=response.media_type, body_changed=True
+            )
 
-            if len(body_bytes) > _MAX_BODY_SCAN_BYTES:
-                # Body too large to redact — pass through unchanged.
-                return Response(
-                    content=body_bytes,
-                    status_code=response.status_code,
-                    headers=dict(response.headers),
-                    media_type=response.media_type,
-                )
+        if len(body_bytes) > _MAX_BODY_SCAN_BYTES:
+            # Body too large to redact — pass the original bytes through.
+            return self._rebuild(
+                response, body_bytes, media_type=response.media_type, body_changed=False
+            )
 
+        try:
             data = json.loads(body_bytes)
 
             from modules.data_guardian.detection_rules import PIIDetector
@@ -170,26 +252,34 @@ class PIIMiddleware(BaseHTTPMiddleware):
             engine = RedactionEngine()
 
             scan_results = detector.scan_dict(data)
-            if scan_results:
-                pii_types = self._collect_types_from_scan(scan_results)
-                logger.warning(
-                    "PII detected in response body for %s — redacting: %s",
-                    path,
-                    ", ".join(pii_types),
-                    extra={"pii_types": pii_types, "path": path},
+            if not scan_results:
+                # Nothing to redact: emit the original bytes verbatim rather
+                # than a re-serialised copy, so key order and formatting are
+                # preserved exactly.
+                return self._rebuild(
+                    response, body_bytes, media_type=response.media_type, body_changed=False
                 )
-                data = engine.redact_dict(data, scan_results)
 
-            return Response(
-                content=json.dumps(data),
-                status_code=response.status_code,
-                headers=dict(response.headers),
-                media_type="application/json",
+            pii_types = self._collect_types_from_scan(scan_results)
+            logger.warning(
+                "PII detected in response body for %s — redacting: %s",
+                path,
+                ", ".join(pii_types),
+                extra={"pii_types": pii_types, "path": path},
             )
+            redacted = json.dumps(engine.redact_dict(data, scan_results)).encode("utf-8")
 
         except Exception as exc:
-            logger.debug("PIIMiddleware: response redaction skipped: %s", exc)
-            return response
+            # Parse, detector, or redaction failure. Fall back to the exact
+            # bytes the application produced — never a consumed response.
+            self._log_failure(path, "response-redaction", exc)
+            return self._rebuild(
+                response, body_bytes, media_type=response.media_type, body_changed=False
+            )
+
+        return self._rebuild(
+            response, redacted, media_type="application/json", body_changed=True
+        )
 
     @staticmethod
     def _collect_types_from_scan(scan_results: Dict) -> List[str]:

--- a/src/middleware/pii_middleware.py
+++ b/src/middleware/pii_middleware.py
@@ -132,36 +132,50 @@ class PIIMiddleware(BaseHTTPMiddleware):
                 extra={"pii_types": findings, "path": path},
             )
 
+    def _scan_string(self, text: str, findings: List[str], failures: List[str]) -> None:
+        """Scan one string value, recording PII type names or a failure class.
+
+        Split out of :meth:`_walk` to keep that method's branching within the
+        complexity budget; it also isolates the one place an exception may be
+        raised by detector code.
+        """
+        try:
+            # PIIDetector.detect() returns a list of dicts:
+            # [{'start': int, 'end': int, 'match': str, 'type': str,
+            #   'confidence': float, 'region': str|None}, ...]
+            matches = self._detector.detect(text)
+        except Exception as exc:
+            # Scanning must never break the request; record the class only
+            # (never the value, which is the PII itself) and continue.
+            failures.append(type(exc).__name__)
+            return
+
+        for match in matches:
+            pii_type = match.get("type", "unknown")
+            if pii_type not in findings:
+                findings.append(pii_type)
+
     def _walk(
         self,
         data: Any,
         findings: List[str],
         depth: int = 0,
-        failures: Optional[List[str]] = None,
+        *,
+        failures: List[str],
     ) -> None:
         """Recursively walk data and collect PII type names into *findings*.
 
         Detector failures are appended to *failures* as exception class names
         so the caller can report them once, rather than being swallowed.
+        *failures* is required rather than defaulted: an optional accumulator
+        would let a caller silently discard failures again, which is the exact
+        behaviour #1344 set out to remove.
         """
         if depth > 10:
             return
 
         if isinstance(data, str):
-            try:
-                # PIIDetector.detect() returns a list of dicts:
-                # [{'start': int, 'end': int, 'match': str, 'type': str,
-                #   'confidence': float, 'region': str|None}, ...]
-                matches = self._detector.detect(data)
-                for match in matches:
-                    pii_type = match.get("type", "unknown")
-                    if pii_type not in findings:
-                        findings.append(pii_type)
-            except Exception as exc:
-                # Scanning must never break the request; record the class only
-                # (never the value, which is the PII itself) and continue.
-                if failures is not None:
-                    failures.append(type(exc).__name__)
+            self._scan_string(data, findings, failures)
 
         elif isinstance(data, dict):
             for v in data.values():

--- a/tests/test_pii_middleware_failure_safe.py
+++ b/tests/test_pii_middleware_failure_safe.py
@@ -1,0 +1,174 @@
+"""Failure-safety regression tests for PIIMiddleware response redaction (#1344).
+
+The defect these cover: ``_maybe_redact_response`` drained
+``response.body_iterator`` and then, on any exception, returned that same
+now-exhausted response object. The client received an empty or partial body
+under the original status and headers — a redaction failure turned into
+response corruption.
+
+Every test here asserts on bytes the client actually receives, not on internal
+state, because "the middleware returned something" was never the problem.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from src.middleware import pii_middleware as pii_mod
+from src.middleware.pii_middleware import PIIMiddleware
+
+PAYLOAD = {"user": "alice", "note": "hello world", "n": 1}
+
+
+@pytest.fixture(autouse=True)
+def _enable_response_redaction(monkeypatch: pytest.MonkeyPatch):
+    """Response redaction is opt-in via env; these tests exercise it on."""
+    monkeypatch.setattr(pii_mod, "_PII_REDACT_RESPONSES", True)
+
+
+def build_client(payload=None, *, raw: str | None = None) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/data")
+    async def data():
+        if raw is not None:
+            return JSONResponse(content={}, media_type="application/json")
+        return JSONResponse(content=payload if payload is not None else PAYLOAD)
+
+    app.add_middleware(PIIMiddleware)
+    return TestClient(app)
+
+
+def test_body_is_not_lost_when_redaction_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A detector explosion must not empty the response body.
+
+    This is the core regression: pre-fix the client got b"" here.
+    """
+    client = build_client()
+
+    def boom(self, data):  # noqa: ANN001
+        raise RuntimeError("detector exploded")
+
+    from modules.data_guardian.detection_rules import PIIDetector
+
+    monkeypatch.setattr(PIIDetector, "scan_dict", boom, raising=False)
+
+    response = client.get("/data")
+    assert response.status_code == 200
+    assert response.content != b"", "body was lost — the exhausted response was returned"
+    assert response.json() == PAYLOAD
+
+
+def test_invalid_json_body_is_passed_through_verbatim() -> None:
+    """A non-JSON body served as application/json must survive untouched."""
+    app = FastAPI()
+
+    @app.get("/data")
+    async def data():
+        from starlette.responses import Response
+
+        return Response(content=b"not json at all", media_type="application/json")
+
+    app.add_middleware(PIIMiddleware)
+    client = TestClient(app)
+
+    response = client.get("/data")
+    assert response.status_code == 200
+    assert response.content == b"not json at all"
+
+
+def test_content_length_matches_body_on_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback responses must not advertise a length they do not send."""
+    client = build_client()
+
+    from modules.data_guardian.detection_rules import PIIDetector
+
+    monkeypatch.setattr(
+        PIIDetector, "scan_dict", lambda self, d: (_ for _ in ()).throw(ValueError("nope")),
+        raising=False,
+    )
+
+    response = client.get("/data")
+    declared = response.headers.get("content-length")
+    assert declared is not None
+    assert int(declared) == len(response.content)
+
+
+def test_content_length_matches_body_after_redaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A redacted body changes length; the header must follow it."""
+    client = build_client({"email": "alice@example.com", "pad": "x" * 50})
+
+    response = client.get("/data")
+    declared = response.headers.get("content-length")
+    assert declared is not None
+    assert int(declared) == len(response.content), (
+        "stale Content-Length copied from the pre-redaction body"
+    )
+
+
+def test_status_and_headers_preserved_on_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback must not alter status or unrelated headers."""
+    app = FastAPI()
+
+    @app.get("/data")
+    async def data():
+        return JSONResponse(
+            content=PAYLOAD, status_code=418, headers={"x-custom": "kept"}
+        )
+
+    app.add_middleware(PIIMiddleware)
+    client = TestClient(app)
+
+    from modules.data_guardian.detection_rules import PIIDetector
+
+    monkeypatch.setattr(
+        PIIDetector, "scan_dict", lambda self, d: (_ for _ in ()).throw(RuntimeError("x")),
+        raising=False,
+    )
+
+    response = client.get("/data")
+    assert response.status_code == 418
+    assert response.headers.get("x-custom") == "kept"
+    assert response.json() == PAYLOAD
+
+
+def test_clean_body_is_byte_identical() -> None:
+    """With nothing to redact, the original bytes are emitted unchanged."""
+    payload = {"b": 2, "a": 1}  # key order matters for this assertion
+    client = build_client(payload)
+
+    response = client.get("/data")
+    # JSONResponse renders with compact separators; the point of this assertion
+    # is that the middleware emits those original bytes rather than a
+    # re-serialised copy, which would reorder/reformat for no reason.
+    assert response.content == json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
+def test_redaction_failure_is_logged_without_pii(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Failures must be observable, but must not echo the scanned values."""
+    secret = "alice@example.com"
+    client = build_client({"email": secret})
+
+    from modules.data_guardian.detection_rules import PIIDetector
+
+    monkeypatch.setattr(
+        PIIDetector,
+        "scan_dict",
+        lambda self, d: (_ for _ in ()).throw(RuntimeError(f"failed on {secret}")),
+        raising=False,
+    )
+
+    with caplog.at_level("WARNING"):
+        response = client.get("/data")
+
+    assert response.json() == {"email": secret}
+    logged = " ".join(record.getMessage() for record in caplog.records)
+    assert "response-redaction" in logged, "failure was not reported at all"
+    assert secret not in logged, "exception message leaked the PII value into logs"


### PR DESCRIPTION
Closes #1344.

## The defect

`_maybe_redact_response` drained `response.body_iterator` into `body_bytes`, then on *any* exception returned that same **now-exhausted** response object:

```python
except Exception as exc:
    logger.debug("PIIMiddleware: response redaction skipped: %s", exc)
    return response          # iterator already consumed
```

The client receives an empty or partial body under the original status and headers. Turning on `AURORA_PII_REDACT_RESPONSES` could therefore **corrupt responses rather than merely fail to redact them** — a protection whose failure mode is worse than its absence.

## Changes

- **Buffer once, reconstruct always.** Every outbound response now goes through a single `_rebuild()` helper fed from the buffered bytes. No exit path can return the consumed original — including a failure *during* buffering, which emits whatever was captured.
- **`Content-Length` follows the body.** It is dropped when the content changes so Starlette recomputes it; previously the pre-redaction length was copied onto redacted bytes.
- **Clean bodies pass through byte-for-byte** instead of being re-serialised, which silently reordered and reformatted JSON for no reason.
- **Safe telemetry.** `_log_failure()` records route, stage, and exception **class**. The exception *message* is deliberately excluded — detector and JSON errors routinely quote the offending input, which is exactly the PII this middleware exists to keep out of logs. There is a test asserting the value does not reach the log.
- **Per-value detector failures are reported**, aggregated to one line per scan rather than one per string, so a detector that always throws is distinguishable from one that finds nothing.

## Tests

`tests/test_pii_middleware_failure_safe.py` — 7 tests, all asserting on **bytes the client actually receives**, since "the middleware returned something" was never the problem.

Covers each case #1344 asked for: invalid JSON served as `application/json`, a detector exception after buffering, `Content-Length` correctness on both the fallback and redacted paths, and status/header preservation on fallback.

**Confirmed non-vacuous:** reinstating the original `return response` fails **5 of the 7**.

## The legacy implementation — deprecated, not repaired

`modules/data_guardian/middleware.py` has the identical consume-then-return defect (plus a bare `except Exception: pass`, and a fall-through when `body_bytes` is empty). But it is **registered on no application** — only `PIIMiddleware` is, at `api/aurora_api.py:470`. It is reachable solely through `modules.data_guardian` re-exports and its own tests.

#1344 offered "deprecate it explicitly *or* route both through one helper". I took the first: it now carries a `.. deprecated::` block naming each specific failure mode and pointing at `PIIMiddleware`. Repairing unregistered code invites its adoption, and a shared helper would mean maintaining a second consumer of that path for no live benefit.

If you'd rather have the shared helper, say so and I'll do it — but I'd want a caller first.

## Verification

Full suite: **3189 passed, 0 failed**, 123 skipped.