### PR TITLE
docs: record AI-assisted authorship provenance

### DIFF
--- a/AI_AUTHORS.md
+++ b/AI_AUTHORS.md
@@ -1,0 +1,93 @@
+# AI-assisted authorship and contribution provenance
+
+Aurora CloudBank Symbolic is maintained by a human owner and developed with
+substantial assistance from software agents and repository automation. This
+document explains how to interpret that work and how new contributions should
+record it.
+
+## Accountability
+
+The repository owner remains accountable for project direction, access,
+publication, and merge decisions. An agent may investigate, propose, implement,
+test, or review work within an authorized task, but agent output does not grant
+itself permission to merge, deploy, alter secrets, promote canon, or cross an
+L1/L2/L3 authority boundary.
+
+Git authorship is provenance, not authority. A named author, co-author, bot, or
+agent identity records participation in producing a change; it does not make the
+commit a canon ruling or an approval receipt.
+
+## What the existing history records
+
+The Git history contains several recurring identity classes:
+
+- human/owner identities, including `Travis Streets` and `AUo959`;
+- historical project identities such as `Aurora CloudBank`;
+- agent identities such as `Claude`, `claude-code`, GitHub Copilot, and
+  `copilot-swe-agent[bot]`;
+- automation identities such as Dependabot, GitHub Actions, and the Aurora
+  constellation bot.
+
+Some agent-assisted changes, especially work performed through Codex, use the
+maintainer's configured Git author identity. Their agent provenance may instead
+be present in the pull-request description, branch name, task receipt, or
+review record. Therefore, `git shortlog` is useful evidence but is not a
+complete attribution ledger.
+
+This policy applies prospectively. Do not rewrite historical commits merely to
+normalize attribution.
+
+## Required provenance for new contributions
+
+For a materially agent-assisted pull request:
+
+1. State the agent or automation system in the pull-request description.
+2. Describe the agent's scope: investigation, implementation, test generation,
+   review, documentation, or another bounded role.
+3. Record the validation actually executed and distinguish local results from
+   hosted checks or human review.
+4. Identify material human decisions, especially authority, security, canon,
+   deployment, and irreversible-state decisions.
+5. Preserve relevant issue, task, receipt, and source links so another reviewer
+   can reconstruct why the change exists.
+
+When the tool controls the commit identity, use a stable, recognizable agent or
+bot identity. When a human author records a commit that was materially
+co-produced by an agent, use a valid `Co-authored-by` trailer when the platform
+provides a stable attributable identity. If it does not, the pull-request
+disclosure is the required provenance record; do not invent an email address or
+impersonate a provider-owned identity.
+
+Minor completion, formatting, search, or command assistance need not produce a
+line-by-line authorship ledger. The disclosure should be proportionate, but it
+must not conceal substantial generated code, analysis, or documentation.
+
+## Review and canon boundaries
+
+Agent-assisted work follows the same quality, security, review, and branch
+protection gates as any other contribution. Automated checks are evidence, not
+approval by themselves.
+
+Generated narrative, recovered material, simulations, and model output do not
+become Aurora canon because they were committed or because an agent described
+them confidently. Canon authority and promotion remain governed by
+[`CANON_INDEX.md`](CANON_INDEX.md),
+[`docs/CANON_PROVENANCE.md`](docs/CANON_PROVENANCE.md), and the applicable
+CanonRec process.
+
+Do not commit private prompts, credentials, hidden chain-of-thought, or raw
+session transcripts as authorship evidence. Record concise decisions, inputs,
+outputs, validations, and receipts instead.
+
+## Reading a contribution record
+
+Use these surfaces together when attribution matters:
+
+1. the issue or task defining the requested outcome and authority;
+2. the pull-request description and review record;
+3. the commit author and any co-author trailers;
+4. hosted checks and deterministic validation receipts;
+5. the final merge identity and protected-branch result.
+
+No single surface substitutes for the others. This layered record is the
+repository's authorship model.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ and both are load-bearing.
 > **Reviewing canon provenance?** [`docs/CANON_PROVENANCE.md`](./docs/CANON_PROVENANCE.md) identifies the CanonRec source revision, mirrored payload hash, and the surfaces that still require reconciliation.
 >
 > **New AI agent or Copilot session?** Start with [`AGENTS.md`](./AGENTS.md) (bootstrap protocol and rules) and [`AURORA_CONTEXT.json`](./AURORA_CONTEXT.json) (machine-readable concept map).
+>
+> **Reviewing contribution provenance?** [`AI_AUTHORS.md`](./AI_AUTHORS.md) explains human accountability, agent-assisted authorship, attribution expectations, and the limits of Git identity evidence.
 
 ---
 
@@ -381,7 +383,9 @@ test: add coverage for joy evolution engine
 4. Run `make check` before pushing.
 5. Open a pull request against `main` with a conventional commit title.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide and
+[AI_AUTHORS.md](AI_AUTHORS.md) for agent-assisted authorship and provenance
+expectations.
 
 ---
 

--- a/config/root_registry.yaml
+++ b/config/root_registry.yaml
@@ -15,7 +15,7 @@
 # no permission step, only a registration step.
 #
 # Generated from the tracked root at the time of the gate's introduction
-# (141 root objects, 9 declared dependency files).
+# (142 root objects, 9 declared dependency files).
 version: 1
 root_objects:
   - ".aurora"
@@ -56,6 +56,7 @@ root_objects:
   - "activate_aurora.sh"
   - "agents"
   - "AGENTS.md"
+  - "AI_AUTHORS.md"
   - "api"
   - "ARCHITECTURE_QUICKMAP.md"
   - "AU_CORE_MASTER_TREE.yaml"


### PR DESCRIPTION
## Summary

- add `AI_AUTHORS.md` as the human-readable index for human, agent, and automation contribution provenance
- distinguish Git authorship evidence from approval, canon authority, and publication authority
- require proportionate agent-assistance disclosure, validation evidence, and material human-decision records for new pull requests
- link the policy from the README orientation and contribution paths
- register the new root policy in the #1509 root-object declaration contract

## Why

CloudBank has substantial agent-assisted history, but attribution is inconsistent across tools. Claude, Copilot, Dependabot, Actions, and constellation automation often use distinct Git identities, while Codex-assisted commits may inherit the maintainer's configured identity. Git's author field therefore cannot serve as a complete provenance ledger by itself.

The outside review in #1504 asked CloudBank to propagate the satellite repositories' explicit agent-attribution pattern and provide a human-readable authorship index. This change establishes that prospective policy without rewriting historical commits or inventing provider email identities.

## Impact

Documentation and contribution governance only. The policy does not alter runtime behavior, canon, secrets, deployment, or L1/L2/L3 authority. It explicitly states that agent output cannot self-authorize any of those actions.

## AI assistance disclosure

Codex inspected Git history and repository guidance, authored the documentation under the maintainer-authorized #1504 backlog task, and ran the validations below. The maintainer retains direction, publication, review, and merge authority.

## Validation

- `npx --yes markdownlint-cli@0.49.1 AI_AUTHORS.md`
- `git ls-files -z | python3 scripts/check_root_declaration.py` — 142 root objects, 9 dependency files
- `python3 -m pytest -q tests/test_root_declaration.py` — 12 passed
- `git diff --check`
- verified every new relative document link exists
- the full README Markdown run reports only the same seven pre-existing MD060 compact-table delimiter findings reproduced from `origin/main`; no changed README line is implicated

Refs #1504
