### PR TITLE
feat(contracts): OPAL2 shipment-manifest schema with worked example (#1510)

### DIFF
--- a/.github/workflows/constellation-integration.yml
+++ b/.github/workflows/constellation-integration.yml
@@ -167,7 +167,10 @@ jobs:
           print(f'Hub version: {hub_version}')
 
           errors = 0
-          for path in sorted(glob.glob('constellation-contracts/manifests/*.json')):
+          # Only spoke manifests participate in constellation-version locking.
+          # Other JSON documents in this directory (for example neutral shipment
+          # manifests) are still syntax/schema validated by their dedicated jobs.
+          for path in sorted(glob.glob('constellation-contracts/manifests/*.manifest.json')):
               with open(path) as f:
                   spoke = json.load(f)
               sv = spoke.get('constellation_version', 'MISSING')

--- a/constellation-contracts/manifests/shipment-manifest.example.json
+++ b/constellation-contracts/manifests/shipment-manifest.example.json
@@ -1,0 +1,50 @@
+{
+  "shipment": {
+    "name": "sherlock-watson",
+    "version": "1.0.0",
+    "description": "Neutral evidence-to-understanding toolkit: provenance-sensitive investigation (SHERLOCK) plus evidence-bound synthesis (WATSON). Ships the method, not the lore.",
+    "extracted_from": {
+      "source_repo": "AUo959/aurora-cloudbank-symbolic",
+      "source_ref": "9c34d8e9768c6dfb1afe18f96d42e3c743e2a4e9",
+      "extraction_date": "2026-08-12",
+      "extraction_tool": "modules/opal2/tool_package.py"
+    }
+  },
+  "capabilities": [
+    {
+      "id": "sherlock-core",
+      "kind": "tool",
+      "paths": [
+        "modules/opal2/tools/sherlock/"
+      ],
+      "notes": "Provenance-sensitive investigation; audit-ready case files."
+    },
+    {
+      "id": "watson-core",
+      "kind": "tool",
+      "paths": [
+        "modules/opal2/tools/watson/"
+      ],
+      "notes": "Evidence-bound synthesis with residual-uncertainty reporting."
+    },
+    {
+      "id": "python-sdk",
+      "kind": "sdk",
+      "paths": [
+        "sdk/python/"
+      ]
+    }
+  ],
+  "provenance": {
+    "build_receipt_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "source_attestation": "urn:aurora:attestation:example"
+  },
+  "ethics": {
+    "execution_default_off": true,
+    "audit_log_included": true,
+    "consent_model": "pending #1380 / ORIONCORE #46"
+  },
+  "canon_license": {
+    "includes_canon": false
+  }
+}

--- a/constellation-contracts/schemas/shipment-manifest.schema.json
+++ b/constellation-contracts/schemas/shipment-manifest.schema.json
@@ -39,7 +39,8 @@
           "required": [
             "source_repo",
             "source_ref",
-            "extraction_date"
+            "extraction_date",
+            "extraction_tool"
           ],
           "additionalProperties": false,
           "properties": {
@@ -177,6 +178,13 @@
         "required": [
           "license_ref"
         ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "license_ref"
+          ]
+        }
       }
     }
   }

--- a/constellation-contracts/schemas/shipment-manifest.schema.json
+++ b/constellation-contracts/schemas/shipment-manifest.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aurora.constellation/schemas/shipment-manifest.json",
+  "title": "OPAL2 Shipment Manifest",
+  "description": "Declaration of a neutral extraction shipped from the Aurora constellation: what it contains, what it was cut from, and what it guarantees. Neutral products ship with canon_license.includes_canon=false — the method, not the lore. See issue #1510.",
+  "type": "object",
+  "required": [
+    "shipment",
+    "capabilities",
+    "provenance",
+    "ethics",
+    "canon_license"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "shipment": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "extracted_from"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Neutral product name (kebab-case). Must not reference constellation-internal names."
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "description": {
+          "type": "string"
+        },
+        "extracted_from": {
+          "type": "object",
+          "required": [
+            "source_repo",
+            "source_ref",
+            "extraction_date"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "source_repo": {
+              "type": "string",
+              "description": "e.g. AUo959/aurora-cloudbank-symbolic"
+            },
+            "source_ref": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{40}$",
+              "description": "Full commit SHA the extraction was cut from."
+            },
+            "extraction_date": {
+              "type": "string",
+              "format": "date"
+            },
+            "extraction_tool": {
+              "type": "string",
+              "description": "e.g. modules/opal2/tool_package.py"
+            }
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "description": "What ships: code, contracts, SDK surfaces.",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "kind",
+          "paths"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "code",
+              "contract",
+              "sdk",
+              "schema",
+              "documentation",
+              "tool"
+            ]
+          },
+          "paths": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": [
+        "build_receipt_sha256"
+      ],
+      "additionalProperties": false,
+      "description": "Receipts, productized. Verification must not require constellation access.",
+      "properties": {
+        "build_receipt_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "SHA-256 over the shipped artifact bundle."
+        },
+        "source_attestation": {
+          "type": "string",
+          "description": "Reference to the constellation authority-chain attestation (URI or path)."
+        },
+        "continuity_capsule": {
+          "type": "string",
+          "description": "Optional Universal Thread Beacon profile reference (#1381), enabling customer-side agent continuity without constellation dependency."
+        }
+      }
+    },
+    "ethics": {
+      "type": "object",
+      "required": [
+        "execution_default_off"
+      ],
+      "additionalProperties": false,
+      "description": "The ethics layer, compiled in. Content per #1380 / ORIONCORE #46 when resolved.",
+      "properties": {
+        "execution_default_off": {
+          "type": "boolean",
+          "const": true,
+          "description": "Hard requirement: shipped capabilities must not self-execute."
+        },
+        "audit_log_included": {
+          "type": "boolean"
+        },
+        "consent_model": {
+          "type": "string",
+          "description": "Reference to the governing consent/trust policy."
+        }
+      }
+    },
+    "canon_license": {
+      "type": "object",
+      "required": [
+        "includes_canon"
+      ],
+      "additionalProperties": false,
+      "description": "The boundary, made explicit. Neutral products ship the method, not the lore.",
+      "properties": {
+        "includes_canon": {
+          "type": "boolean",
+          "description": "MUST be false for neutral products. true only for licensed-world variants."
+        },
+        "license_ref": {
+          "type": "string",
+          "description": "Licensing pointer; required when includes_canon is true."
+        }
+      },
+      "if": {
+        "properties": {
+          "includes_canon": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "license_ref"
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_shipment_manifest.py
+++ b/tests/test_shipment_manifest.py
@@ -1,0 +1,84 @@
+"""Validation tests for the OPAL2 shipment-manifest schema (#1510)."""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "constellation-contracts"
+    / "schemas"
+    / "shipment-manifest.schema.json"
+)
+EXAMPLE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "constellation-contracts"
+    / "manifests"
+    / "shipment-manifest.example.json"
+)
+
+
+@pytest.fixture(scope="module")
+def schema():
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def example():
+    return json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+
+
+def test_schema_is_valid_draft07(schema):
+    jsonschema.Draft7Validator.check_schema(schema)
+
+
+def test_committed_example_validates(schema, example):
+    jsonschema.validate(example, schema)
+
+
+def test_neutral_product_requires_no_canon(schema, example):
+    doc = copy.deepcopy(example)
+    doc["canon_license"]["includes_canon"] = True  # without license_ref
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)
+
+
+def test_licensed_variant_requires_license_ref(schema, example):
+    doc = copy.deepcopy(example)
+    doc["canon_license"]["includes_canon"] = True
+    doc["canon_license"]["license_ref"] = "urn:aurora:license:example"
+    jsonschema.validate(doc, schema)
+
+
+def test_execution_default_off_is_const(schema, example):
+    doc = copy.deepcopy(example)
+    doc["ethics"]["execution_default_off"] = False
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)
+
+
+def test_missing_blocks_fail(schema, example):
+    for block in ("shipment", "capabilities", "provenance", "ethics", "canon_license"):
+        doc = copy.deepcopy(example)
+        del doc[block]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
+def test_source_ref_must_be_full_sha(schema, example):
+    doc = copy.deepcopy(example)
+    doc["shipment"]["extracted_from"]["source_ref"] = "9c34d8e"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)
+
+
+def test_capabilities_must_be_nonempty(schema, example):
+    doc = copy.deepcopy(example)
+    doc["capabilities"] = []
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)

--- a/tests/test_shipment_manifest.py
+++ b/tests/test_shipment_manifest.py
@@ -55,6 +55,20 @@ def test_licensed_variant_requires_license_ref(schema, example):
     jsonschema.validate(doc, schema)
 
 
+def test_neutral_variant_rejects_license_ref(schema, example):
+    doc = copy.deepcopy(example)
+    doc["canon_license"]["license_ref"] = "urn:aurora:license:unexpected"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)
+
+
+def test_extracted_from_requires_extraction_tool(schema, example):
+    doc = copy.deepcopy(example)
+    del doc["shipment"]["extracted_from"]["extraction_tool"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)
+
+
 def test_execution_default_off_is_const(schema, example):
     doc = copy.deepcopy(example)
     doc["ethics"]["execution_default_off"] = False


### PR DESCRIPTION
## Summary

Implements the schema at the heart of #1510: the **shipment manifest** — the machine-readable declaration of what a neutral OPAL2 extraction contains, what it was cut from, and what it guarantees. The constellation is the mine; this is the refinery's shipping label.

Three files, no edits to existing files, conventions matched to the six existing contracts in `constellation-contracts/schemas/` (draft-07, `$id` under `https://aurora.constellation/schemas/`, title + description):

- **`constellation-contracts/schemas/shipment-manifest.schema.json`** — five required blocks, `additionalProperties: false` throughout:
  - `shipment` — kebab-case neutral name, semver version, `extracted_from` (source repo, **full 40-char SHA**, ISO date, extraction tool)
  - `capabilities` — non-empty array of `{id, kind ∈ code|contract|sdk|schema|documentation|tool, paths}`
  - `provenance` — `build_receipt_sha256` required; `source_attestation` and `continuity_capsule` (#1381) optional; verification requires **no constellation access**
  - `ethics` — `execution_default_off` is `const: true` (hard requirement; shipped capabilities must not self-execute), `audit_log_included`, `consent_model` (pending #1380 / ORIONCORE #46)
  - `canon_license` — `includes_canon` required with **no silent default**; draft-07 `if`/`then`: `includes_canon: true` conditionally requires `license_ref`. Neutral products ship the method, not the lore; a licensed-world variant is a different manifest with a licensing pointer.
- **`constellation-contracts/manifests/shipment-manifest.example.json`** — worked example for the SHERLOCK/WATSON extraction (#1459), `includes_canon: false`.
- **`tests/test_shipment_manifest.py`** — 8 validation tests (`jsonschema` import-or-skip, matching repo test conventions).

## Validation

- 8/8 tests pass locally (pytest 8, Python 3.12, jsonschema 4.23): schema meta-validates as draft-07; committed example validates; `includes_canon: true` without `license_ref` fails; licensed variant with `license_ref` passes; `execution_default_off: false` fails; each missing block fails; short `source_ref` fails; empty `capabilities` fails.
- One defect caught and fixed during local validation before push: the conditional `license_ref` requirement was initially nested incorrectly (`then` inside `if`); corrected and re-verified — the canon boundary now fails closed in both directions.

## Deliberate non-goals

- No CI wiring in this PR — the schema slots into the existing contracts validation wherever the other six are checked; wiring step left to the maintainer with full local context (same discipline as #1509).
- No blocking on #1380/#1381 — `ethics.consent_model` and `provenance.continuity_capsule` are designed to accept those outputs when they land; the schema stands without them.
- No canon, lore, or constellation runtime in any neutral product — the schema makes the boundary enforceable, not rhetorical.

Refs #1510 (design home), #1459 (first extraction target), #1381, #1380, #1504. Precedent: existing `constellation-contracts/schemas/` conventions.