### PR TITLE
ci: scope PR Evaluation evidence to the diff and give it tests (#1342)

### DIFF
--- a/.github/workflows/pr_evaluation.yml
+++ b/.github/workflows/pr_evaluation.yml
@@ -33,7 +33,10 @@ jobs:
       if: steps.detect.outputs.should_run == 'true'
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
-        python-version: '3.11'
+        # Must match the interpreter requirements-ci-hashed.txt was compiled
+        # for (--python-version 3.12). The lock pins version-specific wheels
+        # (cp312), which will not install on 3.11.
+        python-version: '3.12'
 
     - name: Install dependencies
       if: steps.detect.outputs.should_run == 'true'
@@ -54,8 +57,11 @@ jobs:
         set -e
         echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
+    # always(): if the evaluator crashes, its partial evidence is exactly what
+    # is needed to diagnose the failure. Without this the upload is skipped on
+    # step failure and the run reports a red gate with nothing to inspect.
     - name: Upload evaluation results
-      if: steps.detect.outputs.should_run == 'true'
+      if: always() && steps.detect.outputs.should_run == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: pr-evaluation-results

--- a/tests/test_pr_evaluator.py
+++ b/tests/test_pr_evaluator.py
@@ -1,0 +1,194 @@
+"""Tests for tools/pr_evaluator.py (#1342).
+
+#1342 found the evaluator had no tests at all while being made a blocking gate.
+These cover the four behaviours that produced false failures on PR #1339:
+
+* evidence scoped to the diff, not the whole repository;
+* no duplicate full-suite run under an unmeetable timeout;
+* traceability judged on the author's commit, not GitHub's synthetic merge;
+* JSON output shape stable enough to act on.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+from pr_evaluator import PREvaluator  # noqa: E402
+
+
+@pytest.fixture
+def evaluator(tmp_path: Path) -> PREvaluator:
+    return PREvaluator(workspace_root=str(tmp_path))
+
+
+# ---------------------------------------------------------------- scoping
+
+def test_changed_python_files_only_returns_changed_py(evaluator, tmp_path):
+    """Non-Python and untouched files must not become evidence."""
+    for rel in ("a.py", "b.txt", "pkg/c.py"):
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x = 1\n")
+    (tmp_path / "untouched.py").write_text("x = 1\n")
+
+    got = evaluator.changed_python_files(["a.py", "b.txt", "pkg/c.py"])
+    assert got == ["a.py", "pkg/c.py"]
+    assert "untouched.py" not in got
+
+
+def test_changed_python_files_skips_deleted(evaluator, tmp_path):
+    """A deleted .py file is in the diff but cannot be compiled."""
+    (tmp_path / "kept.py").write_text("x = 1\n")
+    assert evaluator.changed_python_files(["kept.py", "gone.py"]) == ["kept.py"]
+
+
+def test_changed_python_files_skips_vendored(evaluator, tmp_path):
+    """Vendored trees must never be scanned."""
+    for rel in (".venv/lib/x.py", "node_modules/y.py", "real.py"):
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x = 1\n")
+    assert evaluator.changed_python_files(
+        [".venv/lib/x.py", "node_modules/y.py", "real.py"]
+    ) == ["real.py"]
+
+
+def test_syntax_error_in_changed_file_is_caught(evaluator, tmp_path):
+    """The gate must still fail on a real defect in the diff."""
+    (tmp_path / "broken.py").write_text("def f(:\n")
+    result = evaluator._evaluate_technical_quality(["broken.py"])
+    assert result.score < 1.0
+    assert any("syntax errors" in f.lower() for f in result.findings)
+
+
+def test_preexisting_error_outside_diff_is_ignored(evaluator, tmp_path):
+    """The regression from #1342: unrelated broken files must not fail a PR."""
+    (tmp_path / "preexisting_broken.py").write_text("def f(:\n")
+    (tmp_path / "clean.py").write_text("x = 1\n")
+
+    result = evaluator._evaluate_technical_quality(["clean.py"])
+    assert result.passed, "a clean PR failed because of a file it never touched"
+
+
+def test_no_python_changes_scores_clean(evaluator, tmp_path):
+    """A docs-only PR must not be penalised for Python evidence."""
+    (tmp_path / "README.md").write_text("# hi\n")
+    result = evaluator._evaluate_technical_quality(["README.md"])
+    assert result.passed
+    assert result.score == 1.0
+
+
+# ------------------------------------------------------------ test running
+
+def test_no_changed_tests_applies_no_penalty(evaluator, tmp_path):
+    """Previously the full suite ran and timed out here, costing every PR 0.25."""
+    (tmp_path / "src.py").write_text("x = 1\n")
+    findings, recs, evidence = [], [], []
+    penalty = evaluator._evaluate_changed_tests(["src.py"], evidence, findings, recs)
+
+    assert penalty == 0.0
+    signals = {e.signal for e in evidence}
+    assert "pytest_changed" in signals
+    assert any("aurora-ci-minimal" in e.evidence for e in evidence), (
+        "evidence should say where the authoritative gate actually is"
+    )
+
+
+def test_changed_test_file_is_executed(evaluator, tmp_path):
+    """A changed test that fails must produce a penalty."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_x.py").write_text("def test_fails():\n    assert False\n")
+
+    findings, recs, evidence = [], [], []
+    penalty = evaluator._evaluate_changed_tests(
+        ["tests/test_x.py"], evidence, findings, recs
+    )
+    assert penalty > 0.0
+    assert "Fix failing tests before merge" in recs
+
+
+def test_changed_passing_test_costs_nothing(evaluator, tmp_path):
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_x.py").write_text("def test_ok():\n    assert True\n")
+
+    findings, recs, evidence = [], [], []
+    penalty = evaluator._evaluate_changed_tests(
+        ["tests/test_x.py"], evidence, findings, recs
+    )
+    assert penalty == 0.0
+
+
+# ------------------------------------------------------------- traceability
+
+def init_repo(path: Path, message: str) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=path, check=True)
+    (path / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=path, check=True)
+
+
+def test_traceability_uses_head_when_not_synthetic(evaluator, tmp_path):
+    init_repo(tmp_path, "fix: something real (#123)")
+    assert "fix: something real" in evaluator._traceability_commit_message()
+
+
+def test_synthetic_merge_message_is_detected(evaluator):
+    """The exact shape GitHub generates on pull_request events."""
+    assert evaluator._SYNTHETIC_MERGE_RE.match("Merge a1b2c3d4e5f into 9876543210a")
+    assert not evaluator._SYNTHETIC_MERGE_RE.match("fix: a real commit (#1)")
+    assert not evaluator._SYNTHETIC_MERGE_RE.match("Merge branch 'main' into feature")
+
+
+def test_traceability_falls_back_past_synthetic_merge(evaluator, tmp_path, monkeypatch):
+    """A traceable PR must not be marked untraceable by the merge commit."""
+    init_repo(tmp_path, "fix: real work (#42)")
+    subprocess.run(["git", "checkout", "-q", "-b", "feature"], cwd=tmp_path, check=True)
+    (tmp_path / "g.txt").write_text("y")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "feat: authored change (#42)"], cwd=tmp_path, check=True
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True
+    ).stdout.strip()
+    subprocess.run(["git", "checkout", "-q", "master"], cwd=tmp_path, check=False)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=tmp_path, check=False)
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "merge", "--no-ff", "-q", "-m", f"Merge {head} into {base}", "feature"],
+        cwd=tmp_path, check=True,
+    )
+    monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+
+    message = evaluator._traceability_commit_message()
+    assert "authored change" in message, (
+        "fell back to the synthetic merge instead of the PR head"
+    )
+
+
+# --------------------------------------------------------------- json shape
+
+def test_evaluate_pr_json_shape(tmp_path, monkeypatch):
+    """Consumers parse this; the top-level keys must stay stable."""
+    init_repo(tmp_path, "chore: init (#1)")
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    payload = PREvaluator(workspace_root=str(tmp_path)).evaluate_pr()
+
+    for key in (
+        "overall_score", "passed", "recommendation", "changed_files",
+        "actionable_findings", "results", "score_model",
+    ):
+        assert key in payload, f"missing top-level key: {key}"
+    assert 0.0 <= payload["overall_score"] <= 1.0
+    assert isinstance(payload["results"], list) and payload["results"]
+    for result in payload["results"]:
+        assert {"category", "passed", "score", "weight", "evidence"} <= set(result)

--- a/tools/pr_evaluator.py
+++ b/tools/pr_evaluator.py
@@ -186,6 +186,13 @@ class PREvaluator:
                 result.append(rel)
         return result
 
+    def changed_test_files(self, changed_files: List[str]) -> List[str]:
+        """Changed Python files that pytest would collect as tests."""
+        return [
+            rel for rel in self.changed_python_files(changed_files)
+            if rel.startswith("tests/") or Path(rel).name.startswith("test_")
+        ]
+
     def _evaluate_changed_tests(
         self, changed_files: List[str], evidence: List[ScoreEvidence],
         findings: List[str], recommendations: List[str],
@@ -202,10 +209,7 @@ class PREvaluator:
         attributable. When a PR changes no tests, no penalty is applied and the
         evidence says where the real gate lives, rather than inventing a signal.
         """
-        changed_tests = [
-            rel for rel in self.changed_python_files(changed_files)
-            if rel.startswith("tests/") or Path(rel).name.startswith("test_")
-        ]
+        changed_tests = self.changed_test_files(changed_files)
         if not changed_tests:
             findings.append("No test files changed; full suite gates separately")
             evidence.append(
@@ -255,6 +259,59 @@ class PREvaluator:
         )
         return 0.35
 
+    def _run_py_compile(
+        self, py_files: List[str], evidence: List[ScoreEvidence],
+        findings: List[str], recommendations: List[str],
+    ) -> float:
+        """Compile the changed Python files; return the score penalty."""
+        try:
+            result = subprocess.run(
+                ["python3", "-m", "py_compile", *py_files],
+                capture_output=True, text=True, cwd=self.workspace_root, timeout=45,
+            )
+        except Exception as exc:
+            evidence.append(ScoreEvidence("py_compile_error", 0.35, 0.0, str(exc)))
+            return 0.0
+
+        if result.returncode == 0:
+            findings.append(f"No syntax errors in {len(py_files)} changed file(s)")
+            evidence.append(ScoreEvidence("py_compile", 0.35, 0.0, "py_compile exited 0"))
+            return 0.0
+
+        findings.append("Python syntax errors in changed files")
+        recommendations.append("Fix Python syntax errors")
+        evidence.append(
+            ScoreEvidence("py_compile", 0.35, -0.4, result.stderr[-1000:], "Fix Python syntax errors", True)
+        )
+        return 0.4
+
+    def _run_critical_lint(
+        self, py_files: List[str], evidence: List[ScoreEvidence],
+        findings: List[str], recommendations: List[str],
+    ) -> float:
+        """Run the critical flake8 selection on changed files; return penalty."""
+        try:
+            lint_result = subprocess.run(
+                ["flake8", "--count", "--select=E9,F63,F7,F82", "--show-source", *py_files],
+                capture_output=True, text=True, cwd=self.workspace_root, timeout=30,
+            )
+        except Exception as exc:
+            evidence.append(ScoreEvidence("critical_flake8_unavailable", 0.25, 0.0, str(exc)))
+            return 0.0
+
+        if lint_result.returncode == 0:
+            findings.append("No critical lint errors in changed files")
+            evidence.append(ScoreEvidence("critical_flake8", 0.25, 0.0, "flake8 critical check exited 0"))
+            return 0.0
+
+        findings.append("Critical lint errors in changed files")
+        recommendations.append("Fix critical linting issues")
+        evidence.append(
+            ScoreEvidence("critical_flake8", 0.25, -0.2, lint_result.stdout[-1000:],
+                          "Fix critical linting issues", True)
+        )
+        return 0.2
+
     def _evaluate_technical_quality(self, changed_files: Optional[List[str]] = None) -> EvaluationResult:
         findings: List[str] = []
         recommendations: List[str] = []
@@ -283,54 +340,8 @@ class PREvaluator:
                 evidence=evidence,
             )
 
-        try:
-            result = subprocess.run(
-                ["python3", "-m", "py_compile", *py_files],
-                capture_output=True,
-                text=True,
-                cwd=self.workspace_root,
-                timeout=45,
-            )
-            if result.returncode == 0:
-                findings.append(f"No syntax errors in {len(py_files)} changed file(s)")
-                evidence.append(ScoreEvidence("py_compile", 0.35, 0.0, "py_compile exited 0"))
-            else:
-                findings.append("Python syntax errors in changed files")
-                recommendations.append("Fix Python syntax errors")
-                evidence.append(
-                    ScoreEvidence("py_compile", 0.35, -0.4, result.stderr[-1000:], "Fix Python syntax errors", True)
-                )
-                score -= 0.4
-        except Exception as exc:
-            evidence.append(ScoreEvidence("py_compile_error", 0.35, 0.0, str(exc)))
-
-        try:
-            lint_result = subprocess.run(
-                ["flake8", "--count", "--select=E9,F63,F7,F82", "--show-source", *py_files],
-                capture_output=True,
-                text=True,
-                cwd=self.workspace_root,
-                timeout=30,
-            )
-            if lint_result.returncode == 0:
-                findings.append("No critical lint errors in changed files")
-                evidence.append(ScoreEvidence("critical_flake8", 0.25, 0.0, "flake8 critical check exited 0"))
-            else:
-                findings.append("Critical lint errors in changed files")
-                recommendations.append("Fix critical linting issues")
-                evidence.append(
-                    ScoreEvidence(
-                        "critical_flake8",
-                        0.25,
-                        -0.2,
-                        lint_result.stdout[-1000:],
-                        "Fix critical linting issues",
-                        True,
-                    )
-                )
-                score -= 0.2
-        except Exception as exc:
-            evidence.append(ScoreEvidence("critical_flake8_unavailable", 0.25, 0.0, str(exc)))
+        score -= self._run_py_compile(py_files, evidence, findings, recommendations)
+        score -= self._run_critical_lint(py_files, evidence, findings, recommendations)
 
         return EvaluationResult(
             category="Technical Quality",

--- a/tools/pr_evaluator.py
+++ b/tools/pr_evaluator.py
@@ -9,6 +9,7 @@ without turning routine PRs into noisy review comments.
 
 import json
 import os
+import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -84,8 +85,8 @@ class PREvaluator:
     def __init__(self, workspace_root: Optional[str] = None):
         self.workspace_root = Path(workspace_root or os.getcwd())
 
-    def evaluate_pr(self, pr_number: Optional[int] = None, branch: Optional[str] = None) -> Dict[str, Any]:
-        """Evaluate a pull request and return traceable JSON."""
+    @staticmethod
+    def _print_header(pr_number: Optional[int], branch: Optional[str]) -> None:
         print("=" * 80)
         print("AURORA PR EVALUATION")
         print("=" * 80)
@@ -97,11 +98,28 @@ class PREvaluator:
             print("Evaluating current changes")
         print()
 
+    @staticmethod
+    def _actionable_findings(results: List[EvaluationResult]) -> List[Dict[str, Any]]:
+        """Collect only the evidence a reviewer can act on."""
+        return [
+            {
+                "category": result.category,
+                "recommendations": result.recommendations,
+                "evidence": [item.__dict__ for item in result.evidence if item.actionable],
+            }
+            for result in results
+            if result.actionable
+        ]
+
+    def evaluate_pr(self, pr_number: Optional[int] = None, branch: Optional[str] = None) -> Dict[str, Any]:
+        """Evaluate a pull request and return traceable JSON."""
+        self._print_header(pr_number, branch)
+
         changed_files = self._changed_files()
         print(f"Changed files: {len(changed_files)}")
 
         results = [
-            self._evaluate_technical_quality(),
+            self._evaluate_technical_quality(changed_files),
             self._evaluate_boundary_safety(changed_files),
             self._evaluate_traceability(),
             self._evaluate_documentation_fit(changed_files),
@@ -112,15 +130,7 @@ class PREvaluator:
         weight_sum = sum(result.weight for result in results)
         overall_score = weighted_total / weight_sum if weight_sum else 0.0
         all_passed = all(result.passed for result in results)
-        actionable_findings = [
-            {
-                "category": result.category,
-                "recommendations": result.recommendations,
-                "evidence": [item.__dict__ for item in result.evidence if item.actionable],
-            }
-            for result in results
-            if result.actionable
-        ]
+        actionable_findings = self._actionable_findings(results)
         recommendation = self._generate_recommendation(overall_score, all_passed, actionable_findings)
 
         print("=" * 80)
@@ -157,53 +167,123 @@ class PREvaluator:
         except Exception:
             return []
 
-    def _evaluate_technical_quality(self) -> EvaluationResult:
+    def changed_python_files(self, changed_files: List[str]) -> List[str]:
+        """Changed .py files that still exist, excluding vendored/build trees.
+
+        Evidence must be attributable to the diff. Scanning the whole tree made
+        the evaluator report pre-existing errors in files the PR never touched
+        (#1342), which forces unrelated repo-wide cleanup into every PR.
+        Deleted files are filtered out because they cannot be compiled.
+        """
+        excluded = (".venv", "__pycache__", "node_modules", "site-packages")
+        result: List[str] = []
+        for rel in changed_files:
+            if not rel.endswith(".py"):
+                continue
+            if any(part in rel for part in excluded):
+                continue
+            if (self.workspace_root / rel).is_file():
+                result.append(rel)
+        return result
+
+    def _evaluate_changed_tests(
+        self, changed_files: List[str], evidence: List[ScoreEvidence],
+        findings: List[str], recommendations: List[str],
+    ) -> float:
+        """Run only the test files this PR changed.
+
+        The evaluator used to run the COMPLETE pytest suite with a 90-second
+        timeout while that suite needs roughly six minutes, so it recorded a
+        timeout penalty on every PR (#1342). It also duplicated work: the
+        authoritative full suite is a separate mandatory, fail-closed job in
+        aurora-ci-minimal.yml.
+
+        Running just the changed test files keeps the evidence bounded and
+        attributable. When a PR changes no tests, no penalty is applied and the
+        evidence says where the real gate lives, rather than inventing a signal.
+        """
+        changed_tests = [
+            rel for rel in self.changed_python_files(changed_files)
+            if rel.startswith("tests/") or Path(rel).name.startswith("test_")
+        ]
+        if not changed_tests:
+            findings.append("No test files changed; full suite gates separately")
+            evidence.append(
+                ScoreEvidence(
+                    "pytest_changed", 0.4, 0.0,
+                    "No changed test files. The authoritative full suite runs as a "
+                    "required check in aurora-ci-minimal.yml.",
+                )
+            )
+            return 0.0
+
+        try:
+            test_result = subprocess.run(
+                ["python3", "-m", "pytest", "-q", "--tb=short", *changed_tests],
+                capture_output=True, text=True, cwd=self.workspace_root, timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            findings.append("Changed tests timed out")
+            recommendations.append("Investigate long-running or hanging tests")
+            evidence.append(
+                ScoreEvidence("pytest_changed_timeout", 0.4, -0.25,
+                              f"pytest timed out on {len(changed_tests)} changed test file(s)",
+                              recommendations[-1], True)
+            )
+            return 0.25
+        except Exception as exc:
+            findings.append(f"Could not run changed tests: {exc}")
+            evidence.append(
+                ScoreEvidence("pytest_changed_error", 0.4, -0.1, str(exc), "Review test environment", True)
+            )
+            return 0.1
+
+        if test_result.returncode == 0:
+            findings.append(f"Changed tests pass ({len(changed_tests)} file(s))")
+            evidence.append(
+                ScoreEvidence("pytest_changed", 0.4, 0.0,
+                              f"pytest passed on: {', '.join(changed_tests[:10])}")
+            )
+            return 0.0
+
+        findings.append("Changed tests failing")
+        recommendations.append("Fix failing tests before merge")
+        evidence.append(
+            ScoreEvidence("pytest_changed", 0.4, -0.35,
+                          (test_result.stdout + test_result.stderr)[-1000:],
+                          "Fix failing tests before merge", True)
+        )
+        return 0.35
+
+    def _evaluate_technical_quality(self, changed_files: Optional[List[str]] = None) -> EvaluationResult:
         findings: List[str] = []
         recommendations: List[str] = []
         evidence: List[ScoreEvidence] = []
         score = 1.0
 
-        try:
-            test_result = subprocess.run(
-                ["python3", "-m", "pytest", "-q", "--tb=short"],
-                capture_output=True,
-                text=True,
-                cwd=self.workspace_root,
-                timeout=90,
+        changed_files = changed_files if changed_files is not None else []
+        py_files = self.changed_python_files(changed_files)
+
+        score -= self._evaluate_changed_tests(changed_files, evidence, findings, recommendations)
+
+        if not py_files:
+            evidence.append(
+                ScoreEvidence("py_compile", 0.35, 0.0, "No changed Python files to compile.")
             )
-            if test_result.returncode == 0:
-                findings.append("Tests pass")
-                evidence.append(ScoreEvidence("pytest", 0.6, 0.0, "pytest -q --tb=short exited 0"))
-            else:
-                findings.append("Tests failing")
-                recommendations.append("Fix failing tests before merge")
-                evidence.append(
-                    ScoreEvidence(
-                        "pytest",
-                        0.6,
-                        -0.35,
-                        (test_result.stdout + test_result.stderr)[-1000:],
-                        "Fix failing tests before merge",
-                        True,
-                    )
-                )
-                score -= 0.35
-        except subprocess.TimeoutExpired:
-            findings.append("Tests timed out")
-            recommendations.append("Investigate long-running or hanging tests")
-            evidence.append(ScoreEvidence("pytest_timeout", 0.6, -0.25, "pytest timed out", recommendations[-1], True))
-            score -= 0.25
-        except Exception as exc:
-            findings.append(f"Could not run tests: {exc}")
-            evidence.append(ScoreEvidence("pytest_error", 0.6, -0.1, str(exc), "Review test environment", True))
-            score -= 0.1
+            evidence.append(
+                ScoreEvidence("critical_flake8", 0.25, 0.0, "No changed Python files to lint.")
+            )
+            return EvaluationResult(
+                category="Technical Quality",
+                passed=score >= 0.7,
+                score=max(0.0, score),
+                weight=self.CATEGORY_WEIGHTS["Technical Quality"],
+                findings=findings or ["No Python changes"],
+                recommendations=recommendations,
+                evidence=evidence,
+            )
 
         try:
-            py_files = [
-                str(path)
-                for path in self.workspace_root.rglob("*.py")
-                if not any(part in str(path) for part in [".venv", "__pycache__", "node_modules"])
-            ]
             result = subprocess.run(
                 ["python3", "-m", "py_compile", *py_files],
                 capture_output=True,
@@ -212,36 +292,36 @@ class PREvaluator:
                 timeout=45,
             )
             if result.returncode == 0:
-                findings.append("No Python syntax errors")
-                evidence.append(ScoreEvidence("py_compile", 0.3, 0.0, "py_compile exited 0"))
+                findings.append(f"No syntax errors in {len(py_files)} changed file(s)")
+                evidence.append(ScoreEvidence("py_compile", 0.35, 0.0, "py_compile exited 0"))
             else:
-                findings.append("Python syntax errors present")
+                findings.append("Python syntax errors in changed files")
                 recommendations.append("Fix Python syntax errors")
                 evidence.append(
-                    ScoreEvidence("py_compile", 0.3, -0.4, result.stderr[-1000:], "Fix Python syntax errors", True)
+                    ScoreEvidence("py_compile", 0.35, -0.4, result.stderr[-1000:], "Fix Python syntax errors", True)
                 )
                 score -= 0.4
         except Exception as exc:
-            evidence.append(ScoreEvidence("py_compile_error", 0.3, 0.0, str(exc)))
+            evidence.append(ScoreEvidence("py_compile_error", 0.35, 0.0, str(exc)))
 
         try:
             lint_result = subprocess.run(
-                ["flake8", "--count", "--select=E9,F63,F7,F82", "--show-source"],
+                ["flake8", "--count", "--select=E9,F63,F7,F82", "--show-source", *py_files],
                 capture_output=True,
                 text=True,
                 cwd=self.workspace_root,
                 timeout=30,
             )
             if lint_result.returncode == 0:
-                findings.append("No critical lint errors")
-                evidence.append(ScoreEvidence("critical_flake8", 0.1, 0.0, "flake8 critical check exited 0"))
+                findings.append("No critical lint errors in changed files")
+                evidence.append(ScoreEvidence("critical_flake8", 0.25, 0.0, "flake8 critical check exited 0"))
             else:
-                findings.append("Critical lint errors present")
+                findings.append("Critical lint errors in changed files")
                 recommendations.append("Fix critical linting issues")
                 evidence.append(
                     ScoreEvidence(
                         "critical_flake8",
-                        0.1,
+                        0.25,
                         -0.2,
                         lint_result.stdout[-1000:],
                         "Fix critical linting issues",
@@ -250,7 +330,7 @@ class PREvaluator:
                 )
                 score -= 0.2
         except Exception as exc:
-            evidence.append(ScoreEvidence("critical_flake8_unavailable", 0.1, 0.0, str(exc)))
+            evidence.append(ScoreEvidence("critical_flake8_unavailable", 0.25, 0.0, str(exc)))
 
         return EvaluationResult(
             category="Technical Quality",
@@ -299,6 +379,47 @@ class PREvaluator:
             evidence=evidence,
         )
 
+    # Messages GitHub generates for the synthetic merge commit on pull_request
+    # events. HEAD is that commit, not the author's work, so reading it produced
+    # false "missing prefix" and "missing issue reference" findings on PRs whose
+    # own commits were perfectly traceable (#1342).
+    _SYNTHETIC_MERGE_RE = re.compile(r"^Merge\s+[0-9a-f]{7,40}\s+into\s+[0-9a-f]{7,40}\s*$", re.I)
+
+    def _traceability_commit_message(self) -> str:
+        """Return the message to judge traceability against.
+
+        Prefers the PR head commit. On a ``pull_request`` event HEAD is a
+        synthetic merge commit GitHub creates; ``GITHUB_HEAD_REF`` names the
+        real source branch, and its tip is what the author actually wrote. If
+        HEAD is not synthetic (a push build, or a local run) it is used as-is.
+        """
+        def git(*args: str) -> str:
+            result = subprocess.run(
+                ["git", *args],
+                capture_output=True, text=True, cwd=self.workspace_root, timeout=15,
+            )
+            return result.stdout.strip()
+
+        head_message = git("log", "-1", "--pretty=%B")
+        first_line = head_message.splitlines()[0].strip() if head_message else ""
+        if not self._SYNTHETIC_MERGE_RE.match(first_line):
+            return head_message
+
+        # HEAD is GitHub's synthetic merge; find the real head commit instead.
+        for ref in (
+            os.environ.get("GITHUB_HEAD_REF", ""),
+            "HEAD^2",  # second parent of the merge is the PR head
+        ):
+            if not ref:
+                continue
+            candidate = git("log", "-1", "--pretty=%B", ref)
+            if candidate and not self._SYNTHETIC_MERGE_RE.match(
+                candidate.splitlines()[0].strip()
+            ):
+                return candidate
+
+        return head_message
+
     def _evaluate_traceability(self) -> EvaluationResult:
         findings: List[str] = []
         recommendations: List[str] = []
@@ -306,14 +427,7 @@ class PREvaluator:
         score = 1.0
 
         try:
-            msg_result = subprocess.run(
-                ["git", "log", "-1", "--pretty=%B"],
-                capture_output=True,
-                text=True,
-                cwd=self.workspace_root,
-                timeout=15,
-            )
-            commit_msg = msg_result.stdout.strip()
+            commit_msg = self._traceability_commit_message()
             has_issue_ref = "#" in commit_msg or "issue" in commit_msg.lower()
             has_functional_prefix = any(commit_msg.startswith(prefix) for prefix in ["fix:", "feat:", "docs:", "test:", "chore:"])
             if has_issue_ref:


### PR DESCRIPTION
Addresses #1342. #1339 made this evaluator blocking; it immediately scored 0.58, with most of the negative evidence **not attributable to the PR diff**.

## The four false-signal sources

**1. It duplicated the full suite under an unmeetable timeout.** It ran complete `pytest` with a **90-second** limit while that suite needs ~6 minutes — so every PR collected a timeout penalty. It was also duplicating work: the authoritative suite is already a mandatory fail-closed job in `aurora-ci-minimal.yml`.

Now it runs **only the test files the PR changed**, bounded realistically. A PR that changes no tests takes **no penalty**, and the evidence records where the real gate lives rather than inventing a signal.

**2. `py_compile` scanned the entire repository**, reporting pre-existing errors in files the PR never touched (`scripts/nexus_phase3_init.py`, `simulation/character_loader.py`). That forces unrelated repo-wide cleanup into every PR. Now scoped to changed `.py` files that still exist — deleted files are filtered, since they can't be compiled.

**3. Critical `flake8` scanned the whole repository.** Same scoping.

**4. Traceability judged GitHub's synthetic merge commit.** On `pull_request` events HEAD is `Merge <sha> into <sha>`, producing false "missing prefix" and "missing issue" findings on PRs whose own commits were perfectly traceable. It now detects that exact shape and falls back to `GITHUB_HEAD_REF`, then `HEAD^2`.

## Workflow

- **`python-version` 3.11 → 3.12.** `requirements-ci-hashed.txt` is compiled with `--python-version 3.12` and pins `cp312` wheels, which cannot install on 3.11. **This mismatch was mine** — #1406 pointed this workflow at that lock without checking the interpreter. Caught here rather than in a confusing install failure later.
- **Artifact upload now runs on `always()`**, so a crashed evaluator preserves the evidence needed to diagnose it instead of reporting a red gate with nothing to inspect.

## Tests — there were none

`tests/test_pr_evaluator.py`, 13 tests, for a tool that was being made a required gate with zero coverage. Covers changed-file discovery (including deleted and vendored paths), evidence scoping, changed-test execution, synthetic-merge detection and fallback, and the JSON shape consumers parse.

**Confirmed non-vacuous:** restoring the whole-tree scan fails 2, including the load-bearing one — *"a clean PR must not fail because of a file it never touched."*

## Complexity, measured rather than assumed

| Method | Before | After |
|---|---|---|
| `_evaluate_technical_quality` | 11 | **8** |
| `evaluate_pr` | 13 (pre-existing) | **within budget** |
| `_evaluate_documentation_fit` | 10 | 10 — untouched by this PR |

## Verification

Full suite: **3231 passed, 0 failed**, 123 skipped.

## Still open on #1342

The acceptance criterion *"the workflow can be made blocking without `continue-on-error`"* is now much closer, but flipping the gate is a policy call I'd rather you make deliberately than have ride along in this PR. Leaving #1342 open for that decision.