### PR TITLE
fix(ci): compare against the merge base, not the previous branch head (#1400)

### DIFF
--- a/.github/workflows/catastrophe-prevention.yml
+++ b/.github/workflows/catastrophe-prevention.yml
@@ -15,13 +15,46 @@ jobs:
       with:
         fetch-depth: 0  # Need full history
     
+    # Establish what to compare against.
+    #
+    # `github.event.before` is a PUSH field. On a pull_request `synchronize`
+    # event -- which is what the "Update branch" button fires -- it is the
+    # branch's PREVIOUS head, while `github.sha` is the new merge commit. The
+    # diff between them therefore contains everything `main` did since the
+    # branch diverged, including every file main deleted in that window. The
+    # guard then attributed those deletions to the branch and blocked the PR.
+    #
+    # #1306 tripped this with "150 files deleted" while its actual diff was
+    # +404/-211 across 7 files, deleting nothing. The older a branch is, the
+    # more likely syncing it trips the guard -- so the check penalised exactly
+    # the branches that most needed updating. See #1400.
+    #
+    # For a pull_request, the merge base with the target branch gives the PR's
+    # own net change. For a push to main, `event.before` remains correct.
+    - name: Determine comparison range
+      id: range
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          git fetch --no-tags origin "${{ github.base_ref }}" >/dev/null 2>&1 || true
+          BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        else
+          BASE="${{ github.event.before }}"
+          # All-zeros is a newly created branch with no prior state to diff.
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          fi
+        fi
+        echo "base=$BASE" >> "$GITHUB_OUTPUT"
+        echo "Comparing $BASE..HEAD (event: ${{ github.event_name }})"
+
     - name: Check for mass deletions
       run: |
         echo "🔍 Checking for catastrophic changes..."
         
-        # Count deletions in this push
-        DELETED=$(git diff --name-status ${{ github.event.before }}..${{ github.sha }} | grep -c "^D" || true)
-        TOTAL=$(git diff --name-status ${{ github.event.before }}..${{ github.sha }} | wc -l || echo "0")
+        BASE="${{ steps.range.outputs.base }}"
+        # Count deletions attributable to this change only
+        DELETED=$(git diff --name-status "$BASE"..HEAD | grep -c "^D" || true)
+        TOTAL=$(git diff --name-status "$BASE"..HEAD | wc -l || echo "0")
         
         echo "📊 Changes in this push:"
         echo "   Deleted: $DELETED files"
@@ -41,7 +74,7 @@ jobs:
         # Warn for significant deletions
         if [ "$DELETED" -gt 10 ]; then
           echo "⚠️  Warning: $DELETED files deleted in this push"
-          git diff --name-status ${{ github.event.before }}..${{ github.sha }} | grep "^D"
+          git diff --name-status "${{ steps.range.outputs.base }}"..HEAD | grep "^D"
         fi
         
         echo "✅ No catastrophic changes detected"


### PR DESCRIPTION
Closes #1400. This is currently blocking the effort to get stale branches updated and merged.

## The bug

```bash
DELETED=$(git diff --name-status ${{ github.event.before }}..${{ github.sha }} | grep -c "^D")
```

`event.before` is a **push** field. On a pull_request `synchronize` event — what the *"Update branch"* button fires — it is the branch's **previous head**, while `github.sha` is the new **merge commit**. The diff between them contains everything `main` did since the branch diverged, including every file main deleted in that window.

The guard attributed those deletions to the branch and blocked the PR.

## Measured on the branch it actually blocked

`codex/mesh-security-lint-hardening-2026-07-22` (PR #1306):

| Method | Deletions | Files |
|---|---|---|
| old — `event.before..sha` | **150** | 317 |
| new — `merge-base..HEAD` | **0** | **7** |

7 files is #1306's real diff (`+404/-211`, deleting nothing).

## Why it mattered more than it looks

The older a branch is, the more likely syncing it trips the guard — so the check **penalised exactly the branches that most needed updating**. And its output made a routine sync look like a disaster:

```
❌ CATASTROPHE DETECTED: 150 files deleted!
This push deletes 150 files, similar to the Nov 14, 2025 incident.
If this is intentional, contact repository admin.
```

A guard that cries wolf on routine maintenance gets ignored, which defeats the purpose of having it.

## The fix

- **pull_request** → `git merge-base origin/$base_ref HEAD`, which yields the PR's own net change.
- **push to main** → `event.before` is correct there and is retained, with an all-zeros guard for newly created branches.

The real protection is unchanged: a PR that genuinely deletes >100 files still fails.

## Note

I tripped this myself when updating #1306 to refresh its stale CI, and initially mis-attributed the resulting macOS/Windows `Path checks` failures on other PRs to this same guard — they were actually a `pydantic`/`pydantic-core` conflict (fixed in #1418). Both corrections are recorded on #1400.