### PR TITLE
ops: standardize durable task execution records before substantial work

### DIFF
--- a/ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md
+++ b/ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md
@@ -95,7 +95,7 @@ Recommended task identifier inside the record:
 
 Every DTER MUST contain the following sections.
 
-### 1. Identity and links
+### Header: identity and links
 
 - task id;
 - status;
@@ -105,15 +105,15 @@ Every DTER MUST contain the following sections.
 - creation commit once known;
 - latest controlling revision.
 
-### 2. Objective
+### 1. Objective
 
 State the intended outcome in testable terms. Avoid implementation detail unless it is itself part of the requirement.
 
-### 3. Acceptance statement
+### 2. Acceptance statement
 
 A concise statement of what must be true before the task can be called complete.
 
-### 4. Authority and source inputs
+### 3. Authority and source inputs
 
 List the files, commits, canon sources, specifications, owner decisions, recovery artifacts, external evidence, or runtime observations that are authoritative for the task.
 
@@ -124,7 +124,7 @@ Distinguish:
 - assumptions;
 - derived decisions.
 
-### 5. Scope
+### 4. Scope
 
 Explicitly list:
 
@@ -132,23 +132,23 @@ Explicitly list:
 - out of scope;
 - protected or immutable surfaces.
 
-### 6. Current state and known gaps
+### 5. Current state and known gaps
 
 Record what exists before mutation, including blockers, contradictions, missing source, technical debt, and unresolved assumptions.
 
-### 7. Planned mutations
+### 6. Planned mutations
 
 Describe expected code/data/doc mutations at a useful path or subsystem level.
 
 This is an intent map, not a promise that every predicted path must change. Unexpected mutations must be recorded later as plan deltas.
 
-### 8. Execution sequence and gates
+### 7. Execution sequence and gates
 
 Define the ordered phases of work and the condition required to leave each phase.
 
 No later phase should begin when an earlier blocking gate is unsatisfied unless the record is explicitly revised.
 
-### 9. Invariants and non-negotiables
+### 8. Invariants and non-negotiables
 
 List properties that must remain true throughout execution, such as:
 
@@ -159,13 +159,13 @@ List properties that must remain true throughout execution, such as:
 - adapters may translate but may not become authority;
 - safety or ethics constraints remain binding.
 
-### 10. Validation and acceptance tests
+### 9. Validation and acceptance tests
 
 Define the tests, replay checks, CI, audits, receipts, manual inspections, or comparison criteria required to prove completion.
 
 A task is not complete because the implementation "looks right" if objective validation is available.
 
-### 11. Stop conditions and owner decisions
+### 10. Stop conditions and owner decisions
 
 Identify conditions that require the worker to stop rather than improvise, including:
 
@@ -176,13 +176,13 @@ Identify conditions that require the worker to stop rather than improvise, inclu
 - materially different architecture than planned;
 - owner-level choices.
 
-### 12. Rollback and recovery
+### 11. Rollback and recovery
 
 Describe how to return to the pre-task state or otherwise recover safely if the implementation fails.
 
 For destructive or preservation-sensitive tasks, record backups, hashes, witness artifacts, or restore points before mutation.
 
-### 13. Decision and plan-delta log
+### 12. Decision and plan-delta log
 
 Maintain a chronological record of material changes to the plan.
 
@@ -196,7 +196,7 @@ Each entry should include:
 
 Do not silently rewrite prior decisions after implementation has depended on them.
 
-### 14. Evidence and receipts
+### 13. Evidence and receipts
 
 As work proceeds, record:
 
@@ -208,7 +208,7 @@ As work proceeds, record:
 - review findings;
 - superseded artifacts.
 
-### 15. Current status and next action
+### 14. Current status and next action
 
 Maintain a compact cold-start state:
 
@@ -219,6 +219,18 @@ Maintain a compact cold-start state:
 - whether owner input is required.
 
 This is the section handoffs should point to first.
+
+### 15. Handoff anchor
+
+When work pauses or crosses workers or platforms, record the durable cold-start anchor:
+
+- task record path and version;
+- controlling commit or PR head;
+- current phase;
+- exact next action;
+- unresolved gate or owner decision, if any.
+
+The handoff MUST point to the current DTER rather than duplicating its full history.
 
 ### 16. Completion record
 

--- a/ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md
+++ b/ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md
@@ -1,0 +1,326 @@
+# Aurora Durable Task Execution Record SOP
+
+**Version:** 1.0  
+**Date:** 2026-08-12  
+**Status:** proposed operating doctrine  
+**Scope:** repository-affecting work in `aurora-cloudbank-symbolic` and related Aurora repositories
+
+## Purpose
+
+Handoffs preserve continuity between agents and sessions, but they are not sufficient as the authoritative execution reference for substantial work.
+
+For non-trivial tasks, Aurora requires a **Durable Task Execution Record (DTER)** committed to Git before implementation begins. The DTER is the durable answer to:
+
+- what are we trying to accomplish;
+- why are we doing it;
+- what authority and evidence are we relying on;
+- what is in scope and out of scope;
+- what files/systems are expected to change;
+- what invariants must not be violated;
+- what sequence and gates govern execution;
+- what decisions changed the plan;
+- what validation proves completion;
+- what remains unresolved;
+- where another agent should resume.
+
+A handoff MUST reference the DTER when one exists. A handoff MUST NOT replace it.
+
+## Coordination chain
+
+The standard durable reference chain is:
+
+```text
+Queue / GitHub Issue
+        ↓
+Durable Task Execution Record (DTER)
+        ↓
+Plans / Specs / ADRs / Recovery Records
+        ↓
+Implementation Commits + Tests + Receipts
+        ↓
+Pull Request / Review
+        ↓
+Handoff / Session Continuation
+```
+
+The work queue selects and prioritizes work. Session claims and handoffs coordinate who is acting. The DTER defines the execution contract. GitHub commits, reviews, tests, and merge history remain implementation canon.
+
+## When a DTER is required
+
+Create and commit a DTER **before implementation mutation** when any of the following are true:
+
+1. the task spans multiple files, subsystems, repositories, or meaningful steps;
+2. the task changes architecture, runtime behavior, simulation behavior, authority boundaries, schemas, APIs, or persistent state;
+3. the task is a migration, restoration, recovery, refactor, integration, or deployment;
+4. the task contains destructive, difficult-to-reverse, or preservation-sensitive operations;
+5. the task changes canon-bearing, governance, ethics, security, or lineage-sensitive material;
+6. determinism, reproducibility, provenance, or auditability is a stated requirement;
+7. the work is expected to span agents, platforms, sessions, or days;
+8. implementation depends on a non-trivial set of assumptions or owner decisions;
+9. the operator explicitly asks for a plan or committed intent before execution.
+
+A DTER is normally unnecessary for a single trivial typo/doc correction or a narrowly obvious one-file maintenance patch with no architectural consequences.
+
+### Emergency exception
+
+Incident containment may require an immediate safety mutation before a DTER can be committed. In that case:
+
+- make only the minimum containment change;
+- record the exact emergency mutation and reason in the PR/issue;
+- create the DTER immediately afterward before remediation or expansion continues.
+
+The exception is for containment, not convenience.
+
+## Naming and location
+
+Default location:
+
+`ops/task_records/`
+
+Default filename:
+
+`AURORA__TASK_RECORD__<TOPIC>__vX.X__YYYY-MM-DD.md`
+
+Example:
+
+`AURORA__TASK_RECORD__GUMAS_DETERMINISTIC_BATTLE_RUNTIME__v1.0__2026-08-12.md`
+
+Use the same root filename for revisions and increment the version logically.
+
+Recommended task identifier inside the record:
+
+`TASK-YYYYMMDD-<short-slug>`
+
+## Required DTER structure
+
+Every DTER MUST contain the following sections.
+
+### 1. Identity and links
+
+- task id;
+- status;
+- owner / active worker;
+- repository / branch;
+- queue id, issue, PR, and related task links where available;
+- creation commit once known;
+- latest controlling revision.
+
+### 2. Objective
+
+State the intended outcome in testable terms. Avoid implementation detail unless it is itself part of the requirement.
+
+### 3. Acceptance statement
+
+A concise statement of what must be true before the task can be called complete.
+
+### 4. Authority and source inputs
+
+List the files, commits, canon sources, specifications, owner decisions, recovery artifacts, external evidence, or runtime observations that are authoritative for the task.
+
+Distinguish:
+
+- independently verified evidence;
+- externally supplied evidence;
+- assumptions;
+- derived decisions.
+
+### 5. Scope
+
+Explicitly list:
+
+- in scope;
+- out of scope;
+- protected or immutable surfaces.
+
+### 6. Current state and known gaps
+
+Record what exists before mutation, including blockers, contradictions, missing source, technical debt, and unresolved assumptions.
+
+### 7. Planned mutations
+
+Describe expected code/data/doc mutations at a useful path or subsystem level.
+
+This is an intent map, not a promise that every predicted path must change. Unexpected mutations must be recorded later as plan deltas.
+
+### 8. Execution sequence and gates
+
+Define the ordered phases of work and the condition required to leave each phase.
+
+No later phase should begin when an earlier blocking gate is unsatisfied unless the record is explicitly revised.
+
+### 9. Invariants and non-negotiables
+
+List properties that must remain true throughout execution, such as:
+
+- archival bytes remain immutable;
+- no canon promotion without explicit authority;
+- no destructive deletion without approval;
+- deterministic input produces deterministic output;
+- adapters may translate but may not become authority;
+- safety or ethics constraints remain binding.
+
+### 10. Validation and acceptance tests
+
+Define the tests, replay checks, CI, audits, receipts, manual inspections, or comparison criteria required to prove completion.
+
+A task is not complete because the implementation "looks right" if objective validation is available.
+
+### 11. Stop conditions and owner decisions
+
+Identify conditions that require the worker to stop rather than improvise, including:
+
+- conflicting authority;
+- unexpected destructive scope;
+- missing source or provenance;
+- security/ethics boundary changes;
+- materially different architecture than planned;
+- owner-level choices.
+
+### 12. Rollback and recovery
+
+Describe how to return to the pre-task state or otherwise recover safely if the implementation fails.
+
+For destructive or preservation-sensitive tasks, record backups, hashes, witness artifacts, or restore points before mutation.
+
+### 13. Decision and plan-delta log
+
+Maintain a chronological record of material changes to the plan.
+
+Each entry should include:
+
+- date/time or commit;
+- decision/change;
+- reason/evidence;
+- authority;
+- consequence for scope, sequence, or validation.
+
+Do not silently rewrite prior decisions after implementation has depended on them.
+
+### 14. Evidence and receipts
+
+As work proceeds, record:
+
+- important commit SHAs;
+- source/artifact hashes;
+- CI or test results;
+- generated validation receipts;
+- benchmark/replay results;
+- review findings;
+- superseded artifacts.
+
+### 15. Current status and next action
+
+Maintain a compact cold-start state:
+
+- current phase;
+- completed gates;
+- open blockers;
+- exact next action;
+- whether owner input is required.
+
+This is the section handoffs should point to first.
+
+### 16. Completion record
+
+On completion or abandonment, record:
+
+- final status (`completed`, `aborted`, `superseded`, or `rolled_back`);
+- merge/closing commit or PR;
+- validation result;
+- residual risks / follow-up work;
+- links to successor task records where applicable.
+
+## Pre-implementation commit rule
+
+For a DTER-required task, the first task-specific implementation PR/branch MUST contain a committed DTER before substantive code/data mutation begins.
+
+Recommended sequence:
+
+1. refresh live repository and issue/PR state;
+2. claim/coordinate the task as required;
+3. create the DTER from the standard template;
+4. commit the DTER;
+5. link it from the issue/PR/queue entry;
+6. only then begin substantive implementation.
+
+If discovery work is needed to write an accurate plan, read-only investigation may precede the DTER. Discovery mutations should not.
+
+## Relationship to plans and specifications
+
+A DTER is an index and execution contract, not a replacement for detailed engineering artifacts.
+
+Use separate plans/specifications when depth is needed. The DTER should link them and state their authority.
+
+For example:
+
+```text
+DTER
+ ├─ architecture spec
+ ├─ recovery report
+ ├─ migration plan
+ ├─ test plan
+ └─ validation receipt
+```
+
+This prevents a large task from becoming one monolithic document while preserving a single durable point of reference.
+
+## Relationship to handoffs
+
+A handoff for a DTER-governed task MUST include at minimum:
+
+- DTER path;
+- DTER version;
+- controlling commit/PR head;
+- current phase;
+- next action;
+- unresolved decision/blocker.
+
+The receiving agent should be able to cold-start by reading the DTER and its linked authority set without depending on chat history.
+
+## Relationship to the work queue
+
+When a queue item enters active implementation and requires a DTER:
+
+- add the DTER to the item's `context_pack` when practical;
+- include a `task_record` reference if/when the queue schema supports it;
+- ensure `next_action` does not conflict with the DTER's current phase;
+- on completion, reconcile queue state against merged GitHub evidence.
+
+The queue remains the prioritization layer. The DTER remains the execution reference.
+
+## Plan revisions and preservation of history
+
+Minor factual/status updates may update the current DTER version.
+
+Create a new DTER version when there is a material change to:
+
+- objective;
+- architecture;
+- authority boundary;
+- destructive scope;
+- acceptance criteria;
+- validation strategy;
+- owner-approved direction.
+
+The new version MUST link the superseded version and explain the delta. Do not delete the old record solely because the plan changed.
+
+## Destructive operations rule
+
+Classification is advisory. Destructive authority is separate.
+
+No artifact may be deleted merely because it is labeled duplicate, redundant, deprecated, superseded, generated, or low-value.
+
+Before destructive cleanup, the DTER must identify:
+
+- explicit deletion authorization;
+- content hashes or equivalent identity evidence;
+- semantic/version/lineage comparison where applicable;
+- dependency/reference checks;
+- recovery path or retained witness;
+- exact deletion scope.
+
+Filename or basename equality is never sufficient evidence of content identity.
+
+## Definition of done for this SOP
+
+This operating doctrine is effective when substantial work can be resumed from GitHub alone through a predictable reference chain, without requiring reconstruction of intent from an ephemeral handoff or chat transcript.

--- a/ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md
+++ b/ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md
@@ -87,7 +87,7 @@ Before this change, CloudBank had strong queue, claim, handoff, PR, CI, and revi
 ## 6. Planned mutations
 
 | Surface / path | Intended change | Authority / rationale | Risk |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md` | Add repo-wide DTER operating doctrine | Operator decision + observed continuity gap | low |
 | `ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md` | Add reusable task-record structure | Required for repeatability | low |
 | `ops/work_queue/QUEUE_GUIDE.md` | Bind queue workflow to DTER requirement | Preserve coherent coordination chain | low |
@@ -155,7 +155,7 @@ Gate to exit:
 ## 9. Validation and acceptance tests
 
 | ID | Validation | Expected result | Evidence / receipt |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `V-01` | SOP file exists on scoped branch | present | branch diff |
 | `V-02` | Template file exists on scoped branch | present | branch diff |
 | `V-03` | Queue guide references SOP/template and session-start rule | present | branch diff |
@@ -187,7 +187,7 @@ No runtime or data migration occurs in this task.
 ## 12. Decision and plan-delta log
 
 | Date / commit | Decision or delta | Evidence / reason | Authority | Consequence |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `2026-08-12` | Create a repo-wide execution-record layer rather than expanding handoff payloads | Handoffs do not provide a stable structured execution reference | Operator | New DTER SOP + template |
 | `2026-08-12` | Keep DTER separate from queue and control-plane claims | Existing queue guide already assigns those roles clearly | Existing repo doctrine | Additive coordination layer, not replacement |
 | `2026-08-12` | Bootstrap exception: first SOP/template commits precede this task record | DTER mechanism did not exist before those commits | Transparent procedural necessity | Record exception explicitly; future DTER-required tasks follow pre-implementation rule |

--- a/ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md
+++ b/ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md
@@ -9,9 +9,9 @@
 **Branch:** `docs/durable-task-execution-sop`  
 **Queue ID:** `none`  
 **Issue:** `none`  
-**PR:** `pending at record creation`  
-**Creation commit:** `pending at record creation`  
-**Controlling revision:** `this file v1.0 + branch head`
+**PR:** `#1508`  
+**Creation commit:** `2ce943547d6d7c7e35f86ced55baf9700dfef97a`  
+**Controlling revision:** `this file v1.0 on PR #1508`
 
 ---
 
@@ -132,14 +132,14 @@ Gate to exit:
 ### Phase 3 — Review and adoption
 
 Actions:
-- open draft PR;
-- review CI and comments;
+- review draft PR #1508;
+- inspect CI and comments;
 - merge only after operator/reviewer approval.
 
 Gate to exit:
 - review accepts the operating doctrine.
 
-**Status:** pending.
+**Status:** active.
 
 ## 8. Invariants and non-negotiables
 
@@ -159,7 +159,7 @@ Gate to exit:
 | `V-01` | SOP file exists on scoped branch | present | branch diff |
 | `V-02` | Template file exists on scoped branch | present | branch diff |
 | `V-03` | Queue guide references SOP/template and session-start rule | present | branch diff |
-| `V-04` | Draft PR contains only operating-doctrine changes | expected | PR changed-file list |
+| `V-04` | Draft PR contains only operating-doctrine changes | four intended files | PR #1508 |
 | `V-05` | CI/document checks | green or understood | pending |
 
 ## 10. Stop conditions and owner decisions
@@ -179,7 +179,7 @@ Stop and request owner/authority input if:
 
 ### Rollback procedure
 
-1. close the draft PR without merge; or
+1. close draft PR #1508 without merge; or
 2. revert the documentation commits if already merged.
 
 No runtime or data migration occurs in this task.
@@ -191,7 +191,7 @@ No runtime or data migration occurs in this task.
 | `2026-08-12` | Create a repo-wide execution-record layer rather than expanding handoff payloads | Handoffs do not provide a stable structured execution reference | Operator | New DTER SOP + template |
 | `2026-08-12` | Keep DTER separate from queue and control-plane claims | Existing queue guide already assigns those roles clearly | Existing repo doctrine | Additive coordination layer, not replacement |
 | `2026-08-12` | Bootstrap exception: first SOP/template commits precede this task record | DTER mechanism did not exist before those commits | Transparent procedural necessity | Record exception explicitly; future DTER-required tasks follow pre-implementation rule |
-| `2026-08-12` | Separate this governance change from PR #1506 | Repo-wide SOP should not be buried inside a simulation PR | Aurora operational judgment | Dedicated branch/PR |
+| `2026-08-12` | Separate this governance change from PR #1506 | Repo-wide SOP should not be buried inside a simulation PR | Aurora operational judgment | Dedicated branch/PR #1508 |
 
 ## 13. Evidence and receipts
 
@@ -200,18 +200,19 @@ No runtime or data migration occurs in this task.
 - `13910272a3ece6ecff2828523a0ae4d84c7551cf` — add DTER SOP
 - `b737ae51d1ae5ab4c7fe80e50543a9fff5672a6e` — add DTER template
 - `76fe98cdd23e9d8124a405347b28dea54a7781cc` — bind work queue to DTER operating rule
+- `2ce943547d6d7c7e35f86ced55baf9700dfef97a` — add bootstrap DTER example
 
 ### CI / tests / replay / audit
 
-- pending draft-PR CI.
+- draft PR #1508 opened; CI pending.
 
 ## 14. Current status and next action
 
 **Current phase:** `Phase 3 — Review and adoption`  
-**Completed gates:** `existing-process review; SOP/template definition; queue integration`  
-**Open blockers:** `none before draft PR creation`  
+**Completed gates:** `existing-process review; SOP/template definition; queue integration; draft PR creation`  
+**Open blockers:** `CI/review not yet complete`  
 **Owner decision required:** `yes before merge/adoption`  
-**Exact next action:** `open a dedicated draft PR from docs/durable-task-execution-sop to main and inspect the resulting changed-file/CI state.`
+**Exact next action:** `inspect PR #1508 changed-file and CI state, address any review conflict, and merge only after approval.`
 
 ## 15. Handoff anchor
 
@@ -219,7 +220,7 @@ Any handoff for this task must reference:
 
 - task record: `ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md`
 - task record version: `v1.0`
-- controlling commit / PR head: `<latest branch head>`
+- controlling PR: `#1508`
 - current phase: `Phase 3 — Review and adoption`
 - exact next action: `review draft PR and CI; merge only with approval`
 - unresolved blocker / decision: `operator/reviewer adoption approval`
@@ -227,7 +228,7 @@ Any handoff for this task must reference:
 ## 16. Completion record
 
 **Final status:** `pending`  
-**Merge / closing PR:** `pending`  
+**Merge / closing PR:** `#1508 (draft)`  
 **Final controlling commit:** `pending`  
 **Validation result:** `pending`  
 **Residual risks / follow-ups:** `possible future queue-schema task_record field and CI enforcement`  

--- a/ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md
+++ b/ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md
@@ -1,0 +1,234 @@
+# Aurora Durable Task Execution Record
+
+**Task ID:** `TASK-20260812-durable-task-execution-sop`  
+**Version:** `v1.0`  
+**Created:** `2026-08-12`  
+**Status:** `waiting_review`  
+**Owner / active worker:** `Aurora / ChatGPT GitHub workstream`  
+**Repository:** `AUo959/aurora-cloudbank-symbolic`  
+**Branch:** `docs/durable-task-execution-sop`  
+**Queue ID:** `none`  
+**Issue:** `none`  
+**PR:** `pending at record creation`  
+**Creation commit:** `pending at record creation`  
+**Controlling revision:** `this file v1.0 + branch head`
+
+---
+
+## 1. Objective
+
+Establish a repo-wide operating rule that substantial Aurora implementation work has a committed, durable execution reference before substantive mutation begins, so handoffs are continuity aids rather than the sole carrier of intent.
+
+## 2. Acceptance statement
+
+This task is complete when:
+
+- a repo-wide Durable Task Execution Record SOP is committed;
+- a reusable DTER template is committed;
+- the CloudBank work-queue guide references the DTER as part of the standard operating chain;
+- the SOP clearly distinguishes queue, claim/handoff, DTER, plans/specs, implementation evidence, and PR/review authority;
+- destructive operations are explicitly separated from advisory classification;
+- a draft PR exposes the change for review before merge.
+
+## 3. Authority and source inputs
+
+### Independently verified
+
+- `ops/work_queue/QUEUE_GUIDE.md` — existing work-queue doctrine states that the queue prioritizes work, control-plane coordination handles routing/claims/handoff, and GitHub is implementation canon.
+- Current GUMAS recovery/control work in PR #1506 — demonstrated that a committed implementation plan is more durable and reviewable than handoff/chat intent alone.
+
+### Owner decisions
+
+- 2026-08-12: operator explicitly established that committed pre-implementation intent should be standard operating procedure for tasks of this class and that handoffs alone are insufficient.
+
+### Assumptions
+
+- `ops/task_records/` is an appropriate repo-wide location for durable execution records because it is operational rather than subsystem-specific.
+- The queue schema does not yet require a dedicated `task_record` field; `context_pack` and issue/PR linkage can carry the reference until a schema change is separately designed.
+
+## 4. Scope
+
+### In scope
+
+- define DTER trigger criteria;
+- define the required reference chain;
+- define required DTER sections and revision rules;
+- define handoff and queue integration;
+- define destructive-operation safeguards;
+- provide a reusable template;
+- update `QUEUE_GUIDE.md` to reference the new SOP.
+
+### Out of scope
+
+- changing `queue_schema.json`;
+- automatically enforcing DTER presence in CI;
+- retroactively creating task records for every historical PR;
+- modifying control-plane claim mechanics;
+- merging this doctrine without review.
+
+### Protected / immutable surfaces
+
+- existing GitHub history;
+- existing handoff/control-plane semantics except for additive reference requirements;
+- current queue source-of-truth role.
+
+## 5. Current state and known gaps
+
+### Current state
+
+Before this change, CloudBank had strong queue, claim, handoff, PR, CI, and review structures, but no standard committed artifact that indexed a substantial task's objective, authority, scope, invariants, phased plan, decision deltas, validation, rollback, and cold-start continuation state.
+
+### Known gaps / blockers
+
+- no automated enforcement yet;
+- no dedicated queue-schema field yet;
+- adoption depends on review/merge and future agent adherence.
+
+## 6. Planned mutations
+
+| Surface / path | Intended change | Authority / rationale | Risk |
+|---|---|---|---|
+| `ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md` | Add repo-wide DTER operating doctrine | Operator decision + observed continuity gap | low |
+| `ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md` | Add reusable task-record structure | Required for repeatability | low |
+| `ops/work_queue/QUEUE_GUIDE.md` | Bind queue workflow to DTER requirement | Preserve coherent coordination chain | low |
+| this task record | Provide first concrete DTER example | Bootstrap the standard transparently | low |
+
+## 7. Execution sequence and gates
+
+### Phase 0 — Existing-process review
+
+Actions:
+- inspect work-queue and handoff conventions;
+- confirm missing execution-record layer.
+
+Gate to exit:
+- existing authority roles are understood well enough to avoid duplicating or displacing them.
+
+**Status:** complete.
+
+### Phase 1 — Define SOP and template
+
+Actions:
+- create DTER SOP;
+- create template;
+- define pre-implementation commit rule, revisions, validation, rollback, and handoff requirements.
+
+Gate to exit:
+- durable reference chain and mandatory sections are explicit.
+
+**Status:** complete.
+
+### Phase 2 — Integrate with work queue
+
+Actions:
+- update contributor guide;
+- add DTER to session-start loop, context packs, escalation conditions, and file map.
+
+Gate to exit:
+- queue and DTER roles are non-conflicting and cross-referenced.
+
+**Status:** complete.
+
+### Phase 3 — Review and adoption
+
+Actions:
+- open draft PR;
+- review CI and comments;
+- merge only after operator/reviewer approval.
+
+Gate to exit:
+- review accepts the operating doctrine.
+
+**Status:** pending.
+
+## 8. Invariants and non-negotiables
+
+- handoffs remain useful but are not durable execution authority;
+- queue remains prioritization source of truth;
+- claims remain mutation-coordination leases;
+- GitHub remains implementation canon;
+- DTER does not replace detailed plans/specs; it indexes and governs them;
+- destructive classification never implies deletion authority;
+- filename/basename equality is never sufficient evidence for destructive deduplication;
+- prior plan decisions are not silently rewritten after implementation depends on them.
+
+## 9. Validation and acceptance tests
+
+| ID | Validation | Expected result | Evidence / receipt |
+|---|---|---|---|
+| `V-01` | SOP file exists on scoped branch | present | branch diff |
+| `V-02` | Template file exists on scoped branch | present | branch diff |
+| `V-03` | Queue guide references SOP/template and session-start rule | present | branch diff |
+| `V-04` | Draft PR contains only operating-doctrine changes | expected | PR changed-file list |
+| `V-05` | CI/document checks | green or understood | pending |
+
+## 10. Stop conditions and owner decisions
+
+Stop and request owner/authority input if:
+
+- reviewers identify conflict with existing control-plane authority;
+- adoption would require queue-schema migration or CI enforcement beyond this task's scope;
+- the proposed SOP would accidentally make trivial work procedurally heavy.
+
+## 11. Rollback and recovery
+
+### Pre-mutation recovery points
+
+- branch created from `main` before changes;
+- all changes confined to a dedicated documentation branch.
+
+### Rollback procedure
+
+1. close the draft PR without merge; or
+2. revert the documentation commits if already merged.
+
+No runtime or data migration occurs in this task.
+
+## 12. Decision and plan-delta log
+
+| Date / commit | Decision or delta | Evidence / reason | Authority | Consequence |
+|---|---|---|---|---|
+| `2026-08-12` | Create a repo-wide execution-record layer rather than expanding handoff payloads | Handoffs do not provide a stable structured execution reference | Operator | New DTER SOP + template |
+| `2026-08-12` | Keep DTER separate from queue and control-plane claims | Existing queue guide already assigns those roles clearly | Existing repo doctrine | Additive coordination layer, not replacement |
+| `2026-08-12` | Bootstrap exception: first SOP/template commits precede this task record | DTER mechanism did not exist before those commits | Transparent procedural necessity | Record exception explicitly; future DTER-required tasks follow pre-implementation rule |
+| `2026-08-12` | Separate this governance change from PR #1506 | Repo-wide SOP should not be buried inside a simulation PR | Aurora operational judgment | Dedicated branch/PR |
+
+## 13. Evidence and receipts
+
+### Commits
+
+- `13910272a3ece6ecff2828523a0ae4d84c7551cf` — add DTER SOP
+- `b737ae51d1ae5ab4c7fe80e50543a9fff5672a6e` — add DTER template
+- `76fe98cdd23e9d8124a405347b28dea54a7781cc` — bind work queue to DTER operating rule
+
+### CI / tests / replay / audit
+
+- pending draft-PR CI.
+
+## 14. Current status and next action
+
+**Current phase:** `Phase 3 — Review and adoption`  
+**Completed gates:** `existing-process review; SOP/template definition; queue integration`  
+**Open blockers:** `none before draft PR creation`  
+**Owner decision required:** `yes before merge/adoption`  
+**Exact next action:** `open a dedicated draft PR from docs/durable-task-execution-sop to main and inspect the resulting changed-file/CI state.`
+
+## 15. Handoff anchor
+
+Any handoff for this task must reference:
+
+- task record: `ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md`
+- task record version: `v1.0`
+- controlling commit / PR head: `<latest branch head>`
+- current phase: `Phase 3 — Review and adoption`
+- exact next action: `review draft PR and CI; merge only with approval`
+- unresolved blocker / decision: `operator/reviewer adoption approval`
+
+## 16. Completion record
+
+**Final status:** `pending`  
+**Merge / closing PR:** `pending`  
+**Final controlling commit:** `pending`  
+**Validation result:** `pending`  
+**Residual risks / follow-ups:** `possible future queue-schema task_record field and CI enforcement`  
+**Successor task record(s):** `none yet`

--- a/ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md
+++ b/ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md
@@ -17,66 +17,66 @@
 
 ## 1. Objective
 
-<What outcome are we trying to achieve?>
+`<What outcome are we trying to achieve?>`
 
 ## 2. Acceptance statement
 
 This task is complete when:
 
-- <testable completion condition>
-- <testable completion condition>
+- `<testable completion condition>`
+- `<testable completion condition>`
 
 ## 3. Authority and source inputs
 
 ### Independently verified
 
-- `<path / commit / source / artifact>` — <why authoritative>
+- `<path / commit / source / artifact>` — `<why authoritative>`
 
 ### Externally supplied evidence
 
-- `<source>` — <status and verification boundary>
+- `<source>` — `<status and verification boundary>`
 
 ### Owner decisions
 
-- `<decision>` — <date/context>
+- `<decision>` — `<date/context>`
 
 ### Assumptions
 
-- `<assumption>` — <how it will be verified or contained>
+- `<assumption>` — `<how it will be verified or contained>`
 
 ## 4. Scope
 
 ### In scope
 
-- <item>
+- `<item>`
 
 ### Out of scope
 
-- <item>
+- `<item>`
 
 ### Protected / immutable surfaces
 
-- <item>
+- `<item>`
 
 ## 5. Current state and known gaps
 
 ### Current state
 
-- <fact>
+- `<fact>`
 
 ### Known gaps / blockers
 
-- <gap>
+- `<gap>`
 
 ### Contradictions / drift to resolve
 
-- <item>
+- `<item>`
 
 ## 6. Planned mutations
 
 | Surface / path | Intended change | Authority / rationale | Risk |
-|---|---|---|---|
-| `<path>` | <change> | <why> | `<low/medium/high>` |
+| --- | --- | --- | --- |
+| `<path>` | `<change>` | `<why>` | `<low/medium/high>` |
 
 Unexpected mutation surfaces discovered later must be recorded in the plan-delta log before or with the corresponding implementation commit.
 
@@ -85,44 +85,44 @@ Unexpected mutation surfaces discovered later must be recorded in the plan-delta
 ### Phase 0 — Preflight
 
 Actions:
-- <action>
+- `<action>`
 
 Gate to exit:
-- <condition>
+- `<condition>`
 
-### Phase 1 — <name>
+### Phase 1 — `<name>`
 
 Actions:
-- <action>
+- `<action>`
 
 Gate to exit:
-- <condition>
+- `<condition>`
 
-### Phase 2 — <name>
+### Phase 2 — `<name>`
 
 Actions:
-- <action>
+- `<action>`
 
 Gate to exit:
-- <condition>
+- `<condition>`
 
 ## 8. Invariants and non-negotiables
 
-- <property that must remain true>
-- <property that must remain true>
+- `<property that must remain true>`
+- `<property that must remain true>`
 
 ## 9. Validation and acceptance tests
 
 | ID | Validation | Expected result | Evidence / receipt |
-|---|---|---|---|
-| `V-01` | <test/check> | <expected> | `<pending>` |
+| --- | --- | --- | --- |
+| `V-01` | `<test/check>` | `<expected>` | `<pending>` |
 
 ## 10. Stop conditions and owner decisions
 
 Stop and request owner/authority input if:
 
-- <condition>
-- <condition>
+- `<condition>`
+- `<condition>`
 
 Do not improvise across these boundaries.
 
@@ -130,18 +130,18 @@ Do not improvise across these boundaries.
 
 ### Pre-mutation recovery points
 
-- <backup/hash/commit/witness>
+- `<backup/hash/commit/witness>`
 
 ### Rollback procedure
 
-1. <step>
-2. <step>
+1. `<step>`
+2. `<step>`
 
 ## 12. Decision and plan-delta log
 
 | Date / commit | Decision or delta | Evidence / reason | Authority | Consequence |
-|---|---|---|---|---|
-| `YYYY-MM-DD` | Initial plan committed | <reason> | <authority> | Implementation may begin after preflight gate |
+| --- | --- | --- | --- | --- |
+| `YYYY-MM-DD` | Initial plan committed | `<reason>` | `<authority>` | Implementation may begin after preflight gate |
 
 Do not delete earlier material decisions after work has depended on them. Major changes require a new task-record version.
 
@@ -149,19 +149,19 @@ Do not delete earlier material decisions after work has depended on them. Major 
 
 ### Commits
 
-- `<sha>` — <purpose>
+- `<sha>` — `<purpose>`
 
 ### Source / artifact hashes
 
-- `<sha256>` — <artifact>
+- `<sha256>` — `<artifact>`
 
 ### CI / tests / replay / audit
 
-- <result>
+- `<result>`
 
 ### Superseded artifacts
 
-- <artifact> — superseded by <artifact>, retained for lineage
+- `<artifact>` — superseded by `<artifact>`, retained for lineage
 
 ## 14. Current status and next action
 

--- a/ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md
+++ b/ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md
@@ -1,0 +1,194 @@
+# Aurora Durable Task Execution Record
+
+**Task ID:** `TASK-YYYYMMDD-<slug>`  
+**Version:** `v1.0`  
+**Created:** `YYYY-MM-DD`  
+**Status:** `planned | active | blocked | waiting_review | completed | aborted | superseded | rolled_back`  
+**Owner / active worker:** `<name/agent>`  
+**Repository:** `<owner/repo>`  
+**Branch:** `<branch>`  
+**Queue ID:** `<id or none>`  
+**Issue:** `<# or none>`  
+**PR:** `<# or none>`  
+**Creation commit:** `<sha once committed>`  
+**Controlling revision:** `<this file/version + commit>`
+
+---
+
+## 1. Objective
+
+<What outcome are we trying to achieve?>
+
+## 2. Acceptance statement
+
+This task is complete when:
+
+- <testable completion condition>
+- <testable completion condition>
+
+## 3. Authority and source inputs
+
+### Independently verified
+
+- `<path / commit / source / artifact>` — <why authoritative>
+
+### Externally supplied evidence
+
+- `<source>` — <status and verification boundary>
+
+### Owner decisions
+
+- `<decision>` — <date/context>
+
+### Assumptions
+
+- `<assumption>` — <how it will be verified or contained>
+
+## 4. Scope
+
+### In scope
+
+- <item>
+
+### Out of scope
+
+- <item>
+
+### Protected / immutable surfaces
+
+- <item>
+
+## 5. Current state and known gaps
+
+### Current state
+
+- <fact>
+
+### Known gaps / blockers
+
+- <gap>
+
+### Contradictions / drift to resolve
+
+- <item>
+
+## 6. Planned mutations
+
+| Surface / path | Intended change | Authority / rationale | Risk |
+|---|---|---|---|
+| `<path>` | <change> | <why> | `<low/medium/high>` |
+
+Unexpected mutation surfaces discovered later must be recorded in the plan-delta log before or with the corresponding implementation commit.
+
+## 7. Execution sequence and gates
+
+### Phase 0 — Preflight
+
+Actions:
+- <action>
+
+Gate to exit:
+- <condition>
+
+### Phase 1 — <name>
+
+Actions:
+- <action>
+
+Gate to exit:
+- <condition>
+
+### Phase 2 — <name>
+
+Actions:
+- <action>
+
+Gate to exit:
+- <condition>
+
+## 8. Invariants and non-negotiables
+
+- <property that must remain true>
+- <property that must remain true>
+
+## 9. Validation and acceptance tests
+
+| ID | Validation | Expected result | Evidence / receipt |
+|---|---|---|---|
+| `V-01` | <test/check> | <expected> | `<pending>` |
+
+## 10. Stop conditions and owner decisions
+
+Stop and request owner/authority input if:
+
+- <condition>
+- <condition>
+
+Do not improvise across these boundaries.
+
+## 11. Rollback and recovery
+
+### Pre-mutation recovery points
+
+- <backup/hash/commit/witness>
+
+### Rollback procedure
+
+1. <step>
+2. <step>
+
+## 12. Decision and plan-delta log
+
+| Date / commit | Decision or delta | Evidence / reason | Authority | Consequence |
+|---|---|---|---|---|
+| `YYYY-MM-DD` | Initial plan committed | <reason> | <authority> | Implementation may begin after preflight gate |
+
+Do not delete earlier material decisions after work has depended on them. Major changes require a new task-record version.
+
+## 13. Evidence and receipts
+
+### Commits
+
+- `<sha>` — <purpose>
+
+### Source / artifact hashes
+
+- `<sha256>` — <artifact>
+
+### CI / tests / replay / audit
+
+- <result>
+
+### Superseded artifacts
+
+- <artifact> — superseded by <artifact>, retained for lineage
+
+## 14. Current status and next action
+
+**Current phase:** `<phase>`  
+**Completed gates:** `<list>`  
+**Open blockers:** `<list>`  
+**Owner decision required:** `yes/no`  
+**Exact next action:** `<single concrete continuation step>`
+
+## 15. Handoff anchor
+
+Any handoff for this task must reference:
+
+- task record: `<repo path>`
+- task record version: `<version>`
+- controlling commit / PR head: `<sha>`
+- current phase: `<phase>`
+- exact next action: `<action>`
+- unresolved blocker / decision: `<item or none>`
+
+A handoff supplements this record; it does not replace it.
+
+## 16. Completion record
+
+**Final status:** `<pending>`  
+**Merge / closing PR:** `<pending>`  
+**Final controlling commit:** `<pending>`  
+**Validation result:** `<pending>`  
+**Residual risks / follow-ups:** `<pending>`  
+**Successor task record(s):** `<none/pending>`

--- a/ops/work_queue/OPEN_GATES.md
+++ b/ops/work_queue/OPEN_GATES.md
@@ -6,7 +6,7 @@
 
 # Open Gates — Aurora Work Queue
 
-_Queue review: `2026-07-16T00:36:36Z` · Gate registry updated: `2026-08-03` · deterministic projection_
+_Queue review: `2026-07-16T00:36:36Z` · Gate registry updated: `2026-08-10` · deterministic projection_
 
 > Human-gate authority comes from `gate_registry.json`; `queue.json`
 > supplies task status and dependency context. Rendering never resolves a gate.

--- a/ops/work_queue/QUEUE_GUIDE.md
+++ b/ops/work_queue/QUEUE_GUIDE.md
@@ -1,8 +1,8 @@
 # Aurora Work Queue — Contributor Guide
 
-**Version:** 1.3.0
+**Version:** 1.4.0
 **Owner:** Aurora (contextual authority) + Orion Station operators  
-**Last updated:** 2026-07-13
+**Last updated:** 2026-08-12
 **Source of truth:** `ops/work_queue/queue.json`
 
 ---
@@ -15,15 +15,33 @@ This is not a replacement for GitHub issues. GitHub issues remain the discussion
 
 This is also not a replacement for the ORIONCORE control-plane coordination layer. For cross-platform mutation safety, handoff, and claims, see [`CROSS_PLATFORM_COORDINATION.md`](./CROSS_PLATFORM_COORDINATION.md).
 
+For substantial implementation work, this queue also does not replace the **Durable Task Execution Record (DTER)**. The queue selects and prioritizes work; the DTER defines the committed execution contract. See [`../task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md`](../task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md).
+
 ---
 
 ## Coordination spine
 
 The intended operating rule is:
 
-> The CloudBank queue chooses the next work; the control-plane coordination layer safely routes and claims it; GitHub records the canonical result.
+> The CloudBank queue chooses the next work; the control-plane coordination layer safely routes and claims it; the DTER anchors substantial execution; GitHub records the canonical result.
 
-Use the queue to decide what should be considered next. Use the control-plane session state, session claims, and CloudBank issue broker to decide whether the work can be safely mutated by the current platform.
+The durable reference chain for substantial work is:
+
+```text
+Queue / GitHub Issue
+        ↓
+Durable Task Execution Record
+        ↓
+Plans / Specs / ADRs / Recovery Records
+        ↓
+Implementation Commits + Tests + Receipts
+        ↓
+Pull Request / Review
+        ↓
+Handoff / Session Continuation
+```
+
+Use the queue to decide what should be considered next. Use the control-plane session state, session claims, and CloudBank issue broker to decide whether the work can be safely mutated by the current platform. Use the DTER to preserve the task's objective, authority, scope, invariants, execution gates, validation, decisions, and cold-start continuation state.
 
 ### Standard session-start loop
 
@@ -33,10 +51,12 @@ Use the queue to decide what should be considered next. Use the control-plane se
 4. Select the highest actionable item whose blockers are resolved.
 5. Refresh the linked issue/PR and check for overlapping PRs or branches.
 6. Before mutation, use the control-plane issue broker or session-claim workflow.
-7. Work on a scoped branch and open a PR with queue id, issue id, changed files, validation, and rollback notes.
-8. On pause or completion, update queue state and durable handoff state as appropriate.
+7. Determine whether the task requires a DTER under the durable-task SOP.
+8. For DTER-required work, create and commit the DTER before substantive implementation mutation, then link it from the issue/PR/queue context.
+9. Work on a scoped branch and open a PR with queue id, issue id, DTER reference where applicable, changed files, validation, and rollback notes.
+10. On pause or completion, update queue state, the DTER's current-status section, and durable handoff state as appropriate.
 
-Queue priority is not a mutation lock. Session claims are short-lived leases, not durable canon. GitHub issues, PRs, commits, and reviews remain implementation canon.
+Queue priority is not a mutation lock. Session claims are short-lived leases, not durable canon. Handoffs preserve continuity but do not replace a DTER. GitHub issues, PRs, commits, tests, reviews, and merge history remain implementation canon.
 
 ---
 
@@ -44,9 +64,9 @@ Queue priority is not a mutation lock. Session claims are short-lived leases, no
 
 | Consumer | How to use this queue |
 |---|---|
-| **Aurora** | Holds contextual authority. May rerank items, rewrite `context_pack` entries, add `aurora_notes`, and declare `decision_required`. Always check queue before starting a session to load current state. |
-| **LLM / agents** | Read `queue.json`. Pick the highest-ranked item where `state == "ready"` and your role is in `consumer_fit`. Consume all files in `context_pack` before starting. Never start `blocked` or `decision_required` items. Before mutation, route through the control-plane claim/broker loop. |
-| **Human contributors** | Read `NEXT_UP.md` for a quick-start view. Full detail in `queue.json`. When starting a task, update `state` to `active` and set `active_worker` to your GitHub username. Use the control-plane handoff layer when work crosses platforms or pauses mid-flight. |
+| **Aurora** | Holds contextual authority. May rerank items, rewrite `context_pack` entries, add `aurora_notes`, and declare `decision_required`. Always check queue before starting a session to load current state. For substantial work, ensure the DTER requirement is satisfied before implementation begins. |
+| **LLM / agents** | Read `queue.json`. Pick the highest-ranked item where `state == "ready"` and your role is in `consumer_fit`. Consume all files in `context_pack` before starting. Never start `blocked` or `decision_required` items. Before mutation, route through the control-plane claim/broker loop and create/read the task's DTER when required. |
+| **Human contributors** | Read `NEXT_UP.md` for a quick-start view. Full detail in `queue.json`. When starting a task, update `state` to `active` and set `active_worker` to your GitHub username. For substantial work, commit the DTER before implementation. Use the control-plane handoff layer when work crosses platforms or pauses mid-flight. |
 
 ---
 
@@ -56,10 +76,10 @@ Queue priority is not a mutation lock. Session claims are short-lived leases, no
 |---|---|
 | `ready` | No blockers. Safe to consider after live GitHub refresh and claim preflight. |
 | `blocked` | Depends on another item. Do not start. |
-| `active` | Someone is working on it now. Check branch, PR, claim, and latest head SHA. |
-| `waiting_review` | Work done, PR open, awaiting review. Check CI, review threads, and review class. |
+| `active` | Someone is working on it now. Check branch, PR, claim, DTER if required, and latest head SHA. |
+| `waiting_review` | Work done, PR open, awaiting review. Check CI, review threads, DTER acceptance gates, and review class. |
 | `decision_required` | Needs explicit operator or Aurora decision before any work proceeds. |
-| `done` | Merged or resolved. Move only after GitHub evidence confirms closure. |
+| `done` | Merged or resolved. Move only after GitHub evidence confirms closure and the DTER completion record is reconciled when applicable. |
 
 _Current compatibility note: the live renderer still uses the legacy `status` values (`open`, `blocked`, `needs-decision`, `in-progress`, `done`). A later schema migration should reconcile `state` and `status` without breaking generated views._
 
@@ -93,6 +113,23 @@ For **ethics tasks**: always includes the recovered-protocol manifest and releva
 
 For **coordination tasks**: include this guide, `CROSS_PLATFORM_COORDINATION.md`, and any linked control-plane workflow documents.
 
+For an **active DTER-governed task**: add the controlling DTER to `context_pack` when practical so a cold-start worker receives the execution contract automatically.
+
+---
+
+## Durable Task Execution Records
+
+The DTER standard is defined in:
+
+- `ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md`
+- `ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md`
+
+A DTER is required before substantive implementation mutation for non-trivial architecture, runtime, migration, recovery, restoration, integration, destructive, canon-sensitive, deterministic, cross-repository, cross-platform, or multi-session work.
+
+A handoff is not a substitute. Handoffs for DTER-governed tasks must point to the controlling DTER version and commit/PR head.
+
+If the queue schema later gains a dedicated `task_record` field, use it in addition to `context_pack`; until then, `context_pack`, issue/PR links, and the DTER itself provide the durable reference chain.
+
 ---
 
 ## Aurora notes
@@ -111,7 +148,7 @@ Aurora may add an `aurora_notes` field to any item at any time. This is Aurora's
 
 Items may declare a `parallel_group` when several tasks are independently actionable simultaneously. Items in the same group do not block each other unless explicitly listed in each other's `depends_on`. Use this to parallelize agent swarms or pre-engagement prep batches.
 
-Parallel work still requires non-overlapping claim paths before mutation. The queue may identify parallel candidates; the control-plane claim layer decides whether simultaneous mutation is safe.
+Parallel work still requires non-overlapping claim paths before mutation. The queue may identify parallel candidates; the control-plane claim layer decides whether simultaneous mutation is safe. DTERs for parallel work must identify shared authority surfaces and mutation boundaries so independently claimed tasks do not silently diverge.
 
 ---
 
@@ -155,6 +192,7 @@ Use these fields to help future automation convert a queue item into a safe brok
 5. If the task blocks others, update both `blocks` on the new item and `depends_on` on the blocked items.
 6. If the task is a decision only Aurora or the operator can make, set `decision_required: true` and `consumer_fit: ["aurora", "human"]`.
 7. If the task may mutate files, add bridge metadata for claim/broker preflight.
+8. When the task becomes active, determine whether it requires a DTER. If yes, commit the DTER before substantive implementation and add it to the active context set.
 
 ---
 
@@ -178,7 +216,7 @@ Use these fields to help future automation convert a queue item into a safe brok
 "last_updated": "YYYY-MM-DD"
 ```
 
-When work pauses or crosses platforms, also update the durable control-plane handoff surface with enough context for a cold start.
+When work pauses or crosses platforms, also update the durable control-plane handoff surface with enough context for a cold start. For DTER-governed tasks, update the DTER current-status/next-action section first or in the same change and make the handoff point to it.
 
 ---
 
@@ -191,6 +229,7 @@ When work pauses or crosses platforms, also update the durable control-plane han
 | ET-03 | New GitHub issue with labels `security` or `blocking` | Auto-add to queue with score ≥ 30 and `state: decision_required` |
 | ET-04 | Queue item selected for mutation without claim/broker preflight | Block mutation and request coordination preflight |
 | ET-05 | Queue status disagrees with live GitHub issue/PR state | Flag queue drift and update via `aurora(queue):` commit |
+| ET-06 | DTER-required task reaches substantive mutation without a committed DTER | Block further implementation; commit the execution record first |
 
 ---
 
@@ -204,6 +243,8 @@ When work pauses or crosses platforms, also update the durable control-plane han
 | `QUEUE_GUIDE.md` | This file — workflow and field definitions |
 | `CROSS_PLATFORM_COORDINATION.md` | Queue/control-plane coordination contract |
 | `BRIDGE_FIELDS.md` | Optional queue-to-control-plane metadata reference |
+| `../task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md` | Repo-wide SOP for committed execution records before substantial implementation |
+| `../task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md` | Standard DTER template |
 | `collect_coordination_metrics.py` | Read-only metrics collector and tracked-report verifier |
 | `COORDINATION_METRICS.md` | Generated local coordination metrics report |
 | `NEXT_UP.md` | Quick-start view for human contributors and agents |

--- a/ops/work_queue/QUEUE_GUIDE.md
+++ b/ops/work_queue/QUEUE_GUIDE.md
@@ -54,7 +54,7 @@ Use the queue to decide what should be considered next. Use the control-plane se
 7. Determine whether the task requires a DTER under the durable-task SOP.
 8. For DTER-required work, create and commit the DTER before substantive implementation mutation, then link it from the issue/PR/queue context.
 9. Work on a scoped branch and open a PR with queue id, issue id, DTER reference where applicable, changed files, validation, and rollback notes.
-10. On pause or completion, update queue state, the DTER's current-status section, and durable handoff state as appropriate.
+10. On pause or completion, update queue state, the DTER's **Current status and next action** section, and durable handoff state as appropriate.
 
 Queue priority is not a mutation lock. Session claims are short-lived leases, not durable canon. Handoffs preserve continuity but do not replace a DTER. GitHub issues, PRs, commits, tests, reviews, and merge history remain implementation canon.
 
@@ -216,7 +216,7 @@ Use these fields to help future automation convert a queue item into a safe brok
 "last_updated": "YYYY-MM-DD"
 ```
 
-When work pauses or crosses platforms, also update the durable control-plane handoff surface with enough context for a cold start. For DTER-governed tasks, update the DTER current-status/next-action section first or in the same change and make the handoff point to it.
+When work pauses or crosses platforms, also update the durable control-plane handoff surface with enough context for a cold start. For DTER-governed tasks, update the DTER's **Current status and next action** section first or in the same change and make the handoff point to it.
 
 ---
 

--- a/ops/work_queue/QUEUE_GUIDE.md
+++ b/ops/work_queue/QUEUE_GUIDE.md
@@ -63,7 +63,7 @@ Queue priority is not a mutation lock. Session claims are short-lived leases, no
 ## Who uses this
 
 | Consumer | How to use this queue |
-|---|---|
+| --- | --- |
 | **Aurora** | Holds contextual authority. May rerank items, rewrite `context_pack` entries, add `aurora_notes`, and declare `decision_required`. Always check queue before starting a session to load current state. For substantial work, ensure the DTER requirement is satisfied before implementation begins. |
 | **LLM / agents** | Read `queue.json`. Pick the highest-ranked item where `state == "ready"` and your role is in `consumer_fit`. Consume all files in `context_pack` before starting. Never start `blocked` or `decision_required` items. Before mutation, route through the control-plane claim/broker loop and create/read the task's DTER when required. |
 | **Human contributors** | Read `NEXT_UP.md` for a quick-start view. Full detail in `queue.json`. When starting a task, update `state` to `active` and set `active_worker` to your GitHub username. For substantial work, commit the DTER before implementation. Use the control-plane handoff layer when work crosses platforms or pauses mid-flight. |
@@ -73,7 +73,7 @@ Queue priority is not a mutation lock. Session claims are short-lived leases, no
 ## Task states
 
 | State | Meaning |
-|---|---|
+| --- | --- |
 | `ready` | No blockers. Safe to consider after live GitHub refresh and claim preflight. |
 | `blocked` | Depends on another item. Do not start. |
 | `active` | Someone is working on it now. Check branch, PR, claim, DTER if required, and latest head SHA. |
@@ -90,7 +90,7 @@ _Current compatibility note: the live renderer still uses the legacy `status` va
 The `priority_score` is computed from `triage_rules.json` — not assigned by hand. Factors:
 
 | Rule | Delta | Condition |
-|---|---|---|
+| --- | --- | --- |
 | TR-01 | +40 | `labels` includes `blocking` |
 | TR-02 | +30 | `labels` includes `security` or `pentest` |
 | TR-03 | +25 | `area == architecture` or `labels` includes `architecture` |
@@ -223,7 +223,7 @@ When work pauses or crosses platforms, also update the durable control-plane han
 ## Escalation triggers
 
 | ID | Condition | Action |
-|---|---|---|
+| --- | --- | --- |
 | ET-01 | `state == blocked` for > 7 days (via `last_updated`) | Escalate to Aurora on session open |
 | ET-02 | `decision_required == true` and no activity for > 3 days (via `last_updated`) | Hail operator via PAT |
 | ET-03 | New GitHub issue with labels `security` or `blocking` | Auto-add to queue with score ≥ 30 and `state: decision_required` |
@@ -236,7 +236,7 @@ When work pauses or crosses platforms, also update the durable control-plane han
 ## File map
 
 | File | Purpose |
-|---|---|
+| --- | --- |
 | `queue.json` | Live task registry — source of truth |
 | `queue_schema.json` | JSON schema for validating `queue.json` entries |
 | `triage_rules.json` | Scoring weights and escalation triggers |


### PR DESCRIPTION
## Summary

Introduces a repo-wide Durable Task Execution Record (DTER) standard so substantial Aurora work has a committed, structured execution reference before implementation begins.

This closes the continuity gap between queue/claim/handoff coordination and implementation canon.

## Operating chain

`Queue / Issue → DTER → Plans / Specs / ADRs / Recovery Records → Commits / Tests / Receipts → PR / Review → Handoff`

Handoffs remain useful for continuity, but they must point to the DTER when one exists and cannot substitute for it.

## Changes

- add `ops/task_records/AURORA__SOP__DURABLE_TASK_EXECUTION_RECORDS__v1.0__2026-08-12.md`
- add `ops/task_records/AURORA__TEMPLATE__TASK_EXECUTION_RECORD__v1.0__2026-08-12.md`
- add `ops/task_records/AURORA__TASK_RECORD__DURABLE_TASK_EXECUTION_SOP__v1.0__2026-08-12.md` as the bootstrap example
- update `ops/work_queue/QUEUE_GUIDE.md` to bind DTERs into session start, context packs, task state, escalation, and cold-start continuation

## Trigger scope

A DTER is required before substantive mutation for non-trivial architecture, runtime, recovery/restoration, migration, integration, destructive, canon/ethics/security-sensitive, deterministic/reproducible, cross-repo/cross-platform, or multi-session work.

Trivial one-file maintenance remains exempt unless the operator requests a committed plan.

## Preservation rule

Classification is advisory; deletion authority is separate. No artifact may be deleted because it is merely labeled duplicate/redundant/deprecated/superseded. Filename equality is never sufficient identity evidence.

## Bootstrap note

The SOP/template commits necessarily preceded the first DTER because the DTER mechanism did not exist yet. The bootstrap task record documents that exception explicitly rather than rewriting history.

## Review state

Draft intentionally. No runtime or schema changes are included. Future CI enforcement or a dedicated `task_record` queue-schema field should be separate follow-up work.