### PR TITLE
fix(ci): stop reporting green on red PRs and gate auto-merge on branch protection

### DIFF
--- a/.github/workflows/auto-merge-admin.yml
+++ b/.github/workflows/auto-merge-admin.yml
@@ -1,8 +1,32 @@
 name: Auto-merge Admin PRs
 
+# Queues a PR for merge using GitHub's native auto-merge, which executes only
+# once branch protection is satisfied.
+#
+# The previous version called pulls.merge() directly. It fetched
+# mergeable/mergeable_state into a step output and then never read it, so the
+# merge step ran unconditionally -- no CI gate, no mergeable gate. It also
+# self-approved as the repository owner immediately before merging, which
+# nullified any review requirement. It had not caused damage only because
+# nothing applies the 'auto-merge' label; a single label application would have
+# merged a red PR.
+#
+# Rather than reimplement the gate correctly in JavaScript, this hands the
+# decision to GitHub. enablePullRequestAutoMerge refuses to queue anything that
+# is not blocked on protection, and the merge itself waits for the required
+# checks. The workflow therefore cannot merge past a failing required check
+# even if this file is wrong.
+#
+# IMPORTANT: this is only a real gate if `main` has required status checks
+# configured in branch protection. Without them GitHub reports PRs with failing
+# checks as "unstable" rather than "blocked" and will merge them. If auto-merge
+# cannot be enabled because the PR is already in a clean/unstable state, this
+# workflow fails loudly rather than falling back to a direct merge -- an
+# unprotected branch should surface as a red job, not as a silent merge.
+
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, reopened, labeled]
 
 permissions:
   contents: write
@@ -17,78 +41,70 @@ jobs:
        github.actor == 'AUo959' ||
        contains(github.event.pull_request.title, '#321//.') ||
        contains(github.event.pull_request.title, '⬆️'))
-    
+
     steps:
-      - name: Check PR status
-        id: pr-status
+      - name: Enable native auto-merge
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            
-            console.log('PR mergeable state:', pr.data.mergeable_state);
-            console.log('PR mergeable:', pr.data.mergeable);
-            
-            return {
-              mergeable: pr.data.mergeable,
-              state: pr.data.mergeable_state
-            };
-      
-      - name: Auto-approve PR
-        if: github.actor == 'AUo959'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.pulls.createReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                event: 'APPROVE',
-                body: '✅ Auto-approved by admin workflow'
-              });
-              console.log('PR approved');
-            } catch (error) {
-              console.log('Approval error (may already be approved):', error.message);
+            const pr = context.payload.pull_request;
+
+            if (pr.draft) {
+              core.notice(`PR #${pr.number} is a draft; not queueing for merge.`);
+              return;
             }
-      
-      - name: Enable auto-merge
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              merge_method: 'squash',
-              commit_title: context.payload.pull_request.title,
-              commit_message: 'Auto-merged by admin workflow'
-            });
-            console.log('PR merged successfully');
-      
-      - name: Delete branch
-        if: success()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
+
             try {
-              const branch = context.payload.pull_request.head.ref;
-              if (!branch.startsWith('main') && !branch.startsWith('master')) {
-                await github.rest.git.deleteRef({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: `heads/${branch}`
-                });
-                console.log(`Deleted branch: ${branch}`);
-              }
+              await github.graphql(
+                `mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                   enablePullRequestAutoMerge(input: {
+                     pullRequestId: $pullRequestId,
+                     mergeMethod: $mergeMethod
+                   }) {
+                     pullRequest { number autoMergeRequest { enabledAt } }
+                   }
+                 }`,
+                { pullRequestId: pr.node_id, mergeMethod: 'SQUASH' }
+              );
+              core.notice(
+                `Auto-merge queued for #${pr.number}. GitHub will merge it once ` +
+                `branch protection is satisfied.`
+              );
+              return;
             } catch (error) {
-              console.log('Branch deletion skipped:', error.message);
+              const message = error.message || String(error);
+
+              // Already queued by a previous run of this workflow.
+              if (/already enabled/i.test(message)) {
+                core.notice(`Auto-merge was already enabled on #${pr.number}.`);
+                return;
+              }
+
+              // GitHub refuses to queue a PR that nothing is blocking. That is
+              // not a success: it means no required status check stands between
+              // this PR and main, so "auto-merge" would be an unconditional
+              // merge. Surface it instead of doing it.
+              if (/clean status|not in a mergeable state|pull request is in/i.test(message)) {
+                core.setFailed(
+                  `Refusing to merge #${pr.number}. GitHub reports nothing is ` +
+                  `blocking it, which means 'main' has no required status checks ` +
+                  `covering this PR -- so there is no gate for auto-merge to wait ` +
+                  `on. Configure required checks in branch protection, or merge ` +
+                  `this PR by hand after reading its CI. Underlying error: ${message}`
+                );
+                return;
+              }
+
+              // Auto-merge not enabled at the repository level.
+              if (/auto[- ]merge is not allowed|allowAutoMerge/i.test(message)) {
+                core.setFailed(
+                  `Auto-merge is disabled for this repository. Enable it in ` +
+                  `Settings > General > Pull Requests, or remove the 'auto-merge' ` +
+                  `label. Underlying error: ${message}`
+                );
+                return;
+              }
+
+              core.setFailed(`Could not enable auto-merge on #${pr.number}: ${message}`);
             }

--- a/.github/workflows/ci-status-project-automation.yml
+++ b/.github/workflows/ci-status-project-automation.yml
@@ -49,8 +49,13 @@ jobs:
             // counting them would pin every PR to `ci: pending` forever.
             const SELF = new Set(['Display CI Status on Project Cards']);
 
+            // `ci: passed` is asserted from an allow-list, never by falling
+            // through. A deny-list would mean any conclusion GitHub adds later,
+            // or any this file forgot, silently reads as green -- which is the
+            // shape of the bug this workflow exists to fix.
             const FAILING = new Set([
               'failure', 'cancelled', 'timed_out', 'action_required',
+              'startup_failure',
             ]);
             const PASSING = new Set(['success', 'skipped', 'neutral']);
 
@@ -85,13 +90,25 @@ jobs:
             const unfinished = relevant.filter(
               c => c.status !== 'completed' || c.conclusion === null
             );
+            // Completed, not failing, but not a conclusion we recognise as
+            // passing either -- e.g. `stale`, or whatever GitHub adds next.
+            // Deliberately not treated as green.
+            const unknown = relevant.filter(
+              c => c.status === 'completed' &&
+                   c.conclusion !== null &&
+                   !FAILING.has(c.conclusion) &&
+                   !PASSING.has(c.conclusion)
+            );
 
             // Failure wins over pending: a PR with one red check and three still
-            // running is not "pending", it already needs attention.
+            // running is not "pending", it already needs attention. Unknown
+            // conclusions hold at pending rather than resolving either way --
+            // "I cannot tell" is the honest answer and it does not read as a
+            // merge signal.
             let statusLabel;
             if (failed.length > 0) {
               statusLabel = 'ci: failed';
-            } else if (relevant.length === 0 || unfinished.length > 0) {
+            } else if (relevant.length === 0 || unfinished.length > 0 || unknown.length > 0) {
               statusLabel = 'ci: pending';
             } else {
               statusLabel = 'ci: passed';
@@ -99,10 +116,17 @@ jobs:
 
             core.info(
               `PR #${prNumber} @ ${sha.slice(0, 7)}: ${relevant.length} checks, ` +
-              `${failed.length} failed, ${unfinished.length} unfinished -> ${statusLabel}`
+              `${failed.length} failed, ${unfinished.length} unfinished, ` +
+              `${unknown.length} unknown -> ${statusLabel}`
             );
             if (failed.length > 0) {
               core.info(`Failing: ${failed.map(c => c.name).join(', ')}`);
+            }
+            if (unknown.length > 0) {
+              core.warning(
+                'Unrecognised check conclusions (treated as not-passing): ' +
+                unknown.map(c => `${c.name}=${c.conclusion}`).join(', ')
+              );
             }
 
             const { data: current } = await github.rest.issues.listLabelsOnIssue({

--- a/.github/workflows/ci-status-project-automation.yml
+++ b/.github/workflows/ci-status-project-automation.yml
@@ -1,213 +1,144 @@
 name: CI Status Project Automation
 
-# This workflow manages project board status based on CI/test results
-# - When CI/tests fail: move items to 'In Progress' with warning
-# - When CI passes: move PRs to 'In Review', issues to 'Ready' or 'Done'
-# - Display CI/test status on project cards
+# Maintains the `ci: pending` / `ci: passed` / `ci: failed` label on pull
+# requests.
+#
+# The label used to be written once, at PR-open, and never corrected. Two
+# defects combined to make it actively misleading:
+#
+#   1. The success predicate accepted `conclusion === null`, which is what an
+#      unfinished check reports. At PR-open essentially every check is
+#      unfinished, so "all checks are success, skipped, or null" was true and
+#      the PR was labelled `ci: passed` seconds after opening.
+#   2. The job was gated on `github.event.pull_request`, so the check_run /
+#      check_suite / workflow_run triggers never reached it. Nothing ever
+#      recomputed the label once the checks actually finished.
+#
+# #1441 and #1443 both carried `ci: passed` while a required-in-spirit check
+# was failing. #1441's second matrix leg was `cancelled`, which the old
+# failure test also missed because it only looked for `failure`.
+#
+# This file no longer touches the project board. That work is done properly by
+# project-board-ci-sync.yml; the job here duplicated it, and its only
+# board-facing step referenced `steps.check_status` while the step it meant was
+# `id: check-ci`, so it had never once executed.
 
 on:
-  status:
   check_suite:
-    types: [completed]
-  check_run:
     types: [completed]
   pull_request:
     types: [opened, synchronize, reopened]
-  workflow_run:
-    workflows: ["*"]
-    types: [completed]
 
 permissions:
   contents: read
-  issues: write
+  issues: write        # labels on a PR go through the issues API
   pull-requests: write
-  statuses: read
   checks: read
 
 jobs:
-  update-project-on-ci-status:
-    name: Update Project Based on CI Status
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get PR or Issue Info
-        id: get-info
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            const context_name = context.eventName;
-            let item_number = null;
-            let item_type = null;
-            let sha = null;
-            
-            // Determine the item (PR or issue) and commit SHA
-            if (context.payload.pull_request) {
-              item_number = context.payload.pull_request.number;
-              item_type = 'pull_request';
-              sha = context.payload.pull_request.head.sha;
-            } else if (context.payload.issue) {
-              item_number = context.payload.issue.number;
-              item_type = 'issue';
-            } else if (context.payload.check_suite) {
-              // Get PRs associated with this check suite
-              const prs = context.payload.check_suite.pull_requests;
-              if (prs && prs.length > 0) {
-                item_number = prs[0].number;
-                item_type = 'pull_request';
-              }
-              sha = context.payload.check_suite.head_sha;
-            } else if (context.payload.check_run) {
-              const prs = context.payload.check_run.pull_requests;
-              if (prs && prs.length > 0) {
-                item_number = prs[0].number;
-                item_type = 'pull_request';
-              }
-              sha = context.payload.check_run.head_sha;
-            } else if (context.payload.workflow_run) {
-              const prs = context.payload.workflow_run.pull_requests;
-              if (prs && prs.length > 0) {
-                item_number = prs[0].number;
-                item_type = 'pull_request';
-              }
-              sha = context.payload.workflow_run.head_sha;
-            }
-            
-            core.setOutput('item_number', item_number);
-            core.setOutput('item_type', item_type);
-            core.setOutput('sha', sha);
-
-      - name: Check CI Status
-        id: check-ci
-        if: steps.get-info.outputs.sha
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            const sha = '${{ steps.get-info.outputs.sha }}';
-            
-            // Get all check runs for this commit
-            const { data: checkRuns } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha
-            });
-            
-            // Get combined status
-            const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha
-            });
-            
-            // Determine overall status
-            let ci_passed = true;
-            let ci_status = 'success';
-            let failed_checks = [];
-            
-            // Check if any required checks failed
-            for (const check of checkRuns.check_runs) {
-              if (check.conclusion === 'failure' || check.conclusion === 'cancelled' || check.conclusion === 'timed_out') {
-                ci_passed = false;
-                ci_status = 'failure';
-                failed_checks.push(check.name);
-              }
-            }
-            
-            // Also check commit statuses
-            if (combinedStatus.state === 'failure' || combinedStatus.state === 'error') {
-              ci_passed = false;
-              ci_status = 'failure';
-            }
-            
-            core.setOutput('ci_passed', ci_passed);
-            core.setOutput('ci_status', ci_status);
-            core.setOutput('failed_checks', failed_checks.join(', '));
-
-      - name: Post CI Status Comment
-        if: steps.check_status.outputs.all_passed == 'true' || steps.check_status.outputs.has_failures == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Create comment body
-          cat > /tmp/ci_status_comment.md << 'EOF'
-          ## ✅ CI Status Update
-          
-          **Status:** ${{ steps.check_status.outputs.all_passed == 'true' && 'All Checks Passed' || 'Some Checks Failed' }}
-          **Last Updated:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-          
-          ### Check Summary
-          - Total Checks: ${{ steps.check_status.outputs.total_checks }}
-          - Passed: ${{ steps.check_status.outputs.passed_checks }}
-          - Failed: ${{ steps.check_status.outputs.failed_checks }}
-          
-          ${{ steps.check_status.outputs.all_passed == 'true' && '🎉 Project board updated to **In Review**' || '⚠️ Please review failed checks before merging' }}
-          EOF
-          
-          # Use smart comment handler to update existing comment
-          bash .github/scripts/smart-comment.sh ${{ github.event.pull_request.number }} "CI_STATUS_UPDATE" /tmp/ci_status_comment.md
-
-  add-ci-status-to-cards:
+  label-ci-status:
     name: Display CI Status on Project Cards
     runs-on: ubuntu-latest
-    if: github.event.pull_request || github.event.issue
     steps:
-      - name: Add CI Status Label (Silent)
+      - name: Update CI status label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            const item_number = context.payload.pull_request?.number || context.payload.issue?.number;
-            const sha = context.payload.pull_request?.head?.sha;
-            
-            if (!sha) {
-              console.log('No SHA available, skipping');
+            // Jobs belonging to this workflow. They are themselves check runs on
+            // the same SHA and are still in progress while this code executes, so
+            // counting them would pin every PR to `ci: pending` forever.
+            const SELF = new Set(['Display CI Status on Project Cards']);
+
+            const FAILING = new Set([
+              'failure', 'cancelled', 'timed_out', 'action_required',
+            ]);
+            const PASSING = new Set(['success', 'skipped', 'neutral']);
+
+            // Resolve the PR and its head SHA from whichever event fired.
+            let prNumber = null;
+            let sha = null;
+
+            if (context.payload.pull_request) {
+              prNumber = context.payload.pull_request.number;
+              sha = context.payload.pull_request.head.sha;
+            } else if (context.payload.check_suite) {
+              const prs = context.payload.check_suite.pull_requests || [];
+              prNumber = prs.length ? prs[0].number : null;
+              sha = context.payload.check_suite.head_sha;
+            }
+
+            if (!prNumber || !sha) {
+              core.info('No pull request associated with this event; nothing to label.');
               return;
             }
-            
-            // Get CI status
-            const { data: checkRuns } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha
-            });
-            
-            // Determine status label
-            let statusLabel = 'ci: pending';
-            const hasFailures = checkRuns.check_runs.some(c => c.conclusion === 'failure');
-            const allSuccess = checkRuns.check_runs.length > 0 && 
-                              checkRuns.check_runs.every(c => 
-                                c.conclusion === 'success' || 
-                                c.conclusion === 'skipped' ||
-                                c.conclusion === null
-                              );
-            
-            if (hasFailures) {
+
+            // listForRef defaults to 30 per page. Recent PRs here carry 30-40
+            // check runs, so an unpaginated read silently ignored the tail.
+            const checkRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              { owner: context.repo.owner, repo: context.repo.repo, ref: sha, per_page: 100 }
+            );
+
+            const relevant = checkRuns.filter(c => !SELF.has(c.name));
+
+            const failed = relevant.filter(c => FAILING.has(c.conclusion));
+            const unfinished = relevant.filter(
+              c => c.status !== 'completed' || c.conclusion === null
+            );
+
+            // Failure wins over pending: a PR with one red check and three still
+            // running is not "pending", it already needs attention.
+            let statusLabel;
+            if (failed.length > 0) {
               statusLabel = 'ci: failed';
-            } else if (allSuccess) {
+            } else if (relevant.length === 0 || unfinished.length > 0) {
+              statusLabel = 'ci: pending';
+            } else {
               statusLabel = 'ci: passed';
             }
-            
-            // Remove old CI labels silently
-            const labels = ['ci: pending', 'ci: passed', 'ci: failed'];
-            for (const label of labels) {
+
+            core.info(
+              `PR #${prNumber} @ ${sha.slice(0, 7)}: ${relevant.length} checks, ` +
+              `${failed.length} failed, ${unfinished.length} unfinished -> ${statusLabel}`
+            );
+            if (failed.length > 0) {
+              core.info(`Failing: ${failed.map(c => c.name).join(', ')}`);
+            }
+
+            const { data: current } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const currentNames = current.map(l => l.name);
+
+            if (currentNames.includes(statusLabel)) {
+              core.info(`Label already ${statusLabel}; nothing to change.`);
+              return;
+            }
+
+            for (const stale of ['ci: pending', 'ci: passed', 'ci: failed']) {
+              if (stale === statusLabel || !currentNames.includes(stale)) continue;
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: item_number,
-                  name: label
+                  issue_number: prNumber,
+                  name: stale,
                 });
-              } catch (e) {
-                // Label doesn't exist, ignore
+              } catch (error) {
+                core.info(`Could not remove ${stale}: ${error.message}`);
               }
             }
-            
-            // Add current status label silently
+
             try {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: item_number,
-                labels: [statusLabel]
+                issue_number: prNumber,
+                labels: [statusLabel],
               });
-              console.log(`✅ Updated CI label to: ${statusLabel}`);
-            } catch (e) {
-              console.log(`⚠️ Could not add label: ${e.message}`);
+              core.info(`Set label to ${statusLabel}`);
+            } catch (error) {
+              core.warning(`Could not add ${statusLabel}: ${error.message}`);
             }


### PR DESCRIPTION
## 📋 Summary

Four dependabot PRs were reviewed today. All four carried `ci: passed`; two of them (#1441, #1443) had a failing check at the time. Since that label is the only merge signal this repository produces, it being wrong half the time is the problem.

This fixes the label, and separately removes the ability of `auto-merge-admin.yml` to merge a red PR.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration/infrastructure change

## 🔍 Changes Made

### `ci-status-project-automation.yml`

Two defects combined to make the label misleading rather than merely stale:

1. **The success predicate accepted `conclusion === null`** — which is what an unfinished check reports:
   ```js
   c.conclusion === 'success' || c.conclusion === 'skipped' || c.conclusion === null
   ```
   At PR-open essentially every check is unfinished, so *"every check is success, skipped, or null"* was true and the PR was labelled `ci: passed` within seconds.

2. **The job never re-ran.** It was gated on `if: github.event.pull_request || github.event.issue`, so the `check_run`, `check_suite`, `status` and `workflow_run` triggers declared at the top of the file never reached it. Nothing recomputed the label after the checks finished.

Also fixed:
- The failure test matched only `failure`, missing `cancelled`, `timed_out`, `action_required`. **#1441's second matrix leg was `cancelled`.** The sibling job in the same file already handled those, so the two jobs disagreed with each other.
- `listForRef` was unpaginated at a default of 30, while recent PRs carry 30–40 check runs — the tail was never examined. Same class of bug as #1434 and #1444.
- The workflow's own check run is now excluded; otherwise it observes itself and pins every PR to `ci: pending`.

The `update-project-on-ci-status` job is **removed rather than repaired**. `project-board-ci-sync.yml` already does that work, this job duplicated it, and its only board-facing step referenced `steps.check_status` when the step it meant was `id: check-ci` — so it had never once executed.

### `auto-merge-admin.yml`

It fetched `mergeable` and `mergeable_state` into a step output **and never read them**. The merge step ran unconditionally — no CI gate, no mergeable gate, just `pulls.merge()`. It also self-approved as the repository owner immediately before merging, nullifying any review requirement. It has not caused damage only because nothing applies the `auto-merge` label; one label application would have merged a red PR.

Replaced the direct merge with GraphQL `enablePullRequestAutoMerge`, so the gate belongs to GitHub rather than to this file. The CI-checking logic is deleted rather than corrected.

**If GitHub reports nothing is blocking the PR, the workflow now fails instead of merging.** That state means `main` has no required status checks covering the PR, so there is no gate for auto-merge to wait on. An unprotected branch should surface as a red job, not a silent merge.

## 🧪 Testing

### Local Testing
- [x] Manual testing completed
- [x] New tests added for new functionality — see below
- [ ] `make check` passes (lint + tests) — not run; no Python or JS source is touched, only workflow definitions

### Test Results

Both files validate as YAML, and the inline `github-script` bodies were extracted and syntax-checked with `node --check`:

```text
YAML OK  .github/workflows/auto-merge-admin.yml            jobs: ['auto-merge']
YAML OK  .github/workflows/ci-status-project-automation.yml jobs: ['label-ci-status']
JS OK    auto-merge-admin.yml / Enable native auto-merge
JS OK    ci-status-project-automation.yml / Update CI status label
```

Both predicates were then lifted verbatim and run against eight scenarios drawn from the real check-run data on #1439, #1441 and #1443:

```text
scenario                                                       OLD          NEW          want
----------------------------------------------------------------------------------------------------
PR just opened, everything still queued (#1441/#1443 trigger)  ci: passed   ci: pending  ci: pending
#1441 final: one failure + one cancelled among passing checks  ci: failed   ci: failed   ci: failed
#1441 partial: cancelled leg only, no outright failure         ci: pending  ci: failed   ci: failed
#1443 final: Frontend build and type-check failed              ci: failed   ci: failed   ci: failed
#1439 final: genuinely all green                               ci: passed   ci: passed   ci: passed
one red, three still running -> failure wins over pending      ci: failed   ci: failed   ci: failed
only this workflow's own check present -> pending, not passed  ci: passed   ci: pending  ci: pending
all green except this workflow's own still running -> passed   ci: passed   ci: passed   ci: passed
----------------------------------------------------------------------------------------------------
all new-predicate assertions passed
```

Row 1 is the actual defect: the old predicate returns `ci: passed` on a PR where every check is still queued. Row 3 is the `cancelled` case the old failure test missed.

## 📖 Documentation

- [x] Code comments added/updated — both files carry a header explaining what was broken and why the fix is shaped this way, so the next person does not re-derive it
- [ ] README or docs updated — n/a
- [ ] API documentation updated — n/a

## 🧭 Roadmap / Review Intake / Governance

- [x] This PR does **not** affect roadmap sequencing, review-note status, API/runtime authority, or path-drift status

CI workflow definitions only. No route, service authority, or startup path is touched.

## 🔗 Related Issues/PRs

- Related to #1444 (SonarCloud reporter — same theme of a CI signal that is confidently wrong)
- Related to #1342 (PR Evaluation not trustworthy as a gate)
- Evidence from #1439, #1441, #1443

## ✅ Aurora Principles Checklist

- [x] **DLP Tracking** — n/a, no runtime data path touched
- [x] **Field Dynamics**: Preserves organic self-organization (no centralized control)
- [x] **Ethical Validation**: Maintains geometric ethics integration where applicable
- [x] **Memory Seals**: Respects quantum memory integrity markers
- [x] **Thread Continuity**: Maintains T1→T8→T9→INFINITE thread structure

## ⚠️ Drift Threshold Awareness

- [x] My changes **do not touch** drift thresholds or anomaly detection

## 🚀 Deployment Notes

- [x] No special deployment steps required

## 👀 Reviewer Notes

**This PR is necessary but not sufficient.** The deeper problem is that nothing on `main` is a *required* status check. #1443's `mergeable_state` is `unstable` — GitHub's term for "mergeable, but a non-required check failed" — not `blocked`. GitHub itself would have merged it. Every gate in this repository is currently advisory, which is why a buggy label mattered at all.

Configuring required checks in branch protection is a repository-settings change that cannot be made from a PR. It is written up separately with the exact check names to require; that change is what converts the remaining bugs in this area from "merges bad code" into "shows a wrong label."

The one judgement call worth checking is making `auto-merge-admin.yml` **fail** when nothing blocks the PR. It is deliberately noisy: the alternative is falling back to a direct merge, which is the behaviour being removed.

---

**Thread: T1→T8→T9→INFINITE**
**DLP: context_tag=ci_gate_repair, symbolic_hash=CONTRIBUTION_v1**

---
_Generated by [Claude Code](https://claude.ai/code/session_012bfzbc7qoQfwa5WPweAZNc)_