### PR TITLE
ci: enforce root declaration in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
         additional_dependencies: ['GitPython==3.1.45']
         pass_filenames: false
         stages: [pre-commit]
+      - id: root-declaration
+        name: root-declaration
+        entry: bash -c 'git ls-files -z | python3 scripts/check_root_declaration.py'
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
       - id: aurora-pre-commit
         name: aurora-pre-commit
         entry: bash scripts/run_pre_commit.sh


### PR DESCRIPTION
## Summary

- add the existing root-declaration checker to the repository's standard pre-commit configuration;
- feed the checker the complete NUL-delimited tracked-path inventory so it evaluates the whole root contract rather than only changed filenames;
- keep the hook local and dependency-free.

Refs #1504.

## Validation

- `pre-commit validate-config .pre-commit-config.yaml`
- `pre-commit run root-declaration --all-files`
- `git ls-files -z | python3 scripts/check_root_declaration.py`
- `git diff --check`

## Scope and follow-up

This lands the pre-commit half of the Phase 1 root-declaration fence. Required-CI wiring remains a separate follow-up because `.github/workflows` is actively owned by the concurrent #1506 task. This PR does not change canon, simulation behavior, deployment state, or issue authority.

## AI assistance disclosure

Codex assisted with repository inspection, the hook integration, validation, and PR preparation under maintainer direction. The maintainer retains publication and merge authority per `AI_AUTHORS.md`.
