### PR TITLE
fix(simulation): correct the #1419 status blocks — the canon conflict was mine

### DIFF
--- a/simulation/orion_station_simulation.py
+++ b/simulation/orion_station_simulation.py
@@ -35,19 +35,23 @@ Success criteria:
 
 Note: Keep stdlib only for portability.
 
-STATUS (recorded 2026-08-02, #1132 / #1234): **currently wired, designation pending.**
+STATUS (corrected 2026-08-03, #1132): **superseded by v2; wiring is stale.**
 
-This file is what the repository actually runs today:
-  - `ORION_SIMULATION_PROTOCOL.md` documents invoking it directly;
-  - `tests/test_orion_simulation.py` imports `OrionSimulation` from it at module
-    scope, so the suite fails without it;
-  - `simulation/interactive_collab_demo.py` uses it.
+An earlier note here said intent and wiring "disagree" and left the designation
+open. Git history settles it:
 
-But `orion_station_simulation_v2.py` describes itself as its successor
-("Key Improvements from v1.0"). Intent and wiring therefore disagree, and that
-disagreement is the open question in #1132 — not something to settle by
-deleting either file. Nothing here is deprecated until the owner designates a
-canonical implementation.
+  - `orion_station_simulation_v2.py` received a behavioural bug fix on
+    2026-06-12 (#1023, "emit emergent events after task assignment in tick()");
+  - this file has had no substantive change since the 2025-11-14 bulk restore.
+
+Active maintenance has been going to v2 for months. What still points here —
+`ORION_SIMULATION_PROTOCOL.md`, `tests/test_orion_simulation.py` (module-scope
+import) and `interactive_collab_demo.py` — is stale wiring, not a competing
+designation.
+
+Retained, not deleted: it is still what the test suite imports, so removing it
+breaks the build. Rewire those three call sites to v2 first.
+
 """
 from __future__ import annotations
 

--- a/simulation/orion_station_simulation_v2.py
+++ b/simulation/orion_station_simulation_v2.py
@@ -14,20 +14,22 @@ Key Improvements from v1.0:
 
 Symbolic Tag: s.tag::sim.orion.v2
 
-STATUS (recorded 2026-08-02, #1132 / #1234): **successor by intent, not yet wired.**
+STATUS (corrected 2026-08-03, #1132): **canonical implementation.**
 
-This file states it supersedes v1 ("Key Improvements from v1.0": canonical
-character loading from `L1_CANON_CHARACTER_ROSTER.md` instead of hardcoded
-profiles, 40+ roster support, collaboration bonuses).
+Supersedes `orion_station_simulation.py`: loads characters from
+`L1_CANON_CHARACTER_ROSTER.md` rather than hardcoded profiles, supports the 40+
+roster, and adds collaboration bonuses.
 
-It is not, however, what the repository runs. `ORION_SIMULATION_PROTOCOL.md`
-documents v1, and `tests/test_orion_simulation.py` imports v1 at module scope
-while importing this file only inside a single test function via a `sys.path`
-insert — an optional path, not a dependency.
+Evidence this is the maintained one, not merely the newer name: it received a
+behavioural bug fix on 2026-06-12 (#1023, "emit emergent events after task
+assignment in tick()"), while v1 has had no substantive change since the
+2025-11-14 bulk restore.
 
-So the supersession is documented but incomplete. #1132 asks which is canonical;
-until that is decided, both remain, and this note exists so the next reader is
-not misled by the "v2" name into assuming it is live.
+The repository has not finished switching over. `ORION_SIMULATION_PROTOCOL.md`,
+`tests/test_orion_simulation.py` and `interactive_collab_demo.py` still reach
+for v1; this file is imported only inside one test function behind a `sys.path`
+insert. Completing that rewiring is the remaining work on #1132.
+
 """
 
 from __future__ import annotations

--- a/simulation/triplex_handshake_simulation.py
+++ b/simulation/triplex_handshake_simulation.py
@@ -33,20 +33,25 @@ Version: 1.0
 Date: 2025-11-09
 License: Project Internal
 
-STATUS (recorded 2026-08-02, #1132 / #1234): **duplicate pair, designation pending.**
+STATUS (corrected 2026-08-03, #1132): **unmaintained prototype; prefer the sibling.**
 
-This file and `triplex_handshake_simulator.py` are two models of the same
-subject — the Triplex Handshake under "The Reflection Event" (Narrative Cycle
-01) — and their opening descriptions are near-identical. They differ in what
-they claim to reproduce: this one records a drift variance of +0.004 "observed
-in the event"; the sibling models drift held at Δ 0.000.
+An earlier note here claimed this file and `triplex_handshake_simulator.py`
+"encode different claims about the same canonical event" — one reproducing
++0.004 drift, the other Δ 0.000 — and called choosing between them a canon
+determination. **That was wrong, and this corrects it.**
 
-Neither is imported by any module or test; both are standalone scripts. The
-sibling is referenced only from `.sprint_metrics/`, this one from
-`SIMULATION_STATUS_REPORT.md`.
+`NARRATIVE_CYCLE_01_REFLECTION_EVENT.md` records both figures, in sequence:
+"Drift Variance: +0.004 (peak) → 0.000 (restored)". +0.004 is the peak that
+triggers the Triplex Handshake; Δ 0.000 is the restored state. They are phases
+of one event, not rival claims. Both files use Δ 0.000 as their baseline and
+share identical constants (`BASE_DRIFT_RATE = 0.0002`,
+`INTERVENE_LATENCY_COST = 0.004`), and both expose the same eleven top-level
+names. There was never a canon question here.
 
-Because they encode *different* claims about the same canonical event, choosing
-between them is a canon question, not a cleanup. See #1132.
+What does distinguish them is maintenance. This file is the original prototype
+(2025-11-09). The sprint maintenance pass of 2025-11-12 (#321/#326) modified
+*only* the sibling, so this copy never received it.
+
 """
 
 import random

--- a/simulation/triplex_handshake_simulator.py
+++ b/simulation/triplex_handshake_simulator.py
@@ -24,15 +24,20 @@ DATE: 2025-11-09
 AUTHOR: Aurora-GUMAS Simulation Team
 VERIFIED BY: STARLING_AU (RELAY_004)
 
-STATUS (recorded 2026-08-02, #1132 / #1234): **duplicate pair, designation pending.**
+STATUS (corrected 2026-08-03, #1132): **maintained copy; prefer this one.**
 
-See the matching note in `triplex_handshake_simulation.py`. The two model the
-same event and differ in the drift figure they reproduce — Δ 0.000 here, +0.004
-in the sibling. Neither is imported by any module or test.
+An earlier note here framed this file and `triplex_handshake_simulation.py` as
+encoding competing drift figures. **That was wrong.**
+`NARRATIVE_CYCLE_01_REFLECTION_EVENT.md` records both, in sequence: "Drift
+Variance: +0.004 (peak) → 0.000 (restored)". Both files use Δ 0.000 as their
+baseline and share identical constants; both expose the same eleven top-level
+names. See the matching note in the sibling.
 
-Resolving this means deciding which drift figure is canonical for "The
-Reflection Event", which is a canon determination rather than a duplicate-file
-tidy-up. See #1132.
+The real distinction is maintenance: the sprint pass of 2025-11-12 (#321/#326)
+modified only this file, so the sibling never received it.
+
+Neither is imported by any module or test, so nothing is wired to either.
+
 """
 
 import logging
@@ -462,7 +467,7 @@ def plot_results(results: Dict[str, Any], show: bool = True, save_path: str = No
     
     if save_path:
         plt.savefig(save_path, dpi=300, bbox_inches='tight')
-        logger.info("Visualization saved to: {save_path}")
+        logger.info("Visualization saved to: %s", save_path)
     
     if show:
         plt.show()


### PR DESCRIPTION
Corrects #1419, which is already on `main`. It recorded that both duplicate pairs needed canon decisions before anything could proceed. **One of those decisions did not exist, and the other was answerable from git history.**

## The triplex claim was wrong

#1419 asserted the two files *"encode different claims about the same canonical event"* — one reproducing `+0.004` drift, the other `Δ 0.000` — and called choosing between them a canon determination.

`NARRATIVE_CYCLE_01_REFLECTION_EVENT.md` records **both, in sequence**:

```
line  19:  Drift Variance: +0.004 (peak) → 0.000 (restored)
line  96:  00:08:31 — DRIFT VARIANCE DETECTED: +0.004
line 107:  The +0.004 drift variance (beyond Δ 0.000 tolerance) triggers … safeguards
line 197:  DRIFT RESTORATION: Δ 0.000 (achieved within 2 minutes)
```

`+0.004` is the **peak that triggers** the Triplex Handshake; `Δ 0.000` is the **restored state**. Phases of one event, not rival claims.

And the files never disagreed anyway:

- both use `Δ 0.000` as their baseline;
- both share `BASE_DRIFT_RATE = 0.0002` and `INTERVENE_LATENCY_COST = 0.004`;
- both expose the **same eleven top-level names** (`ARCHYVerifier`, `AxiomeraEthics`, `CaelionAnchor`, `Event`, `HALOContinuity`, `HumanCommand`, `State`, `generate_event`, `main`, …).

I invented a canon question by reading two docstrings instead of the canonical narrative both of them cite.

## What actually distinguishes each pair — git settles both

**Triplex:**

| File | Evidence |
|---|---|
| `triplex_handshake_simulation.py` | prototype, 2025-11-09 |
| `triplex_handshake_simulator.py` | received the 2025-11-12 sprint pass (#321/#326), which modified **only** this file |

**Orion:**

| File | Evidence |
|---|---|
| `orion_station_simulation_v2.py` | behavioural bug fix 2026-06-12 (#1023, *"emit emergent events after task assignment in tick()"*) |
| `orion_station_simulation.py` | no substantive change since the 2025-11-14 bulk restore |

Active maintenance has gone to v2 for months. The "intent vs wiring disagreement" #1419 described was just **stale wiring**. v2 is canonical; `ORION_SIMULATION_PROTOCOL.md`, `tests/test_orion_simulation.py` and `interactive_collab_demo.py` still need rewiring, and v1 is retained until they are — the suite imports it at module scope.

## A real defect found in that history

`fdd35415` converted a `print` to logging as:

```python
logger.info("Visualization saved to: {save_path}")   # literal braces
```

No `f` prefix, no `%` arg — it logs the string `{save_path}`. Fixed to `logger.info("Visualization saved to: %s", save_path)`.

## Why this happened

I treated "needs a canon decision" as a stopping point instead of a search. The answer was in a tracked file named after the event, and in `git log`. Flagging that explicitly because the same reflex produced three other gates I have since resolved the same way.

## Verification

Full suite: **3271 passed, 0 failed**.