### PR TITLE
deps: stop Dependabot proposing pydantic-core on its own

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,18 @@ updates:
     commit-message:
       prefix: "deps"
     labels: ["dependencies", "python"]
+    # pydantic-core is not an independently upgradable package: each pydantic
+    # release pins an EXACT pydantic-core build (pydantic 2.13.4 requires
+    # pydantic-core==2.46.4). Dependabot was proposing pydantic-core on its own,
+    # which is unsatisfiable -- no pydantic release pairs with it yet -- so the
+    # PR failed with ResolutionImpossible and simply re-rolled each week:
+    # #1390, then #1412, identical failure both times.
+    #
+    # Ignoring it here does not freeze it. It still moves whenever pydantic
+    # moves, because regenerating the lock resolves it transitively; it just
+    # stops being offered as a standalone bump.
+    ignore:
+      - dependency-name: "pydantic-core"
     groups:
       python-patch-minor:
         patterns: ["*"]


### PR DESCRIPTION
## The same unsatisfiable PR, twice

Dependabot opened #1390 and then #1412, each bumping `pydantic-core` to 2.47.0 while leaving `pydantic` untouched. Both fail identically:

```
ERROR: Cannot install -r requirements-ci-hashed.txt and pydantic-core==2.47.0
       because these package versions have conflicting dependencies.
The conflict is caused by: pydantic 2.13.4 depends on pydantic-core==2.46.4
ERROR: ResolutionImpossible
```

**`pydantic-core` is not independently upgradable.** Every `pydantic` release pins an *exact* build of it, and `pydantic 2.13.4` — verified as the current latest on PyPI — requires `pydantic-core==2.46.4`. No `pydantic` release pairs with 2.47.0, so the resolution is impossible by construction, not by accident of ordering.

#1412 fails **six** checks on this, the same six #1390 failed. Left alone it re-rolls every Monday.

## The fix does not freeze anything

Adding `pydantic-core` to the root pip `ignore` list stops it being offered as a *standalone* bump. It still moves whenever `pydantic` moves, because regenerating the lock resolves it transitively. The comment in the file says so, since "ignore" reads like "pinned forever" at a glance and it isn't.

## One thing worth correcting in my own earlier triage

When I triaged the open PRs, I listed #1390's `Path checks (macos-latest)` and `Path checks (windows-latest)` failures as cross-platform findings from the workflow I'd added. They aren't. Both jobs fail at the **pip resolve step, before any test runs** — it is this same dependency conflict on every platform, not a platform-specific defect. The cross-platform workflow is reporting correctly; I mis-attributed what it was reporting.

## Follow-up

#1390 and #1412 are now both superseded. Once this lands, closing them and letting Dependabot re-open a clean group would be the tidiest path — but that's a call for whoever owns the dependency queue.