### PR TITLE
supply-chain: install with --require-hashes in CI (#1366)

### DIFF
--- a/.github/workflows/aurora-ci-minimal.yml
+++ b/.github/workflows/aurora-ci-minimal.yml
@@ -46,10 +46,27 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install dependencies
+      # Hash-checked install. requirements-ci-hashed.txt is compiled from BOTH
+      # requirements.txt and requirements-test.txt, so it carries pytest and
+      # every transitive dependency with a sha256 — pip's hash-checking mode
+      # requires *every* package in the resolution to be hashed, which is why
+      # the older requirements-hashed.txt (application deps only) could not be
+      # used by a job that runs tests. See #1366, follow-up to #835.
+      #
+      # --only-binary=:all: is required alongside --require-hashes: an sdist
+      # would be built locally and its artifact hash could not be verified.
+      - name: Install dependencies (hash-checked)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-test.txt
+          python -m pip install --require-hashes --only-binary=:all: \
+            -r requirements-ci-hashed.txt
+
+      # Blocking. The hash-checked install above installs ONLY what the lock
+      # names, so a requirement added to requirements.txt without regenerating
+      # the lock is silently absent and surfaces much later as an ImportError
+      # in an unrelated test. This names the missing package and the fix.
+      - name: Check hashed lock covers declared requirements
+        run: python scripts/check_hashed_lock_drift.py
 
       - name: Check requirements-lock.txt drift (informational)
         continue-on-error: true
@@ -143,10 +160,17 @@ jobs:
           fi
           echo "Critical tests done (exit $PYTEST_EXIT — treating as pass)"
 
-      # SUPPLY-CHAIN INTEGRITY CHECK - non-blocking, warns on hash mismatch
-      # Validates that every installed package matches a known-good SHA-256 hash.
-      # Regenerate requirements-hashed.txt with: bash scripts/generate_hashed_requirements.sh
-      - name: Validate package hashes (informational)
+      # Covers the *container* lock, which this job does not otherwise install.
+      #
+      # The CI dependency install above is now itself hash-checked, so it is
+      # the real supply-chain gate for this workflow. This step remains because
+      # requirements-hashed.txt is a different file, consumed by
+      # Dockerfile.opal2 — nothing else in CI would notice it going stale.
+      #
+      # Still advisory: it guards the container build, not this job, so failing
+      # the test workflow on it would report the breakage in the wrong place.
+      # Regenerate with: bash scripts/generate_hashed_requirements.sh
+      - name: Validate container lock hashes (advisory; covers Dockerfile.opal2)
         continue-on-error: true
         run: |
           if [ -f requirements-hashed.txt ]; then

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -80,7 +80,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-test.txt
+          # Hash-checked: requirements-ci-hashed.txt is compiled from both
+          # requirements.txt and requirements-test.txt (#1366).
+          python -m pip install --require-hashes --only-binary=:all: \
+            -r requirements-ci-hashed.txt
 
       - name: Python syntax check
         run: |

--- a/.github/workflows/pr_evaluation.yml
+++ b/.github/workflows/pr_evaluation.yml
@@ -39,7 +39,10 @@ jobs:
       if: steps.detect.outputs.should_run == 'true'
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-test.txt
+        # Hash-checked: requirements-ci-hashed.txt is compiled from both
+        # requirements.txt and requirements-test.txt (#1366).
+        python -m pip install --require-hashes --only-binary=:all: \
+          -r requirements-ci-hashed.txt
 
     - name: Run PR Evaluation
       if: steps.detect.outputs.should_run == 'true'

--- a/scripts/check_hashed_lock_drift.py
+++ b/scripts/check_hashed_lock_drift.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Verify requirements-ci-hashed.txt still covers every declared requirement.
+
+Why this exists
+---------------
+CI installs with ``--require-hashes -r requirements-ci-hashed.txt``, which
+installs *only* what that lock names. If someone adds a package to
+``requirements.txt`` or ``requirements-test.txt`` without regenerating the
+lock, the install still succeeds — the new package is simply absent — and the
+failure surfaces much later as an ``ImportError`` inside an unrelated test.
+
+This turns that into an explicit, early error naming the missing package and
+the command that fixes it.
+
+Exit codes:
+    0 - every declared requirement is present in the lock
+    1 - drift detected (missing packages listed on stderr)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCES = ("requirements.txt", "requirements-test.txt")
+LOCK = "requirements-ci-hashed.txt"
+
+REGENERATE_CMD = (
+    "uv pip compile --universal --generate-hashes --only-binary=:all: "
+    "--python-version 3.12 --constraints requirements-hashed.txt "
+    "--output-file requirements-ci-hashed.txt requirements.txt requirements-test.txt"
+)
+
+# PEP 503 normalisation: runs of -_. collapse to a single -, case-insensitive.
+_SEPARATORS = re.compile(r"[-_.]+")
+
+
+def normalize(name: str) -> str:
+    return _SEPARATORS.sub("-", name.strip().lower())
+
+
+def requirement_name(line: str) -> str | None:
+    """Extract the distribution name from a requirements line, or None."""
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    # Skip flags (-r, -c, --hash, etc.) and non-name forms.
+    if line.startswith("-"):
+        return None
+    # Strip environment markers, extras, and version specifiers.
+    line = line.split(";", 1)[0]
+    line = line.split("[", 1)[0]
+    name = re.split(r"[=<>!~\s]", line, 1)[0]
+    return normalize(name) if name else None
+
+
+def locked_names(lock_path: Path) -> set[str]:
+    names: set[str] = set()
+    for raw in lock_path.read_text().splitlines():
+        stripped = raw.strip()
+        # Lock entries are unindented "name==version \"; hashes are indented.
+        if not stripped or stripped.startswith(("#", "-")) or raw[:1].isspace():
+            continue
+        name = requirement_name(stripped)
+        if name:
+            names.add(name)
+    return names
+
+
+def main() -> int:
+    lock_path = REPO_ROOT / LOCK
+    if not lock_path.exists():
+        print(f"error: {LOCK} not found", file=sys.stderr)
+        return 1
+
+    locked = locked_names(lock_path)
+    missing: list[tuple[str, str]] = []
+
+    for source in SOURCES:
+        source_path = REPO_ROOT / source
+        if not source_path.exists():
+            continue
+        for raw in source_path.read_text().splitlines():
+            name = requirement_name(raw)
+            if name and name not in locked:
+                missing.append((source, name))
+
+    if missing:
+        print(
+            f"error: {LOCK} is missing {len(missing)} declared requirement(s).\n"
+            "CI installs only what this lock names, so these would be silently\n"
+            "absent and surface later as an ImportError.\n",
+            file=sys.stderr,
+        )
+        for source, name in missing:
+            print(f"  {name}  (declared in {source})", file=sys.stderr)
+        print(f"\nRegenerate with:\n  {REGENERATE_CMD}", file=sys.stderr)
+        return 1
+
+    print(f"{LOCK} covers all {len(locked)} locked distributions; no drift.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_hashed_lock_drift.py
+++ b/scripts/check_hashed_lock_drift.py
@@ -69,15 +69,13 @@ def locked_names(lock_path: Path) -> set[str]:
     return names
 
 
-def main() -> int:
-    lock_path = REPO_ROOT / LOCK
-    if not lock_path.exists():
-        print(f"error: {LOCK} not found", file=sys.stderr)
-        return 1
+def find_missing(locked: set[str]) -> list[tuple[str, str]]:
+    """Return (source_file, package) for every declared requirement not locked.
 
-    locked = locked_names(lock_path)
+    Split out of :func:`main` to keep that function within the complexity
+    budget the repository's static analysis enforces.
+    """
     missing: list[tuple[str, str]] = []
-
     for source in SOURCES:
         source_path = REPO_ROOT / source
         if not source_path.exists():
@@ -86,6 +84,17 @@ def main() -> int:
             name = requirement_name(raw)
             if name and name not in locked:
                 missing.append((source, name))
+    return missing
+
+
+def main() -> int:
+    lock_path = REPO_ROOT / LOCK
+    if not lock_path.exists():
+        print(f"error: {LOCK} not found", file=sys.stderr)
+        return 1
+
+    locked = locked_names(lock_path)
+    missing = find_missing(locked)
 
     if missing:
         print(

--- a/tests/test_hashed_lock_drift.py
+++ b/tests/test_hashed_lock_drift.py
@@ -1,0 +1,111 @@
+"""Tests for the hashed-lock drift checker (#1366).
+
+The checker gates CI, so a bug in it either blocks every PR or — worse — passes
+silently while the lock is stale. Both directions are covered here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_hashed_lock_drift.py"
+
+sys.path.insert(0, str(SCRIPT.parent))
+from check_hashed_lock_drift import locked_names, normalize, requirement_name  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("pytest==9.0.3", "pytest"),
+        ("pytest==9.0.3 \\", "pytest"),
+        ("fastapi>=0.140.1", "fastapi"),
+        ("uvicorn[standard]>=0.51.0", "uvicorn"),
+        ("mcp>=1.28.1,<2.0.0", "mcp"),
+        ("foo ; python_version < '3.13'", "foo"),
+        ("  # a comment", None),
+        ("", None),
+        ("-r requirements.txt", None),
+        ("--hash=sha256:abc", None),
+    ],
+)
+def test_requirement_name_parsing(line: str, expected: str | None) -> None:
+    assert requirement_name(line) == expected
+
+
+def test_normalize_follows_pep503() -> None:
+    """typing_extensions, typing-extensions and Typing.Extensions are one name."""
+    assert normalize("typing_extensions") == "typing-extensions"
+    assert normalize("Typing.Extensions") == "typing-extensions"
+    assert normalize("ruamel--yaml") == "ruamel-yaml"
+
+
+def test_locked_names_ignores_indented_hash_lines(tmp_path: Path) -> None:
+    """Hash continuation lines are indented and must not be read as packages."""
+    lock = tmp_path / "lock.txt"
+    lock.write_text(
+        "# generated\n"
+        "pytest==9.0.3 \\\n"
+        "    --hash=sha256:aaa \\\n"
+        "    --hash=sha256:bbb\n"
+        "    # via -r requirements-test.txt\n"
+        "fastapi==0.136.3 \\\n"
+        "    --hash=sha256:ccc\n"
+    )
+    assert locked_names(lock) == {"pytest", "fastapi"}
+
+
+def test_real_lock_has_no_drift() -> None:
+    """The committed lock must cover everything currently declared."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_detects_a_missing_requirement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A package declared but absent from the lock must fail, and be named."""
+    import check_hashed_lock_drift as mod
+
+    (tmp_path / "requirements.txt").write_text("fastapi==0.136.3\nbrand-new-pkg==1.0\n")
+    (tmp_path / "requirements-test.txt").write_text("pytest==9.0.3\n")
+    (tmp_path / "requirements-ci-hashed.txt").write_text(
+        "fastapi==0.136.3 \\\n    --hash=sha256:a\npytest==9.0.3 \\\n    --hash=sha256:b\n"
+    )
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+
+    assert mod.main() == 1
+
+
+def test_passes_when_lock_is_complete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The inverse: a complete lock must not report drift."""
+    import check_hashed_lock_drift as mod
+
+    (tmp_path / "requirements.txt").write_text("fastapi==0.136.3\n")
+    (tmp_path / "requirements-test.txt").write_text("pytest==9.0.3\n")
+    (tmp_path / "requirements-ci-hashed.txt").write_text(
+        "fastapi==0.136.3 \\\n    --hash=sha256:a\npytest==9.0.3 \\\n    --hash=sha256:b\n"
+    )
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+
+    assert mod.main() == 0
+
+
+def test_name_normalisation_prevents_false_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """typing_extensions in one file and typing-extensions in the other must match."""
+    import check_hashed_lock_drift as mod
+
+    (tmp_path / "requirements.txt").write_text("typing_extensions>=4.0\n")
+    (tmp_path / "requirements-test.txt").write_text("")
+    (tmp_path / "requirements-ci-hashed.txt").write_text(
+        "typing-extensions==4.15.0 \\\n    --hash=sha256:a\n"
+    )
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+
+    assert mod.main() == 0


### PR DESCRIPTION
Addresses #1366 items 1 and 2. Item 3 is deliberately left open — see below.

## The blocker is gone

#1366's core finding was that the CI half of #835 *couldn't* be done: `requirements-hashed.txt` is compiled from `requirements.txt` alone and carries no `pytest`, and pip's hash-checking mode requires **every** package in the resolution to be hashed. No test-running job could use it.

`requirements-ci-hashed.txt` now exists, compiled from **both** files:

```
uv pip compile --universal --generate-hashes --only-binary=:all: --python-version 3.12 \
  --constraints requirements-hashed.txt --output-file requirements-ci-hashed.txt \
  requirements.txt requirements-test.txt
```

Verified before relying on it:

- covers **every** requirement declared in `requirements.txt` (39) and `requirements-test.txt` (6) — no gaps;
- resolves cleanly under `--require-hashes --only-binary=:all:` (dry-run, 85 locked distributions, 1616 hashes);
- `pydantic==2.13.4` / `pydantic-core==2.46.4` are mutually consistent. (The `ResolutionImpossible` in #1390 is Dependabot's *proposed* bump, not `main`.)

## Converted

| Workflow | Was |
|---|---|
| `aurora-ci-minimal.yml` | plain — **the authoritative test job** |
| `pr_evaluation.yml` | plain |
| `k8s-deploy.yml` | plain |

`--only-binary=:all:` accompanies `--require-hashes` everywhere: an sdist would be built locally and its artifact hash could not be verified.

## The silent-failure mode this introduces, and its guard

A hash-checked install installs **only what the lock names**. Add a package to `requirements.txt` without regenerating, and the install still *succeeds* — the package is simply absent — surfacing much later as an `ImportError` inside an unrelated test.

`scripts/check_hashed_lock_drift.py` (blocking) turns that into an early error naming the package and the regeneration command. Name comparison is PEP 503 normalised, so `typing_extensions` vs `typing-extensions` isn't reported as drift.

## An honest relabel

The existing "Validate package hashes (informational)" step validates `requirements-hashed.txt` — a *different* file, consumed by `Dockerfile.opal2`. With the CI install now hash-checked, that step looked redundant; it isn't, because nothing else in CI would notice the container lock going stale.

Renamed to say so, and **left advisory on purpose**: it guards the container build, not this job, so failing the test workflow on it would report the breakage in the wrong place.

## Tests

`tests/test_hashed_lock_drift.py` — 16 tests covering **both** directions, since a checker that gates CI either blocks every PR or passes while the lock rots:

- drift detected and the package named when one is missing;
- no false positive when the lock is complete;
- no false positive when names differ only by PEP 503 normalisation;
- indented `--hash=` continuation lines are not misread as packages.

## Left open

**#1366 item 3** — 39 `requirements.txt` lines carry no upper bound. That's a dependency-policy change with real breakage risk (exactly how the `mcp` 2.x incident happened), and it deserves its own PR rather than riding along with a CI change. Leaving #1366 open for it.

## Verification

Full suite: **3211 passed, 0 failed**, 123 skipped.