### PR TITLE
ci: enforce PR evaluation failures

### DIFF
--- a/.github/workflows/pr_evaluation.yml
+++ b/.github/workflows/pr_evaluation.yml
@@ -144,11 +144,10 @@ jobs:
             });
           }
 
-    - name: Check evaluation status (advisory; tracked in #1342)
+    - name: Enforce evaluation status
       if: steps.detect.outputs.should_run == 'true' && steps.evaluate.outputs.exit_code != '0'
-      continue-on-error: true
       run: |
-        echo "PR evaluation found issues. Review the artifact and #1342 before merge."
+        echo "PR evaluation found blocking issues. Review the artifact before merge."
         exit 1
 
     - name: Skip summary


### PR DESCRIPTION
## Summary

- make a nonzero PR Evaluator result fail the `PR Evaluation` job
- preserve the existing evaluator evidence artifact and PR comment before enforcement
- remove the remaining advisory `continue-on-error` behavior

## Root cause

PR #1407 completed the substantive #1342 repairs: diff-scoped Python evidence, declared CI dependencies, bounded changed-test execution, real PR-head traceability, JSON evidence, and dedicated unit tests. The workflow still labelled the final status step advisory and masked its deliberate `exit 1`, so evaluation findings could not block a merge.

## Impact

A changed syntax error, critical lint error, or other evaluator failure now makes the workflow red after its artifact and actionable comment are preserved. Passing and out-of-scope PR behavior is unchanged.

## Validation

- `tests/test_pr_evaluator.py` — 13 passed
- workflow YAML parsed successfully with PyYAML
- `git diff --check`

`actionlint` was not installed in the local environment; GitHub workflow execution remains the authoritative workflow validation.

Refs #1342