### PR TITLE
fix(test): keep command diagnostics out of node runs

### DIFF
--- a/src/core/command_node/index.js
+++ b/src/core/command_node/index.js
@@ -124,6 +124,7 @@ export class CommandNode {
     }
 
     try {
+      fs.mkdirSync(path.dirname(this.diagnosticsPath), { recursive: true });
       fs.writeFileSync(
         this.diagnosticsPath,
         JSON.stringify(this.diagnostics, null, 2)

--- a/src/core/command_node/index.js
+++ b/src/core/command_node/index.js
@@ -50,6 +50,9 @@ export class CommandNode {
     this.anchorSeed = options.anchorSeed || DEFAULT_ANCHOR_SEED;
     this.ethicsProtocol = options.ethicsProtocol || getDefaultProtocol();
     this.enableEncryption = options.enableEncryption !== false && isEncryptionAvailable();
+    this.persistDiagnostics = options.persistDiagnostics !== false;
+    this.diagnosticsPath =
+      options.diagnosticsPath || path.join(process.cwd(), 'diagnostics.json');
 
     // Initialize router
     this.router = new CommandRouter({
@@ -88,10 +91,18 @@ export class CommandNode {
    * Load diagnostics state
    */
   _loadDiagnostics() {
-    const diagPath = path.join(process.cwd(), 'diagnostics.json');
+    if (!this.persistDiagnostics) {
+      return {
+        commandCount: 0,
+        processedCount: 0,
+        lastCommandAt: null,
+        load: 0,
+      };
+    }
+
     try {
-      if (fs.existsSync(diagPath)) {
-        return JSON.parse(fs.readFileSync(diagPath, 'utf8'));
+      if (fs.existsSync(this.diagnosticsPath)) {
+        return JSON.parse(fs.readFileSync(this.diagnosticsPath, 'utf8'));
       }
     } catch {
       // Ignore errors
@@ -108,9 +119,15 @@ export class CommandNode {
    * Save diagnostics state
    */
   _saveDiagnostics() {
-    const diagPath = path.join(process.cwd(), 'diagnostics.json');
+    if (!this.persistDiagnostics) {
+      return;
+    }
+
     try {
-      fs.writeFileSync(diagPath, JSON.stringify(this.diagnostics, null, 2));
+      fs.writeFileSync(
+        this.diagnosticsPath,
+        JSON.stringify(this.diagnostics, null, 2)
+      );
     } catch {
       // Ignore errors
     }

--- a/src/core/command_node/index.js
+++ b/src/core/command_node/index.js
@@ -98,10 +98,10 @@ export class CommandNode {
       };
     }
 
-    const diagnosticsPath = path.join(process.cwd(), 'diagnostics.json');
+    const diagPath = path.join(process.cwd(), 'diagnostics.json');
     try {
-      if (fs.existsSync(diagnosticsPath)) {
-        return JSON.parse(fs.readFileSync(diagnosticsPath, 'utf8'));
+      if (fs.existsSync(diagPath)) {
+        return JSON.parse(fs.readFileSync(diagPath, 'utf8'));
       }
     } catch {
       // Ignore errors
@@ -122,9 +122,9 @@ export class CommandNode {
       return;
     }
 
-    const diagnosticsPath = path.join(process.cwd(), 'diagnostics.json');
+    const diagPath = path.join(process.cwd(), 'diagnostics.json');
     try {
-      fs.writeFileSync(diagnosticsPath, JSON.stringify(this.diagnostics, null, 2));
+      fs.writeFileSync(diagPath, JSON.stringify(this.diagnostics, null, 2));
     } catch {
       // Ignore errors
     }

--- a/src/core/command_node/index.js
+++ b/src/core/command_node/index.js
@@ -51,8 +51,6 @@ export class CommandNode {
     this.ethicsProtocol = options.ethicsProtocol || getDefaultProtocol();
     this.enableEncryption = options.enableEncryption !== false && isEncryptionAvailable();
     this.persistDiagnostics = options.persistDiagnostics !== false;
-    this.diagnosticsPath =
-      options.diagnosticsPath || path.join(process.cwd(), 'diagnostics.json');
 
     // Initialize router
     this.router = new CommandRouter({
@@ -100,9 +98,10 @@ export class CommandNode {
       };
     }
 
+    const diagnosticsPath = path.join(process.cwd(), 'diagnostics.json');
     try {
-      if (fs.existsSync(this.diagnosticsPath)) {
-        return JSON.parse(fs.readFileSync(this.diagnosticsPath, 'utf8'));
+      if (fs.existsSync(diagnosticsPath)) {
+        return JSON.parse(fs.readFileSync(diagnosticsPath, 'utf8'));
       }
     } catch {
       // Ignore errors
@@ -123,12 +122,9 @@ export class CommandNode {
       return;
     }
 
+    const diagnosticsPath = path.join(process.cwd(), 'diagnostics.json');
     try {
-      fs.mkdirSync(path.dirname(this.diagnosticsPath), { recursive: true });
-      fs.writeFileSync(
-        this.diagnosticsPath,
-        JSON.stringify(this.diagnostics, null, 2)
-      );
+      fs.writeFileSync(diagnosticsPath, JSON.stringify(this.diagnostics, null, 2));
     } catch {
       // Ignore errors
     }

--- a/tests/node/command_node.test.js
+++ b/tests/node/command_node.test.js
@@ -5,6 +5,7 @@
 
 import { test, describe, beforeEach } from 'node:test';
 import assert from 'node:assert';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -34,6 +35,7 @@ describe('CommandNode - Unified Architecture', () => {
     commandNode = new CommandNode({
       logsDir: TEST_LOGS_DIR,
       enableEncryption: false, // Disable encryption for tests (no key in test env)
+      persistDiagnostics: false,
     });
   });
 
@@ -100,6 +102,24 @@ describe('CommandNode - Unified Architecture', () => {
 
     assert.ok(result.includes('executed'));
     assert.ok(result.includes('ANCHOR_TEST_HASH'));
+  });
+
+  test('can disable diagnostics persistence for non-mutating tests', () => {
+    const diagnosticsPath = path.join(
+      TEST_LOGS_DIR,
+      'disabled-diagnostics.json'
+    );
+    const node = new CommandNode({
+      logsDir: TEST_LOGS_DIR,
+      diagnosticsPath,
+      persistDiagnostics: false,
+    });
+
+    node.executeCommand({ name: 'test_action', context: 'TEST' });
+
+    assert.strictEqual(node.diagnostics.commandCount, 1);
+    assert.strictEqual(node.diagnostics.processedCount, 1);
+    assert.strictEqual(fs.existsSync(diagnosticsPath), false);
   });
 
   test('executeCommand throws for forbidden commands', () => {

--- a/tests/node/command_node.test.js
+++ b/tests/node/command_node.test.js
@@ -6,7 +6,6 @@
 import { test, describe, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -27,10 +26,6 @@ import CommandNode, {
 
 // Test logs directory
 const TEST_LOGS_DIR = path.join(process.cwd(), 'logs', 'test');
-
-function makeDiagnosticsTempDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'aurora-command-node-'));
-}
 
 describe('CommandNode - Unified Architecture', () => {
   let commandNode;
@@ -110,44 +105,18 @@ describe('CommandNode - Unified Architecture', () => {
   });
 
   test('can disable diagnostics persistence for non-mutating tests', () => {
-    const tempDir = makeDiagnosticsTempDir();
-    const diagnosticsPath = path.join(tempDir, 'disabled-diagnostics.json');
+    const diagnosticsPath = path.join(process.cwd(), 'diagnostics.json');
+    const diagnosticsBefore = fs.readFileSync(diagnosticsPath);
+    const node = new CommandNode({
+      logsDir: TEST_LOGS_DIR,
+      persistDiagnostics: false,
+    });
 
-    try {
-      const node = new CommandNode({
-        logsDir: TEST_LOGS_DIR,
-        diagnosticsPath,
-        persistDiagnostics: false,
-      });
+    node.executeCommand({ name: 'test_action', context: 'TEST' });
 
-      node.executeCommand({ name: 'test_action', context: 'TEST' });
-
-      assert.strictEqual(node.diagnostics.commandCount, 1);
-      assert.strictEqual(node.diagnostics.processedCount, 1);
-      assert.strictEqual(fs.existsSync(diagnosticsPath), false);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  test('creates parent directories for a custom diagnostics path', () => {
-    const tempDir = makeDiagnosticsTempDir();
-    const diagnosticsPath = path.join(tempDir, 'nested', 'diagnostics.json');
-
-    try {
-      const node = new CommandNode({
-        logsDir: TEST_LOGS_DIR,
-        diagnosticsPath,
-      });
-
-      node.executeCommand({ name: 'test_action', context: 'TEST' });
-
-      const saved = JSON.parse(fs.readFileSync(diagnosticsPath, 'utf8'));
-      assert.strictEqual(saved.commandCount, 1);
-      assert.strictEqual(saved.processedCount, 1);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    assert.strictEqual(node.diagnostics.commandCount, 1);
+    assert.strictEqual(node.diagnostics.processedCount, 1);
+    assert.deepStrictEqual(fs.readFileSync(diagnosticsPath), diagnosticsBefore);
   });
 
   test('executeCommand throws for forbidden commands', () => {

--- a/tests/node/command_node.test.js
+++ b/tests/node/command_node.test.js
@@ -6,6 +6,7 @@
 import { test, describe, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -26,6 +27,10 @@ import CommandNode, {
 
 // Test logs directory
 const TEST_LOGS_DIR = path.join(process.cwd(), 'logs', 'test');
+
+function makeDiagnosticsTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'aurora-command-node-'));
+}
 
 describe('CommandNode - Unified Architecture', () => {
   let commandNode;
@@ -105,21 +110,44 @@ describe('CommandNode - Unified Architecture', () => {
   });
 
   test('can disable diagnostics persistence for non-mutating tests', () => {
-    const diagnosticsPath = path.join(
-      TEST_LOGS_DIR,
-      'disabled-diagnostics.json'
-    );
-    const node = new CommandNode({
-      logsDir: TEST_LOGS_DIR,
-      diagnosticsPath,
-      persistDiagnostics: false,
-    });
+    const tempDir = makeDiagnosticsTempDir();
+    const diagnosticsPath = path.join(tempDir, 'disabled-diagnostics.json');
 
-    node.executeCommand({ name: 'test_action', context: 'TEST' });
+    try {
+      const node = new CommandNode({
+        logsDir: TEST_LOGS_DIR,
+        diagnosticsPath,
+        persistDiagnostics: false,
+      });
 
-    assert.strictEqual(node.diagnostics.commandCount, 1);
-    assert.strictEqual(node.diagnostics.processedCount, 1);
-    assert.strictEqual(fs.existsSync(diagnosticsPath), false);
+      node.executeCommand({ name: 'test_action', context: 'TEST' });
+
+      assert.strictEqual(node.diagnostics.commandCount, 1);
+      assert.strictEqual(node.diagnostics.processedCount, 1);
+      assert.strictEqual(fs.existsSync(diagnosticsPath), false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('creates parent directories for a custom diagnostics path', () => {
+    const tempDir = makeDiagnosticsTempDir();
+    const diagnosticsPath = path.join(tempDir, 'nested', 'diagnostics.json');
+
+    try {
+      const node = new CommandNode({
+        logsDir: TEST_LOGS_DIR,
+        diagnosticsPath,
+      });
+
+      node.executeCommand({ name: 'test_action', context: 'TEST' });
+
+      const saved = JSON.parse(fs.readFileSync(diagnosticsPath, 'utf8'));
+      assert.strictEqual(saved.commandCount, 1);
+      assert.strictEqual(saved.processedCount, 1);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test('executeCommand throws for forbidden commands', () => {


### PR DESCRIPTION
## Summary

- add an explicit persistDiagnostics option to the unified CommandNode while preserving persistence by default
- keep the Node test harness in memory so npm run test:node cannot mutate tracked diagnostics.json
- verify disabled persistence leaves the tracked diagnostics file byte-for-byte unchanged
- remove the unnecessary arbitrary diagnosticsPath option that triggered four critical dynamic-path findings

## Root cause

The CommandNode test fixture used the production diagnostics path at the repository root. Each valid command therefore rewrote the tracked runtime bootstrap file with test counters and timestamps.

## Impact and boundaries

- fixes #1403
- test/runtime-state hygiene only
- production callers retain diagnostics persistence at the original fixed repository path by default
- no L1/L2/L3 authority change
- no GUMAS deterministic behavior change
- no canon or deployment change

## Validation

- node --test tests/node/command_node.test.js — 41 passed
- npm run test:node — 52 passed
- npm run test:web — 1 passed
- diagnostics.json hash before and after the full suite — 3956daf157f99190b6b44a963f4657c5914abbba
- targeted ESLint — 0 errors, 1 pre-existing unused-variable warning
- git diff --check — passed

## Review stabilization

The initial Copilot findings and Codacy gate were incorporated:
- the disabled-persistence regression now compares the tracked diagnostics bytes directly
- the custom diagnostics path surface was removed instead of broadening production filesystem authority
- the production diagnostics path and default persistence behavior remain unchanged