### PR TITLE
docs(simulation): record what is actually wired in the duplicate pairs (#1132)

### DIFF
--- a/simulation/orion_station_simulation.py
+++ b/simulation/orion_station_simulation.py
@@ -34,6 +34,20 @@ Success criteria:
 - Minimal idle time; dependencies respected; emergent boosts logged
 
 Note: Keep stdlib only for portability.
+
+STATUS (recorded 2026-08-02, #1132 / #1234): **currently wired, designation pending.**
+
+This file is what the repository actually runs today:
+  - `ORION_SIMULATION_PROTOCOL.md` documents invoking it directly;
+  - `tests/test_orion_simulation.py` imports `OrionSimulation` from it at module
+    scope, so the suite fails without it;
+  - `simulation/interactive_collab_demo.py` uses it.
+
+But `orion_station_simulation_v2.py` describes itself as its successor
+("Key Improvements from v1.0"). Intent and wiring therefore disagree, and that
+disagreement is the open question in #1132 — not something to settle by
+deleting either file. Nothing here is deprecated until the owner designates a
+canonical implementation.
 """
 from __future__ import annotations
 

--- a/simulation/orion_station_simulation_v2.py
+++ b/simulation/orion_station_simulation_v2.py
@@ -13,6 +13,21 @@ Key Improvements from v1.0:
 - Phase 1 role integration
 
 Symbolic Tag: s.tag::sim.orion.v2
+
+STATUS (recorded 2026-08-02, #1132 / #1234): **successor by intent, not yet wired.**
+
+This file states it supersedes v1 ("Key Improvements from v1.0": canonical
+character loading from `L1_CANON_CHARACTER_ROSTER.md` instead of hardcoded
+profiles, 40+ roster support, collaboration bonuses).
+
+It is not, however, what the repository runs. `ORION_SIMULATION_PROTOCOL.md`
+documents v1, and `tests/test_orion_simulation.py` imports v1 at module scope
+while importing this file only inside a single test function via a `sys.path`
+insert — an optional path, not a dependency.
+
+So the supersession is documented but incomplete. #1132 asks which is canonical;
+until that is decided, both remain, and this note exists so the next reader is
+not misled by the "v2" name into assuming it is live.
 """
 
 from __future__ import annotations

--- a/simulation/triplex_handshake_simulation.py
+++ b/simulation/triplex_handshake_simulation.py
@@ -32,6 +32,21 @@ Author: Aurora-GUMAS Project Team
 Version: 1.0
 Date: 2025-11-09
 License: Project Internal
+
+STATUS (recorded 2026-08-02, #1132 / #1234): **duplicate pair, designation pending.**
+
+This file and `triplex_handshake_simulator.py` are two models of the same
+subject — the Triplex Handshake under "The Reflection Event" (Narrative Cycle
+01) — and their opening descriptions are near-identical. They differ in what
+they claim to reproduce: this one records a drift variance of +0.004 "observed
+in the event"; the sibling models drift held at Δ 0.000.
+
+Neither is imported by any module or test; both are standalone scripts. The
+sibling is referenced only from `.sprint_metrics/`, this one from
+`SIMULATION_STATUS_REPORT.md`.
+
+Because they encode *different* claims about the same canonical event, choosing
+between them is a canon question, not a cleanup. See #1132.
 """
 
 import random

--- a/simulation/triplex_handshake_simulator.py
+++ b/simulation/triplex_handshake_simulator.py
@@ -23,6 +23,16 @@ VERSION: 1.0
 DATE: 2025-11-09
 AUTHOR: Aurora-GUMAS Simulation Team
 VERIFIED BY: STARLING_AU (RELAY_004)
+
+STATUS (recorded 2026-08-02, #1132 / #1234): **duplicate pair, designation pending.**
+
+See the matching note in `triplex_handshake_simulation.py`. The two model the
+same event and differ in the drift figure they reproduce — Δ 0.000 here, +0.004
+in the sibling. Neither is imported by any module or test.
+
+Resolving this means deciding which drift figure is canonical for "The
+Reflection Event", which is a canon determination rather than a duplicate-file
+tidy-up. See #1132.
 """
 
 import logging


### PR DESCRIPTION
Part of #1234. Addresses the *investigation* half of #1132; deliberately stops short of the archiving half.

## Why this isn't the cleanup #1132 asked for

#1132 reads as a tidy-up: pick the canonical file, archive the other. Tracing the references turned up something that makes archiving premature in both cases.

### `orion_station_simulation.py` vs `_v2.py` — intent and wiring disagree

| Evidence | Points to |
|---|---|
| v2's own docstring: *"Key Improvements from v1.0"* — canonical roster loading, 40+ characters, collaboration bonuses | **v2 is the successor** |
| `ORION_SIMULATION_PROTOCOL.md` documents invoking v1 directly | **v1 is live** |
| `tests/test_orion_simulation.py` imports v1 at **module scope** (suite fails without it) | **v1 is live** |
| `interactive_collab_demo.py` uses v1 | **v1 is live** |
| v2 imported only *inside one test function*, behind a `sys.path` insert | v2 is optional |

The supersession is documented but was never completed. Deleting either file resolves the symptom by discarding one side of a genuine disagreement.

### `triplex_handshake_simulation.py` vs `_simulator.py` — different claims, same event

These aren't redundant copies. Both model the Triplex Handshake under *"The Reflection Event"* (Narrative Cycle 01), and they reproduce **different numbers**:

- `..._simulation.py` — drift variance **+0.004**, "observed in the event"
- `..._simulator.py` — drift held at **Δ 0.000**

Neither is imported by any module or test. Picking one decides *which drift figure is canonical for that event* — a canon determination, not a duplicate-file cleanup.

## What this PR does

Each of the four files gains a `STATUS` block naming what references it, what supersedes what, and that the designation is open. **Nothing is deleted, deprecated, or renamed.** The conflict is recorded before anything destructive happens.

The v2 note matters most: the filename invites the assumption that it's live, and it isn't.

## The questions that need you

1. **Orion pair** — complete the supersession (rewire the protocol doc, tests and demo to v2), or designate v1 canonical and mark v2 an unadopted proposal?
2. **Triplex pair** — is the canonical drift for "The Reflection Event" **+0.004** or **Δ 0.000**? The rest follows from that.

I can execute either once decided.

## Verification

Docstring-only change. All four still parse as module docstrings (asserted via `ast.get_docstring`). Full suite: **3264 passed, 0 failed**.