### PR TITLE
fix(l1): narrow Orion locus quarantine

### DIFF
--- a/.aurora/SIMULATION_INIT_PROTOCOL.md
+++ b/.aurora/SIMULATION_INIT_PROTOCOL.md
@@ -1,6 +1,6 @@
 # Aurora CloudBank — Orion L1 INIT Protocol
 
-**Version:** 2.0.0  
+**Version:** 2.1.0
 **Last Updated:** 2026-08-08  
 **Purpose:** Governed, reproducible initialization of a live Orion Station L1 run
 
@@ -43,8 +43,9 @@ L1 genesis authority.
    records, runtime observation, and Pilot knowledge are not interchangeable.
 8. **Run state is not primary canon.** Runtime-derived facts remain run-scoped
    unless separately reviewed and promoted.
-9. **Known canon conflicts are quarantined.** Disputed data may not drive
-   causality merely because it appears in an older state file.
+9. **Resolved canon is projected precisely.** Orion's Lagrange-point siting is
+   causal-safe; only the exact point/system and exact derived parameters remain
+   quarantined.
 10. **Actionable exceptional changes fail closed.** A complete Triplex receipt
     is required before `simulation/l1_runtime.py` applies a governed action.
 11. **Normal runtime persistence stays outside the repository.** Ordinary L1
@@ -67,7 +68,8 @@ Preflight validates, without creating a run:
 - Pilot is Earth-side and non-embodied;
 - the false `36th named human` claim is retired;
 - ambiguous historical population counters are typed/quarantined;
-- the orbital-locus conflict is quarantined from causal use;
+- CanonRec's Lagrange-point siting ruling is active;
+- exact-point and exact-light-time uncertainty remains narrowly quarantined;
 - `.aurora/SIMULATION_STATE.json` is not genesis authority;
 - `simulation/orion_station_simulation_v2.py` is the canonical Phase-1
   benchmark component;
@@ -166,6 +168,12 @@ A Pilot message:
   to Orion's institutional circumstances and authority;
 - grants no implied rank or command authority to the sender.
 
+The runtime uses CanonRec's provenance-labeled approximate, nonzero one-way
+latency model. A queued message is not delivered at the same tick; it becomes a
+station record only after a positive advancement window. This models elapsed
+time without pretending the unresolved exact range or exact light-time is
+known.
+
 Ambiguous text must not silently become transmitted speech.
 
 ---
@@ -192,25 +200,22 @@ See `config/l1_runtime_baseline.json` and issue #1454/#1455 provenance.
 
 ---
 
-## Orbital-locus quarantine
+## Lagrange-point siting and exact-point quarantine
 
-Two historical location claims remain in the repository. Until canon
-reconciliation completes, the live runtime may use only:
+CanonRec's owner ruling resolves the current siting class:
 
-> **Spaceborne and remote from Earth; exact orbital locus unavailable for causal use.**
+> **Orion Station is stationed at a Lagrange point in real space.**
 
-Do not derive from either disputed location claim:
+The historical `38,600 km` datum is STAGING and is not current siting
+authority. `Earth-Moon L4` remains a historical named candidate, not exact
+current canon. Issue #1456 remains open for the narrower question of the exact
+libration point and primary-body system.
 
-- communications light-time;
-- orbital sunrise/sunset;
-- radiation environment;
-- transfer windows;
-- Earth visibility;
-- docking/navigation trajectories;
-- gravity/orbital mechanics.
-
-This quarantine allows a safe INIT while preserving the unresolved historical
-record for #1456.
+The runtime may therefore use Lagrange-point siting and a provenance-labeled
+approximate nonzero communications latency. It must not claim exact
+communications light-time, orbital lighting, radiation environment, transfer
+windows, Earth visibility, docking/navigation trajectories, or orbital
+mechanics until the exact point is reconciled.
 
 ---
 
@@ -266,7 +271,9 @@ Before issuing INIT:
 - [ ] Pilot is Earth-side and non-embodied
 - [ ] CanonRec authority boundary is explicit
 - [ ] false 36th-person claim is inactive
-- [ ] disputed orbital data is quarantined
+- [ ] Lagrange-point siting authority is active
+- [ ] exact point/system uncertainty is narrowly quarantined
+- [ ] communications require a positive advancement window
 - [ ] legacy state is non-genesis
 - [ ] canonical Phase-1 benchmark is v2
 - [ ] Triplex fail-closed policy is present

--- a/.aurora/build_canonical_state.py
+++ b/.aurora/build_canonical_state.py
@@ -3,8 +3,8 @@
 
 This file used to rebuild ``.aurora/SIMULATION_STATE.json`` by combining a v1
 backup with historical infrastructure fragments. That process hard-coded
-physical and population claims that are now explicitly disputed or semantically
-untyped, including Earth-Moon L4 and the aggregate value ``81``.
+physical and population claims without current authority, including Earth-Moon
+L4 as an exact point and the semantically untyped aggregate value ``81``.
 
 It is retained at its historical path so old automation fails safely and points
 to the governed L1 lifecycle instead of silently rewriting tracked state.

--- a/CANON_INDEX.md
+++ b/CANON_INDEX.md
@@ -47,7 +47,7 @@ projection conflict must not override CanonRec canon.
 | Orion Station layout, decks, facilities | `simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md` |
 | Crew roster, divisions, uniforms | `simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md` |
 | Live-run safe population interpretation and 35/36 correction | `config/l1_runtime_baseline.json` |
-| Live-run orbital-locus handling | `config/l1_runtime_baseline.json` (quarantined conflict pending #1456) |
+| Live-run orbital-locus handling | CanonRec `STATION_PURPOSE_DEFINITION.md` via `config/l1_runtime_baseline.json` (Lagrange-point siting canonical; exact point pending #1456) |
 | GUMAS 9-node orbital network | `simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md` |
 | Halo Array, relay-crew pairings | `simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md` |
 | Ethics governance, Picard_Delta_3 | `simulation/ORION_STATION_MASTER_DOSSIER_v2.6.md` |

--- a/config/canon_provenance.json
+++ b/config/canon_provenance.json
@@ -29,6 +29,22 @@
       "cloudbank_sha256": "0a5c6eff0ab8f45a07257e8e99e4f96fdd4e94b7253be9210d2275f4969348ca",
       "cloudbank_role": "runtime_projection_non_authoritative",
       "conflict_policy": "CanonRec controls canon authority. A differing CloudBank projection must not override CanonRec; CloudBank-only details remain provenance-labeled runtime/reference data until traced or promoted through canon review."
+    },
+    {
+      "name": "orion_station_orbital_locus",
+      "status": "resolved_siting_class_exact_point_unresolved",
+      "decision_date": "2026-06-13",
+      "authority_repository": "AUo959/CanonRec",
+      "authority_revision": "1fc35f08a2937b10a2a3c15abe4b7ed39245b64e",
+      "canonrec_path": "canon/L1/station/STATION_PURPOSE_DEFINITION.md",
+      "canonrec_sha256": "d993965f82fef80b63be3c9233473e9f21004c043e2c1bc42e4cea23f141e6d4",
+      "supporting_canonrec_path": "canon/L1/station/POWERED_WATCH_AND_GROUND_SEGMENT.md",
+      "supporting_canonrec_sha256": "710eceefc5c09f17864ea845469d7d6725d19ed4cf560108dcb542e4a2d1bc4c",
+      "cloudbank_path": "config/l1_runtime_baseline.json",
+      "cloudbank_sha256": "358bbd9e7d9a1f549bdb8efbdfedbf4d9e676580c219230ccb96485138d666d4",
+      "cloudbank_role": "runtime_projection_non_authoritative",
+      "resolved_claim": "Orion Station is stationed at a Lagrange point in real space.",
+      "remaining_uncertainty": "Exact libration point, primary-body system, range, and exact one-way light-time remain unresolved."
     }
   ],
   "unreconciled_surfaces": []

--- a/config/l1_runtime_baseline.json
+++ b/config/l1_runtime_baseline.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "runtime_contract_version": "1.0.0",
+  "runtime_contract_version": "1.1.0",
   "status": "INIT_ELIGIBLE_WHEN_PREFLIGHT_PASSES",
   "authority": {
     "canonrec": {
@@ -15,6 +15,18 @@
       "cloudbank_projection_path": "ORION_STATION_CANONICAL_STAFF_REGISTRY.json",
       "cloudbank_projection_role": "runtime_projection_non_authoritative",
       "conflict_policy": "CanonRec controls canon authority. CloudBank-only staff detail may be used only as a provenance-labeled runtime projection and cannot override CanonRec on conflict."
+    },
+    "orbital_locus": {
+      "status": "resolved_authority_boundary",
+      "decision_date": "2026-06-13",
+      "authority_repository": "AUo959/CanonRec",
+      "authority_revision": "1fc35f08a2937b10a2a3c15abe4b7ed39245b64e",
+      "authority_path": "canon/L1/station/STATION_PURPOSE_DEFINITION.md",
+      "authority_sha256": "d993965f82fef80b63be3c9233473e9f21004c043e2c1bc42e4cea23f141e6d4",
+      "supporting_path": "canon/L1/station/POWERED_WATCH_AND_GROUND_SEGMENT.md",
+      "supporting_sha256": "710eceefc5c09f17864ea845469d7d6725d19ed4cf560108dcb542e4a2d1bc4c",
+      "cloudbank_projection_path": "config/l1_runtime_baseline.json",
+      "cloudbank_projection_role": "runtime_projection_non_authoritative"
     }
   },
   "pilot_boundary": {
@@ -44,20 +56,37 @@
     }
   },
   "orbital_locus": {
-    "status": "quarantined_conflict",
-    "safe_runtime_description": "Spaceborne and remote from Earth; exact orbital locus is unavailable for causal use pending canon reconciliation.",
-    "conflicting_claims": [
-      "high-inclination synchronous orbit at approximately 38,600 km",
-      "Earth-Moon L4 Lagrange point"
+    "status": "resolved_siting_class_exact_point_unresolved",
+    "certainty": "CANON",
+    "siting_class": "lagrange_point",
+    "safe_runtime_description": "Orion Station is stationed at a Lagrange point in real space; the exact libration point and primary-body system remain unresolved.",
+    "resolved_claim": "Lagrange-point siting in real space",
+    "historical_claims": {
+      "high_inclination_synchronous_orbit_38600_km": "staging_not_current_siting_authority",
+      "earth_moon_l4": "historical_named_candidate_not_exact_current_canon"
+    },
+    "unresolved_parameters": [
+      "exact_lagrange_point",
+      "primary_body_system",
+      "exact_range_from_earth",
+      "exact_one_way_light_time_seconds"
     ],
+    "communications_latency": {
+      "policy": "modeled_nonzero_exact_value_unresolved",
+      "modeled_one_way_light_time_seconds": 5,
+      "certainty": "APPROX",
+      "exact_value_known": false,
+      "delivery_resolution": "first_positive_advancement_window",
+      "source_path": "canon/L1/station/POWERED_WATCH_AND_GROUND_SEGMENT.md"
+    },
     "prohibited_causal_derivations": [
-      "communications_light_time",
-      "orbital_sunrise_or_sunset",
-      "radiation_environment",
-      "transfer_windows",
-      "earth_visibility",
-      "docking_or_navigation_trajectories",
-      "gravity_or_orbital_mechanics"
+      "exact_communications_light_time",
+      "exact_orbital_sunrise_or_sunset",
+      "exact_radiation_environment",
+      "exact_transfer_windows",
+      "exact_earth_visibility",
+      "exact_docking_or_navigation_trajectories",
+      "exact_gravity_or_orbital_mechanics"
     ]
   },
   "legacy_state": {

--- a/docs/CANON_PROVENANCE.md
+++ b/docs/CANON_PROVENANCE.md
@@ -69,6 +69,26 @@ identical or mechanically merging them.
 Machine-readable status lives in `config/canon_provenance.json` under
 `resolved_surfaces`.
 
+## Orbital-locus authority decision — 2026-06-13
+
+CanonRec's owner ruling in
+`canon/L1/station/STATION_PURPOSE_DEFINITION.md` establishes that Orion Station
+is stationed at a Lagrange point in real space. CloudBank projects that ruling
+into `config/l1_runtime_baseline.json` as
+`resolved_siting_class_exact_point_unresolved`.
+
+This resolves the broad siting conflict without overclaiming precision:
+
+- `38,600 km` remains a STAGING datum and is not current siting authority;
+- `Earth-Moon L4` remains a historical named candidate, not exact current canon;
+- the exact point/system, range, and exact one-way light-time remain unresolved;
+- CanonRec's approximate nonzero latency model is usable only with `APPROX`
+  certainty and a positive advancement window.
+
+The authority and projection hashes are recorded under the
+`orion_station_orbital_locus` resolved surface in
+`config/canon_provenance.json`.
+
 ### Conflict behavior
 
 If the CanonRec authority record and the CloudBank runtime projection disagree:
@@ -93,7 +113,7 @@ the first live L1 run. It records:
 - the staff projection boundary;
 - the Earth-side Pilot boundary;
 - typed population uncertainty;
-- orbital-locus quarantine;
+- canonical Lagrange-point siting with exact-point uncertainty;
 - historical `SIMULATION_STATE.json` as non-genesis provenance;
 - canonical Phase-1 benchmark v2;
 - Picard_Delta_3 / Triplex fail-closed requirements.

--- a/docs/architecture/AURORA_L1_RUNTIME_CONTRACT.md
+++ b/docs/architecture/AURORA_L1_RUNTIME_CONTRACT.md
@@ -1,6 +1,6 @@
 # Aurora L1 Runtime Contract
 
-**Version:** 1.0.0  
+**Version:** 1.1.0
 **Date:** 2026-08-08  
 **Status:** Runtime contract for governed Orion L1 initialization and advancement  
 **Machine-readable baseline:** `config/l1_runtime_baseline.json`  
@@ -106,6 +106,11 @@ An Earth→Orion communication must be explicitly typed/routed as a
 communication. It enters the communications ledger as queued traffic and does
 not automatically become a station action.
 
+Queued traffic is not delivered in the same tick. The runtime records delivery
+only after a positive advancement window, using the approximate nonzero latency
+model described below. Delivery becomes a station record; it is not itself a
+reply or evidence that the named recipient has acted.
+
 The receiving institution may later read, defer, answer, forward, ignore, or
 act on the message under its own circumstances and authority.
 
@@ -154,22 +159,24 @@ The `PopulationSnapshot` type also permits a future evidence-supported state in
 which, for example, human complement is 81 while identified/persona-resolved
 subsets are smaller.
 
-## Orbital-locus quarantine
+## Lagrange-point authority and remaining uncertainty
 
-The repository currently preserves two incompatible literal location claims.
-The live runtime does not select either one by convenience.
+CanonRec's owner ruling establishes the current siting class:
 
-Until #1456 is reconciled, the only causal-safe runtime statement is:
+> Orion Station is stationed at a Lagrange point in real space.
 
-> Orion is spaceborne and remote from Earth; exact orbital locus is unavailable
-> for causal use.
+The historical `38,600 km` value is a STAGING parameter and is not current
+siting authority. The historical `Earth-Moon L4` value remains a named
+candidate, not exact current canon. Issue #1456 therefore remains open only for
+the exact libration point, primary-body system, range, and exact derived
+parameters.
 
-The runtime must not derive communications light-time, orbital lighting,
-radiation environment, transfer windows, Earth visibility, docking/navigation
-trajectories, or orbital mechanics from either disputed claim.
-
-A quarantined contradiction is acceptable preflight state because it is denied
-causal authority rather than silently resolved.
+The runtime uses the canonical Lagrange-point class and CanonRec's explicitly
+approximate, nonzero one-way communications model. A message queued at one tick
+is delivered only after a positive advancement window. Exact communications
+light-time, orbital lighting, radiation environment, transfer windows, Earth
+visibility, docking/navigation trajectories, and orbital mechanics remain
+quarantined until the exact point is reconciled.
 
 ## Governance
 

--- a/simulation/ORION_SIMULATION_PROTOCOL.md
+++ b/simulation/ORION_SIMULATION_PROTOCOL.md
@@ -103,7 +103,7 @@ The live L1 runtime has additional invariants that this benchmark does not own:
 - discovery-through-observation;
 - explicit epistemic-state separation;
 - population/persona semantics;
-- orbital-locus quarantine;
+- canonical Lagrange-point siting with exact-point quarantine;
 - run lifecycle and canon-promotion boundary;
 - Triplex fail-closed authorization for exceptional actionable changes.
 

--- a/simulation/l1_runtime.py
+++ b/simulation/l1_runtime.py
@@ -12,7 +12,9 @@ Core invariants:
 - observation is instrumentation and does not alter world causality;
 - ambiguous operator input is never silently transmitted into L1;
 - epistemic states remain separate;
-- disputed population/orbital claims are quarantined from causal use;
+- canonical Lagrange-point siting is active while exact-point uncertainty is
+  quarantined from causal use;
+- communications use an approximate nonzero latency and require advancement;
 - actionable state changes fail closed without an explicit Triplex receipt;
 - normal runtime persistence is outside the repository and never promotes run
   state into primary canon automatically.
@@ -147,7 +149,7 @@ class OrionL1Runtime:
             status="INITIALIZED",
             canon_status="run_state",
             active_quarantines=[
-                "orion_orbital_locus",
+                "orion_exact_lagrange_point",
                 "current_crew_81",
             ],
             population=self.population,
@@ -166,9 +168,19 @@ class OrionL1Runtime:
                 },
                 "orbital_locus": {
                     "status": self.baseline["orbital_locus"]["status"],
+                    "certainty": self.baseline["orbital_locus"]["certainty"],
+                    "siting_class": self.baseline["orbital_locus"]["siting_class"],
                     "description": self.baseline["orbital_locus"][
                         "safe_runtime_description"
                     ],
+                    "unresolved_parameters": copy.deepcopy(
+                        self.baseline["orbital_locus"]["unresolved_parameters"]
+                    ),
+                },
+                "communications": {
+                    "latency": copy.deepcopy(
+                        self.baseline["orbital_locus"]["communications_latency"]
+                    )
                 },
                 "population": asdict(self.population),
             },
@@ -215,8 +227,41 @@ class OrionL1Runtime:
                 tick=state.manifest.tick,
             )
         )
+        self._deliver_queued_communications()
         self._persist_if_configured()
         return event
+
+    def _deliver_queued_communications(self) -> None:
+        """Deliver prior-tick Earth traffic after a positive time advance."""
+        state = self._require_state()
+        latency = self.baseline["orbital_locus"]["communications_latency"]
+        for message in state.communications:
+            if message.get("origin") != "Earth" or message.get("status") != "queued":
+                continue
+            queued_tick = message.get("tick")
+            if not isinstance(queued_tick, int) or queued_tick >= state.manifest.tick:
+                continue
+
+            message["status"] = "delivered_to_station"
+            message["delivered_tick"] = state.manifest.tick
+            message["latency"] = copy.deepcopy(latency)
+            state.station_records.append(
+                EpistemicRecord(
+                    record_id=str(uuid.uuid4()),
+                    subject=f"communication:{message['message_id']}",
+                    value={
+                        "message_id": message["message_id"],
+                        "origin": message["origin"],
+                        "target": message.get("target"),
+                        "content": message["content"],
+                        "status": message["status"],
+                    },
+                    epistemic_class="station_record",
+                    provenance="earth_to_orion_communications_ledger",
+                    confidence=1.0,
+                    tick=state.manifest.tick,
+                )
+            )
 
     def observe(self, focus: str = "station") -> Dict[str, Any]:
         """Expose instrumentation without advancing or rearranging L1."""
@@ -315,6 +360,7 @@ class OrionL1Runtime:
         state = self._require_state()
         if not content:
             raise ValueError("communication content cannot be empty")
+        latency = self.baseline["orbital_locus"]["communications_latency"]
         message = {
             "message_id": str(uuid.uuid4()),
             "tick": state.manifest.tick,
@@ -324,6 +370,11 @@ class OrionL1Runtime:
             "target": target,
             "content": content,
             "status": "queued",
+            "delivery_resolution": latency["delivery_resolution"],
+            "modeled_one_way_light_time_seconds": latency[
+                "modeled_one_way_light_time_seconds"
+            ],
+            "latency_certainty": latency["certainty"],
             "automatic_l1_action": False,
             "canon_status": "run_state",
         }

--- a/simulation/l1_runtime_support.py
+++ b/simulation/l1_runtime_support.py
@@ -164,26 +164,43 @@ def _check_locus_authority(
 ) -> None:
     authority = baseline.get("authority", {}).get("orbital_locus", {})
     locus = baseline.get("orbital_locus", {})
+    expected_revision = (
+        baseline.get("authority", {}).get("canonrec", {}).get("revision")
+    )
 
+    _check_locus_authority_config(authority, expected_revision, blockers)
+    _check_locus_authority_receipt(authority, provenance_path, blockers)
+    _check_locus_resolution(locus, blockers)
+    _check_locus_latency(locus.get("communications_latency", {}), blockers)
+
+    warnings.append(
+        "exact Lagrange point and exact one-way communications light-time remain "
+        "unresolved; runtime uses a provenance-labeled approximate nonzero latency model"
+    )
+
+
+def _check_locus_authority_config(
+    authority: Dict[str, Any],
+    expected_revision: Optional[str],
+    blockers: List[str],
+) -> None:
     if authority.get("status") != "resolved_authority_boundary":
         blockers.append("orbital locus authority boundary is unresolved")
     if authority.get("authority_repository") != "AUo959/CanonRec":
         blockers.append("CanonRec is not configured as orbital-locus authority")
-    if authority.get("authority_revision") != baseline.get("authority", {}).get(
-        "canonrec", {}
-    ).get("revision"):
+    if authority.get("authority_revision") != expected_revision:
         blockers.append("orbital-locus authority revision does not match CanonRec")
     if (
         authority.get("authority_path")
         != "canon/L1/station/STATION_PURPOSE_DEFINITION.md"
     ):
         blockers.append("orbital-locus authority path is not the owner ruling")
-    _check_locus_authority_receipt(
-        authority,
-        provenance_path,
-        blockers,
-    )
 
+
+def _check_locus_resolution(
+    locus: Dict[str, Any],
+    blockers: List[str],
+) -> None:
     if locus.get("status") != "resolved_siting_class_exact_point_unresolved":
         blockers.append("Lagrange-point siting class is not resolved")
     if locus.get("certainty") != "CANON":
@@ -196,15 +213,15 @@ def _check_locus_authority(
     if not locus.get("prohibited_causal_derivations"):
         blockers.append("exact orbital uncertainty lacks causal-use restrictions")
 
-    latency = locus.get("communications_latency", {})
+
+def _check_locus_latency(
+    latency: Dict[str, Any],
+    blockers: List[str],
+) -> None:
     if latency.get("policy") != "modeled_nonzero_exact_value_unresolved":
         blockers.append("communications latency does not preserve a nonzero model")
     modeled_seconds = latency.get("modeled_one_way_light_time_seconds")
-    if (
-        isinstance(modeled_seconds, bool)
-        or not isinstance(modeled_seconds, int)
-        or modeled_seconds <= 0
-    ):
+    if not _is_positive_integer(modeled_seconds):
         blockers.append("communications latency model must be a positive integer")
     if latency.get("certainty") != "APPROX":
         blockers.append("communications latency model is not marked approximate")
@@ -213,10 +230,9 @@ def _check_locus_authority(
     if latency.get("delivery_resolution") != "first_positive_advancement_window":
         blockers.append("communications delivery does not require elapsed time")
 
-    warnings.append(
-        "exact Lagrange point and exact one-way communications light-time remain "
-        "unresolved; runtime uses a provenance-labeled approximate nonzero latency model"
-    )
+
+def _is_positive_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
 def _check_locus_authority_receipt(
@@ -224,11 +240,18 @@ def _check_locus_authority_receipt(
     provenance_path: Path,
     blockers: List[str],
 ) -> None:
-    try:
-        provenance = read_json(provenance_path)
-    except (OSError, ValueError):
-        blockers.append("canon provenance receipt is unavailable or invalid")
+    provenance = _load_canon_provenance(provenance_path, blockers)
+    if provenance is None:
         return
+    receipt = _locus_authority_receipt(provenance, blockers)
+    if receipt is not None:
+        _check_locus_authority_receipt_values(receipt, authority, blockers)
+
+
+def _locus_authority_receipt(
+    provenance: Dict[str, Any],
+    blockers: List[str],
+) -> Optional[Dict[str, Any]]:
     receipts = [
         item
         for item in provenance.get("resolved_surfaces", [])
@@ -236,8 +259,15 @@ def _check_locus_authority_receipt(
     ]
     if len(receipts) != 1:
         blockers.append("canon provenance lacks one resolved orbital-locus receipt")
-        return
-    receipt = receipts[0]
+        return None
+    return receipts[0]
+
+
+def _check_locus_authority_receipt_values(
+    receipt: Dict[str, Any],
+    authority: Dict[str, Any],
+    blockers: List[str],
+) -> None:
     if receipt.get("status") != "resolved_siting_class_exact_point_unresolved":
         blockers.append("canon provenance does not preserve exact-point uncertainty")
     if receipt.get("authority_revision") != authority.get("authority_revision"):

--- a/simulation/l1_runtime_support.py
+++ b/simulation/l1_runtime_support.py
@@ -33,9 +33,11 @@ def evaluate_preflight(
     _check_staff_authority(baseline, provenance_path, blockers)
     _check_pilot_boundary(baseline, blockers)
     _check_population(population, blockers, warnings)
-    _check_locus_quarantine(baseline, blockers)
+    _check_locus_authority(baseline, provenance_path, blockers, warnings)
     _check_legacy_and_benchmark(baseline, blockers)
     _check_governance(baseline, blockers)
+    locus = baseline["orbital_locus"]
+    unresolved_parameters = locus.get("unresolved_parameters", [])
     return {
         "ready": not blockers,
         "blockers": blockers,
@@ -43,6 +45,12 @@ def evaluate_preflight(
         "tick": 0,
         "run_created": run_created,
         "runtime_contract_version": baseline["runtime_contract_version"],
+        "orbital_locus": {
+            "status": locus["status"],
+            "siting_class": locus["siting_class"],
+            "exact_point_resolved": "exact_lagrange_point" not in unresolved_parameters,
+            "communications_latency": locus["communications_latency"],
+        },
     }
 
 
@@ -148,15 +156,96 @@ def _check_population(
         )
 
 
-def _check_locus_quarantine(
+def _check_locus_authority(
     baseline: Dict[str, Any],
+    provenance_path: Path,
+    blockers: List[str],
+    warnings: List[str],
+) -> None:
+    authority = baseline.get("authority", {}).get("orbital_locus", {})
+    locus = baseline.get("orbital_locus", {})
+
+    if authority.get("status") != "resolved_authority_boundary":
+        blockers.append("orbital locus authority boundary is unresolved")
+    if authority.get("authority_repository") != "AUo959/CanonRec":
+        blockers.append("CanonRec is not configured as orbital-locus authority")
+    if authority.get("authority_revision") != baseline.get("authority", {}).get(
+        "canonrec", {}
+    ).get("revision"):
+        blockers.append("orbital-locus authority revision does not match CanonRec")
+    if (
+        authority.get("authority_path")
+        != "canon/L1/station/STATION_PURPOSE_DEFINITION.md"
+    ):
+        blockers.append("orbital-locus authority path is not the owner ruling")
+    _check_locus_authority_receipt(
+        authority,
+        provenance_path,
+        blockers,
+    )
+
+    if locus.get("status") != "resolved_siting_class_exact_point_unresolved":
+        blockers.append("Lagrange-point siting class is not resolved")
+    if locus.get("certainty") != "CANON":
+        blockers.append("orbital siting class is not marked as canonical")
+    if locus.get("siting_class") != "lagrange_point":
+        blockers.append("orbital siting class is not Lagrange point")
+    unresolved = locus.get("unresolved_parameters", [])
+    if "exact_lagrange_point" not in unresolved:
+        blockers.append("exact Lagrange-point uncertainty is not preserved")
+    if not locus.get("prohibited_causal_derivations"):
+        blockers.append("exact orbital uncertainty lacks causal-use restrictions")
+
+    latency = locus.get("communications_latency", {})
+    if latency.get("policy") != "modeled_nonzero_exact_value_unresolved":
+        blockers.append("communications latency does not preserve a nonzero model")
+    modeled_seconds = latency.get("modeled_one_way_light_time_seconds")
+    if (
+        isinstance(modeled_seconds, bool)
+        or not isinstance(modeled_seconds, int)
+        or modeled_seconds <= 0
+    ):
+        blockers.append("communications latency model must be a positive integer")
+    if latency.get("certainty") != "APPROX":
+        blockers.append("communications latency model is not marked approximate")
+    if latency.get("exact_value_known") is not False:
+        blockers.append("communications latency incorrectly claims exact knowledge")
+    if latency.get("delivery_resolution") != "first_positive_advancement_window":
+        blockers.append("communications delivery does not require elapsed time")
+
+    warnings.append(
+        "exact Lagrange point and exact one-way communications light-time remain "
+        "unresolved; runtime uses a provenance-labeled approximate nonzero latency model"
+    )
+
+
+def _check_locus_authority_receipt(
+    authority: Dict[str, Any],
+    provenance_path: Path,
     blockers: List[str],
 ) -> None:
-    locus = baseline.get("orbital_locus", {})
-    if locus.get("status") != "quarantined_conflict":
-        blockers.append("orbital locus conflict is not safely quarantined")
-    if not locus.get("prohibited_causal_derivations"):
-        blockers.append("orbital locus quarantine lacks causal-use restrictions")
+    try:
+        provenance = read_json(provenance_path)
+    except (OSError, ValueError):
+        blockers.append("canon provenance receipt is unavailable or invalid")
+        return
+    receipts = [
+        item
+        for item in provenance.get("resolved_surfaces", [])
+        if item.get("name") == "orion_station_orbital_locus"
+    ]
+    if len(receipts) != 1:
+        blockers.append("canon provenance lacks one resolved orbital-locus receipt")
+        return
+    receipt = receipts[0]
+    if receipt.get("status") != "resolved_siting_class_exact_point_unresolved":
+        blockers.append("canon provenance does not preserve exact-point uncertainty")
+    if receipt.get("authority_revision") != authority.get("authority_revision"):
+        blockers.append("orbital-locus receipt revision does not match the baseline")
+    if receipt.get("canonrec_path") != authority.get("authority_path"):
+        blockers.append("orbital-locus receipt path does not match the baseline")
+    if receipt.get("canonrec_sha256") != authority.get("authority_sha256"):
+        blockers.append("orbital-locus authority hash does not match the receipt")
 
 
 def _check_legacy_and_benchmark(

--- a/tests/test_canon_provenance.py
+++ b/tests/test_canon_provenance.py
@@ -66,3 +66,24 @@ class TestCanonProvenance(unittest.TestCase):
         receipt = load_provenance()
 
         self.assertEqual(receipt["unreconciled_surfaces"], [])
+
+    def test_orbital_locus_authority_boundary_is_narrowly_resolved(self) -> None:
+        receipt = load_provenance()
+        locus = next(
+            item
+            for item in receipt["resolved_surfaces"]
+            if item["name"] == "orion_station_orbital_locus"
+        )
+
+        self.assertEqual(
+            locus["status"],
+            "resolved_siting_class_exact_point_unresolved",
+        )
+        self.assertEqual(locus["authority_repository"], "AUo959/CanonRec")
+        self.assertRegex(locus["authority_revision"], r"\A[0-9a-f]{40}\Z")
+        self.assertEqual(
+            sha256_file(PROJECT_ROOT / locus["cloudbank_path"]),
+            locus["cloudbank_sha256"],
+        )
+        self.assertIn("Lagrange point", locus["resolved_claim"])
+        self.assertIn("Exact libration point", locus["remaining_uncertainty"])

--- a/tests/test_l1_bootstrap_containment.py
+++ b/tests/test_l1_bootstrap_containment.py
@@ -29,7 +29,7 @@ def test_retired_builder_refuses_to_construct_live_state():
 
 
 @pytest.mark.unit
-def test_retired_builder_status_is_read_only_and_quarantines_old_claims():
+def test_retired_builder_status_is_read_only_and_preserves_old_claims_as_history():
     result = subprocess.run(
         [sys.executable, str(AURORA_DIR / "build_canonical_state.py"), "--status"],
         cwd=PROJECT_ROOT,
@@ -41,7 +41,10 @@ def test_retired_builder_status_is_read_only_and_quarantines_old_claims():
 
     assert payload["status"] == "retired_builder"
     assert payload["legacy_state_genesis_authority"] is False
-    assert payload["orbital_locus_status"] == "quarantined_conflict"
+    assert (
+        payload["orbital_locus_status"]
+        == "resolved_siting_class_exact_point_unresolved"
+    )
     assert payload["historical_current_crew_81"].startswith("quarantined")
 
 

--- a/tests/test_l1_runtime.py
+++ b/tests/test_l1_runtime.py
@@ -37,6 +37,14 @@ def test_preflight_is_ready_and_does_not_advance_or_create_run():
     assert report["blockers"] == []
     assert report["tick"] == 0
     assert report["run_created"] is False
+    assert report["orbital_locus"]["siting_class"] == "lagrange_point"
+    assert report["orbital_locus"]["exact_point_resolved"] is False
+    assert (
+        report["orbital_locus"]["communications_latency"][
+            "modeled_one_way_light_time_seconds"
+        ]
+        == 5
+    )
     assert runtime.state is None
 
 
@@ -58,8 +66,11 @@ def test_init_creates_tick_zero_run_outside_repo(tmp_path: Path):
         "residency": "Earth",
         "l1_entity": False,
     }
-    assert "orion_orbital_locus" in state.manifest.active_quarantines
+    assert "orion_orbital_locus" not in state.manifest.active_quarantines
+    assert "orion_exact_lagrange_point" in state.manifest.active_quarantines
     assert "current_crew_81" in state.manifest.active_quarantines
+    assert state.world_state["orbital_locus"]["siting_class"] == "lagrange_point"
+    assert state.world_state["orbital_locus"]["certainty"] == "CANON"
     persisted = tmp_path / state.manifest.run_id / "state.json"
     assert persisted.is_file()
     payload = json.loads(persisted.read_text(encoding="utf-8"))
@@ -148,6 +159,69 @@ def test_explicit_communication_is_queued_without_automatic_l1_action(tmp_path: 
     assert message["sender_id"] == "pilot"
     assert message["automatic_l1_action"] is False
     assert message["status"] == "queued"
+    assert message["modeled_one_way_light_time_seconds"] == 5
+    assert message["latency_certainty"] == "APPROX"
+
+
+@pytest.mark.unit
+def test_communication_requires_positive_advancement_before_delivery(tmp_path: Path):
+    runtime = OrionL1Runtime()
+    runtime.init_run(
+        cloudbank_revision=CLOUDBANK_SHA,
+        seed=8,
+        run_root=tmp_path,
+    )
+
+    result = runtime.send_communication(
+        "Cmdr Thorne, this is Pilot - Earth side.",
+        target="CMD_001",
+    )
+    message = result["message"]
+
+    assert message["status"] == "queued"
+    assert runtime.state is not None
+    assert runtime.state.manifest.tick == 0
+    assert runtime.state.station_records == []
+
+    runtime.advance(elapsed_minutes=1)
+
+    assert message["status"] == "delivered_to_station"
+    assert message["delivered_tick"] == 1
+    assert message["latency"]["exact_value_known"] is False
+    delivery_record = runtime.state.station_records[-1]
+    assert delivery_record.subject == f"communication:{message['message_id']}"
+    assert delivery_record.provenance == "earth_to_orion_communications_ledger"
+    assert delivery_record.value["target"] == "CMD_001"
+
+
+@pytest.mark.unit
+def test_locus_preflight_rejects_broad_unknown_status(tmp_path: Path):
+    baseline = _baseline_payload()
+    baseline["orbital_locus"]["status"] = "quarantined_conflict"
+    path = tmp_path / "stale-locus-baseline.json"
+    path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    report = OrionL1Runtime(baseline_path=path).preflight()
+
+    assert report["ready"] is False
+    assert "Lagrange-point siting class is not resolved" in report["blockers"]
+
+
+@pytest.mark.unit
+def test_locus_preflight_rejects_zero_latency_model(tmp_path: Path):
+    baseline = _baseline_payload()
+    baseline["orbital_locus"]["communications_latency"][
+        "modeled_one_way_light_time_seconds"
+    ] = 0
+    path = tmp_path / "zero-latency-baseline.json"
+    path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    report = OrionL1Runtime(baseline_path=path).preflight()
+
+    assert report["ready"] is False
+    assert (
+        "communications latency model must be a positive integer" in report["blockers"]
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- project the CanonRec owner ruling that Orion Station is stationed at a Lagrange point
- retire the broad unknown-locus quarantine while preserving exact-point/system uncertainty
- use CanonRec's approximate nonzero one-way latency model without claiming an exact range
- require a positive advancement window before Earth traffic becomes a station record
- add provenance receipts, containment checks, and runtime-contract documentation

## Canon boundary

Canonical: Lagrange-point siting in real space.

Still unresolved: exact libration point, primary-body system, exact range, and exact one-way light-time. This PR narrows #1456; it does not close it.

## Validation

- 39 focused L1/canon tests passed
- corrected L1 preflight: ready=true, blockers=[]
- Ruff checks passed
- Python 3.12 compile checks passed
- git diff --check passed

Refs #1456