### PR TITLE
feat(l1): emit inspectable ACE coherence seams

### DIFF
--- a/simulation/l1_embodiment.py
+++ b/simulation/l1_embodiment.py
@@ -30,6 +30,13 @@ EXPECTED_EMBODIMENT_IDS = frozenset(
     }
 )
 
+ACE_SEAM_SCHEMA_VERSION = "0.1.0"
+ACE_SEAM_TRIGGER_POLICY_REF = "ace.policy.l1-embodiment-coherence-seam.v1"
+ACE_SEAM_CALLER_REF = "cloudbank.l1.embodiment_registry"
+ACE_SUPPORTED_EMBODIMENT_BLOCKERS = {
+    "canonical_location": "facility_topology",
+}
+
 
 def validate_embodiment_registry(registry: Dict[str, Any]) -> None:
     """Reject malformed, activating, incomplete, or over-authoritative registries."""
@@ -97,6 +104,78 @@ def validate_embodiment_projection(
         raise ValueError("persisted embodiment readiness differs from its registry")
 
 
+def build_ace_coherence_seams(registry: Dict[str, Any]) -> list[Dict[str, Any]]:
+    """Emit deterministic ACE handoffs for supported, non-authoritative L1 gaps.
+
+    This is a seam producer, not an ACE implementation. It never imports ACE,
+    changes registry state, promotes canon, activates a provider, or advances a
+    run. The emitted provenance is sufficient for OrionCore to wrap the request
+    in the shared autonomic ACE invocation contract.
+    """
+    validate_embodiment_registry(registry)
+    records = _registry_records(registry)
+    seams: list[Dict[str, Any]] = []
+    for record in records:
+        for blocker in record.blockers:
+            query_kind = ACE_SUPPORTED_EMBODIMENT_BLOCKERS.get(blocker)
+            if query_kind is None:
+                continue
+            if blocker == "canonical_location" and record.location_certainty == "CANON":
+                continue
+            seam_ref = f"{record.embodiment_id}:{blocker}"
+            seams.append(
+                {
+                    "schema_version": ACE_SEAM_SCHEMA_VERSION,
+                    "record_type": "ace_coherence_seam",
+                    "target_engine": "ACE",
+                    "invocation_mode": "autonomic",
+                    "caller": {
+                        "kind": "system",
+                        "caller_ref": ACE_SEAM_CALLER_REF,
+                    },
+                    "trigger": {
+                        "kind": "coherence_seam",
+                        "reason": (
+                            "The audited L1 embodiment registry contains a routine "
+                            f"coherence gap for {record.component}: {blocker}."
+                        ),
+                        "seam_ref": seam_ref,
+                        "trigger_policy_ref": ACE_SEAM_TRIGGER_POLICY_REF,
+                    },
+                    "query_kind": query_kind,
+                    "question": f"Determine the canonical L1 facility location for {record.component}.",
+                    "subject": {
+                        "entity_type": "facility",
+                        "subject_ref": record.embodiment_id,
+                        "existence_status": "confirmed_unrecorded_attribute",
+                        "context": {
+                            "component": record.component,
+                            "l1_kind": record.l1_kind,
+                            "current_location": record.location,
+                            "location_certainty": record.location_certainty,
+                            "authority_class": record.authority_class,
+                            "evidence_class": record.evidence_class,
+                            "source_refs": list(record.source_refs),
+                            "provider_status": record.provider_status,
+                            "required_for_resume": record.required_for_resume,
+                            "causal_use_permitted": record.causal_use_permitted,
+                            "blockers": list(record.blockers),
+                        },
+                    },
+                    "requested_output": blocker,
+                    "constraints": {
+                        "specialist_first": True,
+                        "inspectable": True,
+                        "activation_authority": False,
+                        "runtime_mutation_allowed": False,
+                        "canon_materialization_authority": False,
+                        "experiment_advance_allowed": False,
+                    },
+                }
+            )
+    return sorted(seams, key=lambda item: item["trigger"]["seam_ref"])
+
+
 def assess_embodiment_readiness(registry: Dict[str, Any]) -> Dict[str, Any]:
     """Report resume blockers without treating them as absent station systems."""
     validate_embodiment_registry(registry)
@@ -115,6 +194,7 @@ def assess_embodiment_readiness(registry: Dict[str, Any]) -> Dict[str, Any]:
         status: sum(record.provider_status == status for record in records)
         for status in ("bound", "partial", "unbound", "blocked")
     }
+    seams = build_ace_coherence_seams(registry)
     return {
         "registry_id": registry["registry_id"],
         "registry_status": "verified",
@@ -127,6 +207,8 @@ def assess_embodiment_readiness(registry: Dict[str, Any]) -> Dict[str, Any]:
             for record in records
             if record.causal_use_permitted
         ],
+        "ace_coherence_seam_count": len(seams),
+        "ace_coherence_seams": seams,
     }
 
 

--- a/tests/test_l1_ace_coherence_seams.py
+++ b/tests/test_l1_ace_coherence_seams.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SIMULATION_DIR = PROJECT_ROOT / "simulation"
+if str(SIMULATION_DIR) not in sys.path:
+    sys.path.insert(0, str(SIMULATION_DIR))
+
+from l1_embodiment import (  # noqa: E402
+    ACE_SEAM_CALLER_REF,
+    ACE_SEAM_TRIGGER_POLICY_REF,
+    assess_embodiment_readiness,
+    build_ace_coherence_seams,
+)
+
+
+def _registry() -> dict[str, object]:
+    return json.loads(
+        (PROJECT_ROOT / "config" / "l1_embodiment_registry.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+@pytest.mark.unit
+def test_mcp_canonical_location_gap_emits_autonomic_ace_seam() -> None:
+    registry = _registry()
+
+    seams = build_ace_coherence_seams(registry)
+
+    assert len(seams) == 1
+    seam = seams[0]
+    assert seam["record_type"] == "ace_coherence_seam"
+    assert seam["target_engine"] == "ACE"
+    assert seam["invocation_mode"] == "autonomic"
+    assert seam["caller"] == {
+        "kind": "system",
+        "caller_ref": ACE_SEAM_CALLER_REF,
+    }
+    assert seam["trigger"]["kind"] == "coherence_seam"
+    assert seam["trigger"]["seam_ref"] == "L1-EMB-MCP-SHUTTLE-BAY:canonical_location"
+    assert seam["trigger"]["trigger_policy_ref"] == ACE_SEAM_TRIGGER_POLICY_REF
+    assert seam["query_kind"] == "facility_topology"
+    assert seam["requested_output"] == "canonical_location"
+    assert seam["subject"]["entity_type"] == "facility"
+    assert seam["subject"]["subject_ref"] == "L1-EMB-MCP-SHUTTLE-BAY"
+    assert seam["constraints"] == {
+        "specialist_first": True,
+        "inspectable": True,
+        "activation_authority": False,
+        "runtime_mutation_allowed": False,
+        "canon_materialization_authority": False,
+        "experiment_advance_allowed": False,
+    }
+
+
+@pytest.mark.unit
+def test_seam_production_is_read_only_and_deterministic() -> None:
+    registry = _registry()
+    before = copy.deepcopy(registry)
+
+    first = build_ace_coherence_seams(registry)
+    second = build_ace_coherence_seams(registry)
+
+    assert registry == before
+    assert first == second
+
+
+@pytest.mark.unit
+def test_canonical_location_no_longer_emits_a_seam() -> None:
+    registry = _registry()
+    mcp = next(
+        item
+        for item in registry["embodiments"]
+        if item["embodiment_id"] == "L1-EMB-MCP-SHUTTLE-BAY"
+    )
+    mcp["location"] = "Non-rotating core docking complex"
+    mcp["location_certainty"] = "CANON"
+
+    assert build_ace_coherence_seams(registry) == []
+
+
+@pytest.mark.unit
+def test_unsupported_authority_and_provider_gaps_are_not_silently_sent_to_ace() -> None:
+    registry = _registry()
+    mcp = next(
+        item
+        for item in registry["embodiments"]
+        if item["embodiment_id"] == "L1-EMB-MCP-SHUTTLE-BAY"
+    )
+    mcp["blockers"].remove("canonical_location")
+
+    assert build_ace_coherence_seams(registry) == []
+
+
+@pytest.mark.unit
+def test_preflight_readiness_surfaces_seams_without_changing_resume_authority() -> None:
+    report = assess_embodiment_readiness(_registry())
+
+    assert report["ready"] is False
+    assert report["ace_coherence_seam_count"] == 1
+    assert report["ace_coherence_seams"][0]["trigger"]["seam_ref"].endswith(
+        ":canonical_location"
+    )


### PR DESCRIPTION
## Summary

Adds a pure, non-authoritative seam-producer surface to the Orion L1 Embodiment Registry so routine coherence gaps can be handed to the shared Aurora Canon Engine without importing or reimplementing ACE inside CloudBank.

## What changed

- adds deterministic `build_ace_coherence_seams()` output to `simulation/l1_embodiment.py`;
- emits the current `L1-EMB-MCP-SHUTTLE-BAY:canonical_location` gap as an autonomic ACE handoff;
- carries caller, seam, trigger-policy, subject/context, requested output, and safety constraints required by OrionCore's shared ACE invocation model;
- exposes seam records in embodiment readiness/preflight reporting;
- adds focused tests for deterministic/read-only behavior and no authority widening.

## Boundaries

- CloudBank remains a seam producer only; it does not import, execute, or duplicate ACE.
- No provider is activated or rebound.
- No registry location is promoted or rewritten.
- No canon/materialization authority is granted.
- No L1 runtime state is mutated or advanced.
- Unsupported authority/provider blockers are not automatically sent to ACE.

## Validation

CI pending.