### PR TITLE
docs(opal2): complete shipment-manifest checklist path

### DIFF
--- a/docs/architecture/OPAL2__PRODUCTIZATION_CHECKLIST__v1.0__2026-08-07.md
+++ b/docs/architecture/OPAL2__PRODUCTIZATION_CHECKLIST__v1.0__2026-08-07.md
@@ -16,6 +16,7 @@ neutral OPAL2 product.
 - [ ] Provider/network/model assumptions are explicit.
 - [ ] Clean-room fixtures exist.
 - [ ] `.opaltool` export and verification are supported when package scope is ready.
+- [ ] Emit and validate a shipment manifest against [`shipment-manifest.schema.json`](../../constellation-contracts/schemas/shipment-manifest.schema.json), starting from the [worked example](../../constellation-contracts/manifests/shipment-manifest.example.json).
 - [ ] Standalone execution outside Aurora has been demonstrated.
 - [ ] Product claims do not exceed the implemented boundary.
 


### PR DESCRIPTION
## Summary

Completes the one remaining acceptance criterion in #1510 after #1511 landed the shipment-manifest schema, example, CI validation, and fail-closed canon boundary.

- links the OPAL2 productization checklist directly to the schema
- links the worked manifest example as the emission starting point

## Validation

- `pytest -q tests/test_shipment_manifest.py` — 10 passed
- `markdownlint-cli@0.49.1` — passed
- `git diff --check` — passed

Closes #1510