### PR TITLE
fix(ops): reconcile gate registry projection

### DIFF
--- a/.github/workflows/queue-validation.yml
+++ b/.github/workflows/queue-validation.yml
@@ -8,7 +8,9 @@
 #   - queue.json validates against queue_schema.json
 #     (blocking here; the same tests run non-blocking in the full-suite pass
 #     of Aurora CI (Minimal) — see tests/test_work_queue_schema.py).
-#   - QUEUE.md, NEXT_UP.md, and OPEN_GATES.md are in sync with queue.json.
+#   - QUEUE.md and NEXT_UP.md are in sync with queue.json.
+#   - OPEN_GATES.md is in sync with queue.json + gate_registry.json, and the
+#     two canonical sources do not contain an unacknowledged contradiction.
 #
 # If drift is detected the job fails with a clear remediation message.
 # Fix: run  python ops/work_queue/sync_queue.py  and push the result.
@@ -82,7 +84,7 @@ jobs:
         run: |
           pytest --noconftest tests/test_work_queue_schema.py tests/test_queue_issue_ingestion.py tests/test_gate_escalation.py -q --no-header
 
-      - name: Check generated views are in sync with queue.json
+      - name: Check generated views and gate authority are coherent
         id: drift_check
         run: |
           python ops/work_queue/sync_queue.py --check
@@ -95,7 +97,7 @@ jobs:
           echo "  QUEUE VIEW DRIFT DETECTED"
           echo "========================================"
           echo ""
-          echo "  One or more generated queue views are out of sync with queue.json."
+          echo "  A generated view is stale or queue/gate-registry authority diverges."
           echo ""
           echo "  To fix:"
           echo "    python ops/work_queue/sync_queue.py"
@@ -104,7 +106,8 @@ jobs:
           echo "    git push"
           echo ""
           echo "  DO NOT edit QUEUE.md, NEXT_UP.md, or OPEN_GATES.md by hand."
-          echo "  They are generated artifacts. The source of truth is queue.json."
+          echo "  They are generated artifacts. Canonical task state is queue.json;"
+          echo "  canonical human-gate state is gate_registry.json."
           echo ""
           echo "  See: https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1147"
           echo "========================================"

--- a/ops/work_queue/NEXT_UP.md
+++ b/ops/work_queue/NEXT_UP.md
@@ -11,7 +11,7 @@ _Generated: `2026-07-16T00:36:36Z` — edit `queue.json`, run `sync_queue.py`_
 
 ## 🟢 Ready to Work
 
-Items with `status: open` and all dependencies resolved.
+Items with an `open` or `ready` lifecycle and all dependencies resolved.
 
 | Rank | ID | Title | Tags |
 |---|---|---|---|

--- a/ops/work_queue/OPEN_GATES.md
+++ b/ops/work_queue/OPEN_GATES.md
@@ -16,7 +16,7 @@ _Queue review: `2026-07-16T00:36:36Z` · Gate registry updated: `2026-08-03` · 
 ## Open Gates (3)
 
 | Gate | Queue Item | Title | Gate State | Integrity | Queue Status | Decision Owner |
-|---|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- | --- |
 | GATE-001 | Q-0003 | Pentest vendor selection + pre-condition sign-off | `open` | `reconciliation_required` | `missing` | operator |
 | GATE-002 | sim/SENTINEL-phase0 | PROJECT SENTINEL Phase 0 governance constitution | `open` | `active` | `needs-decision` | Commander Thorne + Sorensen + Sato |
 | GATE-003 | feat/QGIA | QGIA integration routing and crew sign-off | `open` | `active` | `needs-decision` | operator / designated crew reviewers |

--- a/ops/work_queue/OPEN_GATES.md
+++ b/ops/work_queue/OPEN_GATES.md
@@ -1,23 +1,37 @@
 <!-- !! GENERATED FILE — DO NOT EDIT BY HAND !!
-     Source of truth: ops/work_queue/queue.json
-     Regenerate:      python ops/work_queue/sync_queue.py
-     Tracked in:      https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1147 -->
+     Task source:      ops/work_queue/queue.json
+     Gate source:      ops/work_queue/gate_registry.json
+     Regenerate:       python ops/work_queue/sync_queue.py
+     Tracked in:       https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1147 -->
 
 # Open Gates — Aurora Work Queue
 
-_Generated: `2026-07-16T00:36:36Z` — edit `queue.json`, run `sync_queue.py`_
+_Queue review: `2026-07-16T00:36:36Z` · Gate registry updated: `2026-08-03` · deterministic projection_
 
-> Gates are items tagged `gate` or carrying `status: needs-decision`.
-> Nothing downstream can advance until the gate closes.
+> Human-gate authority comes from `gate_registry.json`; `queue.json`
+> supplies task status and dependency context. Rendering never resolves a gate.
 
 ---
 
-## Open Gates (2)
+## Open Gates (3)
 
-| Rank | ID | Title | Status |
-|---|---|---|---|
-| 3 | sim/SENTINEL-phase0 | PROJECT SENTINEL — Phase 0: Ethics review board constitution | `needs-decision` |
-| 6 | feat/QGIA | QGIA integration hooks | `needs-decision` |
+| Gate | Queue Item | Title | Gate State | Integrity | Queue Status | Decision Owner |
+|---|---|---|---|---|---|---|
+| GATE-001 | Q-0003 | Pentest vendor selection + pre-condition sign-off | `open` | `reconciliation_required` | `missing` | operator |
+| GATE-002 | sim/SENTINEL-phase0 | PROJECT SENTINEL Phase 0 governance constitution | `open` | `active` | `needs-decision` | Commander Thorne + Sorensen + Sato |
+| GATE-003 | feat/QGIA | QGIA integration routing and crew sign-off | `open` | `active` | `needs-decision` | operator / designated crew reviewers |
+
+---
+
+## Reconciliation Holds (1)
+
+### GATE-001 — Pentest vendor selection + pre-condition sign-off
+
+- **Integrity:** `reconciliation_required`
+- **Queue item:** `Q-0003` — missing from queue.json
+- **Linked issue:** #841
+- **Note:** Linked issue #841 is closed as completed, while Q-0003 and Q-0008 are absent from the current queue. Automated escalation is suspended until the operator reconciles the gate with current security-review authority; this does not declare the pentest decision resolved.
+
 
 ---
 

--- a/ops/work_queue/README.md
+++ b/ops/work_queue/README.md
@@ -10,10 +10,10 @@ Tracked in: [#1147](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1
 
 | File | Role | Edit? |
 |---|---|---|
-| `queue.json` | **Canonical source of truth** — machine-readable task list | ✅ Yes (via `aurora(queue):` commit) |
+| `queue.json` | **Canonical task source** — machine-readable task list | ✅ Yes (via `aurora(queue):` commit) |
 | `queue_schema.json` | JSON schema for `queue.json` | ✅ Yes (schema owner only) |
 | `triage_rules.json` | Scoring weights and escalation triggers | ✅ Yes (Aurora / queue steward) |
-| `gate_registry.json` | Named gate definitions | ✅ Yes (Aurora / queue steward) |
+| `gate_registry.json` | **Canonical human-gate source** — named decisions and integrity holds | ✅ Yes (Aurora / queue steward) |
 | `QUEUE_GUIDE.md` | Onboarding — how Aurora, agents, and humans use the queue | ✅ Yes |
 | `CROSS_PLATFORM_COORDINATION.md` | Queue → broker/claim → GitHub → handoff contract | ✅ Yes |
 | `BRIDGE_FIELDS.md` | Optional queue-to-control-plane metadata reference | ✅ Yes |
@@ -29,7 +29,10 @@ Tracked in: [#1147](https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1
 
 ## 🚫 Generated Files — Do Not Edit
 
-`QUEUE.md`, `NEXT_UP.md`, `OPEN_GATES.md`, and `COORDINATION_METRICS.md` are **rendered projections** of `queue.json`.
+`QUEUE.md`, `NEXT_UP.md`, and `COORDINATION_METRICS.md` are rendered
+projections of `queue.json`. `OPEN_GATES.md` is a joint projection:
+human-gate authority comes from `gate_registry.json`, while task status and
+dependency context come from `queue.json`.
 They are generated automatically and must not be edited by hand.
 
 **If you edit them directly:**
@@ -37,7 +40,8 @@ They are generated automatically and must not be edited by hand.
 - CI will flag the PR as failing the queue drift check.
 - The queue loses its single-source-of-truth guarantee.
 
-**To change what appears in these files, edit `queue.json` instead, then run:**
+**To change what appears in these files, edit the relevant canonical source
+(`queue.json` for tasks or `gate_registry.json` for human gates), then run:**
 
 ```bash
 python ops/work_queue/sync_queue.py
@@ -56,8 +60,9 @@ python ops/work_queue/collect_coordination_metrics.py --check
 
 ## Queue Authority Model
 
-- **Canonical state:** `queue.json` — the only file agents and scripts read for task truth.
-- **Computed views:** `QUEUE.md`, `NEXT_UP.md`, `OPEN_GATES.md` — rendered by `sync_queue.py`, verified by CI.
+- **Canonical task state:** `queue.json` — task status, rank, dependencies, and completion truth.
+- **Canonical human-gate state:** `gate_registry.json` — gate state, decision owner, and integrity holds.
+- **Computed views:** `QUEUE.md` and `NEXT_UP.md` project `queue.json`; `OPEN_GATES.md` projects both canonical sources. All are rendered by `sync_queue.py` and verified by CI.
 - **Aurora authority:** Items with `aurora_authority: true` may only have `rank` or `aurora_note` changed via a commit prefixed `aurora(queue):`.
 - **Agent rules:** Agents may claim items with `status: open` and `depends_on: []`. Agents may not re-rank items, close gates, or edit generated views.
 - **Human gates:** Items with `status: needs-decision` require a named human or governance decision before any work begins.
@@ -70,7 +75,10 @@ python ops/work_queue/collect_coordination_metrics.py --check
 
 It will **block merge** if:
 - `queue.json` is not valid JSON.
-- Any generated view (`QUEUE.md`, `NEXT_UP.md`, `OPEN_GATES.md`) is out of sync with `queue.json`.
+- Any generated view is out of sync with its canonical source.
+- A queue gate has no registry record, gate/queue lifecycle states contradict,
+  or a missing registry queue reference lacks an explicit
+  `reconciliation_required` integrity hold.
 
 To fix a failing check:
 ```bash

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -127,6 +127,16 @@ def _queue_item_status(item: dict | None) -> str:
     return str(item.get("status", item.get("state", "unknown")))
 
 
+def _queue_items_by_id(data: dict) -> dict[str, dict]:
+    """Index active and completed tasks for lifecycle coherence checks."""
+    return {
+        item["id"]: item
+        for section in ("completed", "active")
+        for item in data.get(section, [])
+        if item.get("id")
+    }
+
+
 def _index_registry_gates(gates: list[dict]) -> tuple[dict[str, dict], list[str]]:
     """Index gates by queue item while reporting duplicate authority records."""
     errors: list[str] = []
@@ -243,9 +253,7 @@ def find_gate_coherence_errors(data: dict, registry: dict) -> list[str]:
     records a reconciliation hold. That preserves GATE-001 without pretending
     its missing historical queue item is ordinary or resolved.
     """
-    queue_items = {
-        item.get("id"): item for item in data.get("active", []) if item.get("id")
-    }
+    queue_items = _queue_items_by_id(data)
     gates = registry.get("gates", [])
     registry_by_queue_item, errors = _index_registry_gates(gates)
 
@@ -490,23 +498,34 @@ def _render_waiting_on_gate(waiting: list[dict], gate_ids: set[str]) -> list[str
     return lines
 
 
+def _open_registry_gates(registry: dict) -> list[dict]:
+    return [gate for gate in registry.get("gates", []) if gate.get("state") == "open"]
+
+
+def _reconciliation_holds(gates: list[dict]) -> list[dict]:
+    return [
+        gate for gate in gates if gate.get("integrity_status", "active") != "active"
+    ]
+
+
+def _waiting_on_gate(items: list[dict], gate_ids: set[str]) -> list[dict]:
+    return [
+        item
+        for item in items
+        if any(dependency in gate_ids for dependency in item.get("depends_on", []))
+    ]
+
+
 def render_open_gates_md(data: dict, registry: dict) -> str:
     items = data.get("active", [])
     queue_by_id = {item.get("id"): item for item in items}
     queue_review = _ts(data)
     registry_updated = str(registry.get("last_updated", "unknown"))
 
-    gates = [gate for gate in registry.get("gates", []) if gate.get("state") == "open"]
-    holds = [
-        gate for gate in gates if gate.get("integrity_status", "active") != "active"
-    ]
-
+    gates = _open_registry_gates(registry)
+    holds = _reconciliation_holds(gates)
     gate_ids = {gate.get("queue_item") for gate in gates if gate.get("queue_item")}
-    waiting = [
-        item
-        for item in items
-        if any(dep in gate_ids for dep in item.get("depends_on", []))
-    ]
+    waiting = _waiting_on_gate(items, gate_ids)
 
     lines: list[str] = [
         OPEN_GATES_BANNER,

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -124,8 +124,7 @@ def _queue_gate_items(data: dict) -> list[dict]:
         for section in ("active", "completed")
         for item in data.get(section, [])
         if "gate" in item.get("tags", [])
-        or item.get("status") in DECISION_GATE_STATES
-        or item.get("state") in DECISION_GATE_STATES
+        or _queue_item_status(item) in DECISION_GATE_STATES
     ]
 
 

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -129,10 +129,13 @@ def _queue_gate_items(data: dict) -> list[dict]:
 def _queue_item_status(item: dict | None) -> str:
     if item is None:
         return "missing"
+    status = item.get("status")
     state = item.get("state")
+    if status == "done" or state == "done":
+        return "done"
     if state == "decision_required":
         return state
-    return str(item.get("status") or state or "unknown")
+    return str(status or state or "unknown")
 
 
 def _index_queue_items(data: dict) -> tuple[dict[str, dict], list[str]]:

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -118,7 +118,8 @@ def _queue_gate_items(data: dict) -> list[dict]:
     """Return queue items that assert a human-gate role."""
     return [
         item
-        for item in data.get("active", [])
+        for section in ("active", "completed")
+        for item in data.get(section, [])
         if "gate" in item.get("tags", [])
         or item.get("status") in DECISION_GATE_STATES
         or item.get("state") in DECISION_GATE_STATES
@@ -128,7 +129,10 @@ def _queue_gate_items(data: dict) -> list[dict]:
 def _queue_item_status(item: dict | None) -> str:
     if item is None:
         return "missing"
-    return str(item.get("status") or item.get("state") or "unknown")
+    state = item.get("state")
+    if state == "decision_required":
+        return state
+    return str(item.get("status") or state or "unknown")
 
 
 def _index_queue_items(data: dict) -> tuple[dict[str, dict], list[str]]:

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -615,17 +615,7 @@ def check_all(rendered: dict[Path, str]) -> bool:
             drift = True
             continue
         existing = path.read_text(encoding="utf-8")
-        # Strip the timestamp line before comparing so clock-skew doesn't cause false positives.
-
-        def strip_ts(text: str) -> str:
-            return "\n".join(
-                line
-                for line in text.splitlines()
-                if not line.startswith("**Generated:**")
-                and not line.startswith("_Generated:")
-            )
-
-        if strip_ts(existing) != strip_ts(new_content):
+        if existing != new_content:
             print(f"STALE:   {path.name}")
             drift = True
         else:

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -70,9 +70,12 @@ def load_gate_registry() -> dict:
 
 STATUS_EMOJI = {
     "open": "🟢",
+    "ready": "🟢",
     "blocked": "🔴",
     "needs-decision": "🟡",
+    "decision_required": "🟡",
     "in-progress": "🔵",
+    "active": "🔵",
     "done": "✅",
 }
 
@@ -80,7 +83,7 @@ DECISION_GATE_STATES = {"needs-decision", "decision_required"}
 
 
 def _status(item: dict) -> str:
-    return STATUS_EMOJI.get(item.get("status", "open"), "⚪")
+    return STATUS_EMOJI.get(_queue_item_status(item), "⚪")
 
 
 def _tags(item: dict) -> str:
@@ -218,7 +221,9 @@ def _resolved_gate_errors(
 
     if not gate.get("closed") or not gate.get("resolved_by"):
         errors.append(f"{gate_id} is resolved without closed and resolved_by metadata")
-    if item is not None and queue_status != "done":
+    if item is None:
+        errors.append(f"{gate_id} is resolved but queue item {queue_item} is missing")
+    elif queue_status != "done":
         errors.append(
             f"{gate_id} is resolved while queue item {queue_item} "
             f"has status {queue_status}"
@@ -328,7 +333,7 @@ def render_queue_md(data: dict) -> str:
         rank = item.get("rank", "?")
         iid = item.get("id", "?")
         title = item.get("title", "Untitled")
-        status = item.get("status", "open")
+        status = _queue_item_status(item)
         emoji = _status(item)
         owner = item.get("owner") or "_unassigned_"
         tags_str = _tags(item)
@@ -378,9 +383,9 @@ def render_next_up_md(data: dict) -> str:
     items = data.get("active", [])
     ts = _ts(data)
 
-    open_items = [x for x in items if x.get("status") == "open"]
-    blocked_items = [x for x in items if x.get("status") == "blocked"]
-    decision_items = [x for x in items if x.get("status") == "needs-decision"]
+    open_items = [x for x in items if _queue_item_status(x) in {"open", "ready"}]
+    blocked_items = [x for x in items if _queue_item_status(x) == "blocked"]
+    decision_items = [x for x in items if _queue_item_status(x) in DECISION_GATE_STATES]
 
     lines: list[str] = [
         GENERATED_BANNER,
@@ -393,7 +398,7 @@ def render_next_up_md(data: dict) -> str:
         "",
         "## 🟢 Ready to Work",
         "",
-        "Items with `status: open` and all dependencies resolved.",
+        "Items with an `open` or `ready` lifecycle and all dependencies resolved.",
         "",
     ]
 

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -11,8 +11,9 @@ Generated files (DO NOT EDIT by hand):
     ops/work_queue/NEXT_UP.md
     ops/work_queue/OPEN_GATES.md
 
-Canonical source:  ops/work_queue/queue.json
-Authority:         Aurora (aurora_authority: true items)
+Canonical task source:  ops/work_queue/queue.json
+Canonical gate source:  ops/work_queue/gate_registry.json
+Authority:              Aurora (aurora_authority: true items)
 Tracked in:        https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1147
 """
 
@@ -28,6 +29,7 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 QUEUE_JSON = HERE / "queue.json"
+GATE_REGISTRY_JSON = HERE / "gate_registry.json"
 QUEUE_MD = HERE / "QUEUE.md"
 NEXT_UP_MD = HERE / "NEXT_UP.md"
 OPEN_GATES_MD = HERE / "OPEN_GATES.md"
@@ -39,6 +41,14 @@ GENERATED_BANNER = (
     "     Tracked in:      https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1147 -->"
 )
 
+OPEN_GATES_BANNER = (
+    "<!-- !! GENERATED FILE — DO NOT EDIT BY HAND !!\n"
+    "     Task source:      ops/work_queue/queue.json\n"
+    "     Gate source:      ops/work_queue/gate_registry.json\n"
+    "     Regenerate:       python ops/work_queue/sync_queue.py\n"
+    "     Tracked in:       https://github.com/AUo959/aurora-cloudbank-symbolic/issues/1147 -->"
+)
+
 # ---------------------------------------------------------------------------
 # Load
 # ---------------------------------------------------------------------------
@@ -46,6 +56,11 @@ GENERATED_BANNER = (
 
 def load_queue() -> dict:
     with QUEUE_JSON.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_gate_registry() -> dict:
+    with GATE_REGISTRY_JSON.open(encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -97,9 +112,114 @@ def _ts(data: dict) -> str:
     return str(data.get("_meta", {}).get("last_aurora_review", "unknown"))
 
 
+def _queue_gate_items(data: dict) -> list[dict]:
+    """Return queue items that assert a human-gate role."""
+    return [
+        item
+        for item in data.get("active", [])
+        if "gate" in item.get("tags", []) or item.get("status") == "needs-decision"
+    ]
+
+
+def _queue_item_status(item: dict | None) -> str:
+    if item is None:
+        return "missing"
+    return str(item.get("status", item.get("state", "unknown")))
+
+
+def find_gate_coherence_errors(data: dict, registry: dict) -> list[str]:
+    """Return blocking queue/gate-registry authority contradictions.
+
+    A registry-only gate is allowed only when its integrity status explicitly
+    records a reconciliation hold. That preserves GATE-001 without pretending
+    its missing historical queue item is ordinary or resolved.
+    """
+    errors: list[str] = []
+    queue_items = {
+        item.get("id"): item for item in data.get("active", []) if item.get("id")
+    }
+    gates = registry.get("gates", [])
+
+    gate_ids: set[str] = set()
+    registry_by_queue_item: dict[str, dict] = {}
+
+    for gate in gates:
+        gate_id = str(gate.get("gate_id", "<missing-gate-id>"))
+        if gate_id in gate_ids:
+            errors.append(f"duplicate registry gate id: {gate_id}")
+        gate_ids.add(gate_id)
+
+        queue_item = gate.get("queue_item")
+        if queue_item:
+            queue_item = str(queue_item)
+            if queue_item in registry_by_queue_item:
+                errors.append(
+                    f"multiple registry gates reference queue item {queue_item}"
+                )
+            registry_by_queue_item[queue_item] = gate
+
+        state = gate.get("state")
+        integrity_status = gate.get("integrity_status", "active")
+        item = queue_items.get(queue_item)
+        queue_status = _queue_item_status(item)
+
+        if state == "open":
+            if gate.get("closed") or gate.get("resolved_by"):
+                errors.append(f"{gate_id} is open but carries closed/resolved metadata")
+            if item is None and integrity_status != "reconciliation_required":
+                errors.append(
+                    f"{gate_id} references missing queue item {queue_item} "
+                    "without a reconciliation_required integrity hold"
+                )
+            if queue_status == "done":
+                errors.append(
+                    f"{gate_id} is open while queue item {queue_item} is done"
+                )
+        elif state == "resolved":
+            if not gate.get("closed") or not gate.get("resolved_by"):
+                errors.append(
+                    f"{gate_id} is resolved without closed and resolved_by metadata"
+                )
+            if item is not None and queue_status != "done":
+                errors.append(
+                    f"{gate_id} is resolved while queue item {queue_item} "
+                    f"has status {queue_status}"
+                )
+        else:
+            errors.append(f"{gate_id} has unsupported state {state!r}")
+
+        if (
+            integrity_status == "reconciliation_required"
+            and not str(gate.get("integrity_note", "")).strip()
+        ):
+            errors.append(
+                f"{gate_id} requires reconciliation but has no integrity_note"
+            )
+
+    for item in _queue_gate_items(data):
+        item_id = str(item.get("id", "<missing-queue-id>"))
+        gate = registry_by_queue_item.get(item_id)
+        if gate is None:
+            errors.append(
+                f"queue gate {item_id} has no canonical gate_registry.json record"
+            )
+            continue
+
+        gate_state = gate.get("state")
+        queue_status = _queue_item_status(item)
+        if gate_state == "resolved" and queue_status != "done":
+            errors.append(
+                f"queue gate {item_id} remains {queue_status} while "
+                f"{gate.get('gate_id')} is resolved"
+            )
+
+    return errors
+
+
 # ---------------------------------------------------------------------------
 # QUEUE.md renderer
 # ---------------------------------------------------------------------------
+
 
 def render_queue_md(data: dict) -> str:
     meta = data.get("_meta", {})
@@ -176,6 +296,7 @@ def render_queue_md(data: dict) -> str:
 # NEXT_UP.md renderer
 # ---------------------------------------------------------------------------
 
+
 def render_next_up_md(data: dict) -> str:
     items = data.get("active", [])
     ts = _ts(data)
@@ -206,9 +327,7 @@ def render_next_up_md(data: dict) -> str:
         ]
         for item in open_items:
             lines.append(
-                f"| {item['rank']} | {item['id']} "
-                f"| {item['title']} "
-                f"| {_tags(item)} |"
+                f"| {item['rank']} | {item['id']} | {item['title']} | {_tags(item)} |"
             )
     else:
         lines.append("_No open items._")
@@ -230,9 +349,7 @@ def render_next_up_md(data: dict) -> str:
         ]
         for item in blocked_items:
             lines.append(
-                f"| {item['rank']} | {item['id']} "
-                f"| {item['title']} "
-                f"| {_deps(item)} |"
+                f"| {item['rank']} | {item['id']} | {item['title']} | {_deps(item)} |"
             )
     else:
         lines.append("_No blocked items._")
@@ -253,9 +370,7 @@ def render_next_up_md(data: dict) -> str:
             "|---|---|---|",
         ]
         for item in decision_items:
-            lines.append(
-                f"| {item['rank']} | {item['id']} | {item['title']} |"
-            )
+            lines.append(f"| {item['rank']} | {item['id']} | {item['title']} |")
     else:
         lines.append("_No decision-gated items._")
 
@@ -267,31 +382,37 @@ def render_next_up_md(data: dict) -> str:
 # OPEN_GATES.md renderer
 # ---------------------------------------------------------------------------
 
-def render_open_gates_md(data: dict) -> str:
-    items = data.get("active", [])
-    ts = _ts(data)
 
-    # Items that are themselves gate-holders: tagged 'gate' or status 'needs-decision'
-    gates = [
-        x for x in items
-        if "gate" in x.get("tags", []) or x.get("status") == "needs-decision"
+def render_open_gates_md(data: dict, registry: dict) -> str:
+    items = data.get("active", [])
+    queue_by_id = {item.get("id"): item for item in items}
+    queue_review = _ts(data)
+    registry_updated = str(registry.get("last_updated", "unknown"))
+
+    gates = [gate for gate in registry.get("gates", []) if gate.get("state") == "open"]
+    holds = [
+        gate for gate in gates if gate.get("integrity_status", "active") != "active"
     ]
-    # Items blocked by gate holders
-    gate_ids = {x["id"] for x in gates}
+
+    gate_ids = {gate.get("queue_item") for gate in gates if gate.get("queue_item")}
     waiting = [
-        x for x in items
-        if any(dep in gate_ids for dep in x.get("depends_on", []))
+        item
+        for item in items
+        if any(dep in gate_ids for dep in item.get("depends_on", []))
     ]
 
     lines: list[str] = [
-        GENERATED_BANNER,
+        OPEN_GATES_BANNER,
         "",
         "# Open Gates — Aurora Work Queue",
         "",
-        f"_Generated: `{ts}` — edit `queue.json`, run `sync_queue.py`_",
+        (
+            f"_Queue review: `{queue_review}` · Gate registry updated: "
+            f"`{registry_updated}` · deterministic projection_"
+        ),
         "",
-        "> Gates are items tagged `gate` or carrying `status: needs-decision`.",
-        "> Nothing downstream can advance until the gate closes.",
+        "> Human-gate authority comes from `gate_registry.json`; `queue.json`",
+        "> supplies task status and dependency context. Rendering never resolves a gate.",
         "",
         "---",
         "",
@@ -301,15 +422,50 @@ def render_open_gates_md(data: dict) -> str:
 
     if gates:
         lines += [
-            "| Rank | ID | Title | Status |",
-            "|---|---|---|---|",
+            "| Gate | Queue Item | Title | Gate State | Integrity | Queue Status | Decision Owner |",
+            "|---|---|---|---|---|---|---|",
         ]
-        for g in gates:
+        for gate in gates:
+            queue_item_id = gate.get("queue_item") or "—"
+            queue_status = _queue_item_status(queue_by_id.get(queue_item_id))
             lines.append(
-                f"| {g['rank']} | {g['id']} | {g['title']} | `{g.get('status', '?')}` |"
+                f"| {gate.get('gate_id', '?')} | {queue_item_id} "
+                f"| {gate.get('title', 'Untitled')} "
+                f"| `{gate.get('state', '?')}` "
+                f"| `{gate.get('integrity_status', 'active')}` "
+                f"| `{queue_status}` "
+                f"| {gate.get('decision_owner', '—')} |"
             )
     else:
         lines.append("_No open gates. 🎉_")
+
+    lines += [
+        "",
+        "---",
+        "",
+        f"## Reconciliation Holds ({len(holds)})",
+        "",
+    ]
+
+    if holds:
+        for gate in holds:
+            queue_item_id = gate.get("queue_item") or "—"
+            queue_link = (
+                "present" if queue_item_id in queue_by_id else "missing from queue.json"
+            )
+            github_issue = gate.get("github_issue")
+            issue_text = f"#{github_issue}" if github_issue else "—"
+            lines += [
+                f"### {gate.get('gate_id', '?')} — {gate.get('title', 'Untitled')}",
+                "",
+                f"- **Integrity:** `{gate.get('integrity_status', 'unknown')}`",
+                f"- **Queue item:** `{queue_item_id}` — {queue_link}",
+                f"- **Linked issue:** {issue_text}",
+                f"- **Note:** {gate.get('integrity_note', '_No integrity note._')}",
+                "",
+            ]
+    else:
+        lines.append("_No reconciliation holds._")
 
     lines += [
         "",
@@ -324,10 +480,13 @@ def render_open_gates_md(data: dict) -> str:
             "| Rank | ID | Title | Waiting On |",
             "|---|---|---|---|",
         ]
-        for w in waiting:
-            blocking_gates = [dep for dep in w.get("depends_on", []) if dep in gate_ids]
+        for item in waiting:
+            blocking_gates = [
+                dep for dep in item.get("depends_on", []) if dep in gate_ids
+            ]
             lines.append(
-                f"| {w['rank']} | {w['id']} | {w['title']} | {', '.join(blocking_gates)} |"
+                f"| {item['rank']} | {item['id']} | {item['title']} "
+                f"| {', '.join(blocking_gates)} |"
             )
     else:
         lines.append("_No items waiting on gates._")
@@ -340,11 +499,12 @@ def render_open_gates_md(data: dict) -> str:
 # Write / Check
 # ---------------------------------------------------------------------------
 
-def render_all(data: dict) -> dict[Path, str]:
+
+def render_all(data: dict, registry: dict) -> dict[Path, str]:
     return {
         QUEUE_MD: render_queue_md(data),
         NEXT_UP_MD: render_next_up_md(data),
-        OPEN_GATES_MD: render_open_gates_md(data),
+        OPEN_GATES_MD: render_open_gates_md(data, registry),
     }
 
 
@@ -367,9 +527,12 @@ def check_all(rendered: dict[Path, str]) -> bool:
 
         def strip_ts(text: str) -> str:
             return "\n".join(
-                line for line in text.splitlines()
-                if not line.startswith("**Generated:**") and not line.startswith("_Generated:")
+                line
+                for line in text.splitlines()
+                if not line.startswith("**Generated:**")
+                and not line.startswith("_Generated:")
             )
+
         if strip_ts(existing) != strip_ts(new_content):
             print(f"STALE:   {path.name}")
             drift = True
@@ -382,24 +545,43 @@ def check_all(rendered: dict[Path, str]) -> bool:
 # Entry point
 # ---------------------------------------------------------------------------
 
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     mode = parser.add_mutually_exclusive_group()
-    mode.add_argument("--render", action="store_true", help="Render generated queue views in place (default).")
-    mode.add_argument("--check", action="store_true", help="Exit non-zero when a generated view is stale.")
+    mode.add_argument(
+        "--render",
+        action="store_true",
+        help="Render generated queue views in place (default).",
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero when a generated view is stale.",
+    )
     args = parser.parse_args()
 
     data = load_queue()
-    rendered = render_all(data)
+    registry = load_gate_registry()
+    coherence_errors = find_gate_coherence_errors(data, registry)
+    if coherence_errors:
+        print("ERROR: Queue/gate-registry coherence check failed:")
+        for error in coherence_errors:
+            print(f"  - {error}")
+        return 1
+
+    rendered = render_all(data, registry)
 
     if args.check:
         print("Queue drift check...")
         ok = check_all(rendered)
         if not ok:
             print()
-            print("ERROR: Generated queue views are out of sync with queue.json.")
+            print("ERROR: Generated queue views are out of sync with their sources.")
             print("FIX:   python ops/work_queue/sync_queue.py")
-            print("       Then commit the regenerated QUEUE.md, NEXT_UP.md, OPEN_GATES.md.")
+            print(
+                "       Then commit the regenerated QUEUE.md, NEXT_UP.md, OPEN_GATES.md."
+            )
             return 1
         print("All generated views are current.")
         return 0

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -76,6 +76,8 @@ STATUS_EMOJI = {
     "done": "✅",
 }
 
+DECISION_GATE_STATES = {"needs-decision", "decision_required"}
+
 
 def _status(item: dict) -> str:
     return STATUS_EMOJI.get(item.get("status", "open"), "⚪")
@@ -117,24 +119,38 @@ def _queue_gate_items(data: dict) -> list[dict]:
     return [
         item
         for item in data.get("active", [])
-        if "gate" in item.get("tags", []) or item.get("status") == "needs-decision"
+        if "gate" in item.get("tags", [])
+        or item.get("status") in DECISION_GATE_STATES
+        or item.get("state") in DECISION_GATE_STATES
     ]
 
 
 def _queue_item_status(item: dict | None) -> str:
     if item is None:
         return "missing"
-    return str(item.get("status", item.get("state", "unknown")))
+    return str(item.get("status") or item.get("state") or "unknown")
 
 
-def _queue_items_by_id(data: dict) -> dict[str, dict]:
-    """Index active and completed tasks for lifecycle coherence checks."""
-    return {
-        item["id"]: item
-        for section in ("completed", "active")
-        for item in data.get(section, [])
-        if item.get("id")
-    }
+def _index_queue_items(data: dict) -> tuple[dict[str, dict], list[str]]:
+    """Index queue items while reporting ambiguous lifecycle identities."""
+    queue_items: dict[str, dict] = {}
+    sections_by_id: dict[str, list[str]] = {}
+
+    for section in ("active", "completed"):
+        for item in data.get(section, []):
+            item_id = item.get("id")
+            if not item_id:
+                continue
+            item_id = str(item_id)
+            sections_by_id.setdefault(item_id, []).append(section)
+            queue_items.setdefault(item_id, item)
+
+    errors = [
+        f"duplicate queue item id {item_id} appears in {', '.join(sections)}"
+        for item_id, sections in sections_by_id.items()
+        if len(sections) > 1
+    ]
+    return queue_items, errors
 
 
 def _index_registry_gates(gates: list[dict]) -> tuple[dict[str, dict], list[str]]:
@@ -177,6 +193,11 @@ def _open_gate_errors(
         )
     if queue_status == "done":
         errors.append(f"{gate_id} is open while queue item {queue_item} is done")
+    elif item is not None and queue_status not in DECISION_GATE_STATES:
+        errors.append(
+            f"{gate_id} is open while queue item {queue_item} "
+            f"has non-decision status {queue_status}"
+        )
 
     return errors
 
@@ -253,9 +274,10 @@ def find_gate_coherence_errors(data: dict, registry: dict) -> list[str]:
     records a reconciliation hold. That preserves GATE-001 without pretending
     its missing historical queue item is ordinary or resolved.
     """
-    queue_items = _queue_items_by_id(data)
+    queue_items, queue_errors = _index_queue_items(data)
     gates = registry.get("gates", [])
     registry_by_queue_item, errors = _index_registry_gates(gates)
+    errors = [*queue_errors, *errors]
 
     for gate in gates:
         errors.extend(_registry_gate_errors(gate, queue_items))

--- a/ops/work_queue/sync_queue.py
+++ b/ops/work_queue/sync_queue.py
@@ -127,19 +127,9 @@ def _queue_item_status(item: dict | None) -> str:
     return str(item.get("status", item.get("state", "unknown")))
 
 
-def find_gate_coherence_errors(data: dict, registry: dict) -> list[str]:
-    """Return blocking queue/gate-registry authority contradictions.
-
-    A registry-only gate is allowed only when its integrity status explicitly
-    records a reconciliation hold. That preserves GATE-001 without pretending
-    its missing historical queue item is ordinary or resolved.
-    """
+def _index_registry_gates(gates: list[dict]) -> tuple[dict[str, dict], list[str]]:
+    """Index gates by queue item while reporting duplicate authority records."""
     errors: list[str] = []
-    queue_items = {
-        item.get("id"): item for item in data.get("active", []) if item.get("id")
-    }
-    gates = registry.get("gates", [])
-
     gate_ids: set[str] = set()
     registry_by_queue_item: dict[str, dict] = {}
 
@@ -150,52 +140,83 @@ def find_gate_coherence_errors(data: dict, registry: dict) -> list[str]:
         gate_ids.add(gate_id)
 
         queue_item = gate.get("queue_item")
-        if queue_item:
-            queue_item = str(queue_item)
-            if queue_item in registry_by_queue_item:
-                errors.append(
-                    f"multiple registry gates reference queue item {queue_item}"
-                )
-            registry_by_queue_item[queue_item] = gate
+        if not queue_item:
+            continue
+        queue_item = str(queue_item)
+        if queue_item in registry_by_queue_item:
+            errors.append(f"multiple registry gates reference queue item {queue_item}")
+        registry_by_queue_item[queue_item] = gate
 
-        state = gate.get("state")
-        integrity_status = gate.get("integrity_status", "active")
-        item = queue_items.get(queue_item)
-        queue_status = _queue_item_status(item)
+    return registry_by_queue_item, errors
 
-        if state == "open":
-            if gate.get("closed") or gate.get("resolved_by"):
-                errors.append(f"{gate_id} is open but carries closed/resolved metadata")
-            if item is None and integrity_status != "reconciliation_required":
-                errors.append(
-                    f"{gate_id} references missing queue item {queue_item} "
-                    "without a reconciliation_required integrity hold"
-                )
-            if queue_status == "done":
-                errors.append(
-                    f"{gate_id} is open while queue item {queue_item} is done"
-                )
-        elif state == "resolved":
-            if not gate.get("closed") or not gate.get("resolved_by"):
-                errors.append(
-                    f"{gate_id} is resolved without closed and resolved_by metadata"
-                )
-            if item is not None and queue_status != "done":
-                errors.append(
-                    f"{gate_id} is resolved while queue item {queue_item} "
-                    f"has status {queue_status}"
-                )
-        else:
-            errors.append(f"{gate_id} has unsupported state {state!r}")
 
-        if (
-            integrity_status == "reconciliation_required"
-            and not str(gate.get("integrity_note", "")).strip()
-        ):
-            errors.append(
-                f"{gate_id} requires reconciliation but has no integrity_note"
-            )
+def _open_gate_errors(
+    gate_id: str, gate: dict, item: dict | None, queue_status: str
+) -> list[str]:
+    """Return contradictions for one open canonical gate."""
+    errors: list[str] = []
+    queue_item = gate.get("queue_item")
+    integrity_status = gate.get("integrity_status", "active")
 
+    if gate.get("closed") or gate.get("resolved_by"):
+        errors.append(f"{gate_id} is open but carries closed/resolved metadata")
+    if item is None and integrity_status != "reconciliation_required":
+        errors.append(
+            f"{gate_id} references missing queue item {queue_item} "
+            "without a reconciliation_required integrity hold"
+        )
+    if queue_status == "done":
+        errors.append(f"{gate_id} is open while queue item {queue_item} is done")
+
+    return errors
+
+
+def _resolved_gate_errors(
+    gate_id: str, gate: dict, item: dict | None, queue_status: str
+) -> list[str]:
+    """Return contradictions for one resolved canonical gate."""
+    errors: list[str] = []
+    queue_item = gate.get("queue_item")
+
+    if not gate.get("closed") or not gate.get("resolved_by"):
+        errors.append(f"{gate_id} is resolved without closed and resolved_by metadata")
+    if item is not None and queue_status != "done":
+        errors.append(
+            f"{gate_id} is resolved while queue item {queue_item} "
+            f"has status {queue_status}"
+        )
+
+    return errors
+
+
+def _registry_gate_errors(gate: dict, queue_items: dict[str, dict]) -> list[str]:
+    """Return state and integrity contradictions for one registry gate."""
+    gate_id = str(gate.get("gate_id", "<missing-gate-id>"))
+    item = queue_items.get(gate.get("queue_item"))
+    queue_status = _queue_item_status(item)
+    state = gate.get("state")
+
+    if state == "open":
+        errors = _open_gate_errors(gate_id, gate, item, queue_status)
+    elif state == "resolved":
+        errors = _resolved_gate_errors(gate_id, gate, item, queue_status)
+    else:
+        errors = [f"{gate_id} has unsupported state {state!r}"]
+
+    if (
+        gate.get("integrity_status") == "reconciliation_required"
+        and not str(gate.get("integrity_note", "")).strip()
+    ):
+        errors.append(f"{gate_id} requires reconciliation but has no integrity_note")
+
+    return errors
+
+
+def _queue_gate_errors(
+    data: dict, registry_by_queue_item: dict[str, dict]
+) -> list[str]:
+    """Return queue-side gate assertions missing or contradicting authority."""
+    errors: list[str] = []
     for item in _queue_gate_items(data):
         item_id = str(item.get("id", "<missing-queue-id>"))
         gate = registry_by_queue_item.get(item_id)
@@ -205,13 +226,32 @@ def find_gate_coherence_errors(data: dict, registry: dict) -> list[str]:
             )
             continue
 
-        gate_state = gate.get("state")
         queue_status = _queue_item_status(item)
-        if gate_state == "resolved" and queue_status != "done":
+        if gate.get("state") == "resolved" and queue_status != "done":
             errors.append(
                 f"queue gate {item_id} remains {queue_status} while "
                 f"{gate.get('gate_id')} is resolved"
             )
+
+    return errors
+
+
+def find_gate_coherence_errors(data: dict, registry: dict) -> list[str]:
+    """Return blocking queue/gate-registry authority contradictions.
+
+    A registry-only gate is allowed only when its integrity status explicitly
+    records a reconciliation hold. That preserves GATE-001 without pretending
+    its missing historical queue item is ordinary or resolved.
+    """
+    queue_items = {
+        item.get("id"): item for item in data.get("active", []) if item.get("id")
+    }
+    gates = registry.get("gates", [])
+    registry_by_queue_item, errors = _index_registry_gates(gates)
+
+    for gate in gates:
+        errors.extend(_registry_gate_errors(gate, queue_items))
+    errors.extend(_queue_gate_errors(data, registry_by_queue_item))
 
     return errors
 
@@ -383,6 +423,73 @@ def render_next_up_md(data: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _render_open_gate_table(gates: list[dict], queue_by_id: dict) -> list[str]:
+    """Render canonical open gates with queue context."""
+    if not gates:
+        return ["_No open gates. 🎉_"]
+
+    lines = [
+        "| Gate | Queue Item | Title | Gate State | Integrity | Queue Status | Decision Owner |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for gate in gates:
+        queue_item_id = gate.get("queue_item") or "—"
+        queue_status = _queue_item_status(queue_by_id.get(queue_item_id))
+        lines.append(
+            f"| {gate.get('gate_id', '?')} | {queue_item_id} "
+            f"| {gate.get('title', 'Untitled')} "
+            f"| `{gate.get('state', '?')}` "
+            f"| `{gate.get('integrity_status', 'active')}` "
+            f"| `{queue_status}` "
+            f"| {gate.get('decision_owner', '—')} |"
+        )
+    return lines
+
+
+def _render_reconciliation_holds(holds: list[dict], queue_by_id: dict) -> list[str]:
+    """Render explicit projection-integrity holds without resolving them."""
+    lines = ["", "---", "", f"## Reconciliation Holds ({len(holds)})", ""]
+    if not holds:
+        return [*lines, "_No reconciliation holds._"]
+
+    for gate in holds:
+        queue_item_id = gate.get("queue_item") or "—"
+        queue_link = (
+            "present" if queue_item_id in queue_by_id else "missing from queue.json"
+        )
+        github_issue = gate.get("github_issue")
+        issue_text = f"#{github_issue}" if github_issue else "—"
+        lines += [
+            f"### {gate.get('gate_id', '?')} — {gate.get('title', 'Untitled')}",
+            "",
+            f"- **Integrity:** `{gate.get('integrity_status', 'unknown')}`",
+            f"- **Queue item:** `{queue_item_id}` — {queue_link}",
+            f"- **Linked issue:** {issue_text}",
+            f"- **Note:** {gate.get('integrity_note', '_No integrity note._')}",
+            "",
+        ]
+    return lines
+
+
+def _render_waiting_on_gate(waiting: list[dict], gate_ids: set[str]) -> list[str]:
+    """Render task dependencies on canonical open gates."""
+    lines = ["", "---", "", f"## Waiting on Gate ({len(waiting)})", ""]
+    if not waiting:
+        return [*lines, "_No items waiting on gates._"]
+
+    lines += [
+        "| Rank | ID | Title | Waiting On |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in waiting:
+        blocking_gates = [dep for dep in item.get("depends_on", []) if dep in gate_ids]
+        lines.append(
+            f"| {item['rank']} | {item['id']} | {item['title']} "
+            f"| {', '.join(blocking_gates)} |"
+        )
+    return lines
+
+
 def render_open_gates_md(data: dict, registry: dict) -> str:
     items = data.get("active", [])
     queue_by_id = {item.get("id"): item for item in items}
@@ -420,77 +527,9 @@ def render_open_gates_md(data: dict, registry: dict) -> str:
         "",
     ]
 
-    if gates:
-        lines += [
-            "| Gate | Queue Item | Title | Gate State | Integrity | Queue Status | Decision Owner |",
-            "|---|---|---|---|---|---|---|",
-        ]
-        for gate in gates:
-            queue_item_id = gate.get("queue_item") or "—"
-            queue_status = _queue_item_status(queue_by_id.get(queue_item_id))
-            lines.append(
-                f"| {gate.get('gate_id', '?')} | {queue_item_id} "
-                f"| {gate.get('title', 'Untitled')} "
-                f"| `{gate.get('state', '?')}` "
-                f"| `{gate.get('integrity_status', 'active')}` "
-                f"| `{queue_status}` "
-                f"| {gate.get('decision_owner', '—')} |"
-            )
-    else:
-        lines.append("_No open gates. 🎉_")
-
-    lines += [
-        "",
-        "---",
-        "",
-        f"## Reconciliation Holds ({len(holds)})",
-        "",
-    ]
-
-    if holds:
-        for gate in holds:
-            queue_item_id = gate.get("queue_item") or "—"
-            queue_link = (
-                "present" if queue_item_id in queue_by_id else "missing from queue.json"
-            )
-            github_issue = gate.get("github_issue")
-            issue_text = f"#{github_issue}" if github_issue else "—"
-            lines += [
-                f"### {gate.get('gate_id', '?')} — {gate.get('title', 'Untitled')}",
-                "",
-                f"- **Integrity:** `{gate.get('integrity_status', 'unknown')}`",
-                f"- **Queue item:** `{queue_item_id}` — {queue_link}",
-                f"- **Linked issue:** {issue_text}",
-                f"- **Note:** {gate.get('integrity_note', '_No integrity note._')}",
-                "",
-            ]
-    else:
-        lines.append("_No reconciliation holds._")
-
-    lines += [
-        "",
-        "---",
-        "",
-        f"## Waiting on Gate ({len(waiting)})",
-        "",
-    ]
-
-    if waiting:
-        lines += [
-            "| Rank | ID | Title | Waiting On |",
-            "|---|---|---|---|",
-        ]
-        for item in waiting:
-            blocking_gates = [
-                dep for dep in item.get("depends_on", []) if dep in gate_ids
-            ]
-            lines.append(
-                f"| {item['rank']} | {item['id']} | {item['title']} "
-                f"| {', '.join(blocking_gates)} |"
-            )
-    else:
-        lines.append("_No items waiting on gates._")
-
+    lines += _render_open_gate_table(gates, queue_by_id)
+    lines += _render_reconciliation_holds(holds, queue_by_id)
+    lines += _render_waiting_on_gate(waiting, gate_ids)
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -10,14 +10,20 @@ surfacing, ungated needs-decision drift detection, and apply semantics
 """
 
 import json
+import sys
 from datetime import date
 from pathlib import Path
 
+import ops.work_queue.sync_queue as sync_queue
 from ops.work_queue.escalate_gates import (
     apply_surfacing,
     find_escalations,
     find_integrity_holds,
     find_ungated_decisions,
+)
+from ops.work_queue.sync_queue import (
+    find_gate_coherence_errors,
+    render_open_gates_md,
 )
 
 TODAY = date(2026, 7, 18)
@@ -37,7 +43,11 @@ def _registry(**gate_overrides):
         "blocks_queue_items": ["Q-0778"],
     }
     gate.update(gate_overrides)
-    return {"registry_authority": "Aurora", "last_updated": "2026-07-01", "gates": [gate]}
+    return {
+        "registry_authority": "Aurora",
+        "last_updated": "2026-07-01",
+        "gates": [gate],
+    }
 
 
 def test_aged_open_gate_escalates():
@@ -80,14 +90,16 @@ def test_integrity_hold_suspends_escalation_and_link_authority():
         integrity_note="Linked issue is closed.",
     )
     assert find_escalations(held, threshold_days=3, today=TODAY) == []
-    assert find_integrity_holds(held) == [{
-        "gate_id": "GATE-777",
-        "title": "Test gate",
-        "integrity_status": "reconciliation_required",
-        "integrity_note": "Linked issue is closed.",
-        "github_issue": 777,
-        "queue_item": "Q-0777",
-    }]
+    assert find_integrity_holds(held) == [
+        {
+            "gate_id": "GATE-777",
+            "title": "Test gate",
+            "integrity_status": "reconciliation_required",
+            "integrity_note": "Linked issue is closed.",
+            "github_issue": 777,
+            "queue_item": "Q-0777",
+        }
+    ]
 
     queue = {
         "active": [
@@ -125,9 +137,17 @@ def test_apply_bumps_last_surfaced_but_never_tier():
 def test_ungated_needs_decision_items_are_reported_as_drift():
     queue = {
         "active": [
-            {"id": "sim/decision-x", "title": "Needs a call", "status": "needs-decision"},
-            {"id": "Q-0777-linked", "title": "Gated", "status": "needs-decision",
-             "github_issue": 777},
+            {
+                "id": "sim/decision-x",
+                "title": "Needs a call",
+                "status": "needs-decision",
+            },
+            {
+                "id": "Q-0777-linked",
+                "title": "Gated",
+                "status": "needs-decision",
+                "github_issue": 777,
+            },
             {"id": "ops/normal", "title": "Just open", "status": "open"},
         ]
     }
@@ -169,3 +189,160 @@ def test_live_registry_and_queue_parse_and_report_cleanly():
     for gate in holds:
         assert gate["gate_id"]
         assert gate["integrity_status"] != "active"
+
+
+def _projection_queue(*items):
+    return {
+        "_meta": {"last_aurora_review": "2026-07-16T00:36:36Z"},
+        "active": list(items),
+    }
+
+
+def _projection_registry(*gates):
+    return {
+        "last_updated": "2026-08-03",
+        "gates": list(gates),
+    }
+
+
+def _projection_gate(**overrides):
+    gate = {
+        "gate_id": "GATE-900",
+        "queue_item": "Q-0900",
+        "github_issue": 900,
+        "title": "Projection test gate",
+        "state": "open",
+        "integrity_status": "active",
+        "decision_owner": "operator",
+        "closed": None,
+        "resolved_by": None,
+    }
+    gate.update(overrides)
+    return gate
+
+
+def _projection_queue_gate(**overrides):
+    item = {
+        "id": "Q-0900",
+        "title": "Projection test queue item",
+        "status": "needs-decision",
+        "tags": ["gate"],
+        "depends_on": [],
+    }
+    item.update(overrides)
+    return item
+
+
+def test_gate_projection_uses_registry_authority_and_source_dates():
+    queue = _projection_queue(_projection_queue_gate())
+    registry = _projection_registry(_projection_gate())
+
+    assert find_gate_coherence_errors(queue, registry) == []
+    rendered = render_open_gates_md(queue, registry)
+
+    assert "GATE-900" in rendered
+    assert "`active`" in rendered
+    assert "Queue review: `2026-07-16T00:36:36Z`" in rendered
+    assert "Gate registry updated: `2026-08-03`" in rendered
+
+
+def test_registry_only_reconciliation_hold_is_visible_and_nonblocking():
+    gate = _projection_gate(
+        queue_item="Q-missing",
+        integrity_status="reconciliation_required",
+        integrity_note="Historical queue item is absent; operator review required.",
+    )
+    queue = _projection_queue()
+    registry = _projection_registry(gate)
+
+    assert find_gate_coherence_errors(queue, registry) == []
+    rendered = render_open_gates_md(queue, registry)
+
+    assert "GATE-900" in rendered
+    assert "`reconciliation_required`" in rendered
+    assert "`Q-missing` — missing from queue.json" in rendered
+    assert "Historical queue item is absent" in rendered
+
+
+def test_missing_active_registry_queue_item_is_a_coherence_error():
+    registry = _projection_registry(_projection_gate(queue_item="Q-missing"))
+
+    errors = find_gate_coherence_errors(_projection_queue(), registry)
+
+    assert any("missing queue item Q-missing" in error for error in errors)
+
+
+def test_queue_gate_without_registry_record_is_a_coherence_error():
+    queue = _projection_queue(_projection_queue_gate())
+
+    errors = find_gate_coherence_errors(queue, _projection_registry())
+
+    assert errors == ["queue gate Q-0900 has no canonical gate_registry.json record"]
+
+
+def test_matching_issue_number_does_not_mask_queue_item_mismatch():
+    queue = _projection_queue(_projection_queue_gate(id="Q-other", github_issue=900))
+    registry = _projection_registry(
+        _projection_gate(
+            queue_item="Q-missing",
+            integrity_status="reconciliation_required",
+            integrity_note="Historical item is absent.",
+        )
+    )
+
+    errors = find_gate_coherence_errors(queue, registry)
+
+    assert errors == ["queue gate Q-other has no canonical gate_registry.json record"]
+
+
+def test_resolved_registry_gate_cannot_leave_queue_decision_open():
+    queue = _projection_queue(_projection_queue_gate())
+    registry = _projection_registry(
+        _projection_gate(
+            state="resolved",
+            closed="2026-08-03",
+            resolved_by="operator",
+        )
+    )
+
+    errors = find_gate_coherence_errors(queue, registry)
+
+    assert any("resolved while queue item Q-0900" in error for error in errors)
+    assert any("Q-0900 remains needs-decision" in error for error in errors)
+
+
+def test_resolved_gate_with_done_queue_item_is_not_rendered_open():
+    queue = _projection_queue(_projection_queue_gate(status="done"))
+    registry = _projection_registry(
+        _projection_gate(
+            state="resolved",
+            closed="2026-08-03",
+            resolved_by="operator",
+        )
+    )
+
+    assert find_gate_coherence_errors(queue, registry) == []
+    rendered = render_open_gates_md(queue, registry)
+    assert "GATE-900" not in rendered
+
+
+def test_check_mode_returns_nonzero_for_cross_source_divergence(monkeypatch):
+    queue = _projection_queue(_projection_queue_gate())
+    registry = _projection_registry()
+    monkeypatch.setattr(sync_queue, "load_queue", lambda: queue)
+    monkeypatch.setattr(sync_queue, "load_gate_registry", lambda: registry)
+    monkeypatch.setattr(sys, "argv", ["sync_queue.py", "--check"])
+
+    assert sync_queue.main() == 1
+
+
+def test_live_registry_queue_and_projection_are_coherent():
+    work_queue = Path(__file__).resolve().parent.parent / "ops" / "work_queue"
+    registry = json.loads((work_queue / "gate_registry.json").read_text())
+    queue = json.loads((work_queue / "queue.json").read_text())
+
+    assert find_gate_coherence_errors(queue, registry) == []
+    rendered = render_open_gates_md(queue, registry)
+    for gate in registry["gates"]:
+        if gate["state"] == "open":
+            assert gate["gate_id"] in rendered

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -265,6 +265,20 @@ def test_registry_only_reconciliation_hold_is_visible_and_nonblocking():
     assert "Historical queue item is absent" in rendered
 
 
+def test_reconciliation_hold_requires_an_integrity_note():
+    registry = _projection_registry(
+        _projection_gate(
+            queue_item="Q-missing",
+            integrity_status="reconciliation_required",
+            integrity_note=" ",
+        )
+    )
+
+    errors = find_gate_coherence_errors(_projection_queue(), registry)
+
+    assert errors == ["GATE-900 requires reconciliation but has no integrity_note"]
+
+
 def test_missing_active_registry_queue_item_is_a_coherence_error():
     registry = _projection_registry(_projection_gate(queue_item="Q-missing"))
 
@@ -279,6 +293,58 @@ def test_queue_gate_without_registry_record_is_a_coherence_error():
     errors = find_gate_coherence_errors(queue, _projection_registry())
 
     assert errors == ["queue gate Q-0900 has no canonical gate_registry.json record"]
+
+
+def test_decision_required_state_without_registry_record_is_a_coherence_error():
+    queue = _projection_queue(
+        _projection_queue_gate(status=None, state="decision_required", tags=[])
+    )
+
+    errors = find_gate_coherence_errors(queue, _projection_registry())
+
+    assert errors == ["queue gate Q-0900 has no canonical gate_registry.json record"]
+
+
+def test_decision_required_state_matches_open_registry_gate():
+    queue = _projection_queue(
+        _projection_queue_gate(status=None, state="decision_required", tags=[])
+    )
+    registry = _projection_registry(_projection_gate())
+
+    assert find_gate_coherence_errors(queue, registry) == []
+
+
+def test_state_gate_marker_is_not_masked_by_legacy_status():
+    queue = _projection_queue(
+        _projection_queue_gate(status="open", state="decision_required", tags=[])
+    )
+
+    errors = find_gate_coherence_errors(queue, _projection_registry())
+
+    assert errors == ["queue gate Q-0900 has no canonical gate_registry.json record"]
+
+
+def test_open_registry_gate_rejects_non_decision_queue_status():
+    queue = _projection_queue(_projection_queue_gate(status="open", tags=[]))
+    registry = _projection_registry(_projection_gate())
+
+    errors = find_gate_coherence_errors(queue, registry)
+
+    assert errors == [
+        "GATE-900 is open while queue item Q-0900 has non-decision status open"
+    ]
+
+
+def test_duplicate_queue_item_id_is_a_coherence_error():
+    queue = _projection_queue(
+        _projection_queue_gate(),
+        completed=[_projection_queue_gate(status="done")],
+    )
+    registry = _projection_registry(_projection_gate())
+
+    errors = find_gate_coherence_errors(queue, registry)
+
+    assert errors == ["duplicate queue item id Q-0900 appears in active, completed"]
 
 
 def test_matching_issue_number_does_not_mask_queue_item_mismatch():

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -335,6 +335,17 @@ def test_state_gate_marker_takes_precedence_for_open_registry_gate():
     assert "`decision_required`" in rendered
 
 
+def test_done_status_takes_precedence_over_stale_decision_state():
+    queue = _projection_queue(
+        _projection_queue_gate(status="done", state="decision_required", tags=[])
+    )
+    registry = _projection_registry(_projection_gate())
+
+    errors = find_gate_coherence_errors(queue, registry)
+
+    assert errors == ["GATE-900 is open while queue item Q-0900 is done"]
+
+
 def test_open_registry_gate_rejects_non_decision_queue_status():
     queue = _projection_queue(_projection_queue_gate(status="open", tags=[]))
     registry = _projection_registry(_projection_gate())

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -22,6 +22,7 @@ from ops.work_queue.escalate_gates import (
     find_ungated_decisions,
 )
 from ops.work_queue.sync_queue import (
+    check_all,
     find_gate_coherence_errors,
     render_next_up_md,
     render_open_gates_md,
@@ -472,6 +473,17 @@ def test_next_up_renders_state_model_decision_gate():
     assert "| 1 | Q-0900 | Projection test queue item |" in rendered
     assert "_No decision-gated items._" not in rendered
     assert "_No open items._" in rendered
+
+
+def test_check_all_detects_source_timestamp_divergence(tmp_path):
+    generated_view = tmp_path / "NEXT_UP.md"
+    generated_view.write_text(
+        "# Next Up\n\n_Generated: `2026-07-16T00:36:36Z`_\n",
+        encoding="utf-8",
+    )
+    rendered = {generated_view: "# Next Up\n\n_Generated: `2026-08-09T23:40:00Z`_\n"}
+
+    assert check_all(rendered) is False
 
 
 def test_check_mode_returns_nonzero_for_cross_source_divergence(monkeypatch):

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -324,6 +324,17 @@ def test_state_gate_marker_is_not_masked_by_legacy_status():
     assert errors == ["queue gate Q-0900 has no canonical gate_registry.json record"]
 
 
+def test_state_gate_marker_takes_precedence_for_open_registry_gate():
+    queue = _projection_queue(
+        _projection_queue_gate(status="open", state="decision_required", tags=[])
+    )
+    registry = _projection_registry(_projection_gate())
+
+    assert find_gate_coherence_errors(queue, registry) == []
+    rendered = render_open_gates_md(queue, registry)
+    assert "`decision_required`" in rendered
+
+
 def test_open_registry_gate_rejects_non_decision_queue_status():
     queue = _projection_queue(_projection_queue_gate(status="open", tags=[]))
     registry = _projection_registry(_projection_gate())
@@ -345,6 +356,14 @@ def test_duplicate_queue_item_id_is_a_coherence_error():
     errors = find_gate_coherence_errors(queue, registry)
 
     assert errors == ["duplicate queue item id Q-0900 appears in active, completed"]
+
+
+def test_completed_queue_gate_without_registry_record_is_a_coherence_error():
+    queue = _projection_queue(completed=[_projection_queue_gate(status="done")])
+
+    errors = find_gate_coherence_errors(queue, _projection_registry())
+
+    assert errors == ["queue gate Q-0900 has no canonical gate_registry.json record"]
 
 
 def test_matching_issue_number_does_not_mask_queue_item_mismatch():

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -349,6 +349,16 @@ def test_done_status_takes_precedence_over_stale_decision_state():
     assert errors == ["GATE-900 is open while queue item Q-0900 is done"]
 
 
+def test_done_status_prevents_stale_state_from_asserting_an_unregistered_gate():
+    queue = _projection_queue(
+        completed=[
+            _projection_queue_gate(status="done", state="decision_required", tags=[])
+        ]
+    )
+
+    assert find_gate_coherence_errors(queue, _projection_registry()) == []
+
+
 def test_open_registry_gate_rejects_non_decision_queue_status():
     queue = _projection_queue(_projection_queue_gate(status="open", tags=[]))
     registry = _projection_registry(_projection_gate())

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -23,6 +23,7 @@ from ops.work_queue.escalate_gates import (
 )
 from ops.work_queue.sync_queue import (
     find_gate_coherence_errors,
+    render_next_up_md,
     render_open_gates_md,
 )
 
@@ -226,6 +227,7 @@ def _projection_queue_gate(**overrides):
     item = {
         "id": "Q-0900",
         "title": "Projection test queue item",
+        "rank": 1,
         "status": "needs-decision",
         "tags": ["gate"],
         "depends_on": [],
@@ -443,6 +445,33 @@ def test_resolved_gate_can_reference_completed_queue_item():
     )
 
     assert find_gate_coherence_errors(queue, registry) == []
+
+
+def test_resolved_gate_cannot_reference_missing_queue_item():
+    registry = _projection_registry(
+        _projection_gate(
+            queue_item="Q-missing",
+            state="resolved",
+            closed="2026-08-03",
+            resolved_by="operator",
+        )
+    )
+
+    errors = find_gate_coherence_errors(_projection_queue(), registry)
+
+    assert errors == ["GATE-900 is resolved but queue item Q-missing is missing"]
+
+
+def test_next_up_renders_state_model_decision_gate():
+    queue = _projection_queue(
+        _projection_queue_gate(status=None, state="decision_required", tags=[])
+    )
+
+    rendered = render_next_up_md(queue)
+
+    assert "| 1 | Q-0900 | Projection test queue item |" in rendered
+    assert "_No decision-gated items._" not in rendered
+    assert "_No open items._" in rendered
 
 
 def test_check_mode_returns_nonzero_for_cross_source_divergence(monkeypatch):

--- a/tests/test_gate_escalation.py
+++ b/tests/test_gate_escalation.py
@@ -191,10 +191,11 @@ def test_live_registry_and_queue_parse_and_report_cleanly():
         assert gate["integrity_status"] != "active"
 
 
-def _projection_queue(*items):
+def _projection_queue(*items, completed=None):
     return {
         "_meta": {"last_aurora_review": "2026-07-16T00:36:36Z"},
         "active": list(items),
+        "completed": list(completed or []),
     }
 
 
@@ -324,6 +325,28 @@ def test_resolved_gate_with_done_queue_item_is_not_rendered_open():
     assert find_gate_coherence_errors(queue, registry) == []
     rendered = render_open_gates_md(queue, registry)
     assert "GATE-900" not in rendered
+
+
+def test_open_gate_cannot_reference_completed_queue_item():
+    queue = _projection_queue(completed=[_projection_queue_gate(status="done")])
+    registry = _projection_registry(_projection_gate())
+
+    errors = find_gate_coherence_errors(queue, registry)
+
+    assert errors == ["GATE-900 is open while queue item Q-0900 is done"]
+
+
+def test_resolved_gate_can_reference_completed_queue_item():
+    queue = _projection_queue(completed=[_projection_queue_gate(status="done")])
+    registry = _projection_registry(
+        _projection_gate(
+            state="resolved",
+            closed="2026-08-03",
+            resolved_by="operator",
+        )
+    )
+
+    assert find_gate_coherence_errors(queue, registry) == []
 
 
 def test_check_mode_returns_nonzero_for_cross_source_divergence(monkeypatch):


### PR DESCRIPTION
## Summary

- make `gate_registry.json` the authority for human-gate projection while retaining `queue.json` for task and dependency context
- render every open registry gate, including GATE-001 as an explicit `reconciliation_required` hold with its missing queue reference visible
- add a blocking cross-source coherence check for unregistered queue gates, duplicate queue identities, active/completed lifecycle contradictions, missing resolved-gate queue references, unacknowledged missing open-gate references, and malformed resolved/open metadata
- recognize both legacy `status: needs-decision` and state-model `state: decision_required` gate markers across `OPEN_GATES.md` and `NEXT_UP.md`, including hybrid and completed records, while preserving completed-state precedence
- compare generated views exactly so canonical source-timestamp divergence is detected
- keep queue-review and registry-update dates distinct from deterministic rendering
- update queue documentation and CI remediation guidance to describe the two-source authority contract

## Root cause

`OPEN_GATES.md` was rendered only from queue items tagged `gate` or carrying `needs-decision`. Because `sync_queue.py --check` regenerated from that same single source, it could report a clean projection while omitting an open gate preserved only in the canonical gate registry.

## Impact and boundaries

- fixes #1446
- no changes to `queue.json` or `gate_registry.json`
- no gate is opened, resolved, closed, or re-ranked
- no pentest vendor, SENTINEL governance, or QGIA routing decision is made
- no L1/L2/L3 authority, GUMAS behavior, or canon state changes

## Validation

- queue/schema/ingestion/gate tests — 48 passed
- `python3 ops/work_queue/sync_queue.py --check` — all generated views current
- `python3 ops/work_queue/collect_coordination_metrics.py --check` — current
- Ruff check, format check, and McCabe complexity check — passed
- Python compile check — passed
- deterministic regeneration hashes — stable
- `git diff --check` — passed
