### PR TITLE
test: broaden root Node and web contracts

### DIFF
--- a/tests/node/crypto.test.js
+++ b/tests/node/crypto.test.js
@@ -1,22 +1,71 @@
-import test from 'node:test';
+import test, { after } from 'node:test';
 import assert from 'node:assert/strict';
 import { randomBytes } from 'node:crypto';
 
 import {
   decryptPayload,
   encryptPayload,
+  isEncryptionAvailable,
 } from '../../src/core/command_node/encryption.js';
 
-if (!process.env.AES_KEY_256_HEX) {
-  process.env.AES_KEY_256_HEX = randomBytes(32).toString('hex');
-}
+const originalEncryptionKey = process.env.AES_KEY_256_HEX;
+process.env.AES_KEY_256_HEX = randomBytes(32).toString('hex');
+
+after(() => {
+  if (originalEncryptionKey === undefined) {
+    delete process.env.AES_KEY_256_HEX;
+  } else {
+    process.env.AES_KEY_256_HEX = originalEncryptionKey;
+  }
+});
 
 test('encrypt/decrypt round trip uses AES-256 key material', () => {
-  const payload = { message: 'Encryption test string' };
+  const payload = {
+    message: 'Encryption test string',
+    metadata: { anchor: 'T1', sequence: 7 },
+  };
   const encrypted = encryptPayload(payload);
   const decrypted = decryptPayload(encrypted);
 
+  assert.equal(isEncryptionAvailable(), true);
   assert.deepEqual(decrypted, payload);
   assert.match(encrypted.iv, /^[0-9a-f]{32}$/i);
   assert.match(encrypted.data, /^[0-9a-f]+$/i);
+});
+
+test('encrypting the same payload uses a fresh IV', () => {
+  const payload = { message: 'repeatable plaintext' };
+  const first = encryptPayload(payload);
+  const second = encryptPayload(payload);
+
+  assert.notEqual(first.iv, second.iv);
+  assert.notEqual(first.data, second.data);
+});
+
+test('malformed ciphertext is rejected', () => {
+  const encrypted = encryptPayload({ message: 'protected payload' });
+
+  assert.throws(
+    () => decryptPayload({ ...encrypted, data: '00' }),
+    /bad decrypt|wrong final block length/i
+  );
+});
+
+test('encryption fails closed when key material is absent', () => {
+  const testKey = process.env.AES_KEY_256_HEX;
+  delete process.env.AES_KEY_256_HEX;
+
+  try {
+    assert.equal(isEncryptionAvailable(), false);
+    assert.throws(
+      () => encryptPayload({ message: 'must not encrypt' }),
+      /AES_KEY_256_HEX missing or invalid/
+    );
+    assert.throws(
+      () => decryptPayload({ iv: '00'.repeat(16), data: '00' }),
+      /AES_KEY_256_HEX missing or invalid/
+    );
+  } finally {
+    process.env.AES_KEY_256_HEX = testKey;
+  }
 });

--- a/tests/node/crypto.test.js
+++ b/tests/node/crypto.test.js
@@ -9,13 +9,19 @@ import {
 } from '../../src/core/command_node/encryption.js';
 
 const originalEncryptionKey = process.env.AES_KEY_256_HEX;
-process.env.AES_KEY_256_HEX = randomBytes(32).toString('hex');
+const replacedEncryptionKey = !/^[0-9a-f]{64}$/i.test(originalEncryptionKey ?? '');
+
+if (replacedEncryptionKey) {
+  process.env.AES_KEY_256_HEX = randomBytes(32).toString('hex');
+}
 
 after(() => {
-  if (originalEncryptionKey === undefined) {
-    delete process.env.AES_KEY_256_HEX;
-  } else {
-    process.env.AES_KEY_256_HEX = originalEncryptionKey;
+  if (replacedEncryptionKey) {
+    if (originalEncryptionKey === undefined) {
+      delete process.env.AES_KEY_256_HEX;
+    } else {
+      process.env.AES_KEY_256_HEX = originalEncryptionKey;
+    }
   }
 });
 

--- a/tests/web/test-web-components.js
+++ b/tests/web/test-web-components.js
@@ -1,108 +1,132 @@
 /**
- * Aurora CloudBank Web Interface Tests
- * Basic tests for web components and API endpoints
+ * Aurora CloudBank browser utility tests.
+ *
+ * The harness supplies only the browser primitives used by the maintained
+ * static modules; assertions exercise those modules directly.
  */
-/* eslint-env browser */
-/* global document */
-import { mock } from 'node:test';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const projectRoot = path.resolve(__dirname, '../..');
+function createMockElement(tagName) {
+  const attributes = new Map();
 
-// Mock DOM globals for testing
+  return {
+    tagName: tagName.toUpperCase(),
+    textContent: '',
+    innerHTML: '',
+    setAttribute(name, value) {
+      attributes.set(name, value);
+    },
+    getAttribute(name) {
+      return attributes.get(name) ?? null;
+    },
+    removeAttribute(name) {
+      attributes.delete(name);
+    },
+  };
+}
+
+const storageData = new Map();
+
 global.window = {
   location: { host: 'localhost:8000', origin: 'http://localhost:8000' },
-  performance: { now: () => Date.now() },
-  addEventListener: () => {},
-  WebSocket: class MockWebSocket {
-    constructor(url) { this.url = url; this.readyState = 1; }
-    send() {}
-    close() {}
-  }
+  performance: { now: () => 42 },
+  addEventListener: mock.fn(),
 };
 
 global.document = {
-  getElementById: () => ({ 
-    value: 'test-value',
-    textContent: '',
-    appendChild: () => {},
-    scrollTop: 0,
-    scrollHeight: 100
-  }),
-  createElement: () => ({
-    className: '',
-    textContent: '',
-    style: {},
-    appendChild: () => {},
-    title: '',
-    setAttribute: () => {},
-    removeAttribute: () => {}
-  }),
-  createTextNode: (text) => ({ textContent: text }),
-  createDocumentFragment: () => ({ appendChild: () => {} }),
-  createTreeWalker: () => ({ nextNode: () => null }),
-  addEventListener: () => {}
+  createElement: createMockElement,
 };
 
 global.localStorage = {
-  data: {},
-  getItem: function(key) { return this.data[key] || null; },
-  setItem: function(key, value) { this.data[key] = value; },
-  removeItem: function(key) { delete this.data[key]; }
+  getItem(key) {
+    return storageData.get(key) ?? null;
+  },
+  setItem(key, value) {
+    storageData.set(key, value);
+  },
+  removeItem(key) {
+    storageData.delete(key);
+  },
+  clear() {
+    storageData.clear();
+  },
 };
 
-global.fetch = mock.fn(() => Promise.resolve({
-  ok: true,
-  json: () => Promise.resolve({ status: 'success' })
-}));
+global.fetch = mock.fn(async () => ({ ok: true }));
 
-global.NodeFilter = {
-  SHOW_ELEMENT: 1,
-  FILTER_ACCEPT: 1,
-  FILTER_REJECT: 2
-};
+test('maintained browser utilities expose and enforce their contracts', async t => {
+  await import('../../static/js/aurora-security.js');
+  await import('../../static/js/aurora-web-logger.js');
 
-/**
- * Enhanced multi-pass sanitization for security
- * 
- * This function implements defense-in-depth sanitization:
- * - Removes control characters (null bytes, carriage returns, etc.)
- * - Strips script tags and JavaScript protocols
- * - Removes event handler attributes
- * - Uses replaceAll() for reliable, complete replacements
- * - Employs iterative sanitization to prevent bypass attempts
- * 
- * @param {string} input - The input string to sanitize
- * @returns {string} The sanitized string, truncated to 1000 characters
- */
-function sanitizeInput(input) {
-  if (typeof input !== 'string') return '';
-  
-  let sanitized = input;
-  let previousLength;
-  
-  // SECURITY: Repeat sanitization until no more changes occur
-  // This prevents bypass via nested patterns like <scr<script>ipt>
-  do {
-    previousLength = sanitized.length;
-    
-    // Remove control characters and potential XSS vectors
-    sanitized = sanitized
-      // Control characters: Remove ASCII control chars (0x00-0x1F) and 
-      // extended control chars (0x7F-0x9F) which can be used to hide malicious
-      // content or bypass filters (null bytes, carriage returns, line feeds, etc.)
-      .replace(/[\x00-\x1f\x7f-\x9f]/g, '')
-      // Script tags: Remove all script tags and their content
-      .replace(/<script[^>]*>.*?<\/script>/gi, '')
-      // JavaScript protocol: Remove javascript: pseudo-protocol from URLs
-      .replace(/javascript:/gi, '')
-      // Event handlers: Remove inline event handler attributes (onclick, onload, etc.)
-      .replace(/on\w+\s*=/gi, '');
-  } while (sanitized.length !== previousLength);
-  
-  // Truncate to reasonable length to prevent DoS
-  return sanitized.substring(0, 1000);
-}
+  const security = global.window.AuroraSecurity;
+  const AuroraWebLogger = global.window.AuroraWebLogger;
+
+  await t.test('modules register their browser APIs', () => {
+    assert.ok(security);
+    assert.equal(typeof AuroraWebLogger, 'function');
+  });
+
+  await t.test('HTML-sensitive characters are escaped', () => {
+    assert.equal(
+      security.escapeHtml('<script>alert("x")</script>'),
+      '&lt;script&gt;alert(&quot;x&quot;)&lt;&#x2F;script&gt;'
+    );
+  });
+
+  await t.test('unsafe control characters are removed from display text', () => {
+    assert.equal(security.sanitizeText('anchor\u0000-safe\u007f'), 'anchor-safe');
+    assert.equal(security.sanitizeText({ message: 'not text' }), '');
+  });
+
+  await t.test('safe elements use text content and reject event attributes', () => {
+    const element = security.createSafeElement('button', '<b>Launch</b>', {
+      class: 'primary',
+      onclick: 'launch()',
+    });
+
+    assert.equal(element.textContent, '<b>Launch</b>');
+    assert.equal(element.getAttribute('class'), 'primary');
+    assert.equal(element.getAttribute('onclick'), null);
+  });
+
+  await t.test('WebSocket payloads are normalized without executing markup', () => {
+    assert.deepEqual(
+      security.sanitizeWebSocketData('{"message":"safe\\u0000text","count":2}'),
+      { message: 'safetext', count: 2 }
+    );
+    assert.match(
+      security.sanitizeWebSocketData('{not-json').error,
+      /Invalid JSON data/
+    );
+  });
+
+  await t.test('logger bounds its in-memory and persisted history', () => {
+    global.localStorage.clear();
+    const logger = new AuroraWebLogger('TEST_COMPONENT', {
+      console: false,
+      maxStorageEntries: 2,
+    });
+
+    logger.info('first');
+    logger.warn('second');
+    logger.error('third');
+
+    assert.deepEqual(logger.logBuffer.map(entry => entry.message), ['second', 'third']);
+    assert.deepEqual(
+      logger.getStoredLogs().map(entry => entry.message),
+      ['second', 'third']
+    );
+  });
+
+  await t.test('logger honors configured severity thresholds', () => {
+    const logger = new AuroraWebLogger('TEST_COMPONENT', {
+      console: false,
+      storage: false,
+      level: 'WARN',
+    });
+
+    assert.equal(logger.shouldLog('INFO'), false);
+    assert.equal(logger.shouldLog('ERROR'), true);
+  });
+});


### PR DESCRIPTION
## Summary

- replace the zero-assertion web harness with direct tests of the maintained browser security and logging modules
- expand the CommandNode encryption tests to cover nested payloads, fresh IVs, malformed ciphertext, and missing-key fail-closed behavior
- keep the existing root npm commands and Node test workflow unchanged because they already target the maintained paths

## Root cause

The root command repair from #1349 restored executable paths, but later history left `tests/web/test-web-components.js` with mocks and a duplicated sanitizer and no registered tests. The historical `crypto_refactored.js` test target was deleted during repository consolidation; the maintained replacement is `src/core/command_node/encryption.js`, already used by the current root crypto test.

## Impact

`npm run test:web` now executes eight assertions against production browser modules instead of completing with zero assertions. The maintained crypto replacement has four explicit contract tests. No legacy crypto module is restored.

## Validation

- `npm run test:node` — 54 passed
- `npm run test:web` — 8 passed
- `npx eslint tests/node/crypto.test.js tests/web/test-web-components.js`
- `git diff --check`

Local validation used Node 26.5.0; the repository and GitHub workflow remain pinned to Node 22.x.

Refs #1362