### PR TITLE
fix(security): repair secure_storage key derivation and unskip its tests

### DIFF
--- a/src/core/secure_storage.py
+++ b/src/core/secure_storage.py
@@ -16,18 +16,32 @@ import stat
 from pathlib import Path
 from typing import Optional, Union
 
+# Broken cryptography builds do not necessarily fail with ImportError
+# (e.g. pyo3 Rust panic from a missing _cffi_backend), so catch BaseException
+# here as modules/insight_ledger/secure_storage.py already does. Letting one of
+# those escape would break importers of this module rather than degrading to
+# CRYPTOGRAPHY_AVAILABLE = False.
 try:
     from cryptography.fernet import Fernet
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
     CRYPTOGRAPHY_AVAILABLE = True
-except ImportError:
+except BaseException:  # noqa: BLE001
     CRYPTOGRAPHY_AVAILABLE = False
 
 
 class SecureStorageError(Exception):
     """Exception raised for secure storage errors."""
     pass
+
+
+# Length of the random per-payload salt prepended to every ciphertext.
+SALT_BYTES = 16
+
+# OWASP's current floor for PBKDF2-HMAC-SHA256. The module previously used
+# 100_000, the 2018-era figure. Raising it cost nothing: the module has never
+# successfully encrypted anything, so there was no stored ciphertext to re-key.
+KDF_ITERATIONS = 600000
 
 
 class SecureStorage:
@@ -74,34 +88,29 @@ class SecureStorage:
         
         if not isinstance(master_key, bytes):
             master_key = master_key.encode('utf-8')
-        
-        # Derive encryption key using PBKDF2HMAC.
-        # This allows using passwords/passphrases as master keys.
-        #
-        # The salt is fixed so that the same master key derives the same cipher
-        # across processes -- without that, nothing written by one instance
-        # could ever be read back by another. A per-installation salt would be
-        # stronger, but requires somewhere to persist it; see #1438.
-        salt = b'aurora_cloudbank_salt_v1'
+
+        # Keep the master key; the cipher is derived per payload against that
+        # payload's own random salt (see _cipher_for). Building a single cipher
+        # in __init__ -- as this did before -- required a hardcoded salt, which
+        # let one precomputation attack every Aurora installation at once.
+        self._master_key = master_key
+
+    def _cipher_for(self, salt: bytes) -> "Fernet":
+        """Derive the Fernet cipher for a given salt.
+
+        Deriving from the master key is what makes ciphertext portable across
+        instances and processes. A previous version derived a key here and then
+        discarded it in favour of Fernet.generate_key(), which silently made
+        every instance's cipher random and unrecoverable.
+        """
         kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=32,
             salt=salt,
-            # OWASP's current floor for PBKDF2-HMAC-SHA256. The previous 100_000
-            # was the 2018-era figure and is no longer sufficient. Raising it is
-            # free here: the module has never successfully encrypted anything,
-            # so there is no stored ciphertext to re-key. Costs ~280ms per
-            # instantiation, which is acceptable for a key-storage path.
-            iterations=600000,
+            iterations=KDF_ITERATIONS,
         )
-        derived_key = kdf.derive(master_key)
-
-        # Fernet wants a url-safe base64-encoded 32-byte key. Deriving one and
-        # then constructing the cipher from Fernet.generate_key() instead --
-        # as this did before -- silently discarded the master key and produced
-        # a fresh random cipher per instance, so encrypted data could never be
-        # decrypted again after the process exited.
-        self.cipher = Fernet(base64.urlsafe_b64encode(derived_key))
+        # Fernet wants a url-safe base64-encoded 32-byte key.
+        return Fernet(base64.urlsafe_b64encode(kdf.derive(self._master_key)))
     
     def encrypt_file(self, file_path: Union[str, Path], data: str) -> None:
         """
@@ -117,10 +126,9 @@ class SecureStorage:
         try:
             path = Path(file_path)
             
-            # Encrypt data
-            if isinstance(data, str):
-                data = data.encode('utf-8')
-            encrypted_data = self.cipher.encrypt(data)
+            # Encrypt data (salt-prefixed, so any instance with the same
+            # master key can read it back)
+            encrypted_data = self.encrypt_string(data)
             
             # Write encrypted data
             path.write_bytes(encrypted_data)
@@ -153,10 +161,8 @@ class SecureStorage:
             # Read encrypted data
             encrypted_data = path.read_bytes()
             
-            # Decrypt
-            decrypted_data = self.cipher.decrypt(encrypted_data)
-            
-            return decrypted_data.decode('utf-8')
+            # Decrypt (the salt travels in the first SALT_BYTES)
+            return self.decrypt_string(encrypted_data)
             
         except SecureStorageError:
             raise
@@ -166,29 +172,38 @@ class SecureStorage:
     def encrypt_string(self, data: str) -> bytes:
         """
         Encrypt a string and return encrypted bytes.
-        
+
+        The returned payload is ``salt || fernet_token``. Carrying the salt
+        alongside the ciphertext is what lets a fresh random salt be used per
+        payload while keeping the result readable by any instance holding the
+        same master key.
+
         Args:
             data: String to encrypt
-            
+
         Returns:
-            Encrypted bytes
+            Encrypted bytes, prefixed with the salt used to derive the key
         """
         if isinstance(data, str):
             data = data.encode('utf-8')
-        return self.cipher.encrypt(data)
-    
+        salt = os.urandom(SALT_BYTES)
+        return salt + self._cipher_for(salt).encrypt(data)
+
     def decrypt_string(self, encrypted_data: bytes) -> str:
         """
         Decrypt bytes and return string.
-        
+
         Args:
-            encrypted_data: Encrypted bytes
-            
+            encrypted_data: Encrypted bytes as produced by encrypt_string
+
         Returns:
             Decrypted string
+
+        Raises:
+            InvalidToken: If the payload is malformed or the key is wrong
         """
-        decrypted = self.cipher.decrypt(encrypted_data)
-        return decrypted.decode('utf-8')
+        salt, token = encrypted_data[:SALT_BYTES], encrypted_data[SALT_BYTES:]
+        return self._cipher_for(salt).decrypt(token).decode('utf-8')
     
     @staticmethod
     def validate_storage_path(file_path: Union[str, Path]) -> Path:

--- a/src/core/secure_storage.py
+++ b/src/core/secure_storage.py
@@ -10,6 +10,7 @@ SRB Anchor: SRB-CRYPTO-STORAGE-v1.0
 DLP Context: secure_storage_implementation
 """
 
+import base64
 import hashlib
 import os
 import stat
@@ -19,7 +20,7 @@ from typing import Optional, Union
 try:
     from cryptography.fernet import Fernet
     from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
     CRYPTOGRAPHY_AVAILABLE = True
 except ImportError:
     CRYPTOGRAPHY_AVAILABLE = False
@@ -75,19 +76,28 @@ class SecureStorage:
         if not isinstance(master_key, bytes):
             master_key = master_key.encode('utf-8')
         
-        # Derive encryption key using PBKDF2
-        # This allows using passwords/passphrases as master keys
-        salt = b'aurora_cloudbank_salt_v1'  # In production: unique per installation
-        kdf = PBKDF2(
+        # Derive encryption key using PBKDF2HMAC.
+        # This allows using passwords/passphrases as master keys.
+        #
+        # The salt is fixed so that the same master key derives the same cipher
+        # across processes -- without that, nothing written by one instance
+        # could ever be read back by another. A per-installation salt would be
+        # stronger, but requires somewhere to persist it; see #1438.
+        salt = b'aurora_cloudbank_salt_v1'
+        kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=32,
             salt=salt,
-            iterations=100000,  # OWASP recommendation
+            iterations=100000,
         )
         derived_key = kdf.derive(master_key)
-        
-        # Create Fernet cipher
-        self.cipher = Fernet(Fernet.generate_key())  # Use derived key for production
+
+        # Fernet wants a url-safe base64-encoded 32-byte key. Deriving one and
+        # then constructing the cipher from Fernet.generate_key() instead --
+        # as this did before -- silently discarded the master key and produced
+        # a fresh random cipher per instance, so encrypted data could never be
+        # decrypted again after the process exited.
+        self.cipher = Fernet(base64.urlsafe_b64encode(derived_key))
     
     def encrypt_file(self, file_path: Union[str, Path], data: str) -> None:
         """

--- a/src/core/secure_storage.py
+++ b/src/core/secure_storage.py
@@ -11,7 +11,6 @@ DLP Context: secure_storage_implementation
 """
 
 import base64
-import hashlib
 import os
 import stat
 from pathlib import Path
@@ -88,7 +87,12 @@ class SecureStorage:
             algorithm=hashes.SHA256(),
             length=32,
             salt=salt,
-            iterations=100000,
+            # OWASP's current floor for PBKDF2-HMAC-SHA256. The previous 100_000
+            # was the 2018-era figure and is no longer sufficient. Raising it is
+            # free here: the module has never successfully encrypted anything,
+            # so there is no stored ciphertext to re-key. Costs ~280ms per
+            # instantiation, which is acceptable for a key-storage path.
+            iterations=600000,
         )
         derived_key = kdf.derive(master_key)
 

--- a/tests/core/test_secure_storage.py
+++ b/tests/core/test_secure_storage.py
@@ -26,6 +26,33 @@ from src.core.secure_storage import (
 
 
 # =============================================================================
+# Import-Health Guard
+# =============================================================================
+
+def test_cryptography_flag_reflects_real_availability():
+    """CRYPTOGRAPHY_AVAILABLE must not mask a broken guarded import.
+
+    Every encryption test below skips itself when this flag is False. That
+    makes a broken import in secure_storage.py silently green: the module
+    imported a class that does not exist, the except ImportError swallowed it,
+    and the whole suite skipped for months while reporting no failures (#1438).
+
+    This asserts the flag against the real world, so the next broken import
+    fails loudly instead of disappearing into the skip count.
+    """
+    try:
+        import cryptography  # noqa: F401
+    except ImportError:
+        pytest.skip("cryptography genuinely not installed in this environment")
+
+    assert CRYPTOGRAPHY_AVAILABLE, (
+        "cryptography imports fine, but secure_storage set "
+        "CRYPTOGRAPHY_AVAILABLE=False -- its guarded import block is broken "
+        "and every encryption test is silently skipping."
+    )
+
+
+# =============================================================================
 # Secure Storage Tests
 # =============================================================================
 
@@ -147,6 +174,64 @@ class TestSecureStorage:
         # Should not raise exception
         storage = SecureStorage()
         assert storage is not None
+
+
+class TestKeyDerivation:
+    """The master key must actually determine the cipher.
+
+    Every other test in this file encrypts and decrypts through a single
+    instance, so all of them passed even while __init__ derived a key and then
+    threw it away in favour of Fernet.generate_key(). These cross-instance
+    cases are what make that failure visible.
+    """
+
+    def test_same_master_key_round_trips_across_instances(self):
+        """Data written by one instance must be readable by another."""
+        if not CRYPTOGRAPHY_AVAILABLE:
+            pytest.skip("Cryptography library not available")
+
+        master_key = b"shared_master_key_for_round_trip"
+        secret = "sensitive_secret_12345"
+
+        writer = SecureStorage(master_key=master_key)
+        reader = SecureStorage(master_key=master_key)
+
+        assert reader.decrypt_string(writer.encrypt_string(secret)) == secret
+
+    def test_different_master_keys_do_not_interoperate(self):
+        """A different master key must not decrypt another key's ciphertext."""
+        if not CRYPTOGRAPHY_AVAILABLE:
+            pytest.skip("Cryptography library not available")
+
+        blob = SecureStorage(master_key=b"first_master_key_value").encrypt_string("secret")
+        other = SecureStorage(master_key=b"second_master_key_value")
+
+        with pytest.raises(Exception):
+            other.decrypt_string(blob)
+
+    def test_file_written_by_one_instance_reads_back_in_another(self, tmp_path):
+        """The on-disk path must survive a process boundary, not just an object."""
+        if not CRYPTOGRAPHY_AVAILABLE:
+            pytest.skip("Cryptography library not available")
+
+        master_key = b"master_key_for_file_round_trip"
+        key_file = tmp_path / "persisted.enc"
+        secret = "a" * 64
+
+        SecureStorage(master_key=master_key).encrypt_file(key_file, secret)
+
+        assert SecureStorage(master_key=master_key).decrypt_file(key_file) == secret
+
+    def test_environment_master_key_is_honoured(self, monkeypatch):
+        """SECURE_STORAGE_KEY must drive derivation, not just be accepted."""
+        if not CRYPTOGRAPHY_AVAILABLE:
+            pytest.skip("Cryptography library not available")
+
+        monkeypatch.setenv("SECURE_STORAGE_KEY", "env_supplied_master_key")
+
+        blob = SecureStorage().encrypt_string("from_env")
+
+        assert SecureStorage().decrypt_string(blob) == "from_env"
 
 
 class TestPathValidation:

--- a/tests/core/test_secure_storage.py
+++ b/tests/core/test_secure_storage.py
@@ -203,10 +203,15 @@ class TestKeyDerivation:
         if not CRYPTOGRAPHY_AVAILABLE:
             pytest.skip("Cryptography library not available")
 
+        from cryptography.fernet import InvalidToken
+
         blob = SecureStorage(master_key=b"first_master_key_value").encrypt_string("secret")
         other = SecureStorage(master_key=b"second_master_key_value")
 
-        with pytest.raises(Exception):
+        # Assert the specific failure, not just "something raised" -- a broad
+        # Exception would also pass if the ciphertext were malformed for an
+        # unrelated reason, which is not what this test is about.
+        with pytest.raises(InvalidToken):
             other.decrypt_string(blob)
 
     def test_file_written_by_one_instance_reads_back_in_another(self, tmp_path):


### PR DESCRIPTION
## 📋 Summary

Fixes #1438. Two defects in `src/core/secure_storage.py`, the second only reachable once the first is fixed — which is why the one-token import fix described in the issue could not be applied on its own. Review then surfaced a third (the hardcoded salt) and a fourth (an insufficiently broad import guard).

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test updates

## 🔍 Changes Made

### 1. Broken import made the module inert

The module imported `PBKDF2` from `cryptography`. That class has never existed; the real name is `PBKDF2HMAC`. The guarded block swallowed the `ImportError` and set `CRYPTOGRAPHY_AVAILABLE = False`, so `SecureStorage` raised *"Cryptography library not available"* on every call — while `cryptography` was installed and pinned. The error message actively misdirected.

It failed **closed**, so nothing was written in plaintext. The real damage was to the tests: every test in `tests/core/test_secure_storage.py` guards on that same flag, so **14 tests silently skipped** and the file reported green.

### 2. The derived key was discarded

```python
derived_key = kdf.derive(master_key)          # computed…
self.cipher = Fernet(Fernet.generate_key())   # …and thrown away
```

`__init__` derived a key and then built the cipher from a **fresh random key**. `master_key` and `SECURE_STORAGE_KEY` had no effect, and anything encrypted became unrecoverable once the process exited.

Fixing only the import would have converted a fail-closed module into silent **data loss**. Neither defect was caught by the existing tests, because all of them encrypt and decrypt through a single instance.

### 3. Hardcoded salt (found by SonarCloud)

The salt was the fixed literal `b'aurora_cloudbank_salt_v1'`, so one precomputation attacked every Aurora installation at once. SonarCloud held the security rating at **D on new code** — and because this PR rewrote that block, the pre-existing lines counted as new.

Replaced with a random 16-byte salt generated **per encrypt** and stored as a prefix on the ciphertext (`salt || fernet_token`). Carrying the salt with the payload removes the weakness without needing anywhere to persist per-installation state, and keeps ciphertext readable by any instance holding the same master key. Derivation moved from `__init__` into a `_cipher_for(salt)` helper.

**PBKDF2 iterations also raised 100,000 → 600,000** (OWASP's current floor for PBKDF2-HMAC-SHA256; the old value is the 2018-era figure). Free to change: the module has never successfully encrypted anything, so there is no stored ciphertext to re-key.

### 4. Import guard too narrow (found by Copilot review)

Broken `cryptography` builds do not reliably raise `ImportError` — a missing `_cffi_backend` surfaces as a **pyo3 Rust panic**, which escaped the guard and broke every importer of this module. Now catches `BaseException`, matching `modules/insight_ledger/secure_storage.py`, which already carries this exact fix and comment.

### Tests

- **Import-health guard** — asserts `CRYPTOGRAPHY_AVAILABLE` against real importability, so a broken guarded import fails loudly instead of disappearing into the skip count.
- **`TestKeyDerivation`** — cross-instance round trips via master key, via file, and via `SECURE_STORAGE_KEY`; plus non-interoperability between different master keys, asserting `InvalidToken` specifically.

## 🧪 Testing

### Local Testing
- [x] Manual testing completed
- [x] New tests added for new functionality
- [x] Existing tests updated if needed

### Test Results

Against `cryptography 50.0.0` (the repo's pinned major) in a clean venv:

```text
tests/core/test_secure_storage.py                           28 passed
tests/core/ + tests/test_secure_storage.py                  58 passed, 1 skipped, 1 xfailed
flake8 (source)                                             clean
```

Before this change the same file produced **14 skips**.

**Both new guards verified non-vacuous** by reintroducing each defect:

| Defect reintroduced | Result |
|---|---|
| Discarded derived key | 3 `TestKeyDerivation` tests **FAIL** |
| Broken `PBKDF2` import | Guard **FAILS** — `1 failed, 13 passed, 14 skipped` |

The second row reproduces the original silent-skip state exactly, except it is now a loud failure rather than green.

**Salt properties verified directly:**

```text
salts differ per payload:                    True
identical plaintext -> different ciphertext: True
cross-instance decrypt still works:          True
no hardcoded salt literal remains:           True
```

**Import guard verified against a genuinely broken build** (a local install whose `cryptography` raises a pyo3 panic): the module now imports cleanly and reports `CRYPTOGRAPHY_AVAILABLE = False` instead of propagating the panic.

## 📖 Documentation

- [x] Code comments added/updated

## 🧭 Roadmap / Review Intake / Governance

- [x] This PR does **not** affect roadmap sequencing, review-note status, API/runtime authority, or path-drift status

## 🔗 Related Issues/PRs

- Closes #1438

## ✅ Aurora Principles Checklist

- [x] **DLP Tracking**: no change — the module's DLP context header is untouched
- [x] **Field Dynamics**: unaffected
- [x] **Ethical Validation**: unaffected
- [x] **Memory Seals**: unaffected
- [x] **Thread Continuity**: unaffected

## ⚠️ Drift Threshold Awareness

- [x] My changes **do not touch** drift thresholds or anomaly detection

## 🚀 Deployment Notes

- [x] No special deployment steps required

No migration is required: because the module has never functioned, there is provably no existing ciphertext to re-key or re-salt.

## 👀 Reviewer Notes

**Ciphertext format changed** to `salt || fernet_token`. Safe here only because nothing has ever been successfully encrypted by this module — worth knowing if that assumption is ever wrong.

**Performance:** derivation now runs per operation rather than per instance, and at 6× the iterations. Suite runtime for this file went 1.0s → 7.6s (~280ms per derivation). Acceptable on a key-storage path; it would not be on a hot path.

Worth noting for #1342: `pytest.skip` on a self-reported capability flag is what hid the original bug. Any suite that skips on a capability flag can mask the very breakage it is meant to detect — that pattern may be worth auditing elsewhere.

A few unrelated pre-existing lint findings in the test file (`os`/`tempfile` unused, `original_size` unused) were left alone to keep the diff focused.