### PR TITLE
fix(ci): stop false CI-failure reports, and hold mcp at v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,8 +70,22 @@ updates:
     # Ignoring it here does not freeze it. It still moves whenever pydantic
     # moves, because regenerating the lock resolves it transitively; it just
     # stops being offered as a standalone bump.
+    #
+    # mcp majors are held back because the connector is written against the
+    # MCP v1 low-level API: connector/server.py registers handlers with
+    # @server.list_tools() / @server.call_tool(), which mcp 2.x removed. A
+    # v2 bump therefore fails the connector suite with
+    # "AttributeError: 'Server' object has no attribute 'list_tools'" -- the
+    # baseline defect tracked in #1384, which #1421 would have re-landed.
+    #
+    # This pins the ceiling in one place rather than relying on every future
+    # grouped bump being caught in review. Minor and patch releases within v1
+    # still flow normally. Lift this together with the connector migration to
+    # the v2 handler API, not before.
     ignore:
       - dependency-name: "pydantic-core"
+      - dependency-name: "mcp"
+        update-types: ["version-update:semver-major"]
     groups:
       python-patch-minor:
         patterns: ["*"]

--- a/.github/workflows/project-board-ci-sync.yml
+++ b/.github/workflows/project-board-ci-sync.yml
@@ -198,7 +198,13 @@ jobs:
               `Intended project board status: ${target_status}.`,
             ].join('\n');
 
-            const { data: existing } = await github.rest.issues.listComments({
+            // Paginate: a single listComments page caps at 100, and comments
+            // come back oldest first. On a PR that already had 100+ comments
+            // before its first status comment -- #1381 sits at 420, #1306 at 88
+            // -- the marker would land on a later page, every run would miss it,
+            // and each would append a new comment: exactly the spam this step
+            // exists to stop.
+            const existing = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr_number,

--- a/.github/workflows/project-board-ci-sync.yml
+++ b/.github/workflows/project-board-ci-sync.yml
@@ -27,8 +27,16 @@ jobs:
         with:
           script: |
             let pr_number = null;
-            let issue_number = null;
-            
+
+            // `workflow_run: workflows: ["*"]` matches EVERY workflow, this one
+            // included, so each run of this job re-triggered another. Bail out
+            // when we are reacting to ourselves.
+            if (context.payload.workflow_run?.name === context.workflow) {
+              core.info('Triggered by this workflow; skipping to avoid self-recursion.');
+              core.setOutput('has_item', false);
+              return;
+            }
+
             // Get PR from check suite or workflow run
             if (context.payload.check_suite?.pull_requests) {
               const prs = context.payload.check_suite.pull_requests;
@@ -37,7 +45,7 @@ jobs:
               const prs = context.payload.workflow_run.pull_requests;
               if (prs.length > 0) pr_number = prs[0].number;
             }
-            
+
             core.setOutput('pr_number', pr_number);
             core.setOutput('has_item', pr_number !== null);
 
@@ -47,18 +55,31 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            const conclusion = context.payload.check_suite?.conclusion || 
+            const conclusion = context.payload.check_suite?.conclusion ||
                               context.payload.workflow_run?.conclusion;
-            
+
             const ci_passed = conclusion === 'success';
-            const ci_failed = conclusion === 'failure' || 
-                             conclusion === 'cancelled' || 
+            const ci_failed = conclusion === 'failure' ||
+                             conclusion === 'cancelled' ||
                              conclusion === 'timed_out';
-            
+
+            // A conclusion is not binary. `skipped`, `neutral`, `stale`, and
+            // `action_required` are none of the above: a workflow that
+            // correctly declined to run has not failed. The comment step used
+            // to branch on ci_passed alone, so every one of these was announced
+            // as "CI checks have failed" and moved the board to In Progress.
+            const ci_decided = ci_passed || ci_failed;
+
             core.setOutput('ci_passed', ci_passed);
             core.setOutput('ci_failed', ci_failed);
+            core.setOutput('ci_decided', ci_decided);
             core.setOutput('conclusion', conclusion);
 
+      # NOTE: both "Update Project Board" steps below are still placeholders --
+      # they run a read-only GraphQL query and log the result, with no mutation.
+      # The status comment therefore says "intended", not "updated", until the
+      # field-ID lookup is implemented. Do not reword it back to a promise
+      # without also writing the mutation.
       - name: Update Project Board - Move to In Progress (CI Failed)
         if: steps.ci-status.outputs.ci_failed == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
@@ -147,24 +168,57 @@ jobs:
               console.error('Error updating project:', error);
             }
 
+      # Only definitive outcomes are worth announcing, and only once. This step
+      # previously ran on every completion of every workflow and called
+      # createComment each time, so a PR accumulated one comment per workflow --
+      # #1434 collected more than fifteen for a single-line config change, which
+      # buries real review conversation. The marker below lets us update one
+      # comment in place instead of appending another.
       - name: Add Status Comment
-        if: steps.get-item.outputs.has_item == 'true'
+        if: steps.get-item.outputs.has_item == 'true' && steps.ci-status.outputs.ci_decided == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const pr_number = parseInt('${{ steps.get-item.outputs.pr_number }}');
             const ci_passed = '${{ steps.ci-status.outputs.ci_passed }}' === 'true';
             const conclusion = '${{ steps.ci-status.outputs.conclusion }}';
-            
-            let emoji = ci_passed ? '✅' : '⚠️';
-            let status = ci_passed ? 'passed' : 'failed';
-            let target_status = ci_passed ? '**In Review**' : '**In Progress**';
-            
-            const comment = `${emoji} **CI Status Update**\n\nCI checks have ${status} (conclusion: ${conclusion}).\n\nProject board status will be updated to ${target_status}.`;
-            
-            await github.rest.issues.createComment({
+
+            const MARKER = '<!-- project-board-ci-sync:status -->';
+
+            const emoji = ci_passed ? '✅' : '⚠️';
+            const status = ci_passed ? 'passed' : 'failed';
+            const target_status = ci_passed ? '**In Review**' : '**In Progress**';
+
+            const body = [
+              MARKER,
+              `${emoji} **CI Status Update**`,
+              '',
+              `Latest run: CI checks have ${status} (conclusion: \`${conclusion}\`).`,
+              '',
+              `Intended project board status: ${target_status}.`,
+            ].join('\n');
+
+            const { data: existing } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr_number,
-              body: comment
+              per_page: 100,
             });
+
+            const prior = existing.find((c) => c.body?.includes(MARKER));
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                body,
+              });
+            }


### PR DESCRIPTION
## 📋 Summary

Two CI-configuration fixes, both found while triaging the PR backlog.

1. **`.github/workflows/project-board-ci-sync.yml`** — stop announcing `skipped` workflows as CI failures, stop posting one comment per workflow, and stop the workflow re-triggering itself.
2. **`.github/dependabot.yml`** — hold `mcp` at v1 so grouped major bumps stop proposing the v2 SDK the connector cannot use.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration/infrastructure change

## 🔍 Changes Made

### Project Board CI Sync

- **`skipped` was reported as failure.** The status comment branched on `ci_passed` alone (`let status = ci_passed ? 'passed' : 'failed'`), so any conclusion that was not exactly `success` was announced as *"CI checks have failed"* and moved the board to **In Progress**. The step already computed `ci_failed` on the line above and then never used it. `skipped`, `neutral`, `stale`, and `action_required` were all mislabelled. Now gated on a new `ci_decided`, and indeterminate conclusions produce no comment.
- **One comment per workflow.** `createComment` ran on every completion of every workflow. This PR collected 15+ identical status comments for a single-line config change. Now upserts one marker-tagged comment.
- **Self-retriggering.** `workflow_run: workflows: ["*"]` matches every workflow *including this one*, so each run queued another. Now bails out when the triggering run is itself.
- **Corrected a false claim.** Both "Update Project Board" steps run a read-only GraphQL query and log the result — there is no mutation, so the board is never actually moved. The comment now reports the *intended* status instead of asserting an update that did not happen, with a note on the steps not to reword it back without writing the mutation.

### Dependabot

- Added `mcp` with `update-types: ["version-update:semver-major"]` to the existing `ignore` block, alongside `pydantic-core`.

`connector/server.py:69-77` registers handlers with the MCP **v1** low-level API (`@server.list_tools()`, `@server.call_tool()`), which mcp 2.x removed. A v2 bump fails the connector suite with `AttributeError: 'Server' object has no attribute 'list_tools'` — the baseline defect in #1384. Open PR #1421 carries `mcp` 1.28.1 → 2.0.0 and rewrites `requirements-optional.txt` to `mcp>=2.0.0,<3.0.0` while leaving the `# Model Context Protocol SDK (v1 API)` comment in place, so it reads as intentional on a skim; merging it would re-land the regression #1392 is fixing.

## 🧪 Testing

### Local Testing
- [x] Manual testing completed

### Test Results

Tri-state logic across every conclusion GitHub can produce:

```text
conclusion       old:            now:
success          passed          passed
failure          failed          failed
cancelled        failed          failed
timed_out        failed          failed
skipped          failed          (no comment)   <-- fixed
neutral          failed          (no comment)   <-- fixed
stale            failed          (no comment)   <-- fixed
action_required  failed          (no comment)   <-- fixed
```

Genuine pass/fail reporting is unchanged; only indeterminate states stop being misreported.

Dependabot ignore block resolves as intended:

```text
- dependency-name: pydantic-core
- dependency-name: mcp
  update-types:
  - version-update:semver-major
```

Both files parse as valid YAML and all step guards resolve correctly. Config-only change — no runtime code touched, so no test suite applies.

## 📖 Documentation

- [x] Code comments added/updated

## 🧭 Roadmap / Review Intake / Governance

- [x] This PR does **not** affect roadmap sequencing, review-note status, API/runtime authority, or path-drift status

## 🔗 Related Issues/PRs

- Related to #1342 (making CI gates trustworthy — this removes a source of false failure signal)
- Related to #1384 (connector/MCP v1 compatibility — the failure the ignore rule prevents)
- Related to #1392 (the in-flight fix that pins `mcp>=1.28.1,<2.0.0`)
- Related to #1421 (the grouped major bump that would re-land the regression)

## ✅ Aurora Principles Checklist

- [x] **DLP Tracking**: n/a — CI configuration only, no runtime operation or symbolic state
- [x] **Field Dynamics**: unaffected
- [x] **Ethical Validation**: unaffected
- [x] **Memory Seals**: unaffected
- [x] **Thread Continuity**: unaffected

## ⚠️ Drift Threshold Awareness

- [x] My changes **do not touch** drift thresholds or anomaly detection

## 🚀 Deployment Notes

- [x] No special deployment steps required

## 👀 Reviewer Notes

The two changes are independent and split cleanly by commit if you'd rather take them separately.

The mcp ignore is deliberately scoped to `semver-major`, not a blanket ignore — v1 patch and minor releases, security fixes included, still arrive normally. Lift it together with the connector migration to the v2 handler API, not before.

Worth noting for #1342: #1421 carries a green `ci: passed` label despite bundling a bump that reintroduces a known-breaking SDK change.