### PR TITLE
supply-chain: bound 30 unbounded requirements (#1366 item 3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,68 +13,68 @@
 # CORE WEB FRAMEWORK
 # ===================================================================
 fastapi>=0.128.8,<1.0.0             # FastAPI web framework (updated for starlette 0.50+ compatibility)
-uvicorn[standard]>=0.24.0           # ASGI server
+uvicorn[standard]>=0.24.0,<1.0.0    # ASGI server
 starlette>=1.3.1,<2.0.0            # ASGI framework (SECURITY: Fixed GHSA-7f5h-v6xp-fcq8 - Range header DoS)
 pydantic>=2.5.0,<3.0.0             # Data validation (cap at next major; V2->V3 would be breaking)
-pydantic-settings>=2.14.2            # Settings management via environment variables
-python-multipart>=0.0.20             # File upload handling
+pydantic-settings>=2.14.2,<3.0.0    # Settings management via environment variables
+python-multipart>=0.0.20,<1.0.0     # File upload handling
 
 # ===================================================================
 # HTTP & NETWORKING
 # ===================================================================
 httpx>=0.28.0,<1.0.0                # Async HTTP client (requires httpcore 1.x)
-httpcore>=1.0.0                     # HTTP core (requires h11 0.16.0+)
-h11>=0.16.0                         # HTTP/1.1 implementation (security updates)
-websockets>=11.0.3                  # WebSocket support
-aiofiles>=24.1.0                    # Async file operations
+httpcore>=1.0.0,<2.0.0              # HTTP core (requires h11 0.16.0+)
+h11>=0.16.0,<1.0.0                  # HTTP/1.1 implementation (security updates)
+websockets>=11.0.3,<17.0.0          # WebSocket support
+aiofiles>=24.1.0,<26.0.0            # Async file operations
 
 # ===================================================================
 # SECURITY & CRYPTOGRAPHY
 # ===================================================================
 cryptography>=49.0.0,<50.0.0        # Cryptographic library (cap reviewed quarterly; bump for security releases)
-bcrypt>=4.1.2                       # Password hashing
+bcrypt>=4.1.2,<6.0.0                # Password hashing
 pyjwt>=2.10.0,<3.0.0                 # JWT tokens (migrated from python-jose)
-passlib[bcrypt]>=1.7.4              # Password handling
+passlib[bcrypt]>=1.7.4,<2.0.0       # Password handling
 # python-jose removed - see security migration Nov 2025 (ecdsa vulnerability)
 
 # ===================================================================
 # DATA PROCESSING & SCIENTIFIC COMPUTING
 # ===================================================================
-numpy>=1.24.3                       # Numerical computing
-scipy>=1.11.4                       # Scientific computing
-pandas>=2.1.0                       # Data analysis
+numpy>=1.24.3,<3.0.0                # Numerical computing
+scipy>=1.11.4,<2.0.0                # Scientific computing
+pandas>=2.1.0,<4.0.0                # Data analysis
 
 # ===================================================================
 # CONFIGURATION & UTILITIES
 # ===================================================================
-python-dotenv>=1.0.0                # Environment variables
-pyyaml>=6.0.3                       # YAML parsing
-click>=8.4.2                        # CLI interface
-structlog>=23.2.0                   # Structured logging
-python-json-logger>=4.1.0           # JSON logging
+python-dotenv>=1.0.0,<2.0.0         # Environment variables
+pyyaml>=6.0.3,<7.0.0                # YAML parsing
+click>=8.4.2,<9.0.0                 # CLI interface
+structlog>=23.2.0,<27.0.0           # Structured logging
+python-json-logger>=4.1.0,<5.0.0    # JSON logging
 
 # ===================================================================
 # QUANTUM COMPUTING (Nexus)
 # ===================================================================
-qiskit>=1.4.2                       # IBM Quantum SDK
-qiskit-aer>=0.13.0                  # Quantum simulators
+qiskit>=1.4.2,<3.0.0                # IBM Quantum SDK
+qiskit-aer>=0.13.0,<1.0.0           # Quantum simulators
 
 # ===================================================================
 # VISUALIZATION & MONITORING
 # ===================================================================
-plotly>=5.17.0                      # Interactive visualizations
-prometheus-client>=0.19.0           # Metrics collection
+plotly>=5.17.0,<7.0.0               # Interactive visualizations
+prometheus-client>=0.19.0,<1.0.0    # Metrics collection
 
 # ===================================================================
 # DATABASE & CACHING
 # ===================================================================
-redis>=5.0.0                        # Redis client
+redis>=5.0.0,<9.0.0                 # Redis client
 
 # ===================================================================
 # RATE LIMITING & API UTILITIES
 # ===================================================================
-limits>=5.5.0                       # Rate limiting
-slowapi>=0.1.9                      # Rate limiting for FastAPI
+limits>=5.5.0,<6.0.0                # Rate limiting
+slowapi>=0.1.9,<1.0.0               # Rate limiting for FastAPI
 
 # ===================================================================
 # AI MODEL INTEGRATIONS
@@ -85,14 +85,14 @@ openai>=2.43.0,<3.0.0               # GPT-4/5 integration
 # ===================================================================
 # VALIDATION
 # ===================================================================
-jsonschema>=4.17.0                  # JSON Schema validation (MCP tool inputSchema enforcement)
+jsonschema>=4.17.0,<5.0.0           # JSON Schema validation (MCP tool inputSchema enforcement)
 
 # ===================================================================
 # SYSTEM UTILITIES
 # ===================================================================
-requests>=2.34.2                    # HTTP library
-urllib3>=2.7.0                      # HTTP connection pooling
+requests>=2.34.2,<3.0.0             # HTTP library
+urllib3>=2.7.0,<3.0.0               # HTTP connection pooling
 certifi>=2026.5.20                   # SSL certificates
-charset-normalizer>=3.4.7           # Character encoding detection
-idna>=3.18                          # Internationalized domain names
-psutil>=7.2.2                       # Process and system monitoring (for R-2 telemetry)
+charset-normalizer>=3.4.7,<4.0.0    # Character encoding detection
+idna>=3.18,<4.0.0                   # Internationalized domain names
+psutil>=7.2.2,<8.0.0                # Process and system monitoring (for R-2 telemetry)

--- a/tests/test_requirements_upper_bounds.py
+++ b/tests/test_requirements_upper_bounds.py
@@ -1,0 +1,96 @@
+"""Every declared requirement must carry an upper bound (#1366).
+
+An unbounded `>=` floor admits the next breaking major on any fresh resolve.
+That is not hypothetical here: `mcp>=1.28.1` admitted `mcp 2.0.0`, whose
+handler-registration API is incompatible, and the failure was misdiagnosed as
+"1.28.1 lacks Server.list_tools" (#1384) because the installed package was
+never 1.28.1.
+
+This test makes the policy self-enforcing instead of a one-off cleanup.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+REQUIREMENT_FILES = ["requirements.txt", "requirements-test.txt"]
+
+# Packages deliberately left unbounded, each with a stated reason. Adding an
+# entry here is a decision; leaving a package out of it is not.
+EXEMPT = {
+    # certifi is the CA trust store, versioned CalVer. An upper bound would
+    # freeze the certificate bundle at a release boundary, which is a security
+    # regression rather than a protection: stale roots are the failure mode.
+    "certifi": "CA trust store on CalVer; pinning would freeze the cert bundle",
+}
+
+
+def normalize(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name.strip().lower())
+
+
+def declared_requirements(path: Path) -> list[tuple[int, str, str]]:
+    """Yield (line_number, package, full_spec) for real requirement lines."""
+    found = []
+    for number, raw in enumerate(path.read_text().splitlines(), start=1):
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        name = re.split(r"[\[><=!~;\s]", line)[0]
+        if name:
+            found.append((number, normalize(name), line))
+    return found
+
+
+@pytest.mark.parametrize("filename", REQUIREMENT_FILES)
+def test_requirement_file_is_readable(filename: str) -> None:
+    """Guards the rest of this file against silently testing nothing."""
+    path = REPO_ROOT / filename
+    assert path.exists(), f"{filename} is missing"
+    assert declared_requirements(path), f"{filename} declares no requirements"
+
+
+@pytest.mark.parametrize("filename", REQUIREMENT_FILES)
+def test_every_requirement_has_an_upper_bound(filename: str) -> None:
+    path = REPO_ROOT / filename
+    unbounded = [
+        f"{filename}:{number} {spec}"
+        for number, name, spec in declared_requirements(path)
+        if name not in EXEMPT and "<" not in spec and "==" not in spec
+    ]
+    assert not unbounded, (
+        "These requirements admit the next breaking major on a fresh resolve:\n  "
+        + "\n  ".join(unbounded)
+        + "\n\nAdd an upper bound (usually the next major), or add the package to "
+        "EXEMPT in this test with a written reason."
+    )
+
+
+def test_exemptions_are_documented_and_real() -> None:
+    """An exemption must name a package that is actually declared."""
+    declared = set()
+    for filename in REQUIREMENT_FILES:
+        declared |= {name for _, name, _ in declared_requirements(REPO_ROOT / filename)}
+    for package, reason in EXEMPT.items():
+        assert reason.strip(), f"{package} is exempt with no stated reason"
+        assert package in declared, (
+            f"{package} is exempt but no longer declared; remove the exemption"
+        )
+
+
+def test_certifi_is_still_unbounded() -> None:
+    """Pins the reasoning, so a future sweep does not 'fix' it back."""
+    text = (REPO_ROOT / "requirements.txt").read_text()
+    line = next(
+        (ln for ln in text.splitlines() if ln.strip().startswith("certifi")), ""
+    )
+    assert line, "certifi is no longer declared"
+    assert "<" not in line.split("#", 1)[0], (
+        "certifi must stay unbounded: it is the CA trust store, and an upper "
+        "bound freezes the certificate bundle. See EXEMPT in this file."
+    )


### PR DESCRIPTION
Completes #1366. Items 1 and 2 landed in #1406; this is item 3.

## The problem is not hypothetical

**31 of 39** `requirements.txt` lines carried a bare `>=` floor, which admits the next breaking major on any fresh resolve.

That is exactly how `mcp>=1.28.1` admitted **mcp 2.0.0**, whose handler-registration API is incompatible — and the failure was then misdiagnosed as *"1.28.1 lacks `Server.list_tools`"* (#1384), because the installed package had never been 1.28.1. Three PRs and an issue were written against a wrong cause.

## How the ceilings were chosen

Each is derived from the version **actually locked** in `requirements-ci-hashed.txt`, so no bound can sit below what already resolves. `0.x` packages get `<1.0.0`; the rest get the next major.

## The one judgement call: certifi stays unbounded

A mechanical sweep would have given `certifi>=2026.5.20` a ceiling of `<2027.0.0`.

**That would freeze the CA trust store at a year boundary.** certifi *is* the certificate bundle, on CalVer — for a trust store, staleness is the vulnerability, so an upper bound there is a security regression rather than a protection. It is excluded, and `test_certifi_is_still_unbounded` pins the reasoning so a future sweep cannot quietly "fix" it back.

## Self-enforcing, not a one-off cleanup

`tests/test_requirements_upper_bounds.py` (6 tests):

- a new unbounded requirement fails, naming its **file and line**;
- exemptions must carry a written reason **and** name a package that is still declared, so the list cannot rot;
- the certifi decision is asserted directly.

**Confirmed non-vacuous:** removing a single bound fails the test pointing at `requirements.txt:71 redis>=5.0.0`.

## Verified on both resolution paths

| Check | Result |
|---|---|
| `pip install -r requirements.txt -r requirements-test.txt --dry-run` | resolves, no conflict |
| hashed lock still satisfies every new bound | yes |
| `scripts/check_hashed_lock_drift.py` | no drift |
| Full suite | **3264 passed, 0 failed** |

## Note on the remaining unbounded floor

`connector/pyproject.toml` still has `mcp>=1.0.0` and `mcp[sse]>=1.0.0` — the actual live exposure from #1384. That is fixed by draft PR #1392, so it is deliberately not touched here to avoid a conflict.