### PR TITLE
docs(simulation): add a generated CODEX phase index (#1133)

### DIFF
--- a/scripts/generate_codex_index.py
+++ b/scripts/generate_codex_index.py
@@ -39,9 +39,7 @@ def load_phases() -> List[Dict[str, Any]]:
         if number is None:
             m = re.search(r"PHASE(\d+)", path.name)
             number = int(m.group(1)) if m else 0
-        narrative = next(
-            (p for p in SIM_DIR.glob(f"CODEX_PHASE{number}_*_COMPLETE.md")), None
-        )
+        narrative = next(SIM_DIR.glob(f"CODEX_PHASE{number}_*_COMPLETE.md"), None)
         phases.append(
             {
                 "number": number,
@@ -56,93 +54,127 @@ def load_phases() -> List[Dict[str, Any]]:
     return sorted(phases, key=lambda p: p["number"])
 
 
+def _pair(source: Any, before: str, after: str) -> str | None:
+    """Return "X → Y" when *source* is a mapping carrying both keys."""
+    if isinstance(source, dict) and before in source and after in source:
+        return f"{source[before]} → {source[after]}"
+    return None
+
+
 def roster_span(data: Dict[str, Any]) -> str:
-    """Roster version movement, which the registers spell three different ways."""
+    """Roster version movement, which the registers spell three different ways.
+
+    Phases 1-2 use integration_status.roster_version_from/to, phase 3 uses
+    integration_status.roster_version_change, phases 4-5 use
+    roster_version.before/after. Missing a shape yields "—", which
+    test_roster_span_handles_every_register_shape treats as a failure.
+    """
     status = data.get("integration_status") or {}
-    for before, after in (
-        ("roster_version_from", "roster_version_to"),
-        ("before", "after"),
-    ):
-        src = status if before in status else data.get("roster_version")
-        if isinstance(src, dict) and before in src and after in src:
-            return f"{src[before]} → {src[after]}"
-    if "roster_version_change" in status:
-        return str(status["roster_version_change"]).replace(" → ", " → ")
     version = data.get("roster_version")
-    if isinstance(version, dict):
-        return f"{version.get('before', '?')} → {version.get('after', '?')}"
+
+    for source, before, after in (
+        (status, "roster_version_from", "roster_version_to"),
+        (version, "before", "after"),
+        (status, "before", "after"),
+    ):
+        found = _pair(source, before, after)
+        if found:
+            return found
+
+    if "roster_version_change" in status:
+        return str(status["roster_version_change"])
     return str(version) if version else "—"
 
 
-def render(phases: List[Dict[str, Any]]) -> str:
-    lines: List[str] = []
-    add = lines.append
-
-    add("# CODEX Phase Index")
-    add("")
-    add("<!-- GENERATED FILE — do not edit by hand.")
-    add("     Regenerate: python scripts/generate_codex_index.py")
-    add("     Source: simulation/CODEX_PHASE*_TECHNICAL_REGISTER.json -->")
-    add("")
-    add("Index of the CODEX character-integration phases. Each phase ships a pair:")
-    add("a `*_COMPLETE.md` narrative record and a `*_TECHNICAL_REGISTER.json`")
-    add("machine-readable register. Created for #1133.")
-    add("")
-    add("## Phases")
-    add("")
-    add("| Phase | Division / scope | Roster | Date | Records |")
-    add("|---|---|---|---|---|")
-    for p in phases:
-        records = f"[register]({p['register']})"
-        if p["narrative"]:
-            records = f"[narrative]({p['narrative']}) · " + records
-        add(
-            f"| {p['number']} | {p['name']} | {p['roster']} | "
-            f"{p['date'] or '—'} | {records} |"
+def _phase_table(phases: List[Dict[str, Any]]) -> List[str]:
+    rows = [
+        "## Phases",
+        "",
+        "| Phase | Division / scope | Roster | Date | Records |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for phase in phases:
+        records = f"[register]({phase['register']})"
+        if phase["narrative"]:
+            records = f"[narrative]({phase['narrative']}) · " + records
+        rows.append(
+            f"| {phase['number']} | {phase['name']} | {phase['roster']} | "
+            f"{phase['date'] or '—'} | {records} |"
         )
-    add("")
+    rows.append("")
 
     final = phases[-1]["status"] if phases else {}
     total = final.get("total_entities_in_roster")
     if total:
-        add(f"The roster reaches **{total} entities** at the final phase, which the")
-        add("Phase 6 register marks `2.0 (COMPLETE)`.")
-        add("")
+        rows += [
+            f"The roster reaches **{total} entities** at the final phase, which the",
+            "Phase 6 register marks `2.0 (COMPLETE)`.",
+            "",
+        ]
+    return rows
 
-    add("## Related documents, with their real paths")
-    add("")
-    add("#1133 refers to two of these as if they sat in `simulation/`. They do not:")
-    add("")
-    add("| Document | Actual path |")
-    add("|---|---|")
-    add("| Layer architecture | [`docs/architecture/LAYER_ARCHITECTURE.md`](../docs/architecture/LAYER_ARCHITECTURE.md) |")
-    add("| Simulation state / mission taxonomy | [`.aurora/SIMULATION_STATE.json`](../.aurora/SIMULATION_STATE.json) |")
-    add("| Canonical roster | [`L1_CANON_CHARACTER_ROSTER.md`](L1_CANON_CHARACTER_ROSTER.md) |")
-    add("| Crew manifest (generated) | [`.aurora/ORION_STATION_CREW_MANIFEST.md`](../.aurora/ORION_STATION_CREW_MANIFEST.md) |")
-    add("")
 
-    add("## Notes recorded while indexing")
-    add("")
-    add("These are observations from the registers themselves, not judgements about")
-    add("the work:")
-    add("")
-    add("- **QGIA postdates every phase.** The `QGIA_Integration/` package is not")
-    add("  accounted for in any phase register, so the phase sequence is not a")
-    add("  complete picture of the simulation layer's integrations.")
-    add("- **Phases 4 and 5 record `git_commit_status: \"Pending\"`** in their")
-    add("  registers, although both are committed. The field was never updated after")
-    add("  the commit landed; it reflects the state at authoring time, not now.")
-    add("- **Phases 4 and 5 both note a character-count discrepancy** (32 loaded vs")
-    add("  33 total human staff; 35 vs 36), attributed in-register to parsing rather")
-    add("  than to missing characters. Unresolved in both.")
-    add("- **Phase 6 has no `integration_date`** and no division summary; it records")
-    add("  L2/L3 systems rather than a staffed division.")
-    add("")
-    add("The Phase 6 terminology audit against `LAYER_ARCHITECTURE.md` that #1133")
-    add("also asks for is *not* done here — it is a canon-consistency review rather")
-    add("than an indexing task.")
-    add("")
-    return "\n".join(lines)
+def _related_documents() -> List[str]:
+    return [
+        "## Related documents, with their real paths",
+        "",
+        "Issue #1133 refers to two of these as if they sat in `simulation/`. They do not:",
+        "",
+        "| Document | Actual path |",
+        "| --- | --- |",
+        "| Layer architecture | [`docs/architecture/LAYER_ARCHITECTURE.md`]"
+        "(../docs/architecture/LAYER_ARCHITECTURE.md) |",
+        "| Simulation state / mission taxonomy | [`.aurora/SIMULATION_STATE.json`]"
+        "(../.aurora/SIMULATION_STATE.json) |",
+        "| Canonical roster | [`L1_CANON_CHARACTER_ROSTER.md`](L1_CANON_CHARACTER_ROSTER.md) |",
+        "| Crew manifest (generated) | [`.aurora/ORION_STATION_CREW_MANIFEST.md`]"
+        "(../.aurora/ORION_STATION_CREW_MANIFEST.md) |",
+        "",
+    ]
+
+
+def _indexing_notes() -> List[str]:
+    return [
+        "## Notes recorded while indexing",
+        "",
+        "These are observations from the registers themselves, not judgements about",
+        "the work:",
+        "",
+        "- **QGIA postdates every phase.** The `QGIA_Integration/` package is not",
+        "  accounted for in any phase register, so the phase sequence is not a",
+        "  complete picture of the simulation layer's integrations.",
+        '- **Phases 4 and 5 record `git_commit_status: "Pending"`** in their',
+        "  registers, although both are committed. The field was never updated after",
+        "  the commit landed; it reflects the state at authoring time, not now.",
+        "- **Phases 4 and 5 both note a character-count discrepancy** (32 loaded vs",
+        "  33 total human staff; 35 vs 36), attributed in-register to parsing rather",
+        "  than to missing characters. Unresolved in both.",
+        "- **Phase 6 has no `integration_date`** and no division summary; it records",
+        "  L2/L3 systems rather than a staffed division.",
+        "",
+        "The Phase 6 terminology audit against `LAYER_ARCHITECTURE.md` that #1133",
+        "also asks for is *not* done here — it is a canon-consistency review rather",
+        "than an indexing task.",
+        "",
+    ]
+
+
+def render(phases: List[Dict[str, Any]]) -> str:
+    header = [
+        "# CODEX Phase Index",
+        "",
+        "<!-- GENERATED FILE — do not edit by hand.",
+        "     Regenerate: python scripts/generate_codex_index.py",
+        "     Source: simulation/CODEX_PHASE*_TECHNICAL_REGISTER.json -->",
+        "",
+        "Index of the CODEX character-integration phases. Each phase ships a pair:",
+        "a `*_COMPLETE.md` narrative record and a `*_TECHNICAL_REGISTER.json`",
+        "machine-readable register. Created for #1133.",
+        "",
+    ]
+    return "\n".join(
+        header + _phase_table(phases) + _related_documents() + _indexing_notes()
+    )
 
 
 def main() -> int:

--- a/scripts/generate_codex_index.py
+++ b/scripts/generate_codex_index.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Generate simulation/CODEX_INDEX.md from the phase technical registers (#1133).
+
+The six CODEX phase pairs (a COMPLETE.md narrative plus a TECHNICAL_REGISTER.json)
+had no index, so there was no single place to see what the phases cover or how
+the roster version advanced across them.
+
+The index is *derived* from the registers rather than hand-maintained, following
+the precedent set by `.aurora/ORION_STATION_CREW_MANIFEST.md` (#1083): a
+hand-written index drifts from its source silently, a generated one cannot.
+Regenerate rather than edit the output.
+
+Usage:
+    python scripts/generate_codex_index.py           # write the index
+    python scripts/generate_codex_index.py --check   # fail if it is stale
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIM_DIR = REPO_ROOT / "simulation"
+OUTPUT = SIM_DIR / "CODEX_INDEX.md"
+
+REGISTER_GLOB = "CODEX_PHASE*_TECHNICAL_REGISTER.json"
+
+
+def load_phases() -> List[Dict[str, Any]]:
+    phases = []
+    for path in sorted(SIM_DIR.glob(REGISTER_GLOB)):
+        data = json.loads(path.read_text())
+        number = data.get("phase")
+        if number is None:
+            m = re.search(r"PHASE(\d+)", path.name)
+            number = int(m.group(1)) if m else 0
+        narrative = next(
+            (p for p in SIM_DIR.glob(f"CODEX_PHASE{number}_*_COMPLETE.md")), None
+        )
+        phases.append(
+            {
+                "number": number,
+                "name": data.get("phase_name") or "(unnamed)",
+                "register": path.name,
+                "narrative": narrative.name if narrative else None,
+                "date": data.get("integration_date"),
+                "roster": roster_span(data),
+                "status": data.get("integration_status") or {},
+            }
+        )
+    return sorted(phases, key=lambda p: p["number"])
+
+
+def roster_span(data: Dict[str, Any]) -> str:
+    """Roster version movement, which the registers spell three different ways."""
+    status = data.get("integration_status") or {}
+    for before, after in (
+        ("roster_version_from", "roster_version_to"),
+        ("before", "after"),
+    ):
+        src = status if before in status else data.get("roster_version")
+        if isinstance(src, dict) and before in src and after in src:
+            return f"{src[before]} → {src[after]}"
+    if "roster_version_change" in status:
+        return str(status["roster_version_change"]).replace(" → ", " → ")
+    version = data.get("roster_version")
+    if isinstance(version, dict):
+        return f"{version.get('before', '?')} → {version.get('after', '?')}"
+    return str(version) if version else "—"
+
+
+def render(phases: List[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    add = lines.append
+
+    add("# CODEX Phase Index")
+    add("")
+    add("<!-- GENERATED FILE — do not edit by hand.")
+    add("     Regenerate: python scripts/generate_codex_index.py")
+    add("     Source: simulation/CODEX_PHASE*_TECHNICAL_REGISTER.json -->")
+    add("")
+    add("Index of the CODEX character-integration phases. Each phase ships a pair:")
+    add("a `*_COMPLETE.md` narrative record and a `*_TECHNICAL_REGISTER.json`")
+    add("machine-readable register. Created for #1133.")
+    add("")
+    add("## Phases")
+    add("")
+    add("| Phase | Division / scope | Roster | Date | Records |")
+    add("|---|---|---|---|---|")
+    for p in phases:
+        records = f"[register]({p['register']})"
+        if p["narrative"]:
+            records = f"[narrative]({p['narrative']}) · " + records
+        add(
+            f"| {p['number']} | {p['name']} | {p['roster']} | "
+            f"{p['date'] or '—'} | {records} |"
+        )
+    add("")
+
+    final = phases[-1]["status"] if phases else {}
+    total = final.get("total_entities_in_roster")
+    if total:
+        add(f"The roster reaches **{total} entities** at the final phase, which the")
+        add("Phase 6 register marks `2.0 (COMPLETE)`.")
+        add("")
+
+    add("## Related documents, with their real paths")
+    add("")
+    add("#1133 refers to two of these as if they sat in `simulation/`. They do not:")
+    add("")
+    add("| Document | Actual path |")
+    add("|---|---|")
+    add("| Layer architecture | [`docs/architecture/LAYER_ARCHITECTURE.md`](../docs/architecture/LAYER_ARCHITECTURE.md) |")
+    add("| Simulation state / mission taxonomy | [`.aurora/SIMULATION_STATE.json`](../.aurora/SIMULATION_STATE.json) |")
+    add("| Canonical roster | [`L1_CANON_CHARACTER_ROSTER.md`](L1_CANON_CHARACTER_ROSTER.md) |")
+    add("| Crew manifest (generated) | [`.aurora/ORION_STATION_CREW_MANIFEST.md`](../.aurora/ORION_STATION_CREW_MANIFEST.md) |")
+    add("")
+
+    add("## Notes recorded while indexing")
+    add("")
+    add("These are observations from the registers themselves, not judgements about")
+    add("the work:")
+    add("")
+    add("- **QGIA postdates every phase.** The `QGIA_Integration/` package is not")
+    add("  accounted for in any phase register, so the phase sequence is not a")
+    add("  complete picture of the simulation layer's integrations.")
+    add("- **Phases 4 and 5 record `git_commit_status: \"Pending\"`** in their")
+    add("  registers, although both are committed. The field was never updated after")
+    add("  the commit landed; it reflects the state at authoring time, not now.")
+    add("- **Phases 4 and 5 both note a character-count discrepancy** (32 loaded vs")
+    add("  33 total human staff; 35 vs 36), attributed in-register to parsing rather")
+    add("  than to missing characters. Unresolved in both.")
+    add("- **Phase 6 has no `integration_date`** and no division summary; it records")
+    add("  L2/L3 systems rather than a staffed division.")
+    add("")
+    add("The Phase 6 terminology audit against `LAYER_ARCHITECTURE.md` that #1133")
+    add("also asks for is *not* done here — it is a canon-consistency review rather")
+    add("than an indexing task.")
+    add("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="fail if the index is stale")
+    args = parser.parse_args()
+
+    phases = load_phases()
+    if not phases:
+        print("error: no CODEX phase registers found", file=sys.stderr)
+        return 1
+
+    content = render(phases)
+
+    if args.check:
+        if not OUTPUT.exists():
+            print(f"error: {OUTPUT.relative_to(REPO_ROOT)} does not exist", file=sys.stderr)
+            return 1
+        if OUTPUT.read_text() != content:
+            print(
+                f"error: {OUTPUT.relative_to(REPO_ROOT)} is stale.\n"
+                "Regenerate: python scripts/generate_codex_index.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{OUTPUT.relative_to(REPO_ROOT)} is up to date ({len(phases)} phases).")
+        return 0
+
+    OUTPUT.write_text(content)
+    print(f"wrote {OUTPUT.relative_to(REPO_ROOT)} ({len(phases)} phases)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/simulation/CODEX_INDEX.md
+++ b/simulation/CODEX_INDEX.md
@@ -1,0 +1,55 @@
+# CODEX Phase Index
+
+<!-- GENERATED FILE — do not edit by hand.
+     Regenerate: python scripts/generate_codex_index.py
+     Source: simulation/CODEX_PHASE*_TECHNICAL_REGISTER.json -->
+
+Index of the CODEX character-integration phases. Each phase ships a pair:
+a `*_COMPLETE.md` narrative record and a `*_TECHNICAL_REGISTER.json`
+machine-readable register. Created for #1133.
+
+## Phases
+
+| Phase | Division / scope | Roster | Date | Records |
+|---|---|---|---|---|
+| 1 | Command & Ethics Division | 1.1 → 1.2 | 2025-11-09 | [narrative](CODEX_PHASE1_COMMAND_ETHICS_COMPLETE.md) · [register](CODEX_PHASE1_TECHNICAL_REGISTER.json) |
+| 2 | Systems & Infrastructure Division | 1.2 → 1.3 | 2025-11-09 | [narrative](CODEX_PHASE2_SYSTEMS_INFRASTRUCTURE_COMPLETE.md) · [register](CODEX_PHASE2_TECHNICAL_REGISTER.json) |
+| 3 | Simulation & Cognitive Systems Division | 1.3 → 1.4 | 2025-11-09 | [narrative](CODEX_PHASE3_SIMULATION_COGNITIVE_COMPLETE.md) · [register](CODEX_PHASE3_TECHNICAL_REGISTER.json) |
+| 4 | Interface & Aesthetics Division | 1.4 → 1.5 | — | [narrative](CODEX_PHASE4_INTERFACE_AESTHETICS_COMPLETE.md) · [register](CODEX_PHASE4_TECHNICAL_REGISTER.json) |
+| 5 | Operations & Quality Assurance Division | 1.5 → 1.6 | — | [narrative](CODEX_PHASE5_OPERATIONS_QA_COMPLETE.md) · [register](CODEX_PHASE5_TECHNICAL_REGISTER.json) |
+| 6 | L2 Relay Agents & L3 Framework Systems | 1.6 → 2.0 (COMPLETE) | — | [narrative](CODEX_PHASE6_L2_L3_SYSTEMS_COMPLETE.md) · [register](CODEX_PHASE6_TECHNICAL_REGISTER.json) |
+
+The roster reaches **49 entities** at the final phase, which the
+Phase 6 register marks `2.0 (COMPLETE)`.
+
+## Related documents, with their real paths
+
+#1133 refers to two of these as if they sat in `simulation/`. They do not:
+
+| Document | Actual path |
+|---|---|
+| Layer architecture | [`docs/architecture/LAYER_ARCHITECTURE.md`](../docs/architecture/LAYER_ARCHITECTURE.md) |
+| Simulation state / mission taxonomy | [`.aurora/SIMULATION_STATE.json`](../.aurora/SIMULATION_STATE.json) |
+| Canonical roster | [`L1_CANON_CHARACTER_ROSTER.md`](L1_CANON_CHARACTER_ROSTER.md) |
+| Crew manifest (generated) | [`.aurora/ORION_STATION_CREW_MANIFEST.md`](../.aurora/ORION_STATION_CREW_MANIFEST.md) |
+
+## Notes recorded while indexing
+
+These are observations from the registers themselves, not judgements about
+the work:
+
+- **QGIA postdates every phase.** The `QGIA_Integration/` package is not
+  accounted for in any phase register, so the phase sequence is not a
+  complete picture of the simulation layer's integrations.
+- **Phases 4 and 5 record `git_commit_status: "Pending"`** in their
+  registers, although both are committed. The field was never updated after
+  the commit landed; it reflects the state at authoring time, not now.
+- **Phases 4 and 5 both note a character-count discrepancy** (32 loaded vs
+  33 total human staff; 35 vs 36), attributed in-register to parsing rather
+  than to missing characters. Unresolved in both.
+- **Phase 6 has no `integration_date`** and no division summary; it records
+  L2/L3 systems rather than a staffed division.
+
+The Phase 6 terminology audit against `LAYER_ARCHITECTURE.md` that #1133
+also asks for is *not* done here — it is a canon-consistency review rather
+than an indexing task.

--- a/simulation/CODEX_INDEX.md
+++ b/simulation/CODEX_INDEX.md
@@ -11,7 +11,7 @@ machine-readable register. Created for #1133.
 ## Phases
 
 | Phase | Division / scope | Roster | Date | Records |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | 1 | Command & Ethics Division | 1.1 → 1.2 | 2025-11-09 | [narrative](CODEX_PHASE1_COMMAND_ETHICS_COMPLETE.md) · [register](CODEX_PHASE1_TECHNICAL_REGISTER.json) |
 | 2 | Systems & Infrastructure Division | 1.2 → 1.3 | 2025-11-09 | [narrative](CODEX_PHASE2_SYSTEMS_INFRASTRUCTURE_COMPLETE.md) · [register](CODEX_PHASE2_TECHNICAL_REGISTER.json) |
 | 3 | Simulation & Cognitive Systems Division | 1.3 → 1.4 | 2025-11-09 | [narrative](CODEX_PHASE3_SIMULATION_COGNITIVE_COMPLETE.md) · [register](CODEX_PHASE3_TECHNICAL_REGISTER.json) |
@@ -24,10 +24,10 @@ Phase 6 register marks `2.0 (COMPLETE)`.
 
 ## Related documents, with their real paths
 
-#1133 refers to two of these as if they sat in `simulation/`. They do not:
+Issue #1133 refers to two of these as if they sat in `simulation/`. They do not:
 
 | Document | Actual path |
-|---|---|
+| --- | --- |
 | Layer architecture | [`docs/architecture/LAYER_ARCHITECTURE.md`](../docs/architecture/LAYER_ARCHITECTURE.md) |
 | Simulation state / mission taxonomy | [`.aurora/SIMULATION_STATE.json`](../.aurora/SIMULATION_STATE.json) |
 | Canonical roster | [`L1_CANON_CHARACTER_ROSTER.md`](L1_CANON_CHARACTER_ROSTER.md) |

--- a/tests/test_codex_index.py
+++ b/tests/test_codex_index.py
@@ -72,6 +72,18 @@ def test_roster_span_handles_every_register_shape() -> None:
 
 
 def test_render_is_deterministic() -> None:
-    """Two renders of the same input must match, or --check would flap."""
-    phases = load_phases()
-    assert render(phases) == render(phases)
+    """Two independent loads must render identically, or --check would flap.
+
+    Loading twice rather than rendering the same list twice: the earlier version
+    asserted `render(phases) == render(phases)`, which compares an expression to
+    itself and so could not detect non-determinism arising in `load_phases`
+    (glob ordering, dict construction). SonarCloud flagged it, correctly.
+    """
+    first = render(load_phases())
+    second = render(load_phases())
+    assert first == second
+
+
+def test_render_matches_the_committed_index() -> None:
+    """The renderer's output is what is actually on disk."""
+    assert render(load_phases()) == INDEX.read_text()

--- a/tests/test_codex_index.py
+++ b/tests/test_codex_index.py
@@ -1,0 +1,77 @@
+"""The CODEX phase index must stay in step with the registers (#1133).
+
+`simulation/CODEX_INDEX.md` is generated from the phase technical registers. A
+generated file that nobody regenerates is worse than none, because it looks
+authoritative while being stale — so staleness is a test failure, and every link
+it emits is checked to actually resolve.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "generate_codex_index.py"
+INDEX = REPO_ROOT / "simulation" / "CODEX_INDEX.md"
+
+sys.path.insert(0, str(SCRIPT.parent))
+from generate_codex_index import load_phases, render  # noqa: E402
+
+
+def test_index_exists() -> None:
+    assert INDEX.exists(), "simulation/CODEX_INDEX.md is missing; run the generator"
+
+
+def test_index_is_not_stale() -> None:
+    """Regenerating must be a no-op.
+
+    If this fails: run `python scripts/generate_codex_index.py`.
+    """
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check"], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_every_phase_register_is_indexed() -> None:
+    """A new phase must not be able to appear without reaching the index."""
+    registers = sorted(
+        p.name for p in (REPO_ROOT / "simulation").glob("CODEX_PHASE*_TECHNICAL_REGISTER.json")
+    )
+    assert registers, "no phase registers found — this test would be vacuous"
+    text = INDEX.read_text()
+    missing = [name for name in registers if name not in text]
+    assert not missing, f"phase registers absent from the index: {missing}"
+
+
+def test_all_relative_links_resolve() -> None:
+    """Every link in the index must point at something that exists."""
+    text = INDEX.read_text()
+    targets = re.findall(r"\]\((?!https?://)([^)]+)\)", text)
+    assert targets, "no relative links found — this test would be vacuous"
+    broken = [t for t in targets if not (INDEX.parent / t).resolve().exists()]
+    assert not broken, f"broken links in CODEX_INDEX.md: {broken}"
+
+
+def test_roster_span_handles_every_register_shape() -> None:
+    """The registers spell roster movement three different ways.
+
+    Phases 1-2 use integration_status.roster_version_from/to, phase 3 uses
+    roster_version_change, phases 4-5 use roster_version.before/after. A span of
+    "—" means a shape was missed.
+    """
+    spans = {p["number"]: p["roster"] for p in load_phases()}
+    assert spans, "no phases loaded"
+    unresolved = [n for n, s in spans.items() if s in ("—", "None", "")]
+    assert not unresolved, f"roster span unresolved for phases {unresolved}: {spans}"
+
+
+def test_render_is_deterministic() -> None:
+    """Two renders of the same input must match, or --check would flap."""
+    phases = load_phases()
+    assert render(phases) == render(phases)


### PR DESCRIPTION
Part of #1234. Covers the index half of #1133.

## What was missing

Six CODEX phase pairs exist — a `*_COMPLETE.md` narrative and a `*_TECHNICAL_REGISTER.json` register each — with no index. Nothing showed what the phases cover or how the roster advanced across them.

| Phase | Scope | Roster |
|---|---|---|
| 1 | Command & Ethics Division | 1.1 → 1.2 |
| 2 | Systems & Infrastructure Division | 1.2 → 1.3 |
| 3 | Simulation & Cognitive Systems Division | 1.3 → 1.4 |
| 4 | Interface & Aesthetics Division | 1.4 → 1.5 |
| 5 | Operations & Quality Assurance Division | 1.5 → 1.6 |
| 6 | L2 Relay Agents & L3 Framework Systems | 1.6 → **2.0 (COMPLETE)**, 49 entities |

## Generated, not hand-written

Following the precedent of `.aurora/ORION_STATION_CREW_MANIFEST.md` (#1083): a hand-maintained index drifts from its source silently; a generated one cannot. `scripts/generate_codex_index.py` derives it, and `--check` fails when the output is stale.

The registers spell roster movement **three different ways** — `integration_status.roster_version_from/to`, `roster_version_change`, and `roster_version.before/after`. The generator resolves all three, and a test asserts no phase falls through to an unresolved `—`.

## Recorded while indexing

From the registers themselves, not judgements about the work:

- **QGIA postdates every phase** and appears in no register — so the phase sequence is not a complete picture of the simulation layer.
- **Phases 4 and 5 still carry `git_commit_status: "Pending"`** although both are committed. The field reflects authoring time, not now.
- **Phases 4 and 5 both note an unresolved character-count discrepancy** (32 loaded vs 33 staff; 35 vs 36), attributed in-register to parsing rather than missing characters.
- **Phase 6 has no `integration_date`** and no division summary — it records L2/L3 systems rather than a staffed division.

## Two paths #1133 gets wrong

The issue refers to both as if they sat under `simulation/`:

| Document | Actual path |
|---|---|
| `LAYER_ARCHITECTURE.md` | `docs/architecture/LAYER_ARCHITECTURE.md` |
| `SIMULATION_STATE.json` | `.aurora/SIMULATION_STATE.json` |

## Not claimed

The **Phase 6 terminology audit** against `LAYER_ARCHITECTURE.md` that #1133 also asks for is *not* done. That is a canon-consistency review, not an indexing task, and the index says so in its own text rather than leaving a reader to assume it was covered.

## Tests

`tests/test_codex_index.py` — 6 tests: staleness (regenerating must be a no-op), every register reaching the index, **every relative link resolving**, all roster-span shapes resolving, and render determinism.

**Confirmed non-vacuous:** a one-line hand edit to the index fails the staleness test.

## Verification

Full suite: **3270 passed, 0 failed**.