### PR TITLE
fix(docs): normalize OPAL2 table spacing

### DIFF
--- a/docs/architecture/OPAL2__PRODUCT_DISCOVERY_REGISTER__v1.0__2026-08-07.md
+++ b/docs/architecture/OPAL2__PRODUCT_DISCOVERY_REGISTER__v1.0__2026-08-07.md
@@ -7,7 +7,7 @@ This register records capabilities that have demonstrated independent utility
 inside Aurora and are candidates for neutral OPAL2 extraction.
 
 | Capability | Discovery context | Independent product value | Status |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | SHERLOCK | Provenance-sensitive canon and repository investigations | Evidence intelligence, contradiction tracing, audit-ready case files | Protocol core implemented on productization branch |
 | WATSON | Contextual synthesis after SHERLOCK investigation | Evidence-bound interpretation, hypotheses, recommendations, residual uncertainty | Protocol core implemented on productization branch |
 | SHERLOCK -> WATSON | Orion locus reconciliation and other preflight audits | General evidence-to-understanding workflow with immutable handoff | Reference extraction in progress |


### PR DESCRIPTION
## Summary

- fix the single Codacy table-pipe spacing finding carried by merged PR #1460
- normalize only the OPAL2 product discovery register separator row
- preserve OPAL2 behavior, schemas, hashes, and tests unchanged

## Validation

- `markdownlint-cli@0.49.1 docs/architecture/OPAL2__PRODUCT_DISCOVERY_REGISTER__v1.0__2026-08-07.md`
- `pytest -q tests/test_opal2_sherlock_watson.py` — 5 passed
- `git diff --check`

Follow-up to #1460.