### PR TITLE
fix(l1): harden restored fleet authority evidence

### DIFF
--- a/docs/architecture/AURORA_L1_RUNTIME_CONTRACT.md
+++ b/docs/architecture/AURORA_L1_RUNTIME_CONTRACT.md
@@ -248,6 +248,13 @@ explicit ORD-to-L1 adapter first creates a non-executing proposal; physical
 drone mission state changes only after a separate call supplies a complete
 Triplex governance receipt.
 
+Restoration applies the same boundary to persisted state. Every active
+`active_explicit_adapter` entity must match one exact fleet transition, a
+complete Triplex receipt named by that transition, and the corresponding
+governed activation event. A syntactically valid ORD mission state without
+that linked evidence is rejected rather than exposed as resumed physical
+state.
+
 ## Lagrange-point authority and remaining uncertainty
 
 CanonRec's owner ruling establishes the current siting class:
@@ -291,6 +298,7 @@ INIT records at minimum:
 - pinned CanonRec revision;
 - deterministic seed;
 - runtime-contract version;
+- exact SHA-256 of the fleet authority receipt bytes retained at INIT;
 - station-cycle position;
 - active quarantines;
 - typed population snapshot;
@@ -301,10 +309,17 @@ INIT records at minimum:
 Contract `1.2.0` accepts persisted `1.1.0` continuation states from PR #1480.
 When their fleet field is absent, the runtime reconstructs it from seed plus the
 contiguous autonomous-event ledger without advancing the tick, station cycle,
-or central replay generator. The upgraded state is persisted only on a later
-explicit run mutation, including advancement, governed action, or the normal
-recording of an observation into the run-scoped epistemic ledgers. Loading by
-itself remains non-mutating.
+or central replay generator. The verified current fleet-receipt digest is
+attached to that in-memory upgrade. The upgraded state is persisted only on a
+later explicit run mutation, including advancement, governed action, or the
+normal recording of an observation into the run-scoped epistemic ledgers.
+Loading by itself remains non-mutating.
+
+Current-contract persisted runs must carry the exact fleet-receipt digest and
+must match the receipt bytes verified by preflight. A current-contract state
+created before that digest was recorded is blocked rather than silently rebound
+to a later receipt; compatibility requires separate evidence and an explicit
+migration decision.
 
 Run persistence is rejected if the requested run root is inside the repository.
 The default is external user state under `~/.aurora/l1-runs`.

--- a/docs/architecture/AURORA_L1_RUNTIME_CONTRACT.md
+++ b/docs/architecture/AURORA_L1_RUNTIME_CONTRACT.md
@@ -315,11 +315,12 @@ later explicit run mutation, including advancement, governed action, or the
 normal recording of an observation into the run-scoped epistemic ledgers.
 Loading by itself remains non-mutating.
 
-Current-contract persisted runs must carry the exact fleet-receipt digest and
-must match the receipt bytes verified by preflight. A current-contract state
-created before that digest was recorded is blocked rather than silently rebound
-to a later receipt; compatibility requires separate evidence and an explicit
-migration decision.
+Current-contract persisted runs with a fleet-receipt digest must match the
+receipt bytes verified by preflight. A `1.2.0` state created before the digest
+field was introduced may bind the verified digest in memory only after its
+complete bound fleet projection and governed ORD adapter evidence pass current
+validation. Loading remains non-mutating; the digest is persisted only by a
+later explicit run mutation. A present but mismatched digest is always rejected.
 
 Run persistence is rejected if the requested run root is inside the repository.
 The default is external user state under `~/.aurora/l1-runs`.

--- a/simulation/l1_runtime.py
+++ b/simulation/l1_runtime.py
@@ -1111,6 +1111,8 @@ class OrionL1Runtime:
                     "persisted contract 1.1.0 cannot claim a fleet receipt digest"
                 )
             return
+        if manifest.runtime_contract_version == "1.2.0" and digest is None:
+            return
         if digest != self._require_fleet_receipt_sha256():
             raise PreflightError(
                 "persisted fleet authority receipt digest does not match runtime"
@@ -1278,6 +1280,10 @@ class OrionL1Runtime:
             raise PreflightError(
                 "persisted fleet identities do not match runtime authority receipt"
             ) from exc
+        if state.manifest.fleet_authority_receipt_sha256 is None:
+            state.manifest.fleet_authority_receipt_sha256 = (
+                self._require_fleet_receipt_sha256()
+            )
         state.manifest.runtime_contract_version = current_version
 
     def _validate_loaded_communications(self, state: L1RunState) -> None:

--- a/simulation/l1_runtime.py
+++ b/simulation/l1_runtime.py
@@ -58,6 +58,7 @@ from l1_runtime_support import (
 from l1_runtime_types import (
     DeterministicReplayRNG,
     EpistemicRecord,
+    FleetEntityState,
     GovernanceReceipt,
     L1RunState,
     PopulationSnapshot,
@@ -84,6 +85,7 @@ class OrionL1Runtime:
         self.baseline_path = baseline_path
         self.baseline = read_json(baseline_path)
         self.fleet_receipt: Optional[Dict[str, Any]] = None
+        self.fleet_receipt_sha256: Optional[str] = None
         self.population = PopulationSnapshot.from_baseline(self.baseline)
         self.state: Optional[L1RunState] = None
         self._rng: Optional[DeterministicReplayRNG] = None
@@ -94,6 +96,7 @@ class OrionL1Runtime:
     def preflight(self) -> Dict[str, Any]:
         """Validate bootstrap invariants without creating or advancing a run."""
         self.fleet_receipt = None
+        self.fleet_receipt_sha256 = None
         report = evaluate_preflight(
             self.baseline,
             self.population,
@@ -133,6 +136,7 @@ class OrionL1Runtime:
             ) from exc
         if not isinstance(receipt, dict):
             raise PreflightError("fleet authority receipt must remain a JSON object")
+        self.fleet_receipt_sha256 = actual_hash
         return receipt
 
     def init_run(
@@ -225,6 +229,7 @@ class OrionL1Runtime:
             created_at=utcnow(),
             cloudbank_revision=cloudbank_revision,
             canonrec_revision=canonrec_revision,
+            fleet_authority_receipt_sha256=self._require_fleet_receipt_sha256(),
             seed=seed,
             station_cycle_length_minutes=int(defaults["station_cycle_length_minutes"]),
             station_cycle_minute=int(defaults["station_cycle_start_minute"]),
@@ -907,6 +912,7 @@ class OrionL1Runtime:
             )
         self._validate_revision(manifest.cloudbank_revision, "cloudbank_revision")
         self._validate_revision(manifest.canonrec_revision, "canonrec_revision")
+        self._validate_loaded_fleet_receipt_digest(state)
         if manifest.tick < 0:
             raise PreflightError("persisted run tick cannot be negative")
         if (
@@ -1094,6 +1100,150 @@ class OrionL1Runtime:
             and state.fleet.process_position != state.manifest.tick
         ):
             raise PreflightError("persisted fleet replay position does not match run tick")
+        self._validate_loaded_ord_adapter_evidence(state)
+
+    def _validate_loaded_fleet_receipt_digest(self, state: L1RunState) -> None:
+        manifest = state.manifest
+        digest = manifest.fleet_authority_receipt_sha256
+        if manifest.runtime_contract_version == "1.1.0":
+            if digest is not None:
+                raise PreflightError(
+                    "persisted contract 1.1.0 cannot claim a fleet receipt digest"
+                )
+            return
+        if digest != self._require_fleet_receipt_sha256():
+            raise PreflightError(
+                "persisted fleet authority receipt digest does not match runtime"
+            )
+
+    def _validate_loaded_ord_adapter_evidence(self, state: L1RunState) -> None:
+        active_entities = [
+            entity
+            for entity in state.fleet.entities.values()
+            if entity.mission_state_class == "active_explicit_adapter"
+        ]
+        for entity in active_entities:
+            transition = self._loaded_adapter_transition(state, entity)
+            receipt_id = transition.get("governance_receipt_id")
+            self._require_loaded_triplex_receipt(state, receipt_id)
+            self._require_loaded_adapter_event(state, entity, transition, receipt_id)
+
+    @staticmethod
+    def _loaded_adapter_transition(
+        state: L1RunState,
+        entity: FleetEntityState,
+    ) -> Dict[str, Any]:
+        candidates = [
+            item
+            for item in state.fleet.transitions
+            if OrionL1Runtime._is_adapter_transition_for_entity(item, entity)
+        ]
+        if len(candidates) != 1:
+            raise PreflightError(
+                "persisted ORD adapter state lacks an exact activation transition"
+            )
+        transition = candidates[0]
+        if not OrionL1Runtime._adapter_transition_matches_entity(
+            transition,
+            entity,
+        ):
+            raise PreflightError(
+                "persisted ORD adapter transition does not match active fleet state"
+            )
+        transition_id = transition.get("transition_id")
+        if not isinstance(transition_id, str) or not transition_id:
+            raise PreflightError(
+                "persisted ORD adapter transition lacks transition identity"
+            )
+        return transition
+
+    @staticmethod
+    def _is_adapter_transition_for_entity(
+        transition: Dict[str, Any],
+        entity: FleetEntityState,
+    ) -> bool:
+        return (
+            transition.get("fleet_id") == entity.fleet_id
+            and transition.get("tick") == entity.last_transition_tick
+            and transition.get("cause") == "explicit_ord_physical_mission_adapter"
+        )
+
+    @staticmethod
+    def _adapter_transition_matches_entity(
+        transition: Dict[str, Any],
+        entity: FleetEntityState,
+    ) -> bool:
+        after = transition.get("after")
+        expected = {
+            "status": entity.status,
+            "mission_state_class": entity.mission_state_class,
+            "docking_location_class": entity.docking_location_class,
+            "mission_id": entity.mission_id,
+            "mission_class": entity.mission_class,
+        }
+        return isinstance(after, dict) and all(
+            after.get(field) == value for field, value in expected.items()
+        )
+
+    @staticmethod
+    def _require_loaded_triplex_receipt(
+        state: L1RunState,
+        receipt_id: Any,
+    ) -> None:
+        if not isinstance(receipt_id, str) or not receipt_id:
+            raise PreflightError(
+                "persisted ORD adapter transition lacks Triplex receipt identity"
+            )
+        if not any(
+            receipt.receipt_id == receipt_id and receipt.complete
+            for receipt in state.governance_receipts
+        ):
+            raise PreflightError(
+                "persisted ORD adapter transition lacks complete Triplex evidence"
+            )
+
+    @staticmethod
+    def _require_loaded_adapter_event(
+        state: L1RunState,
+        entity: FleetEntityState,
+        transition: Dict[str, Any],
+        receipt_id: str,
+    ) -> None:
+        transition_id = transition["transition_id"]
+        matching_events = [
+            event
+            for event in state.events
+            if OrionL1Runtime._is_loaded_adapter_event(
+                event,
+                entity,
+                transition,
+                receipt_id,
+                transition_id,
+            )
+        ]
+        if len(matching_events) != 1:
+            raise PreflightError(
+                "persisted ORD adapter transition lacks a governed activation event"
+            )
+
+    @staticmethod
+    def _is_loaded_adapter_event(
+        event: Dict[str, Any],
+        entity: FleetEntityState,
+        transition: Dict[str, Any],
+        receipt_id: str,
+        transition_id: str,
+    ) -> bool:
+        transition_ids = event.get("transition_ids")
+        return (
+            event.get("kind") == "governed_ord_physical_mission_activation"
+            and event.get("cause") == "explicit_ord_physical_mission_adapter"
+            and event.get("tick") == transition.get("tick")
+            and event.get("proposal_id") == entity.mission_id
+            and event.get("receipt_id") == receipt_id
+            and isinstance(transition_ids, list)
+            and transition_id in transition_ids
+        )
 
     def _upgrade_loaded_fleet(
         self,
@@ -1117,6 +1267,9 @@ class OrionL1Runtime:
                     elapsed_minutes=event["elapsed_minutes"],
                 )
             state.fleet.migrated_from_contract_version = source_contract_version
+            state.manifest.fleet_authority_receipt_sha256 = (
+                self._require_fleet_receipt_sha256()
+            )
         if state.fleet.authority_receipt_id != receipt.get("receipt_id"):
             raise PreflightError("persisted fleet authority receipt does not match runtime")
         try:
@@ -1211,6 +1364,13 @@ class OrionL1Runtime:
         if self.fleet_receipt is None:
             raise PreflightError("fleet authority receipt is unavailable after preflight")
         return self.fleet_receipt
+
+    def _require_fleet_receipt_sha256(self) -> str:
+        if self.fleet_receipt_sha256 is None:
+            raise PreflightError(
+                "fleet authority receipt digest is unavailable after preflight"
+            )
+        return self.fleet_receipt_sha256
 
     def _require_state(self) -> L1RunState:
         if self.state is None:

--- a/simulation/l1_runtime_types.py
+++ b/simulation/l1_runtime_types.py
@@ -407,6 +407,7 @@ class RunManifest:
     created_at: str
     cloudbank_revision: str
     canonrec_revision: str
+    fleet_authority_receipt_sha256: Optional[str]
     seed: int
     station_cycle_length_minutes: int
     station_cycle_minute: int
@@ -603,6 +604,10 @@ def _manifest_from_payload(payload: Dict[str, Any]) -> RunManifest:
         ),
         canonrec_revision=_string(
             payload.get("canonrec_revision"), "canonrec_revision"
+        ),
+        fleet_authority_receipt_sha256=_optional_string(
+            payload.get("fleet_authority_receipt_sha256"),
+            "fleet_authority_receipt_sha256",
         ),
         seed=required_int(payload.get("seed"), "seed"),
         station_cycle_length_minutes=required_int(

--- a/tests/test_l1_fleet_runtime.py
+++ b/tests/test_l1_fleet_runtime.py
@@ -93,6 +93,10 @@ def test_fleet_receipt_projects_modular_identities_without_stale_missions():
     assert runtime.preflight()["ready"] is True
     assert state.fleet.provider_status == "bound"
     assert state.fleet.projection_role == "runtime_projection_non_authoritative"
+    assert (
+        state.manifest.fleet_authority_receipt_sha256
+        == runtime.baseline["authority"]["fleet"]["receipt_sha256"]
+    )
     assert set(state.fleet.entities) == EXPECTED_FLEET_IDS
     assert all(
         entity.status == "identity_projected"
@@ -357,6 +361,78 @@ def test_ord_policy_requires_explicit_adapter_and_triplex_before_physical_flight
 
 
 @pytest.mark.unit
+def test_persisted_ord_adapter_state_requires_complete_linked_evidence(
+    tmp_path: Path,
+):
+    runtime = OrionL1Runtime()
+    state = runtime.init_run(
+        cloudbank_revision=CLOUDBANK_SHA,
+        seed=7,
+        run_root=tmp_path,
+    )
+    proposal = runtime.propose_ord_physical_mission(
+        _supported_dispatch_order(),
+        physical_mission_class="physical_reconnaissance",
+        docking_location_class="station_proximity",
+    )
+    runtime.activate_ord_physical_mission(
+        proposal,
+        receipt=_complete_receipt(),
+    )
+    state_path = tmp_path / state.manifest.run_id / "state.json"
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+
+    loaded = OrionL1Runtime().load_run(state.manifest.run_id, run_root=tmp_path)
+    assert loaded.fleet.entities["ORD-2"].mission_id == proposal.proposal_id
+
+    tamper_cases = (
+        ("governance_receipts", []),
+        ("events", []),
+        ("fleet.transitions", []),
+    )
+    for field, value in tamper_cases:
+        payload = json.loads(json.dumps(persisted))
+        if field == "fleet.transitions":
+            payload["fleet"]["transitions"] = value
+        else:
+            payload[field] = value
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(PreflightError, match="persisted ORD adapter"):
+            OrionL1Runtime().load_run(state.manifest.run_id, run_root=tmp_path)
+
+
+@pytest.mark.unit
+def test_forged_persisted_adapter_state_without_evidence_is_rejected(
+    tmp_path: Path,
+):
+    runtime = OrionL1Runtime()
+    state = runtime.init_run(
+        cloudbank_revision=CLOUDBANK_SHA,
+        seed=7,
+        run_root=tmp_path,
+    )
+    state_path = tmp_path / state.manifest.run_id / "state.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    entity = payload["fleet"]["entities"]["ORD-2"]
+    entity.update(
+        {
+            "status": "operating",
+            "mission_state_class": "active_explicit_adapter",
+            "docking_location_class": "station_proximity",
+            "mission_id": "ord-physical-forged",
+            "mission_class": "physical_reconnaissance",
+        }
+    )
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        PreflightError,
+        match="lacks an exact activation transition",
+    ):
+        OrionL1Runtime().load_run(state.manifest.run_id, run_root=tmp_path)
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("field", "value", "match"),
     (
@@ -471,6 +547,30 @@ def test_bound_persisted_fleet_requires_receipt_identity_metadata(tmp_path: Path
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("digest", [None, "0" * 64])
+def test_persisted_run_requires_exact_fleet_receipt_digest(
+    tmp_path: Path,
+    digest: str | None,
+):
+    runtime = OrionL1Runtime()
+    state = runtime.init_run(
+        cloudbank_revision=CLOUDBANK_SHA,
+        seed=99,
+        run_root=tmp_path,
+    )
+    state_path = tmp_path / state.manifest.run_id / "state.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    if digest is None:
+        payload["manifest"].pop("fleet_authority_receipt_sha256")
+    else:
+        payload["manifest"]["fleet_authority_receipt_sha256"] = digest
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PreflightError, match="receipt digest does not match"):
+        OrionL1Runtime().load_run(state.manifest.run_id, run_root=tmp_path)
+
+
+@pytest.mark.unit
 def test_pr1480_contract_run_migrates_at_paused_tick_seven_without_advancing(
     tmp_path: Path,
 ):
@@ -486,6 +586,7 @@ def test_pr1480_contract_run_migrates_at_paused_tick_seven_without_advancing(
     state_path = tmp_path / state.manifest.run_id / "state.json"
     legacy_payload = json.loads(state_path.read_text(encoding="utf-8"))
     legacy_payload["manifest"]["runtime_contract_version"] = "1.1.0"
+    legacy_payload["manifest"].pop("fleet_authority_receipt_sha256")
     legacy_payload.pop("fleet")
     state_path.write_text(json.dumps(legacy_payload), encoding="utf-8")
 
@@ -495,6 +596,10 @@ def test_pr1480_contract_run_migrates_at_paused_tick_seven_without_advancing(
     assert loaded.manifest.tick == 7
     assert loaded.manifest.station_cycle_minute == 21
     assert loaded.manifest.runtime_contract_version == "1.2.0"
+    assert (
+        loaded.manifest.fleet_authority_receipt_sha256
+        == resumed.baseline["authority"]["fleet"]["receipt_sha256"]
+    )
     assert loaded.fleet.process_position == 7
     assert loaded.fleet.migrated_from_contract_version == "1.1.0"
     reconstructed = asdict(loaded.fleet)
@@ -509,7 +614,34 @@ def test_pr1480_contract_run_migrates_at_paused_tick_seven_without_advancing(
     persisted_after_observation = json.loads(state_path.read_text(encoding="utf-8"))
     assert persisted_after_observation["manifest"]["tick"] == 7
     assert persisted_after_observation["manifest"]["station_cycle_minute"] == 21
+    assert (
+        persisted_after_observation["manifest"]["fleet_authority_receipt_sha256"]
+        == resumed.baseline["authority"]["fleet"]["receipt_sha256"]
+    )
     assert persisted_after_observation["fleet"]["process_position"] == 7
+
+
+@pytest.mark.unit
+def test_contract_v1_1_rejects_injected_bound_fleet_before_migration(
+    tmp_path: Path,
+):
+    runtime = OrionL1Runtime()
+    state = runtime.init_run(
+        cloudbank_revision=CLOUDBANK_SHA,
+        seed=314159,
+        run_root=tmp_path,
+    )
+    state_path = tmp_path / state.manifest.run_id / "state.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    payload["manifest"]["runtime_contract_version"] = "1.1.0"
+    payload["manifest"].pop("fleet_authority_receipt_sha256")
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        PreflightError,
+        match="persisted L1 run state is unavailable or invalid",
+    ):
+        OrionL1Runtime().load_run(state.manifest.run_id, run_root=tmp_path)
 
 
 @pytest.mark.unit

--- a/tests/test_l1_fleet_runtime.py
+++ b/tests/test_l1_fleet_runtime.py
@@ -547,10 +547,8 @@ def test_bound_persisted_fleet_requires_receipt_identity_metadata(tmp_path: Path
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("digest", [None, "0" * 64])
-def test_persisted_run_requires_exact_fleet_receipt_digest(
+def test_persisted_run_rejects_mismatched_fleet_receipt_digest(
     tmp_path: Path,
-    digest: str | None,
 ):
     runtime = OrionL1Runtime()
     state = runtime.init_run(
@@ -560,14 +558,36 @@ def test_persisted_run_requires_exact_fleet_receipt_digest(
     )
     state_path = tmp_path / state.manifest.run_id / "state.json"
     payload = json.loads(state_path.read_text(encoding="utf-8"))
-    if digest is None:
-        payload["manifest"].pop("fleet_authority_receipt_sha256")
-    else:
-        payload["manifest"]["fleet_authority_receipt_sha256"] = digest
+    payload["manifest"]["fleet_authority_receipt_sha256"] = "0" * 64
     state_path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(PreflightError, match="receipt digest does not match"):
         OrionL1Runtime().load_run(state.manifest.run_id, run_root=tmp_path)
+
+
+@pytest.mark.unit
+def test_pre_digest_v1_2_run_binds_digest_after_full_fleet_validation(
+    tmp_path: Path,
+):
+    runtime = OrionL1Runtime()
+    state = runtime.init_run(
+        cloudbank_revision=CLOUDBANK_SHA,
+        seed=99,
+        run_root=tmp_path,
+    )
+    state_path = tmp_path / state.manifest.run_id / "state.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    payload["manifest"].pop("fleet_authority_receipt_sha256")
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = OrionL1Runtime().load_run(state.manifest.run_id, run_root=tmp_path)
+
+    assert (
+        loaded.manifest.fleet_authority_receipt_sha256
+        == runtime.baseline["authority"]["fleet"]["receipt_sha256"]
+    )
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert "fleet_authority_receipt_sha256" not in persisted["manifest"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What changed

- bind every new L1 run to the exact verified fleet-authority receipt digest
- validate restored ORD adapter state against its transition, Triplex receipt, and governed event
- reject forged or incomplete restored fleet activation evidence
- safely bind pre-digest contract 1.2 state in memory only after the complete fleet projection passes current validation

## Why

Post-merge review of #1482 reproduced two restoration gaps: persisted ORD physical state was not cross-checked against its governance evidence, and the verified fleet receipt bytes were not retained in the run manifest. The compatibility path preserves already-running contract 1.2 state without reading or mutating any live run during this change.

## Validation

- `83 passed`: L1 fleet, instrumentation, and runtime suites
- `36 passed`: focused fleet regression suite after the compatibility adjustment
- Ruff, Python compilation, diff check, and complexity thresholds pass
- isolated preflight remains ready and creates no run
