### PR TITLE
fix(ai): separate catalog availability from routing policy

### DIFF
--- a/.github/workflows/model-catalog-validation.yml
+++ b/.github/workflows/model-catalog-validation.yml
@@ -50,16 +50,18 @@ jobs:
         with:
           python-version: '3.12'
 
-      # Only the anthropic SDK: this job's whole purpose is the live provider
-      # call, and installing the full application set would couple it to a lock
-      # it does not need.
+      # Only the Anthropic SDK plus the metrics dependency imported by the
+      # catalog module: installing the full application set would couple this
+      # focused job to a lock it does not need.
       #
       # Pinned exactly, matching requirements-ci-hashed.txt. An unpinned floor
       # here would be the same class of hole #1366 closed everywhere else, and
       # SonarCloud rightly flagged the first version of this file for it.
       - name: Install validator dependency
         run: |
-          python -m pip install --only-binary=:all: 'anthropic==0.107.1'
+          python -m pip install --only-binary=:all: \
+            'anthropic==0.107.1' \
+            'prometheus-client==0.26.0'
 
       # NOTE: the offline guardrails (tests/test_model_catalog_freshness.py)
       # deliberately do NOT run here. They need no secret and already run in
@@ -69,8 +71,8 @@ jobs:
       # them, and failed: the root conftest.py imports fastapi, which this
       # job does not install.
 
-      # Exits 0 with a visible SKIPPED notice when the secret is absent, so a
-      # missing key never reads as a verified catalog.
+      # Fails closed when the secret is absent: a live check that did not run
+      # must not display as a green catalog validation.
       - name: Validate against provider catalog
         id: validate
         env:

--- a/modules/ai_core/unified_ai_interface.py
+++ b/modules/ai_core/unified_ai_interface.py
@@ -428,8 +428,13 @@ class UnifiedAIInterface:
         status_code = getattr(error, "status_code", None)
         if status_code is None:
             status_code = getattr(getattr(error, "response", None), "status_code", None)
+        if status_code is not None:
+            return status_code == 404
         detail = str(error).lower()
-        return status_code == 404 or "404" in detail or "not_found" in detail
+        return any(
+            marker in detail
+            for marker in ("model_not_found", "model not found", "not_found_error")
+        )
 
     @classmethod
     def _alert_on_model_not_found(

--- a/modules/ai_core/unified_ai_interface.py
+++ b/modules/ai_core/unified_ai_interface.py
@@ -18,7 +18,15 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from prometheus_client import Counter
+
 logger = logging.getLogger(__name__)
+
+MODEL_PROVIDER_NOT_FOUND_TOTAL = Counter(
+    "aurora_ai_model_provider_not_found_total",
+    "Provider model-not-found responses observed before AI fallback",
+    ("provider", "model"),
+)
 
 
 class AIProvider(Enum):
@@ -35,10 +43,11 @@ class AIModel(Enum):
 
     Identifiers tagged "UNVERIFIED placeholder" below are aspirational and are
     NOT confirmed against the provider's live catalog. They are gated by
-    ``available=False`` in ``CAPABILITIES`` so they can never be selected
-    through the public interface (see ``select_optimal_model``). Promote one to
-    a live identifier only after confirming it against the provider catalog and
-    flipping its ``available`` flag in the same change.
+    ``available=False`` and ``enabled=False`` in ``CAPABILITIES`` so they can
+    never be selected through the public interface (see
+    ``select_optimal_model``). Promote one to a live identifier only after
+    confirming it against the provider catalog and recording a dated source;
+    routing policy can then enable it independently.
 
     A "Verified live" tag means the identifier was checked against the
     provider's own catalog on the reconciliation date above — not that it was
@@ -79,7 +88,11 @@ class ModelCapabilities:
     mathematical_strength: int = 5  # 1-10 scale
     cost_per_1k_tokens: float = 0.0  # USD
     latency_avg_ms: int = 1000
+    # Provider/catalog fact: this identifier exists and has a dated source.
     available: bool = True
+    # Local routing policy: operators may disable a verified model without
+    # erasing the catalog fact that it exists.
+    enabled: bool = True
 
     # Machine-readable verification claim, replacing the "# Verified live"
     # comment convention. A comment is a *claim*; nothing can falsify it, which
@@ -99,6 +112,11 @@ class ModelCapabilities:
     # numbers no API can confirm.
     verified_on: str = ""
     verified_source: str = "unverified"
+
+    @property
+    def routable(self) -> bool:
+        """Whether live selection may route traffic to this model."""
+        return self.available and self.enabled
 
 
 @dataclass
@@ -226,6 +244,7 @@ class UnifiedAIInterface:
             cost_per_1k_tokens=0.02,  # Expected pricing
             latency_avg_ms=1000,
             available=False,  # Not yet released
+            enabled=False,
             verified_on="",
             verified_source="unverified",
         ),
@@ -243,6 +262,7 @@ class UnifiedAIInterface:
             cost_per_1k_tokens=0.025,  # Expected pricing
             latency_avg_ms=900,
             available=False,  # Not yet released
+            enabled=False,
             verified_on="",
             verified_source="unverified",
         ),
@@ -285,8 +305,8 @@ class UnifiedAIInterface:
         #
         # CAPABILITIES is declared at class level, so every instance shared one
         # dict and enable_model()/disable_model() mutated it process-wide: one
-        # caller ungating a model ungated it for every other caller, including
-        # the IDs deliberately shipped as available=False unverified
+        # caller changing routing policy changed it for every other caller,
+        # including the IDs deliberately shipped as unavailable, unverified
         # placeholders. A gate that any instance can silently open for all the
         # others is not a gate.
         #
@@ -338,8 +358,8 @@ class UnifiedAIInterface:
 
         # Try OpenAI
         try:
-            import openai
             import httpx
+            import openai
 
             _TIMEOUT = httpx.Timeout(connect=5.0, read=60.0, write=10.0, pool=60.0)
             _MAX_RETRIES = 2
@@ -355,13 +375,12 @@ class UnifiedAIInterface:
         except Exception as e:
             logger.warning(f"⚠️  OpenAI client initialization failed: {e}")
 
-        # Surface the active model catalog so operators can verify which IDs are
-        # actually selectable (available=True) versus gated placeholders.
-        active = [model.value for model, caps in self.CAPABILITIES.items() if caps.available]
-        gated = [model.value for model, caps in self.CAPABILITIES.items() if not caps.available]
-        logger.info("🧭 Active AI models (available=True): %s", ", ".join(active) or "none")
+        # Surface routing state separately from provider/catalog existence.
+        active = [model.value for model, caps in self.CAPABILITIES.items() if caps.routable]
+        gated = [model.value for model, caps in self.CAPABILITIES.items() if not caps.routable]
+        logger.info("🧭 Routable AI models (available and enabled): %s", ", ".join(active) or "none")
         if gated:
-            logger.info("🚧 Gated AI models (available=False, not selectable): %s", ", ".join(gated))
+            logger.info("🚧 Gated AI models (unavailable or disabled): %s", ", ".join(gated))
 
     async def select_optimal_model(
         self, request: AIRequest, task_type: str = "general"
@@ -376,32 +395,62 @@ class UnifiedAIInterface:
         Returns:
             Selected AI model
         """
-        # Use explicit preference if provided and available
+        # Use explicit preference if provided and routable
         if request.model_preference:
             caps = self.CAPABILITIES.get(request.model_preference)
-            if caps and caps.available:
+            if caps and caps.routable:
                 return request.model_preference
 
         # Use fallback chain if provided
         if request.fallback_chain:
             for model in request.fallback_chain:
                 caps = self.CAPABILITIES.get(model)
-                if caps and caps.available:
+                if caps and caps.routable:
                     return model
 
         # Use task-specific fallback chain
         fallback = self.FALLBACK_CHAINS.get(task_type, self.FALLBACK_CHAINS["general"])
         for model in fallback:
             caps = self.CAPABILITIES.get(model)
-            if caps and caps.available:
+            if caps and caps.routable:
                 return model
 
-        # Final fallback to any available model
+        # Final fallback to any routable model
         for model, caps in self.CAPABILITIES.items():
-            if caps.available:
+            if caps.routable:
                 return model
 
-        raise RuntimeError("No AI models available")
+        raise RuntimeError("No AI models available and enabled")
+
+    @staticmethod
+    def _is_model_not_found(error: Exception) -> bool:
+        """Recognize provider model-not-found failures across SDK shapes."""
+        status_code = getattr(error, "status_code", None)
+        if status_code is None:
+            status_code = getattr(getattr(error, "response", None), "status_code", None)
+        detail = str(error).lower()
+        return status_code == 404 or "404" in detail or "not_found" in detail
+
+    @classmethod
+    def _alert_on_model_not_found(
+        cls,
+        model: AIModel,
+        caps: ModelCapabilities,
+        error: Exception,
+    ) -> None:
+        """Emit an operator-visible metric and log before attempting fallback."""
+        if not cls._is_model_not_found(error):
+            return
+        MODEL_PROVIDER_NOT_FOUND_TOTAL.labels(
+            provider=caps.provider.value,
+            model=model.value,
+        ).inc()
+        logger.critical(
+            "MODEL CATALOG ALERT: provider returned 404/not-found for enabled "
+            "model %s (%s); attempting fallback",
+            model.value,
+            caps.provider.value,
+        )
 
     async def execute_request(
         self, request: AIRequest, task_type: str = "general"
@@ -457,6 +506,7 @@ class UnifiedAIInterface:
 
         except Exception as e:
             logger.error(f"Model {model.value} failed: {e}")
+            self._alert_on_model_not_found(model, caps, e)
 
             # Try fallback chain
             fallback = request.fallback_chain or self.FALLBACK_CHAINS.get(
@@ -468,7 +518,7 @@ class UnifiedAIInterface:
                     continue  # Skip the failed model
 
                 fallback_caps = self.CAPABILITIES.get(fallback_model)
-                if not fallback_caps or not fallback_caps.available:
+                if not fallback_caps or not fallback_caps.routable:
                     continue
 
                 if attempt > 0:
@@ -498,6 +548,11 @@ class UnifiedAIInterface:
 
                 except Exception as fallback_error:
                     logger.error(f"Fallback model {fallback_model.value} failed: {fallback_error}")
+                    self._alert_on_model_not_found(
+                        fallback_model,
+                        fallback_caps,
+                        fallback_error,
+                    )
                     continue
 
             # All models failed
@@ -594,19 +649,25 @@ class UnifiedAIInterface:
         return self.CAPABILITIES[model]
 
     def get_available_models(self) -> List[AIModel]:
-        """Get list of currently available models"""
-        return [model for model, caps in self.CAPABILITIES.items() if caps.available]
+        """Get models that both exist in the provider catalog and are enabled."""
+        return [model for model, caps in self.CAPABILITIES.items() if caps.routable]
 
     def enable_model(self, model: AIModel):
-        """Enable a model (e.g., when a gated placeholder like GPT-5 becomes available)"""
-        if model in self.CAPABILITIES:
-            self.CAPABILITIES[model].available = True
-            logger.info(f"✅ Model {model.value} enabled")
+        """Enable routing for a model whose provider existence is verified."""
+        if model not in self.CAPABILITIES:
+            return
+        caps = self.CAPABILITIES[model]
+        if not caps.available or not caps.verified_on or caps.verified_source == "unverified":
+            raise ValueError(
+                f"Cannot enable unverified or provider-unavailable model: {model.value}"
+            )
+        caps.enabled = True
+        logger.info(f"✅ Model {model.value} enabled")
 
     def disable_model(self, model: AIModel):
-        """Disable a model (e.g., for maintenance or cost control)"""
+        """Disable routing without erasing the provider/catalog fact."""
         if model in self.CAPABILITIES:
-            self.CAPABILITIES[model].available = False
+            self.CAPABILITIES[model].enabled = False
             logger.info(f"⚠️  Model {model.value} disabled")
 
 

--- a/scripts/validate_model_catalog.py
+++ b/scripts/validate_model_catalog.py
@@ -6,7 +6,7 @@
 every Anthropic call 404'd and quietly fell back to GPT-4o. A single
 `client.models.retrieve(...)` would have caught it the day it was written.
 
-This script performs that check for every selectable Anthropic entry in
+This script performs that check for every provider-available Anthropic entry in
 ``UnifiedAIInterface.CAPABILITIES``:
 
 * the identifier resolves (a 404 fails, distinguishing retired from typo);
@@ -22,13 +22,14 @@ What this CANNOT check, and must not be claimed to:
   returns no context window, so OpenAI entries are existence-only.
 * **Bedrock / Vertex / Foundry.** No Models API; not routed through today.
 
-Requires ANTHROPIC_API_KEY. The Models endpoint bills no tokens. Without the
-key the script exits 0 with a SKIPPED notice rather than a false pass — a
-missing secret must not read as a green catalog.
+Requires ANTHROPIC_API_KEY. The Models endpoint bills no tokens. A missing key
+or validator dependency fails closed: a check that did not run must not read as
+a green catalog.
 
 Exit codes:
-    0 - all checked entries agree with the provider catalog (or skipped)
+    0 - all checked entries agree with the provider catalog
     1 - a mismatch or unresolvable identifier was found
+    2 - validation could not run because its key or dependency is missing
 """
 
 from __future__ import annotations
@@ -106,7 +107,7 @@ def compare_entry(
 
 
 def anthropic_entries() -> List[Any]:
-    """Selectable Anthropic entries — the ones live traffic can reach."""
+    """Anthropic entries that claim to exist in the provider catalog."""
     return [
         cap
         for cap in UnifiedAIInterface.CAPABILITIES.values()
@@ -131,17 +132,21 @@ def fetch_remote(client: Any, model_id: str) -> Optional[Dict[str, Any]]:
 def main() -> int:
     if not os.environ.get("ANTHROPIC_API_KEY"):
         print(
-            "SKIPPED: ANTHROPIC_API_KEY is not set, so the catalog was not "
-            "checked against the provider. This is not a pass — wire the "
-            "secret to make this check meaningful (#1329)."
+            "ERROR: ANTHROPIC_API_KEY is not set, so the catalog could not be "
+            "checked against the provider (#1329).",
+            file=sys.stderr,
         )
-        return 0
+        return 2
 
     try:
         from anthropic import Anthropic
     except ImportError:
-        print("SKIPPED: the anthropic package is not installed.")
-        return 0
+        print(
+            "ERROR: the anthropic package is not installed; live catalog "
+            "validation could not run.",
+            file=sys.stderr,
+        )
+        return 2
 
     client = Anthropic()
     entries = anthropic_entries()

--- a/tests/test_model_catalog_freshness.py
+++ b/tests/test_model_catalog_freshness.py
@@ -38,6 +38,11 @@ CATALOG = UnifiedAIInterface.CAPABILITIES
 
 
 def selectable_entries():
+    return [(model, cap) for model, cap in CATALOG.items() if cap.routable]
+
+
+def available_entries():
+    """Entries that claim provider existence, independent of routing policy."""
     return [(model, cap) for model, cap in CATALOG.items() if cap.available]
 
 
@@ -59,29 +64,43 @@ def test_selectable_models_carry_a_dated_claim():
     """A model we will actually route to must say when it was last checked."""
     for model, cap in selectable_entries():
         assert cap.verified_on, (
-            f"{model.name} is selectable (available=True) but carries no "
+            f"{model.name} is routable (available=True, enabled=True) but carries no "
             f"verified_on date. An unverifiable claim is what #1329 removed."
         )
         datetime.strptime(cap.verified_on, "%Y-%m-%d")  # raises if malformed
 
 
-def test_selectable_models_are_not_marked_unverified():
-    """available=True and verified_source='unverified' is a contradiction."""
-    for model, cap in selectable_entries():
+def test_available_models_are_not_marked_unverified():
+    """Provider availability and an unverified source are contradictory."""
+    for model, cap in available_entries():
         assert cap.verified_source != "unverified", (
             f"{model.name} is selectable but its source is 'unverified'. "
             f"Either verify it against the provider catalog or set available=False."
         )
 
 
-def test_unverified_models_are_not_selectable():
+def test_unverified_models_are_unavailable_and_disabled():
     """The gate that kept the fabricated ID inert must stay closed."""
     for model, cap in CATALOG.items():
         if cap.verified_source == "unverified" or not cap.verified_on:
             assert not cap.available, (
-                f"{model.name} has no verification claim but is selectable. "
+                f"{model.name} has no verification claim but claims provider availability. "
                 f"This is exactly the state that routed live traffic to a "
                 f"retired model in #1329."
+            )
+            assert not cap.enabled, (
+                f"{model.name} has no verification claim but routing is enabled."
+            )
+
+
+def test_enabled_models_are_provider_available_and_verified():
+    """Routing policy cannot override provider existence or verification."""
+    for model, cap in CATALOG.items():
+        if cap.enabled:
+            assert cap.available, f"{model.name} is enabled but provider-unavailable"
+            assert cap.verified_on, f"{model.name} is enabled without a verification date"
+            assert cap.verified_source != "unverified", (
+                f"{model.name} is enabled with an unverified source"
             )
 
 
@@ -96,7 +115,7 @@ def test_verification_claims_are_not_stale():
     """
     today = date.today()
     stale = []
-    for model, cap in selectable_entries():
+    for model, cap in available_entries():
         age = (today - datetime.strptime(cap.verified_on, "%Y-%m-%d").date()).days
         if age > MAX_CLAIM_AGE_DAYS:
             stale.append(f"{model.name} ({cap.model.value}): {age} days old")

--- a/tests/test_model_catalog_freshness.py
+++ b/tests/test_model_catalog_freshness.py
@@ -74,7 +74,7 @@ def test_available_models_are_not_marked_unverified():
     """Provider availability and an unverified source are contradictory."""
     for model, cap in available_entries():
         assert cap.verified_source != "unverified", (
-            f"{model.name} is selectable but its source is 'unverified'. "
+            f"{model.name} claims provider availability but its source is 'unverified'. "
             f"Either verify it against the provider catalog or set available=False."
         )
 

--- a/tests/test_unified_ai_interface.py
+++ b/tests/test_unified_ai_interface.py
@@ -566,6 +566,14 @@ class TestAIIntegrationErrorHandling:
         assert "MODEL CATALOG ALERT" in caplog.text
         assert AIModel.CLAUDE_OPUS_5.value in caplog.text
 
+    def test_not_found_detection_rejects_unrelated_404_text(self):
+        assert UnifiedAIInterface._is_model_not_found(
+            RuntimeError("processed 404 tokens")
+        ) is False
+        assert UnifiedAIInterface._is_model_not_found(
+            RuntimeError("provider says model_not_found")
+        ) is True
+
     @pytest.mark.asyncio
     async def test_all_models_unavailable(self):
         """Test behavior when all models are unavailable."""

--- a/tests/test_unified_ai_interface.py
+++ b/tests/test_unified_ai_interface.py
@@ -5,11 +5,13 @@ Tests model selection, fallback chains, and integration
 """
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from modules.ai_core.unified_ai_interface import (
+    MODEL_PROVIDER_NOT_FOUND_TOTAL,
     AIModel,
     AIProvider,
     AIRequest,
@@ -20,20 +22,20 @@ from modules.ai_core.unified_ai_interface import (
 
 
 @pytest.fixture(autouse=True)
-def restore_model_availability():
-    """Restore the shipped ``available`` flags after every test.
+def restore_model_catalog_gates():
+    """Restore the shipped catalog and routing flags after every test.
 
-    ``UnifiedAIInterface.CAPABILITIES`` is a class attribute, so every instance
-    (including the module-level ``unified_ai`` singleton) shares one dict.
-    Tests that flip availability would otherwise leak into later tests and make
-    assertions about shipped defaults order-dependent.
+    Instances deep-copy the class catalog, but guarding the class defaults here
+    also protects future tests that deliberately exercise those defaults.
     """
     original = {
-        model: caps.available for model, caps in UnifiedAIInterface.CAPABILITIES.items()
+        model: (caps.available, caps.enabled)
+        for model, caps in UnifiedAIInterface.CAPABILITIES.items()
     }
     yield
-    for model, available in original.items():
+    for model, (available, enabled) in original.items():
         UnifiedAIInterface.CAPABILITIES[model].available = available
+        UnifiedAIInterface.CAPABILITIES[model].enabled = enabled
 
 
 @pytest.mark.unit
@@ -114,6 +116,7 @@ class TestUnifiedAIInterface:
         # Make all models available
         for model in interface.CAPABILITIES:
             interface.CAPABILITIES[model].available = True
+            interface.CAPABILITIES[model].enabled = True
 
         request = AIRequest(prompt="test")
 
@@ -126,31 +129,45 @@ class TestUnifiedAIInterface:
         assert selected_reasoning == AIModel.CLAUDE_OPUS_5  # First in reasoning chain
 
     def test_get_available_models(self):
-        """Test getting list of available models"""
+        """The compatibility API returns only available and enabled models."""
         interface = UnifiedAIInterface()
 
         # Set some models as available
         interface.CAPABILITIES[AIModel.GPT_4O].available = True
+        interface.CAPABILITIES[AIModel.GPT_4O].enabled = False
         interface.CAPABILITIES[AIModel.CLAUDE_SONNET_5].available = True
         interface.CAPABILITIES[AIModel.GPT_5].available = False
 
         available = interface.get_available_models()
 
-        assert AIModel.GPT_4O in available
+        assert AIModel.GPT_4O not in available
         assert AIModel.CLAUDE_SONNET_5 in available
         assert AIModel.GPT_5 not in available
 
     def test_enable_disable_models(self):
-        """Test runtime model enable/disable"""
+        """Routing policy changes do not rewrite provider availability."""
+        interface = UnifiedAIInterface()
+        model = AIModel.GPT_4O
+
+        interface.disable_model(model)
+        assert interface.CAPABILITIES[model].available
+        assert not interface.CAPABILITIES[model].enabled
+        assert not interface.CAPABILITIES[model].routable
+
+        interface.enable_model(model)
+        assert interface.CAPABILITIES[model].available
+        assert interface.CAPABILITIES[model].enabled
+        assert interface.CAPABILITIES[model].routable
+
+    def test_unverified_model_cannot_be_enabled(self):
+        """Local routing policy cannot promote an unverified catalog entry."""
         interface = UnifiedAIInterface()
 
-        # Disable GPT-5
-        interface.disable_model(AIModel.GPT_5)
-        assert not interface.CAPABILITIES[AIModel.GPT_5].available
+        with pytest.raises(ValueError, match="unverified or provider-unavailable"):
+            interface.enable_model(AIModel.GPT_5)
 
-        # Enable GPT-5
-        interface.enable_model(AIModel.GPT_5)
-        assert interface.CAPABILITIES[AIModel.GPT_5].available
+        assert not interface.CAPABILITIES[AIModel.GPT_5].available
+        assert not interface.CAPABILITIES[AIModel.GPT_5].enabled
 
     def test_aspirational_models_default_unavailable(self):
         """Aspirational placeholder IDs must ship gated (available=False)."""
@@ -161,6 +178,7 @@ class TestUnifiedAIInterface:
                 f"{model.value} is an unverified placeholder and must default to "
                 "available=False"
             )
+            assert interface.CAPABILITIES[model].enabled is False
 
     def test_claude_models_are_current_catalog_ids(self):
         """Claude entries must carry live, date-suffix-free catalog IDs and be
@@ -187,6 +205,7 @@ class TestUnifiedAIInterface:
             assert interface.CAPABILITIES[model].available is True, (
                 f"{model.value} is verified live and must be selectable"
             )
+            assert interface.CAPABILITIES[model].routable is True
 
         assert AIModel.CLAUDE_OPUS_5.value == "claude-opus-5"
         assert AIModel.CLAUDE_SONNET_5.value == "claude-sonnet-5"
@@ -499,6 +518,55 @@ class TestAIIntegrationErrorHandling:
         assert selected == AIModel.CLAUDE_SONNET_5
 
     @pytest.mark.asyncio
+    async def test_provider_404_alerts_before_successful_fallback(self, caplog):
+        """An enabled model disappearing must be observable, even if fallback works."""
+
+        class ModelNotFoundError(RuntimeError):
+            status_code = 404
+
+        interface = UnifiedAIInterface()
+        interface._budget = None
+        request = AIRequest(
+            prompt="test",
+            model_preference=AIModel.CLAUDE_OPUS_5,
+            fallback_chain=[AIModel.GPT_4O],
+        )
+        fallback_response = AIResponse(
+            content="fallback worked",
+            model_used=AIModel.GPT_4O,
+            provider=AIProvider.OPENAI,
+            tokens_used=5,
+            latency_ms=10,
+        )
+        metric = MODEL_PROVIDER_NOT_FOUND_TOTAL.labels(
+            provider=AIProvider.ANTHROPIC.value,
+            model=AIModel.CLAUDE_OPUS_5.value,
+        )
+        before = metric._value.get()
+
+        with caplog.at_level(logging.CRITICAL):
+            with (
+                patch.object(
+                    interface,
+                    "_execute_anthropic",
+                    new_callable=AsyncMock,
+                    side_effect=ModelNotFoundError("HTTP 404 model_not_found"),
+                ),
+                patch.object(
+                    interface,
+                    "_execute_openai",
+                    new_callable=AsyncMock,
+                    return_value=fallback_response,
+                ),
+            ):
+                response = await interface.execute_request(request)
+
+        assert response is fallback_response
+        assert metric._value.get() == before + 1
+        assert "MODEL CATALOG ALERT" in caplog.text
+        assert AIModel.CLAUDE_OPUS_5.value in caplog.text
+
+    @pytest.mark.asyncio
     async def test_all_models_unavailable(self):
         """Test behavior when all models are unavailable."""
         interface = UnifiedAIInterface()
@@ -727,11 +795,13 @@ class TestAIIntegrationResilience:
 
         # Simulate failure
         interface.disable_model(model)
-        assert not interface.CAPABILITIES[model].available
+        assert interface.CAPABILITIES[model].available
+        assert not interface.CAPABILITIES[model].enabled
 
         # Simulate recovery
         interface.enable_model(model)
         assert interface.CAPABILITIES[model].available
+        assert interface.CAPABILITIES[model].enabled
 
     @pytest.mark.asyncio
     async def test_request_metadata_preservation(self):

--- a/tests/test_validate_model_catalog.py
+++ b/tests/test_validate_model_catalog.py
@@ -67,10 +67,10 @@ def test_absent_remote_fields_are_not_treated_as_mismatch():
     assert findings == []
 
 
-def test_missing_api_key_skips_rather_than_passing_falsely(monkeypatch, capsys):
-    """A missing secret must be visibly SKIPPED, never a silent green."""
+def test_missing_api_key_fails_closed(monkeypatch, capsys):
+    """A live validator that cannot run must not produce a green check."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    assert main() == 0
-    out = capsys.readouterr().out
-    assert "SKIPPED" in out
-    assert "not a pass" in out
+    assert main() == 2
+    err = capsys.readouterr().err
+    assert "ERROR" in err
+    assert "could not be checked" in err

--- a/tests/test_validate_model_catalog.py
+++ b/tests/test_validate_model_catalog.py
@@ -14,7 +14,9 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
-from validate_model_catalog import compare_entry, main  # noqa: E402
+from validate_model_catalog import anthropic_entries, compare_entry, main  # noqa: E402
+
+from modules.ai_core.unified_ai_interface import AIModel, UnifiedAIInterface  # noqa: E402
 
 
 def test_unresolvable_model_is_a_finding():
@@ -74,3 +76,20 @@ def test_missing_api_key_fails_closed(monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "ERROR" in err
     assert "could not be checked" in err
+
+
+def test_missing_anthropic_dependency_fails_closed(monkeypatch, capsys):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-only-not-a-real-key")
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+
+    assert main() == 2
+    assert "not installed" in capsys.readouterr().err
+
+
+def test_disabled_available_entry_still_gets_live_validation(monkeypatch):
+    """Routing policy must not hide a provider-existence claim from validation."""
+    cap = UnifiedAIInterface.CAPABILITIES[AIModel.CLAUDE_OPUS_5]
+    monkeypatch.setattr(cap, "enabled", False)
+
+    assert cap.available
+    assert cap in anthropic_entries()


### PR DESCRIPTION
## Summary
- separate verified provider availability from local routing enablement
- prevent unverified or provider-unavailable entries from being enabled
- emit a Prometheus counter and critical log when an enabled model returns 404/not-found before fallback
- fail the live Anthropic catalog validator closed when its API key or dependency is missing
- keep the focused workflow dependency set pinned

Refs #1329.

## Validation
- `114 passed, 1 skipped` across the unified AI, model catalog, token budget, orchestration, RAG, SDK hardening, and AI management security suites
- `flake8 --select=E9,F63,F7,F82` on changed Python files
- `isort --check-only` on changed Python files
- workflow YAML parsed successfully
- `git diff --check`

## Review stabilization
- tightened not-found detection to structured status codes or explicit model-not-found markers
- corrected provider-availability wording in freshness failures
- added regression coverage rejecting unrelated bare `404` text
- review threads were not replied to or resolved

## Boundaries
- Draft only; no issue closure, merge, ready transition, or canon promotion is authorized.
- The live provider call was not run locally because no Anthropic API key was supplied.
- GitHub confirmed the repository secret is currently absent: the live catalog workflow failed closed at its validation step, as designed. Configuring `ANTHROPIC_API_KEY` is an owner gate.
- Repository-wide formatting and unused-import cleanup remain outside this issue scope.