### PR TITLE
feat(salvage): add deterministic corpus archaeology Phase 1

### DIFF
--- a/schemas/salvage/corpus_archaeology_input.schema.json
+++ b/schemas/salvage/corpus_archaeology_input.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/AUo959/aurora-cloudbank-symbolic/main/schemas/salvage/corpus_archaeology_input.schema.json",
+  "title": "Prepared Corpus Archaeology Input",
+  "description": "Domain-neutral custody-cleared source envelope for deterministic Phase-1 corpus archaeology.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "corpus_id", "sources"],
+  "properties": {
+    "schema_version": {"const": "0.1.0"},
+    "corpus_id": {"type": "string", "minLength": 1},
+    "source_inventory_ref": {"type": ["string", "null"], "minLength": 1},
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/source"}
+    },
+    "relationship_hints": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/relationship_hint"}
+    }
+  },
+  "$defs": {
+    "unit_interval": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_ref",
+        "title",
+        "source_type",
+        "creator_type",
+        "authority_status",
+        "content_access"
+      ],
+      "properties": {
+        "source_ref": {"type": "string", "minLength": 1},
+        "title": {"type": "string", "minLength": 1},
+        "source_type": {
+          "enum": [
+            "chat",
+            "document",
+            "issue",
+            "pull_request",
+            "commit",
+            "code",
+            "test",
+            "artifact",
+            "report",
+            "unknown"
+          ]
+        },
+        "platform": {"type": ["string", "null"], "minLength": 1},
+        "creator_type": {
+          "enum": ["human", "assistant", "model", "system", "mixed", "unknown"]
+        },
+        "authority_status": {
+          "enum": ["current", "historical", "reference", "draft", "unknown"]
+        },
+        "confidence": {"$ref": "#/$defs/unit_interval"},
+        "artifact_id": {"type": ["string", "null"], "minLength": 1},
+        "inventory_report_id": {"type": ["string", "null"], "minLength": 1},
+        "content_access": {"enum": ["released", "metadata_only"]},
+        "content": {"type": ["string", "null"]},
+        "sha256": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"}
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"content_access": {"const": "released"}},
+            "required": ["content_access"]
+          },
+          "then": {
+            "required": ["content"],
+            "properties": {"content": {"type": "string"}}
+          }
+        },
+        {
+          "if": {
+            "properties": {"content_access": {"const": "metadata_only"}},
+            "required": ["content_access"]
+          },
+          "then": {
+            "properties": {
+              "content": {
+                "anyOf": [
+                  {"type": "null"},
+                  {"type": "string", "maxLength": 0}
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "relationship_hint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "left_intent_key",
+        "right_intent_key",
+        "relationship",
+        "rationale",
+        "evidence_source_refs"
+      ],
+      "properties": {
+        "left_intent_key": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.:/-]+$"
+        },
+        "right_intent_key": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.:/-]+$"
+        },
+        "relationship": {
+          "enum": [
+            "convergent",
+            "successor",
+            "parallel",
+            "merged",
+            "divergent",
+            "superseded",
+            "dormant",
+            "lost_in_transition",
+            "orphaned",
+            "uncertain"
+          ]
+        },
+        "rationale": {"type": "string", "minLength": 1},
+        "evidence_source_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/schemas/salvage/corpus_archaeology_input.schema.json
+++ b/schemas/salvage/corpus_archaeology_input.schema.json
@@ -129,6 +129,7 @@
         "rationale": {"type": "string", "minLength": 1},
         "evidence_source_refs": {
           "type": "array",
+          "minItems": 1,
           "uniqueItems": true,
           "items": {"type": "string", "minLength": 1}
         }

--- a/schemas/salvage/corpus_archaeology_report.schema.json
+++ b/schemas/salvage/corpus_archaeology_report.schema.json
@@ -1,0 +1,328 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/AUo959/aurora-cloudbank-symbolic/main/schemas/salvage/corpus_archaeology_report.schema.json",
+  "title": "Corpus Archaeology Report",
+  "description": "Read-only provenance-aware report for deterministic prepared-corpus archaeology.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_id",
+    "generated_at",
+    "corpus_id",
+    "source_inventory_ref",
+    "read_only",
+    "mutation_performed",
+    "analysis_profile",
+    "ranking_model",
+    "sources",
+    "claims",
+    "relationships",
+    "candidates",
+    "unkeyed_claim_ids"
+  ],
+  "properties": {
+    "schema_version": {"const": "0.1.0"},
+    "report_id": {"type": "string", "pattern": "^corpus-report:[a-f0-9]{64}$"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "corpus_id": {"type": "string", "minLength": 1},
+    "source_inventory_ref": {"type": ["string", "null"]},
+    "read_only": {"const": true},
+    "mutation_performed": {"const": false},
+    "analysis_profile": {"const": "explicit_markers_v1"},
+    "ranking_model": {"$ref": "#/$defs/ranking_model"},
+    "sources": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/source"}},
+    "claims": {"type": "array", "items": {"$ref": "#/$defs/claim"}},
+    "relationships": {"type": "array", "items": {"$ref": "#/$defs/relationship"}},
+    "candidates": {"type": "array", "items": {"$ref": "#/$defs/candidate"}},
+    "unkeyed_claim_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^claim:[a-f0-9]{24}$"}
+    }
+  },
+  "$defs": {
+    "unit_interval": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_ref",
+        "source_id",
+        "title",
+        "source_type",
+        "platform",
+        "creator_type",
+        "authority_status",
+        "confidence",
+        "artifact_id",
+        "inventory_report_id",
+        "content_access",
+        "sha256"
+      ],
+      "properties": {
+        "source_ref": {"type": "string", "minLength": 1},
+        "source_id": {"type": "string", "pattern": "^source:[a-f0-9]{24}$"},
+        "title": {"type": "string", "minLength": 1},
+        "source_type": {
+          "enum": [
+            "chat",
+            "document",
+            "issue",
+            "pull_request",
+            "commit",
+            "code",
+            "test",
+            "artifact",
+            "report",
+            "unknown"
+          ]
+        },
+        "platform": {"type": ["string", "null"]},
+        "creator_type": {"enum": ["human", "assistant", "model", "system", "mixed", "unknown"]},
+        "authority_status": {"enum": ["current", "historical", "reference", "draft", "unknown"]},
+        "confidence": {"$ref": "#/$defs/unit_interval"},
+        "artifact_id": {"type": ["string", "null"]},
+        "inventory_report_id": {"type": ["string", "null"]},
+        "content_access": {"enum": ["released", "metadata_only"]},
+        "sha256": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_id", "source_ref", "line_start", "line_end", "text_sha256", "excerpt"],
+      "properties": {
+        "source_id": {"type": "string", "pattern": "^source:[a-f0-9]{24}$"},
+        "source_ref": {"type": "string", "minLength": 1},
+        "line_start": {"type": "integer", "minimum": 1},
+        "line_end": {"type": "integer", "minimum": 1},
+        "text_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "excerpt": {"type": "string", "minLength": 1}
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claim_id",
+        "claim_type",
+        "intent_key",
+        "claim",
+        "evidence_kind",
+        "authority_status",
+        "confidence",
+        "span"
+      ],
+      "properties": {
+        "claim_id": {"type": "string", "pattern": "^claim:[a-f0-9]{24}$"},
+        "claim_type": {
+          "enum": [
+            "decision",
+            "approval",
+            "rejection",
+            "requirement",
+            "constraint",
+            "unresolved_question",
+            "todo",
+            "proposed_patch",
+            "rationale",
+            "implementation_evidence",
+            "partial_implementation_evidence"
+          ]
+        },
+        "intent_key": {"type": ["string", "null"], "pattern": "^[A-Za-z0-9_.:/-]+$"},
+        "claim": {"type": "string", "minLength": 1},
+        "evidence_kind": {
+          "enum": [
+            "human_statement",
+            "model_statement",
+            "system_record",
+            "mixed_source",
+            "implementation_artifact",
+            "test_result",
+            "unknown"
+          ]
+        },
+        "authority_status": {"enum": ["current", "historical", "reference", "draft", "unknown"]},
+        "confidence": {"$ref": "#/$defs/unit_interval"},
+        "span": {"$ref": "#/$defs/span"}
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relationship_id",
+        "left_intent_key",
+        "right_intent_key",
+        "relationship",
+        "rationale",
+        "evidence_source_refs"
+      ],
+      "properties": {
+        "relationship_id": {"type": "string", "pattern": "^relationship:[a-f0-9]{24}$"},
+        "left_intent_key": {"type": "string", "minLength": 1},
+        "right_intent_key": {"type": "string", "minLength": 1},
+        "relationship": {
+          "enum": [
+            "convergent",
+            "successor",
+            "parallel",
+            "merged",
+            "divergent",
+            "superseded",
+            "dormant",
+            "lost_in_transition",
+            "orphaned",
+            "uncertain"
+          ]
+        },
+        "rationale": {"type": "string", "minLength": 1},
+        "evidence_source_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "historical_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "explicit_rejection",
+        "implementation_evidence_present",
+        "partial_implementation_evidence_present"
+      ],
+      "properties": {
+        "status": {"enum": ["proposed", "approved", "implemented", "partial", "rejected"]},
+        "explicit_rejection": {"type": "boolean"},
+        "implementation_evidence_present": {"type": "boolean"},
+        "partial_implementation_evidence_present": {"type": "boolean"}
+      }
+    },
+    "preservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implementation_preserved", "capability_preserved", "intent_preserved", "intent_delta"],
+      "properties": {
+        "implementation_preserved": {"type": ["boolean", "null"]},
+        "capability_preserved": {"type": ["boolean", "null"]},
+        "intent_preserved": {"type": ["boolean", "null"]},
+        "intent_delta": {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0}
+      }
+    },
+    "recovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disposition", "rationale", "confidence", "dependencies"],
+      "properties": {
+        "disposition": {
+          "enum": ["restore", "integrate", "evolve", "merge", "preserve", "investigate", "reject_with_evidence"]
+        },
+        "rationale": {"type": "string", "minLength": 1},
+        "confidence": {"$ref": "#/$defs/unit_interval"},
+        "dependencies": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "relevance_components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "explicit_decision",
+        "requirement_strength",
+        "unresolved_commitment",
+        "implementation_gap",
+        "recurrence",
+        "evidence_confidence"
+      ],
+      "properties": {
+        "explicit_decision": {"$ref": "#/$defs/unit_interval"},
+        "requirement_strength": {"$ref": "#/$defs/unit_interval"},
+        "unresolved_commitment": {"$ref": "#/$defs/unit_interval"},
+        "implementation_gap": {"$ref": "#/$defs/unit_interval"},
+        "recurrence": {"$ref": "#/$defs/unit_interval"},
+        "evidence_confidence": {"$ref": "#/$defs/unit_interval"}
+      }
+    },
+    "ranking": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relevance_score", "components"],
+      "properties": {
+        "relevance_score": {"$ref": "#/$defs/unit_interval"},
+        "components": {"$ref": "#/$defs/relevance_components"}
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "intent_key",
+        "source_refs",
+        "source_ids",
+        "claim_ids",
+        "historical_state",
+        "preservation",
+        "recovery",
+        "ranking"
+      ],
+      "properties": {
+        "candidate_id": {"type": "string", "pattern": "^candidate:[a-f0-9]{24}$"},
+        "intent_key": {"type": "string", "pattern": "^[A-Za-z0-9_.:/-]+$"},
+        "source_refs": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "source_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^source:[a-f0-9]{24}$"}
+        },
+        "claim_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^claim:[a-f0-9]{24}$"}
+        },
+        "historical_state": {"$ref": "#/$defs/historical_state"},
+        "preservation": {"$ref": "#/$defs/preservation"},
+        "recovery": {"$ref": "#/$defs/recovery"},
+        "ranking": {"$ref": "#/$defs/ranking"}
+      }
+    },
+    "ranking_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "weights"],
+      "properties": {
+        "name": {"const": "explainable_relevance_v1"},
+        "weights": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "explicit_decision",
+            "requirement_strength",
+            "unresolved_commitment",
+            "implementation_gap",
+            "recurrence",
+            "evidence_confidence"
+          ],
+          "properties": {
+            "explicit_decision": {"const": 0.25},
+            "requirement_strength": {"const": 0.20},
+            "unresolved_commitment": {"const": 0.20},
+            "implementation_gap": {"const": 0.20},
+            "recurrence": {"const": 0.10},
+            "evidence_confidence": {"const": 0.05}
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/salvage/corpus_archaeology_report.schema.json
+++ b/schemas/salvage/corpus_archaeology_report.schema.json
@@ -196,7 +196,7 @@
         "partial_implementation_evidence_present"
       ],
       "properties": {
-        "status": {"enum": ["proposed", "approved", "implemented", "partial", "rejected"]},
+        "status": {"enum": ["proposed", "approved", "implemented", "partial", "rejected", "unknown"]},
         "explicit_rejection": {"type": "boolean"},
         "implementation_evidence_present": {"type": "boolean"},
         "partial_implementation_evidence_present": {"type": "boolean"}

--- a/tests/test_corpus_archaeology.py
+++ b/tests/test_corpus_archaeology.py
@@ -1,0 +1,385 @@
+"""Determinism, provenance, and preservation tests for corpus archaeology."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = REPO_ROOT / "tools" / "salvage" / "corpus_archaeology.py"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "salvage" / "corpus_archaeology_report.schema.json"
+FIXED_TIME = "2026-08-18T03:00:00Z"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("corpus_archaeology", TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def archaeology_module():
+    return _load_module()
+
+
+@pytest.fixture(scope="module")
+def report_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _source(
+    *,
+    source_ref: str,
+    title: str,
+    content: str | None,
+    source_type: str = "document",
+    creator_type: str = "human",
+    authority_status: str = "historical",
+    content_access: str = "released",
+    confidence: float = 1.0,
+) -> dict:
+    return {
+        "source_ref": source_ref,
+        "title": title,
+        "source_type": source_type,
+        "platform": "fixture",
+        "creator_type": creator_type,
+        "authority_status": authority_status,
+        "confidence": confidence,
+        "artifact_id": None,
+        "inventory_report_id": None,
+        "content_access": content_access,
+        "content": content,
+    }
+
+
+@pytest.mark.unit
+def test_report_is_deterministic_schema_valid_and_read_only(
+    archaeology_module,
+    report_schema: dict,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:threadcore",
+        "source_inventory_ref": "inventory:" + "a" * 64,
+        "sources": [
+            _source(
+                source_ref="chat:001",
+                title="Native thread",
+                content=(
+                    "REQUIREMENT[threadcore.unutilized_logic]: Extract unutilized logic.\n"
+                    "APPROVED[threadcore.unutilized_logic]: Proceed with the extractor.\n"
+                    "TODO[threadcore.unutilized_logic]: Implement the read-only pass.\n"
+                ),
+            ),
+            _source(
+                source_ref="doc:002",
+                title="Current implementation note",
+                creator_type="assistant",
+                content=(
+                    "RATIONALE[threadcore.unutilized_logic]: "
+                    "Absence of implementation is not rejection.\n"
+                ),
+            ),
+        ],
+        "relationship_hints": [],
+    }
+
+    first = archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    second = archaeology_module.analyze_corpus(
+        {
+            **corpus,
+            "sources": list(reversed(corpus["sources"])),
+        },
+        generated_at=FIXED_TIME,
+    )
+
+    assert first == second
+    assert first["read_only"] is True
+    assert first["mutation_performed"] is False
+    assert len(first["claims"]) == 4
+    assert len(first["candidates"]) == 1
+    candidate = first["candidates"][0]
+    assert candidate["intent_key"] == "threadcore.unutilized_logic"
+    assert candidate["recovery"]["disposition"] == "investigate"
+    assert candidate["ranking"]["components"]["implementation_gap"] == 1.0
+    assert candidate["historical_state"]["status"] == "approved"
+
+    jsonschema.Draft202012Validator.check_schema(report_schema)
+    jsonschema.Draft202012Validator(
+        report_schema,
+        format_checker=jsonschema.FormatChecker(),
+    ).validate(first)
+
+
+@pytest.mark.unit
+def test_claims_retain_exact_line_span_and_creator_evidence_type(
+    archaeology_module,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:evidence",
+        "sources": [
+            _source(
+                source_ref="chat:human",
+                title="Human source",
+                content=(
+                    "ordinary context\n"
+                    "REQUIREMENT[evidence.boundary]: Preserve exact spans.\n"
+                ),
+            ),
+            _source(
+                source_ref="chat:assistant",
+                title="Assistant source",
+                creator_type="assistant",
+                content="PATCH[evidence.boundary]: Add a deterministic span record.\n",
+            ),
+        ],
+    }
+
+    report = archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    human_claim = next(
+        claim for claim in report["claims"] if claim["span"]["source_ref"] == "chat:human"
+    )
+    model_claim = next(
+        claim for claim in report["claims"] if claim["span"]["source_ref"] == "chat:assistant"
+    )
+
+    assert human_claim["span"]["line_start"] == 2
+    assert human_claim["span"]["line_end"] == 2
+    assert human_claim["span"]["excerpt"] == (
+        "REQUIREMENT[evidence.boundary]: Preserve exact spans."
+    )
+    assert human_claim["evidence_kind"] == "human_statement"
+    assert model_claim["evidence_kind"] == "model_statement"
+
+
+@pytest.mark.unit
+def test_explicit_implementation_and_rejection_are_not_treated_as_missing(
+    archaeology_module,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:status",
+        "sources": [
+            _source(
+                source_ref="doc:requirements",
+                title="Requirements",
+                content=(
+                    "REQUIREMENT[feature.one]: Keep feature one.\n"
+                    "REQUIREMENT[feature.two]: Keep feature two.\n"
+                ),
+            ),
+            _source(
+                source_ref="code:implementation",
+                title="Implementation record",
+                source_type="code",
+                creator_type="system",
+                authority_status="current",
+                content="IMPLEMENTED[feature.one]: Current handler exists.\n",
+            ),
+            _source(
+                source_ref="issue:decision",
+                title="Decision record",
+                source_type="issue",
+                content="REJECTED[feature.two]: Rejected after explicit review.\n",
+            ),
+        ],
+    }
+
+    report = archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    candidates = {item["intent_key"]: item for item in report["candidates"]}
+
+    implemented = candidates["feature.one"]
+    rejected = candidates["feature.two"]
+
+    assert implemented["historical_state"]["status"] == "implemented"
+    assert implemented["recovery"]["disposition"] == "preserve"
+    assert implemented["ranking"]["components"]["implementation_gap"] == 0.0
+    implementation_claim = next(
+        claim
+        for claim in report["claims"]
+        if claim["intent_key"] == "feature.one"
+        and claim["claim_type"] == "implementation_evidence"
+    )
+    assert implementation_claim["evidence_kind"] == "implementation_artifact"
+
+    assert rejected["historical_state"]["status"] == "rejected"
+    assert rejected["historical_state"]["explicit_rejection"] is True
+    assert rejected["recovery"]["disposition"] == "reject_with_evidence"
+    assert rejected["ranking"]["components"]["implementation_gap"] == 0.0
+
+
+@pytest.mark.unit
+def test_metadata_only_source_is_preserved_without_content_analysis(
+    archaeology_module,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:metadata-only",
+        "sources": [
+            {
+                "source_ref": "artifact:blocked",
+                "title": "Quarantined archive member",
+                "source_type": "artifact",
+                "platform": "legacy_inventory",
+                "creator_type": "unknown",
+                "authority_status": "reference",
+                "confidence": 0.5,
+                "artifact_id": "artifact:" + "1" * 24,
+                "inventory_report_id": "inventory:" + "2" * 64,
+                "content_access": "metadata_only",
+                "content": None,
+                "sha256": "3" * 64,
+            }
+        ],
+    }
+
+    report = archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+
+    assert report["sources"][0]["content_access"] == "metadata_only"
+    assert report["sources"][0]["sha256"] == "3" * 64
+    assert report["claims"] == []
+    assert report["candidates"] == []
+
+
+@pytest.mark.unit
+def test_metadata_only_source_rejects_supplied_content(archaeology_module) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:metadata-violation",
+        "sources": [
+            _source(
+                source_ref="artifact:blocked",
+                title="Blocked source",
+                content="TODO[unsafe.read]: This must not be analyzed.\n",
+                source_type="artifact",
+                content_access="metadata_only",
+            )
+        ],
+    }
+
+    with pytest.raises(
+        archaeology_module.CorpusArchaeologyError,
+        match="metadata_only",
+    ):
+        archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+
+
+@pytest.mark.unit
+def test_released_source_hash_must_match_prepared_content(
+    archaeology_module,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:hash-mismatch",
+        "sources": [
+            {
+                **_source(
+                    source_ref="doc:hash",
+                    title="Hashed source",
+                    content="REQUIREMENT[hash.check]: Validate source content.\n",
+                ),
+                "sha256": "0" * 64,
+            }
+        ],
+    }
+
+    with pytest.raises(
+        archaeology_module.CorpusArchaeologyError,
+        match="does not match prepared content",
+    ):
+        archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+
+
+@pytest.mark.unit
+def test_unkeyed_claim_keeps_provenance_without_candidate_promotion(
+    archaeology_module,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:unkeyed",
+        "sources": [
+            _source(
+                source_ref="doc:unkeyed",
+                title="Unkeyed source",
+                content="TODO: Review this later.\n",
+            )
+        ],
+    }
+
+    report = archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+
+    assert len(report["claims"]) == 1
+    assert report["claims"][0]["intent_key"] is None
+    assert report["candidates"] == []
+    assert report["unkeyed_claim_ids"] == [report["claims"][0]["claim_id"]]
+
+
+@pytest.mark.unit
+def test_relationship_hints_preserve_parallel_history_without_adjudication(
+    archaeology_module,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:relationship",
+        "sources": [
+            _source(
+                source_ref="doc:a",
+                title="History A",
+                content="REQUIREMENT[history.a]: Preserve history A.\n",
+            ),
+            _source(
+                source_ref="doc:b",
+                title="History B",
+                content="REQUIREMENT[history.b]: Preserve history B.\n",
+            ),
+        ],
+        "relationship_hints": [
+            {
+                "left_intent_key": "history.a",
+                "right_intent_key": "history.b",
+                "relationship": "parallel",
+                "rationale": "The prepared sources describe concurrent histories.",
+                "evidence_source_refs": ["doc:a", "doc:b"],
+            }
+        ],
+    }
+
+    report = archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+
+    assert len(report["relationships"]) == 1
+    relationship = report["relationships"][0]
+    assert relationship["relationship"] == "parallel"
+    assert relationship["evidence_source_refs"] == ["doc:a", "doc:b"]
+
+
+@pytest.mark.unit
+def test_markdown_renderer_is_deterministic_and_reports_candidate_state(
+    archaeology_module,
+) -> None:
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:markdown",
+        "sources": [
+            _source(
+                source_ref="doc:one",
+                title="One",
+                content="REQUIREMENT[feature.md]: Render a stable summary.\n",
+            )
+        ],
+    }
+
+    report = archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    markdown = archaeology_module.render_markdown(report)
+
+    assert markdown.startswith("# Corpus Archaeology Report\n")
+    assert "`feature.md`" in markdown
+    assert "Disposition: `investigate`" in markdown
+    assert report["report_id"] in markdown

--- a/tests/test_corpus_archaeology.py
+++ b/tests/test_corpus_archaeology.py
@@ -267,7 +267,7 @@ def test_metadata_only_source_rejects_supplied_content(archaeology_module) -> No
 
     with pytest.raises(
         archaeology_module.CorpusArchaeologyError,
-        match="metadata_only",
+        match=r"sources\.0\.content",
     ):
         archaeology_module.analyze_corpus(corpus, generated_at=FIXED_TIME)
 

--- a/tests/test_corpus_archaeology_evidence_boundary.py
+++ b/tests/test_corpus_archaeology_evidence_boundary.py
@@ -1,0 +1,61 @@
+"""Evidence-boundary regression tests for corpus archaeology."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = REPO_ROOT / "tools" / "salvage" / "corpus_archaeology.py"
+FIXED_TIME = "2026-08-18T03:00:00Z"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("corpus_archaeology_boundary", TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_model_implemented_assertion_does_not_count_as_implementation_proof() -> None:
+    archaeology = _load_module()
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:model-implementation-claim",
+        "sources": [
+            {
+                "source_ref": "chat:assistant",
+                "title": "Assistant assertion",
+                "source_type": "chat",
+                "platform": "fixture",
+                "creator_type": "assistant",
+                "authority_status": "historical",
+                "confidence": 1.0,
+                "artifact_id": None,
+                "inventory_report_id": None,
+                "content_access": "released",
+                "content": (
+                    "REQUIREMENT[feature.asserted]: Preserve the capability.\n"
+                    "IMPLEMENTED[feature.asserted]: I believe the handler exists.\n"
+                ),
+            }
+        ],
+    }
+
+    report = archaeology.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    candidate = report["candidates"][0]
+    implementation_claim = next(
+        claim
+        for claim in report["claims"]
+        if claim["claim_type"] == "implementation_evidence"
+    )
+
+    assert implementation_claim["evidence_kind"] == "model_statement"
+    assert candidate["historical_state"]["implementation_evidence_present"] is False
+    assert candidate["historical_state"]["status"] == "proposed"
+    assert candidate["recovery"]["disposition"] == "investigate"
+    assert candidate["ranking"]["components"]["implementation_gap"] == 1.0

--- a/tests/test_corpus_archaeology_evidence_boundary.py
+++ b/tests/test_corpus_archaeology_evidence_boundary.py
@@ -36,6 +36,22 @@ def _model_source(content: str) -> dict:
     }
 
 
+def _human_source(content: str, *, authority_status: str) -> dict:
+    return {
+        "source_ref": f"chat:human:{authority_status}",
+        "title": "Human assertion",
+        "source_type": "chat",
+        "platform": "fixture",
+        "creator_type": "human",
+        "authority_status": authority_status,
+        "confidence": 1.0,
+        "artifact_id": None,
+        "inventory_report_id": None,
+        "content_access": "released",
+        "content": content,
+    }
+
+
 @pytest.mark.unit
 def test_model_implemented_assertion_does_not_count_as_implementation_proof() -> None:
     archaeology = _load_module()
@@ -96,4 +112,39 @@ def test_model_approval_rejection_and_requirements_do_not_create_human_authority
     assert rejected["historical_state"]["status"] == "proposed"
     assert rejected["historical_state"]["explicit_rejection"] is False
     assert rejected["ranking"]["components"]["requirement_strength"] == 0.0
+    assert rejected["recovery"]["disposition"] == "investigate"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("authority_status", ["draft", "reference", "unknown"])
+def test_lower_authority_human_markers_remain_evidence_not_decision_authority(
+    authority_status: str,
+) -> None:
+    archaeology = _load_module()
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": f"fixture:human-{authority_status}",
+        "sources": [
+            _human_source(
+                "APPROVED[feature.pending]: Proceed.\n"
+                "REQUIREMENT[feature.pending]: Treat this as required.\n"
+                "REJECTED[feature.rejected]: Do not proceed.\n",
+                authority_status=authority_status,
+            )
+        ],
+    }
+
+    report = archaeology.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    candidates = {item["intent_key"]: item for item in report["candidates"]}
+
+    pending = candidates["feature.pending"]
+    rejected = candidates["feature.rejected"]
+
+    assert pending["historical_state"]["status"] == "proposed"
+    assert pending["ranking"]["components"]["explicit_decision"] == 0.0
+    assert pending["ranking"]["components"]["requirement_strength"] == 0.0
+    assert pending["recovery"]["disposition"] == "investigate"
+
+    assert rejected["historical_state"]["status"] == "proposed"
+    assert rejected["historical_state"]["explicit_rejection"] is False
     assert rejected["recovery"]["disposition"] == "investigate"

--- a/tests/test_corpus_archaeology_evidence_boundary.py
+++ b/tests/test_corpus_archaeology_evidence_boundary.py
@@ -20,6 +20,22 @@ def _load_module():
     return module
 
 
+def _model_source(content: str) -> dict:
+    return {
+        "source_ref": "chat:assistant",
+        "title": "Assistant assertion",
+        "source_type": "chat",
+        "platform": "fixture",
+        "creator_type": "assistant",
+        "authority_status": "historical",
+        "confidence": 1.0,
+        "artifact_id": None,
+        "inventory_report_id": None,
+        "content_access": "released",
+        "content": content,
+    }
+
+
 @pytest.mark.unit
 def test_model_implemented_assertion_does_not_count_as_implementation_proof() -> None:
     archaeology = _load_module()
@@ -27,22 +43,10 @@ def test_model_implemented_assertion_does_not_count_as_implementation_proof() ->
         "schema_version": "0.1.0",
         "corpus_id": "fixture:model-implementation-claim",
         "sources": [
-            {
-                "source_ref": "chat:assistant",
-                "title": "Assistant assertion",
-                "source_type": "chat",
-                "platform": "fixture",
-                "creator_type": "assistant",
-                "authority_status": "historical",
-                "confidence": 1.0,
-                "artifact_id": None,
-                "inventory_report_id": None,
-                "content_access": "released",
-                "content": (
-                    "REQUIREMENT[feature.asserted]: Preserve the capability.\n"
-                    "IMPLEMENTED[feature.asserted]: I believe the handler exists.\n"
-                ),
-            }
+            _model_source(
+                "REQUIREMENT[feature.asserted]: Preserve the capability.\n"
+                "IMPLEMENTED[feature.asserted]: I believe the handler exists.\n"
+            )
         ],
     }
 
@@ -58,4 +62,38 @@ def test_model_implemented_assertion_does_not_count_as_implementation_proof() ->
     assert candidate["historical_state"]["implementation_evidence_present"] is False
     assert candidate["historical_state"]["status"] == "proposed"
     assert candidate["recovery"]["disposition"] == "investigate"
-    assert candidate["ranking"]["components"]["implementation_gap"] == 1.0
+    assert candidate["ranking"]["components"]["implementation_gap"] == 0.0
+
+
+@pytest.mark.unit
+def test_model_approval_rejection_and_requirements_do_not_create_human_authority() -> None:
+    archaeology = _load_module()
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:model-authority-claims",
+        "sources": [
+            _model_source(
+                "APPROVED[feature.approved]: Proceed.\n"
+                "REQUIREMENT[feature.approved]: Treat this as required.\n"
+                "REJECTED[feature.rejected]: Do not proceed.\n"
+                "REQUIREMENT[feature.rejected]: Treat this as required.\n"
+            )
+        ],
+    }
+
+    report = archaeology.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    candidates = {item["intent_key"]: item for item in report["candidates"]}
+
+    approved = candidates["feature.approved"]
+    rejected = candidates["feature.rejected"]
+
+    assert approved["historical_state"]["status"] == "proposed"
+    assert approved["historical_state"]["explicit_rejection"] is False
+    assert approved["ranking"]["components"]["explicit_decision"] == 0.0
+    assert approved["ranking"]["components"]["requirement_strength"] == 0.0
+    assert approved["recovery"]["disposition"] == "investigate"
+
+    assert rejected["historical_state"]["status"] == "proposed"
+    assert rejected["historical_state"]["explicit_rejection"] is False
+    assert rejected["ranking"]["components"]["requirement_strength"] == 0.0
+    assert rejected["recovery"]["disposition"] == "investigate"

--- a/tests/test_corpus_archaeology_input_schema.py
+++ b/tests/test_corpus_archaeology_input_schema.py
@@ -1,0 +1,119 @@
+"""JSON Schema tests for the prepared corpus archaeology input contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "schemas" / "salvage" / "corpus_archaeology_input.schema.json"
+
+
+@pytest.fixture(scope="module")
+def input_schema() -> dict:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def _validator(schema: dict) -> jsonschema.Draft202012Validator:
+    return jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+
+
+def _source(*, access: str, content) -> dict:
+    return {
+        "source_ref": "fixture:source",
+        "title": "Fixture source",
+        "source_type": "document",
+        "platform": "fixture",
+        "creator_type": "human",
+        "authority_status": "historical",
+        "confidence": 1.0,
+        "artifact_id": None,
+        "inventory_report_id": None,
+        "content_access": access,
+        "content": content,
+    }
+
+
+@pytest.mark.unit
+def test_released_source_contract_accepts_content(input_schema: dict) -> None:
+    payload = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:released",
+        "source_inventory_ref": "inventory:" + "1" * 64,
+        "sources": [
+            _source(
+                access="released",
+                content="REQUIREMENT[fixture.one]: Preserve this source.\n",
+            )
+        ],
+        "relationship_hints": [],
+    }
+
+    _validator(input_schema).validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_only_source_contract_accepts_absent_content(input_schema: dict) -> None:
+    source = _source(access="metadata_only", content=None)
+    source.pop("content")
+    source["sha256"] = "2" * 64
+    payload = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:metadata",
+        "sources": [source],
+    }
+
+    _validator(input_schema).validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_only_source_contract_rejects_semantic_content(input_schema: dict) -> None:
+    payload = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:blocked-content",
+        "sources": [
+            _source(
+                access="metadata_only",
+                content="TODO[unsafe.read]: This must remain inaccessible.\n",
+            )
+        ],
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _validator(input_schema).validate(payload)
+
+
+@pytest.mark.unit
+def test_relationship_hint_contract_is_domain_neutral(input_schema: dict) -> None:
+    payload = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:relationships",
+        "sources": [
+            _source(
+                access="released",
+                content=(
+                    "REQUIREMENT[history.a]: Preserve A.\n"
+                    "REQUIREMENT[history.b]: Preserve B.\n"
+                ),
+            )
+        ],
+        "relationship_hints": [
+            {
+                "left_intent_key": "history.a",
+                "right_intent_key": "history.b",
+                "relationship": "parallel",
+                "rationale": "The prepared corpus records concurrent histories.",
+                "evidence_source_refs": ["fixture:source"],
+            }
+        ],
+    }
+
+    _validator(input_schema).validate(payload)

--- a/tests/test_corpus_archaeology_input_schema.py
+++ b/tests/test_corpus_archaeology_input_schema.py
@@ -117,3 +117,32 @@ def test_relationship_hint_contract_is_domain_neutral(input_schema: dict) -> Non
     }
 
     _validator(input_schema).validate(payload)
+
+
+@pytest.mark.unit
+def test_relationship_hint_requires_at_least_one_evidence_source(input_schema: dict) -> None:
+    payload = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:unsourced-relationship",
+        "sources": [
+            _source(
+                access="released",
+                content=(
+                    "REQUIREMENT[history.a]: Preserve A.\n"
+                    "REQUIREMENT[history.b]: Preserve B.\n"
+                ),
+            )
+        ],
+        "relationship_hints": [
+            {
+                "left_intent_key": "history.a",
+                "right_intent_key": "history.b",
+                "relationship": "parallel",
+                "rationale": "This relationship must not be accepted without evidence.",
+                "evidence_source_refs": [],
+            }
+        ],
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        _validator(input_schema).validate(payload)

--- a/tests/test_corpus_archaeology_lineage_conflicts.py
+++ b/tests/test_corpus_archaeology_lineage_conflicts.py
@@ -29,6 +29,7 @@ def _source(
     *,
     source_type: str = "document",
     creator_type: str = "human",
+    authority_status: str = "historical",
 ) -> dict:
     return {
         "source_ref": source_ref,
@@ -36,7 +37,7 @@ def _source(
         "source_type": source_type,
         "platform": "fixture",
         "creator_type": creator_type,
-        "authority_status": "historical",
+        "authority_status": authority_status,
         "confidence": 1.0,
         "artifact_id": None,
         "inventory_report_id": None,
@@ -74,7 +75,7 @@ def test_top_level_inventory_reference_changes_report_identity() -> None:
 
 
 @pytest.mark.unit
-def test_rejection_and_implementation_coexist_as_unknown_investigation_state() -> None:
+def test_rejection_and_historical_implementation_preserve_conflict_without_claiming_current_state() -> None:
     archaeology = _load_module()
     corpus = {
         "schema_version": "0.1.0",
@@ -86,8 +87,8 @@ def test_rejection_and_implementation_coexist_as_unknown_investigation_state() -
                 source_type="issue",
             ),
             _source(
-                "code:later-artifact",
-                "IMPLEMENTED[feature.conflict]: A concrete implementation exists.\n",
+                "code:historical-artifact",
+                "IMPLEMENTED[feature.conflict]: A concrete implementation existed.\n",
                 source_type="code",
                 creator_type="system",
             ),
@@ -105,7 +106,7 @@ def test_rejection_and_implementation_coexist_as_unknown_investigation_state() -
     }
     assert candidate["recovery"]["disposition"] == "investigate"
     assert "coexist" in candidate["recovery"]["rationale"]
-    assert candidate["preservation"]["implementation_preserved"] is True
+    assert candidate["preservation"]["implementation_preserved"] is None
     assert candidate["preservation"]["capability_preserved"] is None
     assert candidate["preservation"]["intent_preserved"] is None
 
@@ -114,3 +115,33 @@ def test_rejection_and_implementation_coexist_as_unknown_investigation_state() -
         schema,
         format_checker=jsonschema.FormatChecker(),
     ).validate(report)
+
+
+@pytest.mark.unit
+def test_current_implementation_artifact_can_establish_implementation_preserved() -> None:
+    archaeology = _load_module()
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:current-implementation",
+        "sources": [
+            _source(
+                "doc:requirement",
+                "REQUIREMENT[feature.current]: Preserve the current implementation.\n",
+            ),
+            _source(
+                "code:current-artifact",
+                "IMPLEMENTED[feature.current]: Current code implements the capability.\n",
+                source_type="code",
+                creator_type="system",
+                authority_status="current",
+            ),
+        ],
+    }
+
+    report = archaeology.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    candidate = report["candidates"][0]
+
+    assert candidate["historical_state"]["status"] == "implemented"
+    assert candidate["preservation"]["implementation_preserved"] is True
+    assert candidate["preservation"]["capability_preserved"] is None
+    assert candidate["preservation"]["intent_preserved"] is None

--- a/tests/test_corpus_archaeology_lineage_conflicts.py
+++ b/tests/test_corpus_archaeology_lineage_conflicts.py
@@ -1,0 +1,116 @@
+"""Custody-identity and conflicting-history tests for corpus archaeology."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = REPO_ROOT / "tools" / "salvage" / "corpus_archaeology.py"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "salvage" / "corpus_archaeology_report.schema.json"
+FIXED_TIME = "2026-08-18T03:00:00Z"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("corpus_archaeology_conflicts", TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _source(
+    source_ref: str,
+    content: str,
+    *,
+    source_type: str = "document",
+    creator_type: str = "human",
+) -> dict:
+    return {
+        "source_ref": source_ref,
+        "title": source_ref,
+        "source_type": source_type,
+        "platform": "fixture",
+        "creator_type": creator_type,
+        "authority_status": "historical",
+        "confidence": 1.0,
+        "artifact_id": None,
+        "inventory_report_id": None,
+        "content_access": "released",
+        "content": content,
+    }
+
+
+@pytest.mark.unit
+def test_top_level_inventory_reference_changes_report_identity() -> None:
+    archaeology = _load_module()
+    base = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:custody-identity",
+        "sources": [
+            _source(
+                "doc:one",
+                "REQUIREMENT[custody.identity]: Bind analysis to custody.\n",
+            )
+        ],
+    }
+
+    first = archaeology.analyze_corpus(
+        {**base, "source_inventory_ref": "inventory:" + "1" * 64},
+        generated_at=FIXED_TIME,
+    )
+    second = archaeology.analyze_corpus(
+        {**base, "source_inventory_ref": "inventory:" + "2" * 64},
+        generated_at=FIXED_TIME,
+    )
+
+    assert first["report_id"] != second["report_id"]
+    assert first["sources"] == second["sources"]
+    assert first["claims"] == second["claims"]
+
+
+@pytest.mark.unit
+def test_rejection_and_implementation_coexist_as_unknown_investigation_state() -> None:
+    archaeology = _load_module()
+    corpus = {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:conflicting-history",
+        "sources": [
+            _source(
+                "issue:human-decision",
+                "REJECTED[feature.conflict]: Do not build this capability.\n",
+                source_type="issue",
+            ),
+            _source(
+                "code:later-artifact",
+                "IMPLEMENTED[feature.conflict]: A concrete implementation exists.\n",
+                source_type="code",
+                creator_type="system",
+            ),
+        ],
+    }
+
+    report = archaeology.analyze_corpus(corpus, generated_at=FIXED_TIME)
+    candidate = report["candidates"][0]
+
+    assert candidate["historical_state"] == {
+        "status": "unknown",
+        "explicit_rejection": True,
+        "implementation_evidence_present": True,
+        "partial_implementation_evidence_present": False,
+    }
+    assert candidate["recovery"]["disposition"] == "investigate"
+    assert "coexist" in candidate["recovery"]["rationale"]
+    assert candidate["preservation"]["implementation_preserved"] is True
+    assert candidate["preservation"]["capability_preserved"] is None
+    assert candidate["preservation"]["intent_preserved"] is None
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    ).validate(report)

--- a/tests/test_corpus_archaeology_runtime_schema_binding.py
+++ b/tests/test_corpus_archaeology_runtime_schema_binding.py
@@ -1,0 +1,116 @@
+"""Runtime binding tests for the prepared-corpus JSON Schema contract."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = REPO_ROOT / "tools" / "salvage" / "corpus_archaeology.py"
+FIXED_TIME = "2026-08-18T03:00:00Z"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("corpus_archaeology_schema_binding", TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _source() -> dict:
+    return {
+        "source_ref": "fixture:source",
+        "title": "Fixture source",
+        "source_type": "document",
+        "creator_type": "human",
+        "authority_status": "historical",
+        "content_access": "released",
+        "content": "REQUIREMENT[fixture.schema]: Preserve schema parity.\n",
+    }
+
+
+def _corpus(source: dict | None = None) -> dict:
+    return {
+        "schema_version": "0.1.0",
+        "corpus_id": "fixture:runtime-schema-binding",
+        "sources": [source or _source()],
+    }
+
+
+@pytest.mark.unit
+def test_runtime_rejects_unknown_top_level_and_source_fields() -> None:
+    archaeology = _load_module()
+
+    top_level = _corpus()
+    top_level["unexpected"] = "must fail"
+    with pytest.raises(archaeology.CorpusArchaeologyError, match="additionalProperties"):
+        archaeology.analyze_corpus(top_level, generated_at=FIXED_TIME)
+
+    source = _source()
+    source["unexpected"] = "must fail"
+    with pytest.raises(archaeology.CorpusArchaeologyError, match="additionalProperties"):
+        archaeology.analyze_corpus(_corpus(source), generated_at=FIXED_TIME)
+
+
+@pytest.mark.unit
+def test_runtime_rejects_missing_schema_required_source_fields() -> None:
+    archaeology = _load_module()
+
+    for field in ("source_type", "creator_type", "authority_status", "content_access"):
+        source = _source()
+        source.pop(field)
+        with pytest.raises(archaeology.CorpusArchaeologyError, match="required"):
+            archaeology.analyze_corpus(_corpus(source), generated_at=FIXED_TIME)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["0.5", True])
+def test_runtime_rejects_non_schema_numeric_confidence(value) -> None:
+    archaeology = _load_module()
+    source = _source()
+    source["confidence"] = value
+
+    with pytest.raises(archaeology.CorpusArchaeologyError, match="violates type"):
+        archaeology.analyze_corpus(_corpus(source), generated_at=FIXED_TIME)
+
+
+@pytest.mark.unit
+def test_runtime_rejects_malformed_metadata_only_digest() -> None:
+    archaeology = _load_module()
+    source = _source()
+    source.update(
+        {
+            "content_access": "metadata_only",
+            "content": None,
+            "sha256": "not-a-sha256",
+        }
+    )
+
+    with pytest.raises(archaeology.CorpusArchaeologyError, match="violates pattern"):
+        archaeology.analyze_corpus(_corpus(source), generated_at=FIXED_TIME)
+
+
+@pytest.mark.unit
+def test_runtime_fails_closed_when_committed_schema_is_unavailable(tmp_path: Path) -> None:
+    archaeology = _load_module()
+    archaeology.INPUT_SCHEMA_PATH = tmp_path / "missing.schema.json"
+
+    with pytest.raises(
+        archaeology.CorpusArchaeologyError,
+        match="committed prepared-corpus input schema is unavailable or invalid",
+    ):
+        archaeology.analyze_corpus(_corpus(), generated_at=FIXED_TIME)
+
+
+@pytest.mark.unit
+def test_schema_bound_runtime_still_accepts_valid_prepared_corpus() -> None:
+    archaeology = _load_module()
+    report = archaeology.analyze_corpus(_corpus(), generated_at=FIXED_TIME)
+
+    assert report["schema_version"] == "0.1.0"
+    assert report["read_only"] is True
+    assert report["mutation_performed"] is False
+    assert report["candidates"][0]["intent_key"] == "fixture.schema"

--- a/tests/test_corpus_archaeology_runtime_schema_binding.py
+++ b/tests/test_corpus_archaeology_runtime_schema_binding.py
@@ -46,12 +46,12 @@ def test_runtime_rejects_unknown_top_level_and_source_fields() -> None:
 
     top_level = _corpus()
     top_level["unexpected"] = "must fail"
-    with pytest.raises(archaeology.CorpusArchaeologyError, match="additionalProperties"):
+    with pytest.raises(archaeology.CorpusArchaeologyError, match="Additional properties"):
         archaeology.analyze_corpus(top_level, generated_at=FIXED_TIME)
 
     source = _source()
     source["unexpected"] = "must fail"
-    with pytest.raises(archaeology.CorpusArchaeologyError, match="additionalProperties"):
+    with pytest.raises(archaeology.CorpusArchaeologyError, match="Additional properties"):
         archaeology.analyze_corpus(_corpus(source), generated_at=FIXED_TIME)
 
 

--- a/tools/salvage/__init__.py
+++ b/tools/salvage/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only salvage and corpus archaeology tooling."""

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
-"""Public CLI and schema boundary for deterministic Phase-1 corpus archaeology.
+"""Public schema/API boundary for deterministic Phase-1 corpus archaeology.
 
-The public entry point owns structural input validation and filesystem output policy.
-Pure semantic analysis lives in ``corpus_archaeology_core`` so custody, authority,
-and reporting responsibilities remain independently reviewable.
+Structural input validation remains here because callers import ``analyze_corpus``
+from this module. Filesystem/CLI output policy lives in ``corpus_archaeology_cli``;
+semantic analysis lives in ``corpus_archaeology_core``.
 """
 
 from __future__ import annotations
 
-import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -21,6 +19,7 @@ _REPO_ROOT = str(Path(__file__).resolve().parents[2])
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
+from tools.salvage.corpus_archaeology_cli import run_cli  # noqa: E402
 from tools.salvage.corpus_archaeology_core import (  # noqa: E402
     RANKING_WEIGHTS,
     SCHEMA_VERSION,
@@ -100,73 +99,8 @@ def analyze_corpus(
     return analyze_validated_corpus(corpus, generated_at=generated_at)
 
 
-def _write_new(path: Path, payload: str) -> None:
-    path = path.resolve(strict=False)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-    try:
-        fd = os.open(path, flags, 0o600)
-    except FileExistsError as exc:
-        raise CorpusArchaeologyError(
-            f"output already exists and will not be replaced: {path}"
-        ) from exc
-    with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as stream:
-        stream.write(payload)
-        stream.flush()
-        os.fsync(stream.fileno())
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Analyze a custody-cleared prepared corpus without mutation"
-    )
-    parser.add_argument("corpus", type=Path)
-    parser.add_argument("--output", type=Path)
-    parser.add_argument("--markdown-output", type=Path)
-    parser.add_argument("--generated-at")
-    return parser
-
-
-def _write_optional_output(
-    output: Path | None,
-    source: Path,
-    payload: str,
-    label: str,
-) -> None:
-    if output is None:
-        return
-    if output.resolve(strict=False) == source.resolve():
-        raise CorpusArchaeologyError(f"{label} path must not replace the source corpus")
-    _write_new(output, payload)
-
-
-def _emit_outputs(args: argparse.Namespace, report: dict[str, Any]) -> None:
-    payload = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
-    if args.output is None:
-        print(payload, end="")
-    _write_optional_output(args.output, args.corpus, payload, "output")
-    _write_optional_output(
-        args.markdown_output,
-        args.corpus,
-        render_markdown(report),
-        "markdown output",
-    )
-
-
-def _execute(args: argparse.Namespace) -> None:
-    corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
-    report = analyze_corpus(corpus, generated_at=args.generated_at)
-    _emit_outputs(args, report)
-
-
 def main() -> int:
-    args = _build_parser().parse_args()
-    try:
-        _execute(args)
-    except (OSError, json.JSONDecodeError, CorpusArchaeologyError) as exc:
-        print(f"INVALID: {exc}")
-        return 1
-    return 0
+    return run_cli(analyze_corpus, render_markdown)
 
 
 if __name__ == "__main__":

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -17,7 +17,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import jsonschema
+
 SCHEMA_VERSION = "0.1.0"
+INPUT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "salvage"
+    / "corpus_archaeology_input.schema.json"
+)
 
 CLAIM_RE = re.compile(
     r"^\s*(?P<label>DECISION|APPROVED|REJECTED|REQUIREMENT|CONSTRAINT|QUESTION|"
@@ -80,6 +88,38 @@ RANKING_WEIGHTS = {
 
 class CorpusArchaeologyError(ValueError):
     """Prepared corpus is invalid or violates a Phase-1 safety boundary."""
+
+
+def _validate_input_contract(corpus: dict[str, Any]) -> None:
+    """Bind runtime validation to the committed prepared-corpus JSON Schema."""
+    try:
+        schema = json.loads(INPUT_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(
+            schema,
+            format_checker=jsonschema.FormatChecker(),
+        )
+    except (OSError, json.JSONDecodeError, jsonschema.SchemaError) as exc:
+        raise CorpusArchaeologyError(
+            "committed prepared-corpus input schema is unavailable or invalid"
+        ) from exc
+
+    errors = sorted(
+        validator.iter_errors(corpus),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    if not errors:
+        return
+
+    error = errors[0]
+    path = ".".join(str(part) for part in error.absolute_path) or "<root>"
+    if error.validator in {"required", "additionalProperties"}:
+        detail = error.message
+    else:
+        detail = f"violates {error.validator}"
+    raise CorpusArchaeologyError(
+        f"input schema validation failed at {path}: {detail}"
+    )
 
 
 def _canonical_bytes(value: Any) -> bytes:
@@ -506,6 +546,7 @@ def analyze_corpus(
     """Analyze a prepared corpus without mutating source or external state."""
     if not isinstance(corpus, dict):
         raise CorpusArchaeologyError("corpus input must be an object")
+    _validate_input_contract(corpus)
     if corpus.get("schema_version") != SCHEMA_VERSION:
         raise CorpusArchaeologyError(
             f"unsupported corpus schema_version: {corpus.get('schema_version')!r}"

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -1,26 +1,40 @@
 #!/usr/bin/env python3
-"""Deterministic, read-only corpus archaeology for prepared source records.
+"""Public CLI and schema boundary for deterministic Phase-1 corpus archaeology.
 
-Phase 1 accepts only custody-cleared JSON records. It does not crawl repositories,
-open archives, execute recovered content, mutate sources, promote canon, or write
-to the Aurora work queue.
+The public entry point owns structural input validation and filesystem output policy.
+Pure semantic analysis lives in ``corpus_archaeology_core`` so custody, authority,
+and reporting responsibilities remain independently reviewable.
 """
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
-import re
-from collections.abc import Callable
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import jsonschema
 
-SCHEMA_VERSION = "0.1.0"
+try:
+    from tools.salvage.corpus_archaeology_core import (
+        RANKING_WEIGHTS,
+        SCHEMA_VERSION,
+        CorpusArchaeologyError,
+        analyze_validated_corpus,
+        render_markdown,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name not in {"tools", "tools.salvage"}:
+        raise
+    from corpus_archaeology_core import (
+        RANKING_WEIGHTS,
+        SCHEMA_VERSION,
+        CorpusArchaeologyError,
+        analyze_validated_corpus,
+        render_markdown,
+    )
+
 INPUT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
     / "schemas"
@@ -28,60 +42,15 @@ INPUT_SCHEMA_PATH = (
     / "corpus_archaeology_input.schema.json"
 )
 
-CLAIM_RE = re.compile(
-    r"^\s*(?P<label>DECISION|APPROVED|REJECTED|REQUIREMENT|CONSTRAINT|QUESTION|"
-    r"TODO|PATCH|RATIONALE|IMPLEMENTED|PARTIAL_IMPLEMENTATION)"
-    r"(?:\[(?P<intent>[A-Za-z0-9_.:/-]+)\])?\s*:\s*(?P<body>.+?)\s*$",
-    re.IGNORECASE,
-)
-
-CLAIM_TYPES = {
-    "DECISION": "decision",
-    "APPROVED": "approval",
-    "REJECTED": "rejection",
-    "REQUIREMENT": "requirement",
-    "CONSTRAINT": "constraint",
-    "QUESTION": "unresolved_question",
-    "TODO": "todo",
-    "PATCH": "proposed_patch",
-    "RATIONALE": "rationale",
-    "IMPLEMENTED": "implementation_evidence",
-    "PARTIAL_IMPLEMENTATION": "partial_implementation_evidence",
-}
-
-IMPLEMENTATION_CLAIM_TYPES = {
-    "implementation_evidence",
-    "partial_implementation_evidence",
-}
-IMPLEMENTATION_EVIDENCE_KINDS = {"implementation_artifact", "test_result"}
-IMPLEMENTATION_SOURCE_KINDS = {
-    "test": "test_result",
-    "code": "implementation_artifact",
-    "commit": "implementation_artifact",
-    "pull_request": "implementation_artifact",
-    "artifact": "implementation_artifact",
-}
-CREATOR_EVIDENCE_KINDS = {
-    "human": "human_statement",
-    "assistant": "model_statement",
-    "model": "model_statement",
-    "system": "system_record",
-    "mixed": "mixed_source",
-    "unknown": "unknown",
-}
-
-RANKING_WEIGHTS = {
-    "explicit_decision": 0.25,
-    "requirement_strength": 0.20,
-    "unresolved_commitment": 0.20,
-    "implementation_gap": 0.20,
-    "recurrence": 0.10,
-    "evidence_confidence": 0.05,
-}
-
-
-class CorpusArchaeologyError(ValueError):
-    """Prepared corpus is invalid or violates a Phase-1 safety boundary."""
+__all__ = [
+    "CorpusArchaeologyError",
+    "INPUT_SCHEMA_PATH",
+    "RANKING_WEIGHTS",
+    "SCHEMA_VERSION",
+    "analyze_corpus",
+    "main",
+    "render_markdown",
+]
 
 
 def _load_input_validator() -> jsonschema.Draft202012Validator:
@@ -120,622 +89,19 @@ def _schema_error_message(error: jsonschema.ValidationError) -> str:
 
 
 def _validate_input_contract(corpus: dict[str, Any]) -> None:
-    """Bind runtime validation to the committed prepared-corpus JSON Schema."""
     error = _first_schema_error(_load_input_validator(), corpus)
     if error is not None:
         raise CorpusArchaeologyError(_schema_error_message(error))
 
 
-def _canonical_bytes(value: Any) -> bytes:
-    return json.dumps(
-        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    ).encode("utf-8")
-
-
-def _id(prefix: str, value: Any, length: int = 24) -> str:
-    return f"{prefix}:{hashlib.sha256(_canonical_bytes(value)).hexdigest()[:length]}"
-
-
-def _sha256(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def _parse_timestamp(value: str) -> str:
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except (AttributeError, ValueError) as exc:
-        raise CorpusArchaeologyError(
-            "generated_at must be timezone-aware ISO-8601"
-        ) from exc
-    if parsed.tzinfo is None or parsed.utcoffset() is None:
-        raise CorpusArchaeologyError("generated_at must include timezone information")
-    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _timestamp(value: str | None) -> str:
-    if value is None:
-        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    return _parse_timestamp(value)
-
-
-def _string(value: Any, name: str) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise CorpusArchaeologyError(f"{name} must be a non-empty string")
-    return value.strip()
-
-
-def _validate_optional_source_strings(source_ref: str, raw: dict[str, Any]) -> None:
-    for name in ("artifact_id", "inventory_report_id", "platform"):
-        value = raw.get(name)
-        if value is not None:
-            _string(value, f"{source_ref}.{name}")
-
-
-def _released_content(raw: dict[str, Any], source_ref: str) -> tuple[str, str]:
-    content = raw["content"]
-    digest = _sha256(content)
-    supplied_digest = raw.get("sha256")
-    if supplied_digest is not None and supplied_digest != digest:
-        raise CorpusArchaeologyError(
-            f"{source_ref}.sha256 does not match prepared content"
-        )
-    return content, digest
-
-
-def _prepared_content(
-    raw: dict[str, Any], source_ref: str
-) -> tuple[str | None, str | None]:
-    if raw["content_access"] == "released":
-        return _released_content(raw, source_ref)
-    return None, raw.get("sha256")
-
-
-def _source(raw: dict[str, Any]) -> dict[str, Any]:
-    source_ref = _string(raw["source_ref"], "source_ref")
-    _validate_optional_source_strings(source_ref, raw)
-    content, digest = _prepared_content(raw, source_ref)
-    artifact_id = raw.get("artifact_id")
-    inventory_ref = raw.get("inventory_report_id")
-    stable_identity = {
-        "source_ref": source_ref,
-        "sha256": digest,
-        "artifact_id": artifact_id,
-        "inventory_report_id": inventory_ref,
-    }
-    return {
-        "source_ref": source_ref,
-        "source_id": _id("source", stable_identity),
-        "title": _string(raw["title"], f"{source_ref}.title"),
-        "source_type": raw["source_type"],
-        "platform": raw.get("platform"),
-        "creator_type": raw["creator_type"],
-        "authority_status": raw["authority_status"],
-        "confidence": float(raw.get("confidence", 1.0)),
-        "artifact_id": artifact_id,
-        "inventory_report_id": inventory_ref,
-        "content_access": raw["content_access"],
-        "sha256": digest,
-        "_content": content,
-    }
-
-
-def _evidence_kind(source: dict[str, Any], claim_type: str) -> str:
-    creator_kind = CREATOR_EVIDENCE_KINDS[source["creator_type"]]
-    if claim_type not in IMPLEMENTATION_CLAIM_TYPES:
-        return creator_kind
-    return IMPLEMENTATION_SOURCE_KINDS.get(source["source_type"], creator_kind)
-
-
-def _claim_from_line(
-    source: dict[str, Any], line_number: int, line: str
-) -> dict[str, Any] | None:
-    match = CLAIM_RE.match(line)
-    if match is None:
-        return None
-    claim_type = CLAIM_TYPES[match.group("label").upper()]
-    intent = match.group("intent")
-    span = {
-        "source_id": source["source_id"],
-        "source_ref": source["source_ref"],
-        "line_start": line_number,
-        "line_end": line_number,
-        "text_sha256": _sha256(line),
-        "excerpt": line,
-    }
-    material = {
-        "source_id": source["source_id"],
-        "line": line_number,
-        "claim_type": claim_type,
-        "intent_key": intent,
-        "text_sha256": span["text_sha256"],
-    }
-    return {
-        "claim_id": _id("claim", material),
-        "claim_type": claim_type,
-        "intent_key": intent,
-        "claim": match.group("body").strip(),
-        "evidence_kind": _evidence_kind(source, claim_type),
-        "authority_status": source["authority_status"],
-        "confidence": source["confidence"],
-        "span": span,
-    }
-
-
-def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
-    content = source["_content"]
-    if content is None:
-        return []
-    extracted = (
-        _claim_from_line(source, line_number, line)
-        for line_number, line in enumerate(content.splitlines(), start=1)
-    )
-    return [claim for claim in extracted if claim is not None]
-
-
-def _human_claim_types(claims: list[dict[str, Any]]) -> set[str]:
-    return {
-        item["claim_type"]
-        for item in claims
-        if item["evidence_kind"] == "human_statement"
-    }
-
-
-def _matches_implementation_claim(
-    item: dict[str, Any], claim_type: str, authority: str | None
-) -> bool:
-    if item["claim_type"] != claim_type:
-        return False
-    if item["evidence_kind"] not in IMPLEMENTATION_EVIDENCE_KINDS:
-        return False
-    return authority is None or item["authority_status"] == authority
-
-
-def _has_implementation_claim(
-    claims: list[dict[str, Any]], claim_type: str, authority: str | None = None
-) -> bool:
-    return any(
-        _matches_implementation_claim(item, claim_type, authority) for item in claims
-    )
-
-
-def _candidate_flags(claims: list[dict[str, Any]]) -> dict[str, bool]:
-    human_types = _human_claim_types(claims)
-    commitment_types = {
-        "approval",
-        "decision",
-        "requirement",
-        "constraint",
-        "todo",
-        "unresolved_question",
-        "proposed_patch",
-    }
-    return {
-        "rejected": "rejection" in human_types,
-        "implemented": _has_implementation_claim(claims, "implementation_evidence"),
-        "partial": _has_implementation_claim(
-            claims, "partial_implementation_evidence"
-        ),
-        "current_implemented": _has_implementation_claim(
-            claims, "implementation_evidence", "current"
-        ),
-        "current_partial": _has_implementation_claim(
-            claims, "partial_implementation_evidence", "current"
-        ),
-        "decision": bool({"approval", "decision"} & human_types),
-        "requirement": bool({"requirement", "constraint"} & human_types),
-        "unresolved": bool(
-            {"todo", "unresolved_question", "proposed_patch"} & human_types
-        ),
-        "commitment": bool(commitment_types & human_types),
-    }
-
-
-def _candidate_conflict(flags: dict[str, bool]) -> bool:
-    return flags["rejected"] and (flags["implemented"] or flags["partial"])
-
-
-def _default_candidate_state(flags: dict[str, bool]) -> tuple[str, str, str]:
-    status = "approved" if flags["decision"] else "proposed"
-    rationale = (
-        "An explicit human commitment is present without implementation or "
-        "rejection evidence; preserve for investigation."
-        if flags["commitment"]
-        else "No authoritative commitment, implementation, or rejection evidence "
-        "is established; retain as an uncertain recovery candidate."
-    )
-    return status, "investigate", rationale
-
-
-def _state_conflict(_: dict[str, bool]) -> tuple[str, str, str]:
-    return (
-        "unknown",
-        "investigate",
-        "Explicit human rejection and implementation evidence coexist; preserve both "
-        "histories and investigate chronology, scope, and authority.",
-    )
-
-
-def _state_rejected(_: dict[str, bool]) -> tuple[str, str, str]:
-    return (
-        "rejected",
-        "reject_with_evidence",
-        "Explicit human rejection evidence is present; preserve the record and do not "
-        "restore automatically.",
-    )
-
-
-def _state_implemented(_: dict[str, bool]) -> tuple[str, str, str]:
-    return (
-        "implemented",
-        "preserve",
-        "Implementation evidence is present; preserve the implementation record and "
-        "verify whether a current successor remains.",
-    )
-
-
-def _state_partial(_: dict[str, bool]) -> tuple[str, str, str]:
-    return (
-        "partial",
-        "investigate",
-        "Only partial implementation evidence is present; investigate intent and "
-        "capability preservation.",
-    )
-
-
-def _candidate_state(flags: dict[str, bool]) -> tuple[str, str, str]:
-    rules: tuple[
-        tuple[Callable[[dict[str, bool]], bool], Callable[[dict[str, bool]], tuple[str, str, str]]],
-        ...,
-    ] = (
-        (_candidate_conflict, _state_conflict),
-        (lambda state: state["rejected"], _state_rejected),
-        (lambda state: state["implemented"], _state_implemented),
-        (lambda state: state["partial"], _state_partial),
-    )
-    for predicate, result in rules:
-        if predicate(flags):
-            return result(flags)
-    return _default_candidate_state(flags)
-
-
-def _implementation_gap(flags: dict[str, bool]) -> float:
-    has_resolution = flags["implemented"] or flags["partial"] or flags["rejected"]
-    return float(flags["commitment"] and not has_resolution)
-
-
-def _candidate_components(
-    flags: dict[str, bool], source_refs: list[str], claims: list[dict[str, Any]]
-) -> dict[str, float]:
-    return {
-        "explicit_decision": float(flags["decision"]),
-        "requirement_strength": float(flags["requirement"]),
-        "unresolved_commitment": float(flags["unresolved"]),
-        "implementation_gap": _implementation_gap(flags),
-        "recurrence": min(len(source_refs) / 3.0, 1.0),
-        "evidence_confidence": sum(item["confidence"] for item in claims) / len(claims),
-    }
-
-
-def _implementation_preserved(flags: dict[str, bool]) -> bool | None:
-    if flags["current_implemented"]:
-        return True
-    if flags["current_partial"]:
-        return False
-    return None
-
-
-def _sorted_candidate_claims(claims: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return sorted(
-        claims,
-        key=lambda item: (
-            item["span"]["source_ref"],
-            item["span"]["line_start"],
-            item["claim_id"],
-        ),
-    )
-
-
-def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
-    claims = _sorted_candidate_claims(claims)
-    flags = _candidate_flags(claims)
-    status, disposition, rationale = _candidate_state(flags)
-    source_refs = sorted({item["span"]["source_ref"] for item in claims})
-    source_ids = sorted({item["span"]["source_id"] for item in claims})
-    components = _candidate_components(flags, source_refs, claims)
-    score = round(
-        sum(components[name] * weight for name, weight in RANKING_WEIGHTS.items()),
-        6,
-    )
-    material = {
-        "intent_key": intent,
-        "claim_ids": [item["claim_id"] for item in claims],
-        "disposition": disposition,
-    }
-    return {
-        "candidate_id": _id("candidate", material),
-        "intent_key": intent,
-        "source_refs": source_refs,
-        "source_ids": source_ids,
-        "claim_ids": [item["claim_id"] for item in claims],
-        "historical_state": {
-            "status": status,
-            "explicit_rejection": flags["rejected"],
-            "implementation_evidence_present": flags["implemented"],
-            "partial_implementation_evidence_present": flags["partial"],
-        },
-        "preservation": {
-            "implementation_preserved": _implementation_preserved(flags),
-            "capability_preserved": None,
-            "intent_preserved": None,
-            "intent_delta": None,
-        },
-        "recovery": {
-            "disposition": disposition,
-            "rationale": rationale,
-            "confidence": round(components["evidence_confidence"], 6),
-            "dependencies": [],
-        },
-        "ranking": {
-            "relevance_score": score,
-            "components": {
-                name: round(value, 6) for name, value in components.items()
-            },
-        },
-    }
-
-
-def _known_relationship_intents(
-    raw: dict[str, Any], known_intents: set[str], index: int
-) -> tuple[str, str]:
-    left = raw["left_intent_key"]
-    right = raw["right_intent_key"]
-    unknown = {left, right} - known_intents
-    if unknown:
-        raise CorpusArchaeologyError(
-            f"relationship_hints[{index}] references an unknown intent key"
-        )
-    return left, right
-
-
-def _known_relationship_sources(
-    raw: dict[str, Any], known_sources: set[str], index: int
-) -> list[str]:
-    refs = sorted(set(raw["evidence_source_refs"]))
-    unknown = set(refs) - known_sources
-    if unknown:
-        raise CorpusArchaeologyError(
-            f"relationship_hints[{index}] references unknown sources: "
-            f"{', '.join(sorted(unknown))}"
-        )
-    return refs
-
-
-def _relationship(
-    raw: dict[str, Any],
-    index: int,
-    known_intents: set[str],
-    known_sources: set[str],
-) -> dict[str, Any]:
-    left, right = _known_relationship_intents(raw, known_intents, index)
-    refs = _known_relationship_sources(raw, known_sources, index)
-    material = {
-        "left_intent_key": left,
-        "right_intent_key": right,
-        "relationship": raw["relationship"],
-        "rationale": raw["rationale"],
-        "evidence_source_refs": refs,
-    }
-    return {"relationship_id": _id("relationship", material), **material}
-
-
-def _relationships(
-    hints: list[dict[str, Any]] | None,
-    known_intents: set[str],
-    known_sources: set[str],
-) -> list[dict[str, Any]]:
-    items = hints or []
-    result = [
-        _relationship(raw, index, known_intents, known_sources)
-        for index, raw in enumerate(items)
-    ]
-    return sorted(
-        result,
-        key=lambda item: (
-            item["left_intent_key"],
-            item["right_intent_key"],
-            item["relationship"],
-            item["relationship_id"],
-        ),
-    )
-
-
-def _normalized_sources(raw_sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    sources = [_source(raw) for raw in raw_sources]
-    refs = [item["source_ref"] for item in sources]
-    if len(refs) != len(set(refs)):
-        raise CorpusArchaeologyError("source_ref values must be unique")
-    return sorted(sources, key=lambda item: (item["source_ref"], item["source_id"]))
-
-
-def _sorted_claims(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    claims = [claim for source in sources for claim in _claims(source)]
-    return sorted(
-        claims,
-        key=lambda item: (
-            item["span"]["source_ref"],
-            item["span"]["line_start"],
-            item["claim_id"],
-        ),
-    )
-
-
-def _claims_by_intent(
-    claims: list[dict[str, Any]],
-) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
-    by_intent: dict[str, list[dict[str, Any]]] = {}
-    unkeyed: list[str] = []
-    for claim in claims:
-        intent = claim["intent_key"]
-        target = unkeyed if intent is None else by_intent.setdefault(intent, [])
-        target.append(claim["claim_id"] if intent is None else claim)
-    return by_intent, unkeyed
-
-
-def _public_sources(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        {key: value for key, value in item.items() if key != "_content"}
-        for item in sources
-    ]
-
-
-def _stable_report_material(
-    corpus_id: str,
-    source_inventory_ref: str | None,
-    public_sources: list[dict[str, Any]],
-    claims: list[dict[str, Any]],
-    relationships: list[dict[str, Any]],
-    candidates: list[dict[str, Any]],
-    unkeyed: list[str],
-) -> dict[str, Any]:
-    return {
-        "corpus_id": corpus_id,
-        "source_inventory_ref": source_inventory_ref,
-        "sources": public_sources,
-        "claims": claims,
-        "relationships": relationships,
-        "candidates": candidates,
-        "unkeyed_claim_ids": sorted(unkeyed),
-        "ranking_weights": RANKING_WEIGHTS,
-    }
-
-
-def _report(
-    *,
-    corpus_id: str,
-    source_inventory_ref: str | None,
-    generated_at: str | None,
-    public_sources: list[dict[str, Any]],
-    claims: list[dict[str, Any]],
-    relationships: list[dict[str, Any]],
-    candidates: list[dict[str, Any]],
-    unkeyed: list[str],
-) -> dict[str, Any]:
-    stable = _stable_report_material(
-        corpus_id,
-        source_inventory_ref,
-        public_sources,
-        claims,
-        relationships,
-        candidates,
-        unkeyed,
-    )
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "report_id": (
-            "corpus-report:"
-            f"{hashlib.sha256(_canonical_bytes(stable)).hexdigest()}"
-        ),
-        "generated_at": _timestamp(generated_at),
-        "corpus_id": corpus_id,
-        "source_inventory_ref": source_inventory_ref,
-        "read_only": True,
-        "mutation_performed": False,
-        "analysis_profile": "explicit_markers_v1",
-        "ranking_model": {
-            "name": "explainable_relevance_v1",
-            "weights": RANKING_WEIGHTS,
-        },
-        "sources": public_sources,
-        "claims": claims,
-        "relationships": relationships,
-        "candidates": candidates,
-        "unkeyed_claim_ids": sorted(unkeyed),
-    }
-
-
 def analyze_corpus(
     corpus: dict[str, Any], *, generated_at: str | None = None
 ) -> dict[str, Any]:
-    """Analyze a prepared corpus without mutating source or external state."""
+    """Validate and analyze a prepared corpus without mutating external state."""
     if not isinstance(corpus, dict):
         raise CorpusArchaeologyError("corpus input must be an object")
     _validate_input_contract(corpus)
-    corpus_id = _string(corpus["corpus_id"], "corpus_id")
-    source_inventory_ref = corpus.get("source_inventory_ref")
-    if source_inventory_ref is not None:
-        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
-
-    sources = _normalized_sources(corpus["sources"])
-    claims = _sorted_claims(sources)
-    by_intent, unkeyed = _claims_by_intent(claims)
-    candidates = [
-        _candidate(intent, by_intent[intent]) for intent in sorted(by_intent)
-    ]
-    refs = {item["source_ref"] for item in sources}
-    relationships = _relationships(
-        corpus.get("relationship_hints"), set(by_intent), refs
-    )
-    return _report(
-        corpus_id=corpus_id,
-        source_inventory_ref=source_inventory_ref,
-        generated_at=generated_at,
-        public_sources=_public_sources(sources),
-        claims=claims,
-        relationships=relationships,
-        candidates=candidates,
-        unkeyed=unkeyed,
-    )
-
-
-def _candidate_markdown_lines(item: dict[str, Any]) -> list[str]:
-    return [
-        f"### `{item['intent_key']}`",
-        "",
-        f"- Disposition: `{item['recovery']['disposition']}`",
-        f"- Historical state: `{item['historical_state']['status']}`",
-        f"- Relevance: `{item['ranking']['relevance_score']:.6f}`",
-        f"- Sources: {', '.join(f'`{source}`' for source in item['source_refs'])}",
-        f"- Rationale: {item['recovery']['rationale']}",
-        "",
-    ]
-
-
-def _candidate_markdown_section(candidates: list[dict[str, Any]]) -> list[str]:
-    if not candidates:
-        return ["_No keyed recovery candidates were extracted._"]
-    return [line for item in candidates for line in _candidate_markdown_lines(item)]
-
-
-def _unkeyed_markdown_section(claim_ids: list[str]) -> list[str]:
-    if not claim_ids:
-        return []
-    return [
-        "## Unkeyed claims",
-        "",
-        "These claims retain provenance but are not promoted because no deterministic "
-        "intent key was supplied.",
-        "",
-        *[f"- `{claim_id}`" for claim_id in claim_ids],
-        "",
-    ]
-
-
-def render_markdown(report: dict[str, Any]) -> str:
-    lines = [
-        "# Corpus Archaeology Report",
-        "",
-        f"- Report: `{report['report_id']}`",
-        f"- Corpus: `{report['corpus_id']}`",
-        f"- Sources: {len(report['sources'])}",
-        f"- Claims: {len(report['claims'])}",
-        f"- Candidates: {len(report['candidates'])}",
-        "",
-        "## Recovery candidates",
-        "",
-        *_candidate_markdown_section(report["candidates"]),
-        *_unkeyed_markdown_section(report["unkeyed_claim_ids"]),
-    ]
-    return "\n".join(lines).rstrip() + "\n"
+    return analyze_validated_corpus(corpus, generated_at=generated_at)
 
 
 def _write_new(path: Path, payload: str) -> None:

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -235,7 +235,9 @@ def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
     types = {item["claim_type"] for item in claims}
-    rejected = "rejection" in types
+    human_claims = [item for item in claims if item["evidence_kind"] == "human_statement"]
+    human_types = {item["claim_type"] for item in human_claims}
+    rejected = "rejection" in human_types
     implemented = any(
         item["claim_type"] == "implementation_evidence"
         and item["evidence_kind"] in {"implementation_artifact", "test_result"}
@@ -246,12 +248,12 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
         and item["evidence_kind"] in {"implementation_artifact", "test_result"}
         for item in claims
     )
-    decision = bool({"approval", "decision"} & types)
-    requirement = bool({"requirement", "constraint"} & types)
-    unresolved = bool({"todo", "unresolved_question", "proposed_patch"} & types)
+    decision = bool({"approval", "decision"} & human_types)
+    requirement = bool({"requirement", "constraint"} & human_types)
+    unresolved = bool({"todo", "unresolved_question", "proposed_patch"} & human_types)
     commitment = bool(
         {"approval", "decision", "requirement", "constraint", "todo",
-         "unresolved_question", "proposed_patch"} & types
+         "unresolved_question", "proposed_patch"} & human_types
     )
 
     if rejected:

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Deterministic, read-only corpus archaeology for prepared source records.
+
+Phase 1 accepts only custody-cleared JSON records. It does not crawl repositories,
+open archives, execute recovered content, mutate sources, promote canon, or write
+to the Aurora work queue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "0.1.0"
+
+CLAIM_RE = re.compile(
+    r"^\s*(?P<label>DECISION|APPROVED|REJECTED|REQUIREMENT|CONSTRAINT|QUESTION|"
+    r"TODO|PATCH|RATIONALE|IMPLEMENTED|PARTIAL_IMPLEMENTATION)"
+    r"(?:\[(?P<intent>[A-Za-z0-9_.:/-]+)\])?\s*:\s*(?P<body>.+?)\s*$",
+    re.IGNORECASE,
+)
+
+CLAIM_TYPES = {
+    "DECISION": "decision",
+    "APPROVED": "approval",
+    "REJECTED": "rejection",
+    "REQUIREMENT": "requirement",
+    "CONSTRAINT": "constraint",
+    "QUESTION": "unresolved_question",
+    "TODO": "todo",
+    "PATCH": "proposed_patch",
+    "RATIONALE": "rationale",
+    "IMPLEMENTED": "implementation_evidence",
+    "PARTIAL_IMPLEMENTATION": "partial_implementation_evidence",
+}
+
+RELATIONSHIPS = {
+    "convergent", "successor", "parallel", "merged", "divergent", "superseded",
+    "dormant", "lost_in_transition", "orphaned", "uncertain",
+}
+SOURCE_TYPES = {
+    "chat", "document", "issue", "pull_request", "commit", "code", "test",
+    "artifact", "report", "unknown",
+}
+CREATOR_TYPES = {"human", "assistant", "model", "system", "mixed", "unknown"}
+AUTHORITY = {"current", "historical", "reference", "draft", "unknown"}
+CONTENT_ACCESS = {"released", "metadata_only"}
+
+RANKING_WEIGHTS = {
+    "explicit_decision": 0.25,
+    "requirement_strength": 0.20,
+    "unresolved_commitment": 0.20,
+    "implementation_gap": 0.20,
+    "recurrence": 0.10,
+    "evidence_confidence": 0.05,
+}
+
+
+class CorpusArchaeologyError(ValueError):
+    """Prepared corpus is invalid or violates a Phase-1 safety boundary."""
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _id(prefix: str, value: Any, length: int = 24) -> str:
+    return f"{prefix}:{hashlib.sha256(_canonical_bytes(value)).hexdigest()[:length]}"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _timestamp(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise CorpusArchaeologyError("generated_at must be timezone-aware ISO-8601") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CorpusArchaeologyError("generated_at must include timezone information")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CorpusArchaeologyError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _enum(value: Any, name: str, allowed: set[str]) -> str:
+    normalized = _string(value, name)
+    if normalized not in allowed:
+        raise CorpusArchaeologyError(
+            f"{name} must be one of: {', '.join(sorted(allowed))}"
+        )
+    return normalized
+
+
+def _confidence(value: Any, name: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise CorpusArchaeologyError(f"{name} must be between 0 and 1") from exc
+    if not 0.0 <= result <= 1.0:
+        raise CorpusArchaeologyError(f"{name} must be between 0 and 1")
+    return result
+
+
+def _source(raw: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise CorpusArchaeologyError("every source must be an object")
+
+    source_ref = _string(raw.get("source_ref"), "source_ref")
+    source_type = _enum(raw.get("source_type", "unknown"), f"{source_ref}.source_type", SOURCE_TYPES)
+    creator_type = _enum(raw.get("creator_type", "unknown"), f"{source_ref}.creator_type", CREATOR_TYPES)
+    authority = _enum(raw.get("authority_status", "unknown"), f"{source_ref}.authority_status", AUTHORITY)
+    access = _enum(raw.get("content_access", "released"), f"{source_ref}.content_access", CONTENT_ACCESS)
+    confidence = _confidence(raw.get("confidence", 1.0), f"{source_ref}.confidence")
+
+    artifact_id = raw.get("artifact_id")
+    inventory_ref = raw.get("inventory_report_id")
+    platform = raw.get("platform")
+    for name, value in (
+        ("artifact_id", artifact_id),
+        ("inventory_report_id", inventory_ref),
+        ("platform", platform),
+    ):
+        if value is not None:
+            _string(value, f"{source_ref}.{name}")
+
+    content = raw.get("content")
+    supplied_digest = raw.get("sha256")
+    if access == "metadata_only":
+        if content not in (None, ""):
+            raise CorpusArchaeologyError(f"{source_ref} is metadata_only and must not include content")
+        digest = _string(supplied_digest, f"{source_ref}.sha256") if supplied_digest is not None else None
+        content = None
+    else:
+        if not isinstance(content, str):
+            raise CorpusArchaeologyError(f"{source_ref} requires string content")
+        digest = _sha256(content)
+        if supplied_digest is not None and _string(supplied_digest, f"{source_ref}.sha256") != digest:
+            raise CorpusArchaeologyError(f"{source_ref}.sha256 does not match prepared content")
+
+    stable_identity = {
+        "source_ref": source_ref,
+        "sha256": digest,
+        "artifact_id": artifact_id,
+        "inventory_report_id": inventory_ref,
+    }
+    return {
+        "source_ref": source_ref,
+        "source_id": _id("source", stable_identity),
+        "title": _string(raw.get("title"), f"{source_ref}.title"),
+        "source_type": source_type,
+        "platform": platform,
+        "creator_type": creator_type,
+        "authority_status": authority,
+        "confidence": confidence,
+        "artifact_id": artifact_id,
+        "inventory_report_id": inventory_ref,
+        "content_access": access,
+        "sha256": digest,
+        "_content": content,
+    }
+
+
+def _evidence_kind(source: dict[str, Any], claim_type: str) -> str:
+    if claim_type in {"implementation_evidence", "partial_implementation_evidence"}:
+        if source["source_type"] == "test":
+            return "test_result"
+        return "implementation_artifact"
+    return {
+        "human": "human_statement",
+        "assistant": "model_statement",
+        "model": "model_statement",
+        "system": "system_record",
+        "mixed": "mixed_source",
+        "unknown": "unknown",
+    }[source["creator_type"]]
+
+
+def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
+    if source["_content"] is None:
+        return []
+
+    result = []
+    for line_number, line in enumerate(source["_content"].splitlines(), start=1):
+        match = CLAIM_RE.match(line)
+        if not match:
+            continue
+        claim_type = CLAIM_TYPES[match.group("label").upper()]
+        intent = match.group("intent")
+        span = {
+            "source_id": source["source_id"],
+            "source_ref": source["source_ref"],
+            "line_start": line_number,
+            "line_end": line_number,
+            "text_sha256": _sha256(line),
+            "excerpt": line,
+        }
+        material = {
+            "source_id": source["source_id"],
+            "line": line_number,
+            "claim_type": claim_type,
+            "intent_key": intent,
+            "text_sha256": span["text_sha256"],
+        }
+        result.append(
+            {
+                "claim_id": _id("claim", material),
+                "claim_type": claim_type,
+                "intent_key": intent,
+                "claim": match.group("body").strip(),
+                "evidence_kind": _evidence_kind(source, claim_type),
+                "authority_status": source["authority_status"],
+                "confidence": source["confidence"],
+                "span": span,
+            }
+        )
+    return result
+
+
+def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
+    types = {item["claim_type"] for item in claims}
+    rejected = "rejection" in types
+    implemented = "implementation_evidence" in types
+    partial = "partial_implementation_evidence" in types
+    decision = bool({"approval", "decision"} & types)
+    requirement = bool({"requirement", "constraint"} & types)
+    unresolved = bool({"todo", "unresolved_question", "proposed_patch"} & types)
+    commitment = bool(
+        {"approval", "decision", "requirement", "constraint", "todo",
+         "unresolved_question", "proposed_patch"} & types
+    )
+
+    if rejected:
+        status, disposition = "rejected", "reject_with_evidence"
+        rationale = "Explicit rejection evidence is present; preserve the record and do not restore automatically."
+    elif implemented:
+        status, disposition = "implemented", "preserve"
+        rationale = "Explicit implementation evidence is present; preserve and verify the current successor."
+    elif partial:
+        status, disposition = "partial", "investigate"
+        rationale = "Only partial implementation evidence is present; investigate intent and capability preservation."
+    else:
+        status = "approved" if decision else "proposed"
+        disposition = "investigate"
+        rationale = (
+            "An explicit commitment is present without implementation or rejection evidence; preserve for investigation."
+            if commitment
+            else "No implementation or rejection evidence is established; retain as an uncertain recovery candidate."
+        )
+
+    source_refs = sorted({item["span"]["source_ref"] for item in claims})
+    source_ids = sorted({item["span"]["source_id"] for item in claims})
+    claims = sorted(
+        claims,
+        key=lambda item: (item["span"]["source_ref"], item["span"]["line_start"], item["claim_id"]),
+    )
+    gap = 1.0 if commitment and not (implemented or partial or rejected) else 0.0
+    components = {
+        "explicit_decision": 1.0 if decision else 0.0,
+        "requirement_strength": 1.0 if requirement else 0.0,
+        "unresolved_commitment": 1.0 if unresolved else 0.0,
+        "implementation_gap": gap,
+        "recurrence": min(len(source_refs) / 3.0, 1.0),
+        "evidence_confidence": sum(item["confidence"] for item in claims) / len(claims),
+    }
+    score = round(sum(components[name] * weight for name, weight in RANKING_WEIGHTS.items()), 6)
+    material = {"intent_key": intent, "claim_ids": [item["claim_id"] for item in claims], "disposition": disposition}
+
+    return {
+        "candidate_id": _id("candidate", material),
+        "intent_key": intent,
+        "source_refs": source_refs,
+        "source_ids": source_ids,
+        "claim_ids": [item["claim_id"] for item in claims],
+        "historical_state": {
+            "status": status,
+            "explicit_rejection": rejected,
+            "implementation_evidence_present": implemented,
+            "partial_implementation_evidence_present": partial,
+        },
+        "preservation": {
+            "implementation_preserved": True if implemented else (False if partial else None),
+            "capability_preserved": None,
+            "intent_preserved": None,
+            "intent_delta": None,
+        },
+        "recovery": {
+            "disposition": disposition,
+            "rationale": rationale,
+            "confidence": round(components["evidence_confidence"], 6),
+            "dependencies": [],
+        },
+        "ranking": {
+            "relevance_score": score,
+            "components": {name: round(value, 6) for name, value in components.items()},
+        },
+    }
+
+
+def _relationships(
+    hints: Any,
+    known_intents: set[str],
+    known_sources: set[str],
+) -> list[dict[str, Any]]:
+    if hints is None:
+        return []
+    if not isinstance(hints, list):
+        raise CorpusArchaeologyError("relationship_hints must be an array")
+
+    result = []
+    for index, raw in enumerate(hints):
+        if not isinstance(raw, dict):
+            raise CorpusArchaeologyError(f"relationship_hints[{index}] must be an object")
+        left = _string(raw.get("left_intent_key"), f"relationship_hints[{index}].left_intent_key")
+        right = _string(raw.get("right_intent_key"), f"relationship_hints[{index}].right_intent_key")
+        relationship = _enum(raw.get("relationship"), f"relationship_hints[{index}].relationship", RELATIONSHIPS)
+        rationale = _string(raw.get("rationale"), f"relationship_hints[{index}].rationale")
+        if left not in known_intents or right not in known_intents:
+            raise CorpusArchaeologyError(f"relationship_hints[{index}] references an unknown intent key")
+
+        refs = raw.get("evidence_source_refs", [])
+        if not isinstance(refs, list):
+            raise CorpusArchaeologyError(f"relationship_hints[{index}].evidence_source_refs must be an array")
+        refs = sorted({_string(item, f"relationship_hints[{index}].evidence_source_refs") for item in refs})
+        unknown = set(refs) - known_sources
+        if unknown:
+            raise CorpusArchaeologyError(
+                f"relationship_hints[{index}] references unknown sources: {', '.join(sorted(unknown))}"
+            )
+        material = {
+            "left_intent_key": left,
+            "right_intent_key": right,
+            "relationship": relationship,
+            "rationale": rationale,
+            "evidence_source_refs": refs,
+        }
+        result.append({"relationship_id": _id("relationship", material), **material})
+
+    return sorted(
+        result,
+        key=lambda item: (
+            item["left_intent_key"], item["right_intent_key"],
+            item["relationship"], item["relationship_id"],
+        ),
+    )
+
+
+def analyze_corpus(corpus: dict[str, Any], *, generated_at: str | None = None) -> dict[str, Any]:
+    """Analyze a prepared corpus without mutating source or external state."""
+    if not isinstance(corpus, dict):
+        raise CorpusArchaeologyError("corpus input must be an object")
+    if corpus.get("schema_version") != SCHEMA_VERSION:
+        raise CorpusArchaeologyError(f"unsupported corpus schema_version: {corpus.get('schema_version')!r}")
+
+    corpus_id = _string(corpus.get("corpus_id"), "corpus_id")
+    raw_sources = corpus.get("sources")
+    if not isinstance(raw_sources, list) or not raw_sources:
+        raise CorpusArchaeologyError("sources must be a non-empty array")
+
+    sources = [_source(raw) for raw in raw_sources]
+    refs = [item["source_ref"] for item in sources]
+    if len(refs) != len(set(refs)):
+        raise CorpusArchaeologyError("source_ref values must be unique")
+    sources.sort(key=lambda item: (item["source_ref"], item["source_id"]))
+
+    claims = [claim for source in sources for claim in _claims(source)]
+    claims.sort(key=lambda item: (item["span"]["source_ref"], item["span"]["line_start"], item["claim_id"]))
+
+    by_intent: dict[str, list[dict[str, Any]]] = {}
+    unkeyed = []
+    for claim in claims:
+        if claim["intent_key"] is None:
+            unkeyed.append(claim["claim_id"])
+        else:
+            by_intent.setdefault(claim["intent_key"], []).append(claim)
+
+    candidates = [_candidate(intent, by_intent[intent]) for intent in sorted(by_intent)]
+    relationships = _relationships(corpus.get("relationship_hints"), set(by_intent), set(refs))
+    public_sources = [{key: value for key, value in item.items() if key != "_content"} for item in sources]
+
+    stable = {
+        "corpus_id": corpus_id,
+        "sources": public_sources,
+        "claims": claims,
+        "relationships": relationships,
+        "candidates": candidates,
+        "unkeyed_claim_ids": sorted(unkeyed),
+        "ranking_weights": RANKING_WEIGHTS,
+    }
+    source_inventory_ref = corpus.get("source_inventory_ref")
+    if source_inventory_ref is not None:
+        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_id": f"corpus-report:{hashlib.sha256(_canonical_bytes(stable)).hexdigest()}",
+        "generated_at": _timestamp(generated_at),
+        "corpus_id": corpus_id,
+        "source_inventory_ref": source_inventory_ref,
+        "read_only": True,
+        "mutation_performed": False,
+        "analysis_profile": "explicit_markers_v1",
+        "ranking_model": {"name": "explainable_relevance_v1", "weights": RANKING_WEIGHTS},
+        "sources": public_sources,
+        "claims": claims,
+        "relationships": relationships,
+        "candidates": candidates,
+        "unkeyed_claim_ids": sorted(unkeyed),
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Corpus Archaeology Report", "",
+        f"- Report: `{report['report_id']}`",
+        f"- Corpus: `{report['corpus_id']}`",
+        f"- Sources: {len(report['sources'])}",
+        f"- Claims: {len(report['claims'])}",
+        f"- Candidates: {len(report['candidates'])}", "",
+        "## Recovery candidates", "",
+    ]
+    if not report["candidates"]:
+        lines.append("_No keyed recovery candidates were extracted._")
+    for item in report["candidates"]:
+        lines.extend([
+            f"### `{item['intent_key']}`", "",
+            f"- Disposition: `{item['recovery']['disposition']}`",
+            f"- Historical state: `{item['historical_state']['status']}`",
+            f"- Relevance: `{item['ranking']['relevance_score']:.6f}`",
+            f"- Sources: {', '.join(f'`{source}`' for source in item['source_refs'])}",
+            f"- Rationale: {item['recovery']['rationale']}", "",
+        ])
+    if report["unkeyed_claim_ids"]:
+        lines.extend([
+            "## Unkeyed claims", "",
+            "These claims retain provenance but are not promoted because no deterministic intent key was supplied.", "",
+            *[f"- `{claim_id}`" for claim_id in report["unkeyed_claim_ids"]],
+            "",
+        ])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _write_new(path: Path, payload: str) -> None:
+    path = path.resolve(strict=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags, 0o600)
+    except FileExistsError as exc:
+        raise CorpusArchaeologyError(f"output already exists and will not be replaced: {path}") from exc
+    with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze a custody-cleared prepared corpus without mutation")
+    parser.add_argument("corpus", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--generated-at")
+    args = parser.parse_args()
+
+    try:
+        corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
+        report = analyze_corpus(corpus, generated_at=args.generated_at)
+        payload = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        if args.output:
+            if args.output.resolve(strict=False) == args.corpus.resolve():
+                raise CorpusArchaeologyError("output path must not replace the source corpus")
+            _write_new(args.output, payload)
+        else:
+            print(payload, end="")
+        if args.markdown_output:
+            if args.markdown_output.resolve(strict=False) == args.corpus.resolve():
+                raise CorpusArchaeologyError("markdown output path must not replace the source corpus")
+            _write_new(args.markdown_output, render_markdown(report))
+    except (OSError, json.JSONDecodeError, CorpusArchaeologyError) as exc:
+        print(f"INVALID: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -41,12 +41,28 @@ CLAIM_TYPES = {
 }
 
 RELATIONSHIPS = {
-    "convergent", "successor", "parallel", "merged", "divergent", "superseded",
-    "dormant", "lost_in_transition", "orphaned", "uncertain",
+    "convergent",
+    "successor",
+    "parallel",
+    "merged",
+    "divergent",
+    "superseded",
+    "dormant",
+    "lost_in_transition",
+    "orphaned",
+    "uncertain",
 }
 SOURCE_TYPES = {
-    "chat", "document", "issue", "pull_request", "commit", "code", "test",
-    "artifact", "report", "unknown",
+    "chat",
+    "document",
+    "issue",
+    "pull_request",
+    "commit",
+    "code",
+    "test",
+    "artifact",
+    "report",
+    "unknown",
 }
 CREATOR_TYPES = {"human", "assistant", "model", "system", "mixed", "unknown"}
 AUTHORITY = {"current", "historical", "reference", "draft", "unknown"}
@@ -86,7 +102,9 @@ def _timestamp(value: str | None) -> str:
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (AttributeError, ValueError) as exc:
-        raise CorpusArchaeologyError("generated_at must be timezone-aware ISO-8601") from exc
+        raise CorpusArchaeologyError(
+            "generated_at must be timezone-aware ISO-8601"
+        ) from exc
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise CorpusArchaeologyError("generated_at must include timezone information")
     return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -122,10 +140,26 @@ def _source(raw: dict[str, Any]) -> dict[str, Any]:
         raise CorpusArchaeologyError("every source must be an object")
 
     source_ref = _string(raw.get("source_ref"), "source_ref")
-    source_type = _enum(raw.get("source_type", "unknown"), f"{source_ref}.source_type", SOURCE_TYPES)
-    creator_type = _enum(raw.get("creator_type", "unknown"), f"{source_ref}.creator_type", CREATOR_TYPES)
-    authority = _enum(raw.get("authority_status", "unknown"), f"{source_ref}.authority_status", AUTHORITY)
-    access = _enum(raw.get("content_access", "released"), f"{source_ref}.content_access", CONTENT_ACCESS)
+    source_type = _enum(
+        raw.get("source_type", "unknown"),
+        f"{source_ref}.source_type",
+        SOURCE_TYPES,
+    )
+    creator_type = _enum(
+        raw.get("creator_type", "unknown"),
+        f"{source_ref}.creator_type",
+        CREATOR_TYPES,
+    )
+    authority = _enum(
+        raw.get("authority_status", "unknown"),
+        f"{source_ref}.authority_status",
+        AUTHORITY,
+    )
+    access = _enum(
+        raw.get("content_access", "released"),
+        f"{source_ref}.content_access",
+        CONTENT_ACCESS,
+    )
     confidence = _confidence(raw.get("confidence", 1.0), f"{source_ref}.confidence")
 
     artifact_id = raw.get("artifact_id")
@@ -143,15 +177,26 @@ def _source(raw: dict[str, Any]) -> dict[str, Any]:
     supplied_digest = raw.get("sha256")
     if access == "metadata_only":
         if content not in (None, ""):
-            raise CorpusArchaeologyError(f"{source_ref} is metadata_only and must not include content")
-        digest = _string(supplied_digest, f"{source_ref}.sha256") if supplied_digest is not None else None
+            raise CorpusArchaeologyError(
+                f"{source_ref} is metadata_only and must not include content"
+            )
+        digest = (
+            _string(supplied_digest, f"{source_ref}.sha256")
+            if supplied_digest is not None
+            else None
+        )
         content = None
     else:
         if not isinstance(content, str):
             raise CorpusArchaeologyError(f"{source_ref} requires string content")
         digest = _sha256(content)
-        if supplied_digest is not None and _string(supplied_digest, f"{source_ref}.sha256") != digest:
-            raise CorpusArchaeologyError(f"{source_ref}.sha256 does not match prepared content")
+        if (
+            supplied_digest is not None
+            and _string(supplied_digest, f"{source_ref}.sha256") != digest
+        ):
+            raise CorpusArchaeologyError(
+                f"{source_ref}.sha256 does not match prepared content"
+            )
 
     stable_identity = {
         "source_ref": source_ref,
@@ -234,8 +279,9 @@ def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
-    types = {item["claim_type"] for item in claims}
-    human_claims = [item for item in claims if item["evidence_kind"] == "human_statement"]
+    human_claims = [
+        item for item in claims if item["evidence_kind"] == "human_statement"
+    ]
     human_types = {item["claim_type"] for item in human_claims}
     rejected = "rejection" in human_types
     implemented = any(
@@ -252,33 +298,62 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
     requirement = bool({"requirement", "constraint"} & human_types)
     unresolved = bool({"todo", "unresolved_question", "proposed_patch"} & human_types)
     commitment = bool(
-        {"approval", "decision", "requirement", "constraint", "todo",
-         "unresolved_question", "proposed_patch"} & human_types
+        {
+            "approval",
+            "decision",
+            "requirement",
+            "constraint",
+            "todo",
+            "unresolved_question",
+            "proposed_patch",
+        }
+        & human_types
     )
 
-    if rejected:
+    if rejected and (implemented or partial):
+        status, disposition = "unknown", "investigate"
+        rationale = (
+            "Explicit human rejection and implementation evidence coexist; "
+            "preserve both histories and investigate chronology, scope, and authority."
+        )
+    elif rejected:
         status, disposition = "rejected", "reject_with_evidence"
-        rationale = "Explicit rejection evidence is present; preserve the record and do not restore automatically."
+        rationale = (
+            "Explicit human rejection evidence is present; preserve the record and "
+            "do not restore automatically."
+        )
     elif implemented:
         status, disposition = "implemented", "preserve"
-        rationale = "Explicit implementation evidence is present; preserve and verify the current successor."
+        rationale = (
+            "Explicit implementation evidence is present; preserve and verify the "
+            "current successor."
+        )
     elif partial:
         status, disposition = "partial", "investigate"
-        rationale = "Only partial implementation evidence is present; investigate intent and capability preservation."
+        rationale = (
+            "Only partial implementation evidence is present; investigate intent and "
+            "capability preservation."
+        )
     else:
         status = "approved" if decision else "proposed"
         disposition = "investigate"
         rationale = (
-            "An explicit commitment is present without implementation or rejection evidence; preserve for investigation."
+            "An explicit human commitment is present without implementation or "
+            "rejection evidence; preserve for investigation."
             if commitment
-            else "No implementation or rejection evidence is established; retain as an uncertain recovery candidate."
+            else "No authoritative commitment, implementation, or rejection evidence "
+            "is established; retain as an uncertain recovery candidate."
         )
 
     source_refs = sorted({item["span"]["source_ref"] for item in claims})
     source_ids = sorted({item["span"]["source_id"] for item in claims})
     claims = sorted(
         claims,
-        key=lambda item: (item["span"]["source_ref"], item["span"]["line_start"], item["claim_id"]),
+        key=lambda item: (
+            item["span"]["source_ref"],
+            item["span"]["line_start"],
+            item["claim_id"],
+        ),
     )
     gap = 1.0 if commitment and not (implemented or partial or rejected) else 0.0
     components = {
@@ -289,8 +364,15 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
         "recurrence": min(len(source_refs) / 3.0, 1.0),
         "evidence_confidence": sum(item["confidence"] for item in claims) / len(claims),
     }
-    score = round(sum(components[name] * weight for name, weight in RANKING_WEIGHTS.items()), 6)
-    material = {"intent_key": intent, "claim_ids": [item["claim_id"] for item in claims], "disposition": disposition}
+    score = round(
+        sum(components[name] * weight for name, weight in RANKING_WEIGHTS.items()),
+        6,
+    )
+    material = {
+        "intent_key": intent,
+        "claim_ids": [item["claim_id"] for item in claims],
+        "disposition": disposition,
+    }
 
     return {
         "candidate_id": _id("candidate", material),
@@ -305,7 +387,9 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
             "partial_implementation_evidence_present": partial,
         },
         "preservation": {
-            "implementation_preserved": True if implemented else (False if partial else None),
+            "implementation_preserved": (
+                True if implemented else (False if partial else None)
+            ),
             "capability_preserved": None,
             "intent_preserved": None,
             "intent_delta": None,
@@ -318,7 +402,9 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "ranking": {
             "relevance_score": score,
-            "components": {name: round(value, 6) for name, value in components.items()},
+            "components": {
+                name: round(value, 6) for name, value in components.items()
+            },
         },
     }
 
@@ -336,22 +422,49 @@ def _relationships(
     result = []
     for index, raw in enumerate(hints):
         if not isinstance(raw, dict):
-            raise CorpusArchaeologyError(f"relationship_hints[{index}] must be an object")
-        left = _string(raw.get("left_intent_key"), f"relationship_hints[{index}].left_intent_key")
-        right = _string(raw.get("right_intent_key"), f"relationship_hints[{index}].right_intent_key")
-        relationship = _enum(raw.get("relationship"), f"relationship_hints[{index}].relationship", RELATIONSHIPS)
-        rationale = _string(raw.get("rationale"), f"relationship_hints[{index}].rationale")
+            raise CorpusArchaeologyError(
+                f"relationship_hints[{index}] must be an object"
+            )
+        left = _string(
+            raw.get("left_intent_key"),
+            f"relationship_hints[{index}].left_intent_key",
+        )
+        right = _string(
+            raw.get("right_intent_key"),
+            f"relationship_hints[{index}].right_intent_key",
+        )
+        relationship = _enum(
+            raw.get("relationship"),
+            f"relationship_hints[{index}].relationship",
+            RELATIONSHIPS,
+        )
+        rationale = _string(
+            raw.get("rationale"), f"relationship_hints[{index}].rationale"
+        )
         if left not in known_intents or right not in known_intents:
-            raise CorpusArchaeologyError(f"relationship_hints[{index}] references an unknown intent key")
+            raise CorpusArchaeologyError(
+                f"relationship_hints[{index}] references an unknown intent key"
+            )
 
         refs = raw.get("evidence_source_refs", [])
         if not isinstance(refs, list):
-            raise CorpusArchaeologyError(f"relationship_hints[{index}].evidence_source_refs must be an array")
-        refs = sorted({_string(item, f"relationship_hints[{index}].evidence_source_refs") for item in refs})
+            raise CorpusArchaeologyError(
+                f"relationship_hints[{index}].evidence_source_refs must be an array"
+            )
+        refs = sorted(
+            {
+                _string(
+                    item,
+                    f"relationship_hints[{index}].evidence_source_refs",
+                )
+                for item in refs
+            }
+        )
         unknown = set(refs) - known_sources
         if unknown:
             raise CorpusArchaeologyError(
-                f"relationship_hints[{index}] references unknown sources: {', '.join(sorted(unknown))}"
+                f"relationship_hints[{index}] references unknown sources: "
+                f"{', '.join(sorted(unknown))}"
             )
         material = {
             "left_intent_key": left,
@@ -365,20 +478,30 @@ def _relationships(
     return sorted(
         result,
         key=lambda item: (
-            item["left_intent_key"], item["right_intent_key"],
-            item["relationship"], item["relationship_id"],
+            item["left_intent_key"],
+            item["right_intent_key"],
+            item["relationship"],
+            item["relationship_id"],
         ),
     )
 
 
-def analyze_corpus(corpus: dict[str, Any], *, generated_at: str | None = None) -> dict[str, Any]:
+def analyze_corpus(
+    corpus: dict[str, Any], *, generated_at: str | None = None
+) -> dict[str, Any]:
     """Analyze a prepared corpus without mutating source or external state."""
     if not isinstance(corpus, dict):
         raise CorpusArchaeologyError("corpus input must be an object")
     if corpus.get("schema_version") != SCHEMA_VERSION:
-        raise CorpusArchaeologyError(f"unsupported corpus schema_version: {corpus.get('schema_version')!r}")
+        raise CorpusArchaeologyError(
+            f"unsupported corpus schema_version: {corpus.get('schema_version')!r}"
+        )
 
     corpus_id = _string(corpus.get("corpus_id"), "corpus_id")
+    source_inventory_ref = corpus.get("source_inventory_ref")
+    if source_inventory_ref is not None:
+        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
+
     raw_sources = corpus.get("sources")
     if not isinstance(raw_sources, list) or not raw_sources:
         raise CorpusArchaeologyError("sources must be a non-empty array")
@@ -390,7 +513,13 @@ def analyze_corpus(corpus: dict[str, Any], *, generated_at: str | None = None) -
     sources.sort(key=lambda item: (item["source_ref"], item["source_id"]))
 
     claims = [claim for source in sources for claim in _claims(source)]
-    claims.sort(key=lambda item: (item["span"]["source_ref"], item["span"]["line_start"], item["claim_id"]))
+    claims.sort(
+        key=lambda item: (
+            item["span"]["source_ref"],
+            item["span"]["line_start"],
+            item["claim_id"],
+        )
+    )
 
     by_intent: dict[str, list[dict[str, Any]]] = {}
     unkeyed = []
@@ -400,12 +529,20 @@ def analyze_corpus(corpus: dict[str, Any], *, generated_at: str | None = None) -
         else:
             by_intent.setdefault(claim["intent_key"], []).append(claim)
 
-    candidates = [_candidate(intent, by_intent[intent]) for intent in sorted(by_intent)]
-    relationships = _relationships(corpus.get("relationship_hints"), set(by_intent), set(refs))
-    public_sources = [{key: value for key, value in item.items() if key != "_content"} for item in sources]
+    candidates = [
+        _candidate(intent, by_intent[intent]) for intent in sorted(by_intent)
+    ]
+    relationships = _relationships(
+        corpus.get("relationship_hints"), set(by_intent), set(refs)
+    )
+    public_sources = [
+        {key: value for key, value in item.items() if key != "_content"}
+        for item in sources
+    ]
 
     stable = {
         "corpus_id": corpus_id,
+        "source_inventory_ref": source_inventory_ref,
         "sources": public_sources,
         "claims": claims,
         "relationships": relationships,
@@ -413,20 +550,23 @@ def analyze_corpus(corpus: dict[str, Any], *, generated_at: str | None = None) -
         "unkeyed_claim_ids": sorted(unkeyed),
         "ranking_weights": RANKING_WEIGHTS,
     }
-    source_inventory_ref = corpus.get("source_inventory_ref")
-    if source_inventory_ref is not None:
-        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "report_id": f"corpus-report:{hashlib.sha256(_canonical_bytes(stable)).hexdigest()}",
+        "report_id": (
+            "corpus-report:"
+            f"{hashlib.sha256(_canonical_bytes(stable)).hexdigest()}"
+        ),
         "generated_at": _timestamp(generated_at),
         "corpus_id": corpus_id,
         "source_inventory_ref": source_inventory_ref,
         "read_only": True,
         "mutation_performed": False,
         "analysis_profile": "explicit_markers_v1",
-        "ranking_model": {"name": "explainable_relevance_v1", "weights": RANKING_WEIGHTS},
+        "ranking_model": {
+            "name": "explainable_relevance_v1",
+            "weights": RANKING_WEIGHTS,
+        },
         "sources": public_sources,
         "claims": claims,
         "relationships": relationships,
@@ -437,32 +577,47 @@ def analyze_corpus(corpus: dict[str, Any], *, generated_at: str | None = None) -
 
 def render_markdown(report: dict[str, Any]) -> str:
     lines = [
-        "# Corpus Archaeology Report", "",
+        "# Corpus Archaeology Report",
+        "",
         f"- Report: `{report['report_id']}`",
         f"- Corpus: `{report['corpus_id']}`",
         f"- Sources: {len(report['sources'])}",
         f"- Claims: {len(report['claims'])}",
-        f"- Candidates: {len(report['candidates'])}", "",
-        "## Recovery candidates", "",
+        f"- Candidates: {len(report['candidates'])}",
+        "",
+        "## Recovery candidates",
+        "",
     ]
     if not report["candidates"]:
         lines.append("_No keyed recovery candidates were extracted._")
     for item in report["candidates"]:
-        lines.extend([
-            f"### `{item['intent_key']}`", "",
-            f"- Disposition: `{item['recovery']['disposition']}`",
-            f"- Historical state: `{item['historical_state']['status']}`",
-            f"- Relevance: `{item['ranking']['relevance_score']:.6f}`",
-            f"- Sources: {', '.join(f'`{source}`' for source in item['source_refs'])}",
-            f"- Rationale: {item['recovery']['rationale']}", "",
-        ])
+        lines.extend(
+            [
+                f"### `{item['intent_key']}`",
+                "",
+                f"- Disposition: `{item['recovery']['disposition']}`",
+                f"- Historical state: `{item['historical_state']['status']}`",
+                f"- Relevance: `{item['ranking']['relevance_score']:.6f}`",
+                f"- Sources: {', '.join(f'`{source}`' for source in item['source_refs'])}",
+                f"- Rationale: {item['recovery']['rationale']}",
+                "",
+            ]
+        )
     if report["unkeyed_claim_ids"]:
-        lines.extend([
-            "## Unkeyed claims", "",
-            "These claims retain provenance but are not promoted because no deterministic intent key was supplied.", "",
-            *[f"- `{claim_id}`" for claim_id in report["unkeyed_claim_ids"]],
-            "",
-        ])
+        lines.extend(
+            [
+                "## Unkeyed claims",
+                "",
+                "These claims retain provenance but are not promoted because no "
+                "deterministic intent key was supplied.",
+                "",
+                *[
+                    f"- `{claim_id}`"
+                    for claim_id in report["unkeyed_claim_ids"]
+                ],
+                "",
+            ]
+        )
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -473,7 +628,9 @@ def _write_new(path: Path, payload: str) -> None:
     try:
         fd = os.open(path, flags, 0o600)
     except FileExistsError as exc:
-        raise CorpusArchaeologyError(f"output already exists and will not be replaced: {path}") from exc
+        raise CorpusArchaeologyError(
+            f"output already exists and will not be replaced: {path}"
+        ) from exc
     with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as stream:
         stream.write(payload)
         stream.flush()
@@ -481,7 +638,9 @@ def _write_new(path: Path, payload: str) -> None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Analyze a custody-cleared prepared corpus without mutation")
+    parser = argparse.ArgumentParser(
+        description="Analyze a custody-cleared prepared corpus without mutation"
+    )
     parser.add_argument("corpus", type=Path)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--markdown-output", type=Path)
@@ -491,16 +650,22 @@ def main() -> int:
     try:
         corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
         report = analyze_corpus(corpus, generated_at=args.generated_at)
-        payload = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        payload = json.dumps(
+            report, indent=2, sort_keys=True, ensure_ascii=False
+        ) + "\n"
         if args.output:
             if args.output.resolve(strict=False) == args.corpus.resolve():
-                raise CorpusArchaeologyError("output path must not replace the source corpus")
+                raise CorpusArchaeologyError(
+                    "output path must not replace the source corpus"
+                )
             _write_new(args.output, payload)
         else:
             print(payload, end="")
         if args.markdown_output:
             if args.markdown_output.resolve(strict=False) == args.corpus.resolve():
-                raise CorpusArchaeologyError("markdown output path must not replace the source corpus")
+                raise CorpusArchaeologyError(
+                    "markdown output path must not replace the source corpus"
+                )
             _write_new(args.markdown_output, render_markdown(report))
     except (OSError, json.JSONDecodeError, CorpusArchaeologyError) as exc:
         print(f"INVALID: {exc}")

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -180,7 +180,8 @@ def _evidence_kind(source: dict[str, Any], claim_type: str) -> str:
     if claim_type in {"implementation_evidence", "partial_implementation_evidence"}:
         if source["source_type"] == "test":
             return "test_result"
-        return "implementation_artifact"
+        if source["source_type"] in {"code", "commit", "pull_request", "artifact"}:
+            return "implementation_artifact"
     return {
         "human": "human_statement",
         "assistant": "model_statement",
@@ -235,8 +236,16 @@ def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
 def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
     types = {item["claim_type"] for item in claims}
     rejected = "rejection" in types
-    implemented = "implementation_evidence" in types
-    partial = "partial_implementation_evidence" in types
+    implemented = any(
+        item["claim_type"] == "implementation_evidence"
+        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
+        for item in claims
+    )
+    partial = any(
+        item["claim_type"] == "partial_implementation_evidence"
+        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
+        for item in claims
+    )
     decision = bool({"approval", "decision"} & types)
     requirement = bool({"requirement", "constraint"} & types)
     unresolved = bool({"todo", "unresolved_question", "proposed_patch"} & types)

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -24,9 +24,11 @@ if _REPO_ROOT not in sys.path:
 from tools.salvage.corpus_archaeology_core import (  # noqa: E402
     RANKING_WEIGHTS,
     SCHEMA_VERSION,
-    CorpusArchaeologyError,
     analyze_validated_corpus,
     render_markdown,
+)
+from tools.salvage.corpus_archaeology_shared import (  # noqa: E402
+    CorpusArchaeologyError,
 )
 
 INPUT_SCHEMA_PATH = (

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -294,6 +294,18 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
         and item["evidence_kind"] in {"implementation_artifact", "test_result"}
         for item in claims
     )
+    current_implemented = any(
+        item["claim_type"] == "implementation_evidence"
+        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
+        and item["authority_status"] == "current"
+        for item in claims
+    )
+    current_partial = any(
+        item["claim_type"] == "partial_implementation_evidence"
+        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
+        and item["authority_status"] == "current"
+        for item in claims
+    )
     decision = bool({"approval", "decision"} & human_types)
     requirement = bool({"requirement", "constraint"} & human_types)
     unresolved = bool({"todo", "unresolved_question", "proposed_patch"} & human_types)
@@ -325,8 +337,8 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
     elif implemented:
         status, disposition = "implemented", "preserve"
         rationale = (
-            "Explicit implementation evidence is present; preserve and verify the "
-            "current successor."
+            "Implementation evidence is present; preserve the implementation record "
+            "and verify whether a current successor remains."
         )
     elif partial:
         status, disposition = "partial", "investigate"
@@ -388,7 +400,9 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "preservation": {
             "implementation_preserved": (
-                True if implemented else (False if partial else None)
+                True
+                if current_implemented
+                else (False if current_partial else None)
             ),
             "capability_preserved": None,
             "intent_preserved": None,

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import os
 import re
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -48,33 +49,26 @@ CLAIM_TYPES = {
     "PARTIAL_IMPLEMENTATION": "partial_implementation_evidence",
 }
 
-RELATIONSHIPS = {
-    "convergent",
-    "successor",
-    "parallel",
-    "merged",
-    "divergent",
-    "superseded",
-    "dormant",
-    "lost_in_transition",
-    "orphaned",
-    "uncertain",
+IMPLEMENTATION_CLAIM_TYPES = {
+    "implementation_evidence",
+    "partial_implementation_evidence",
 }
-SOURCE_TYPES = {
-    "chat",
-    "document",
-    "issue",
-    "pull_request",
-    "commit",
-    "code",
-    "test",
-    "artifact",
-    "report",
-    "unknown",
+IMPLEMENTATION_EVIDENCE_KINDS = {"implementation_artifact", "test_result"}
+IMPLEMENTATION_SOURCE_KINDS = {
+    "test": "test_result",
+    "code": "implementation_artifact",
+    "commit": "implementation_artifact",
+    "pull_request": "implementation_artifact",
+    "artifact": "implementation_artifact",
 }
-CREATOR_TYPES = {"human", "assistant", "model", "system", "mixed", "unknown"}
-AUTHORITY = {"current", "historical", "reference", "draft", "unknown"}
-CONTENT_ACCESS = {"released", "metadata_only"}
+CREATOR_EVIDENCE_KINDS = {
+    "human": "human_statement",
+    "assistant": "model_statement",
+    "model": "model_statement",
+    "system": "system_record",
+    "mixed": "mixed_source",
+    "unknown": "unknown",
+}
 
 RANKING_WEIGHTS = {
     "explicit_decision": 0.25,
@@ -90,36 +84,46 @@ class CorpusArchaeologyError(ValueError):
     """Prepared corpus is invalid or violates a Phase-1 safety boundary."""
 
 
-def _validate_input_contract(corpus: dict[str, Any]) -> None:
-    """Bind runtime validation to the committed prepared-corpus JSON Schema."""
+def _load_input_validator() -> jsonschema.Draft202012Validator:
     try:
         schema = json.loads(INPUT_SCHEMA_PATH.read_text(encoding="utf-8"))
         jsonschema.Draft202012Validator.check_schema(schema)
-        validator = jsonschema.Draft202012Validator(
-            schema,
-            format_checker=jsonschema.FormatChecker(),
-        )
     except (OSError, json.JSONDecodeError, jsonschema.SchemaError) as exc:
         raise CorpusArchaeologyError(
             "committed prepared-corpus input schema is unavailable or invalid"
         ) from exc
+    return jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
 
+
+def _first_schema_error(
+    validator: jsonschema.Draft202012Validator,
+    corpus: dict[str, Any],
+) -> jsonschema.ValidationError | None:
     errors = sorted(
         validator.iter_errors(corpus),
         key=lambda error: tuple(str(part) for part in error.absolute_path),
     )
-    if not errors:
-        return
+    return errors[0] if errors else None
 
-    error = errors[0]
+
+def _schema_error_message(error: jsonschema.ValidationError) -> str:
     path = ".".join(str(part) for part in error.absolute_path) or "<root>"
-    if error.validator in {"required", "additionalProperties"}:
-        detail = error.message
-    else:
-        detail = f"violates {error.validator}"
-    raise CorpusArchaeologyError(
-        f"input schema validation failed at {path}: {detail}"
+    detail = (
+        error.message
+        if error.validator in {"required", "additionalProperties"}
+        else f"violates {error.validator}"
     )
+    return f"input schema validation failed at {path}: {detail}"
+
+
+def _validate_input_contract(corpus: dict[str, Any]) -> None:
+    """Bind runtime validation to the committed prepared-corpus JSON Schema."""
+    error = _first_schema_error(_load_input_validator(), corpus)
+    if error is not None:
+        raise CorpusArchaeologyError(_schema_error_message(error))
 
 
 def _canonical_bytes(value: Any) -> bytes:
@@ -136,9 +140,7 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _timestamp(value: str | None) -> str:
-    if value is None:
-        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+def _parse_timestamp(value: str) -> str:
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (AttributeError, ValueError) as exc:
@@ -150,94 +152,50 @@ def _timestamp(value: str | None) -> str:
     return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _timestamp(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return _parse_timestamp(value)
+
+
 def _string(value: Any, name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise CorpusArchaeologyError(f"{name} must be a non-empty string")
     return value.strip()
 
 
-def _enum(value: Any, name: str, allowed: set[str]) -> str:
-    normalized = _string(value, name)
-    if normalized not in allowed:
-        raise CorpusArchaeologyError(
-            f"{name} must be one of: {', '.join(sorted(allowed))}"
-        )
-    return normalized
-
-
-def _confidence(value: Any, name: str) -> float:
-    try:
-        result = float(value)
-    except (TypeError, ValueError) as exc:
-        raise CorpusArchaeologyError(f"{name} must be between 0 and 1") from exc
-    if not 0.0 <= result <= 1.0:
-        raise CorpusArchaeologyError(f"{name} must be between 0 and 1")
-    return result
-
-
-def _source(raw: dict[str, Any]) -> dict[str, Any]:
-    if not isinstance(raw, dict):
-        raise CorpusArchaeologyError("every source must be an object")
-
-    source_ref = _string(raw.get("source_ref"), "source_ref")
-    source_type = _enum(
-        raw.get("source_type", "unknown"),
-        f"{source_ref}.source_type",
-        SOURCE_TYPES,
-    )
-    creator_type = _enum(
-        raw.get("creator_type", "unknown"),
-        f"{source_ref}.creator_type",
-        CREATOR_TYPES,
-    )
-    authority = _enum(
-        raw.get("authority_status", "unknown"),
-        f"{source_ref}.authority_status",
-        AUTHORITY,
-    )
-    access = _enum(
-        raw.get("content_access", "released"),
-        f"{source_ref}.content_access",
-        CONTENT_ACCESS,
-    )
-    confidence = _confidence(raw.get("confidence", 1.0), f"{source_ref}.confidence")
-
-    artifact_id = raw.get("artifact_id")
-    inventory_ref = raw.get("inventory_report_id")
-    platform = raw.get("platform")
-    for name, value in (
-        ("artifact_id", artifact_id),
-        ("inventory_report_id", inventory_ref),
-        ("platform", platform),
-    ):
+def _validate_optional_source_strings(source_ref: str, raw: dict[str, Any]) -> None:
+    for name in ("artifact_id", "inventory_report_id", "platform"):
+        value = raw.get(name)
         if value is not None:
             _string(value, f"{source_ref}.{name}")
 
-    content = raw.get("content")
-    supplied_digest = raw.get("sha256")
-    if access == "metadata_only":
-        if content not in (None, ""):
-            raise CorpusArchaeologyError(
-                f"{source_ref} is metadata_only and must not include content"
-            )
-        digest = (
-            _string(supplied_digest, f"{source_ref}.sha256")
-            if supplied_digest is not None
-            else None
-        )
-        content = None
-    else:
-        if not isinstance(content, str):
-            raise CorpusArchaeologyError(f"{source_ref} requires string content")
-        digest = _sha256(content)
-        if (
-            supplied_digest is not None
-            and _string(supplied_digest, f"{source_ref}.sha256") != digest
-        ):
-            raise CorpusArchaeologyError(
-                f"{source_ref}.sha256 does not match prepared content"
-            )
 
+def _released_content(raw: dict[str, Any], source_ref: str) -> tuple[str, str]:
+    content = raw["content"]
+    digest = _sha256(content)
+    supplied_digest = raw.get("sha256")
+    if supplied_digest is not None and supplied_digest != digest:
+        raise CorpusArchaeologyError(
+            f"{source_ref}.sha256 does not match prepared content"
+        )
+    return content, digest
+
+
+def _prepared_content(
+    raw: dict[str, Any], source_ref: str
+) -> tuple[str | None, str | None]:
+    if raw["content_access"] == "released":
+        return _released_content(raw, source_ref)
+    return None, raw.get("sha256")
+
+
+def _source(raw: dict[str, Any]) -> dict[str, Any]:
+    source_ref = _string(raw["source_ref"], "source_ref")
+    _validate_optional_source_strings(source_ref, raw)
+    content, digest = _prepared_content(raw, source_ref)
+    artifact_id = raw.get("artifact_id")
+    inventory_ref = raw.get("inventory_report_id")
     stable_identity = {
         "source_ref": source_ref,
         "sha256": digest,
@@ -247,159 +205,227 @@ def _source(raw: dict[str, Any]) -> dict[str, Any]:
     return {
         "source_ref": source_ref,
         "source_id": _id("source", stable_identity),
-        "title": _string(raw.get("title"), f"{source_ref}.title"),
-        "source_type": source_type,
-        "platform": platform,
-        "creator_type": creator_type,
-        "authority_status": authority,
-        "confidence": confidence,
+        "title": _string(raw["title"], f"{source_ref}.title"),
+        "source_type": raw["source_type"],
+        "platform": raw.get("platform"),
+        "creator_type": raw["creator_type"],
+        "authority_status": raw["authority_status"],
+        "confidence": float(raw.get("confidence", 1.0)),
         "artifact_id": artifact_id,
         "inventory_report_id": inventory_ref,
-        "content_access": access,
+        "content_access": raw["content_access"],
         "sha256": digest,
         "_content": content,
     }
 
 
 def _evidence_kind(source: dict[str, Any], claim_type: str) -> str:
-    if claim_type in {"implementation_evidence", "partial_implementation_evidence"}:
-        if source["source_type"] == "test":
-            return "test_result"
-        if source["source_type"] in {"code", "commit", "pull_request", "artifact"}:
-            return "implementation_artifact"
+    creator_kind = CREATOR_EVIDENCE_KINDS[source["creator_type"]]
+    if claim_type not in IMPLEMENTATION_CLAIM_TYPES:
+        return creator_kind
+    return IMPLEMENTATION_SOURCE_KINDS.get(source["source_type"], creator_kind)
+
+
+def _claim_from_line(
+    source: dict[str, Any], line_number: int, line: str
+) -> dict[str, Any] | None:
+    match = CLAIM_RE.match(line)
+    if match is None:
+        return None
+    claim_type = CLAIM_TYPES[match.group("label").upper()]
+    intent = match.group("intent")
+    span = {
+        "source_id": source["source_id"],
+        "source_ref": source["source_ref"],
+        "line_start": line_number,
+        "line_end": line_number,
+        "text_sha256": _sha256(line),
+        "excerpt": line,
+    }
+    material = {
+        "source_id": source["source_id"],
+        "line": line_number,
+        "claim_type": claim_type,
+        "intent_key": intent,
+        "text_sha256": span["text_sha256"],
+    }
     return {
-        "human": "human_statement",
-        "assistant": "model_statement",
-        "model": "model_statement",
-        "system": "system_record",
-        "mixed": "mixed_source",
-        "unknown": "unknown",
-    }[source["creator_type"]]
+        "claim_id": _id("claim", material),
+        "claim_type": claim_type,
+        "intent_key": intent,
+        "claim": match.group("body").strip(),
+        "evidence_kind": _evidence_kind(source, claim_type),
+        "authority_status": source["authority_status"],
+        "confidence": source["confidence"],
+        "span": span,
+    }
 
 
 def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
-    if source["_content"] is None:
+    content = source["_content"]
+    if content is None:
         return []
-
-    result = []
-    for line_number, line in enumerate(source["_content"].splitlines(), start=1):
-        match = CLAIM_RE.match(line)
-        if not match:
-            continue
-        claim_type = CLAIM_TYPES[match.group("label").upper()]
-        intent = match.group("intent")
-        span = {
-            "source_id": source["source_id"],
-            "source_ref": source["source_ref"],
-            "line_start": line_number,
-            "line_end": line_number,
-            "text_sha256": _sha256(line),
-            "excerpt": line,
-        }
-        material = {
-            "source_id": source["source_id"],
-            "line": line_number,
-            "claim_type": claim_type,
-            "intent_key": intent,
-            "text_sha256": span["text_sha256"],
-        }
-        result.append(
-            {
-                "claim_id": _id("claim", material),
-                "claim_type": claim_type,
-                "intent_key": intent,
-                "claim": match.group("body").strip(),
-                "evidence_kind": _evidence_kind(source, claim_type),
-                "authority_status": source["authority_status"],
-                "confidence": source["confidence"],
-                "span": span,
-            }
-        )
-    return result
+    extracted = (
+        _claim_from_line(source, line_number, line)
+        for line_number, line in enumerate(content.splitlines(), start=1)
+    )
+    return [claim for claim in extracted if claim is not None]
 
 
-def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
-    human_claims = [
-        item for item in claims if item["evidence_kind"] == "human_statement"
-    ]
-    human_types = {item["claim_type"] for item in human_claims}
-    rejected = "rejection" in human_types
-    implemented = any(
-        item["claim_type"] == "implementation_evidence"
-        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
+def _human_claim_types(claims: list[dict[str, Any]]) -> set[str]:
+    return {
+        item["claim_type"]
         for item in claims
-    )
-    partial = any(
-        item["claim_type"] == "partial_implementation_evidence"
-        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
-        for item in claims
-    )
-    current_implemented = any(
-        item["claim_type"] == "implementation_evidence"
-        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
-        and item["authority_status"] == "current"
-        for item in claims
-    )
-    current_partial = any(
-        item["claim_type"] == "partial_implementation_evidence"
-        and item["evidence_kind"] in {"implementation_artifact", "test_result"}
-        and item["authority_status"] == "current"
-        for item in claims
-    )
-    decision = bool({"approval", "decision"} & human_types)
-    requirement = bool({"requirement", "constraint"} & human_types)
-    unresolved = bool({"todo", "unresolved_question", "proposed_patch"} & human_types)
-    commitment = bool(
-        {
-            "approval",
-            "decision",
-            "requirement",
-            "constraint",
-            "todo",
-            "unresolved_question",
-            "proposed_patch",
-        }
-        & human_types
+        if item["evidence_kind"] == "human_statement"
+    }
+
+
+def _matches_implementation_claim(
+    item: dict[str, Any], claim_type: str, authority: str | None
+) -> bool:
+    if item["claim_type"] != claim_type:
+        return False
+    if item["evidence_kind"] not in IMPLEMENTATION_EVIDENCE_KINDS:
+        return False
+    return authority is None or item["authority_status"] == authority
+
+
+def _has_implementation_claim(
+    claims: list[dict[str, Any]], claim_type: str, authority: str | None = None
+) -> bool:
+    return any(
+        _matches_implementation_claim(item, claim_type, authority) for item in claims
     )
 
-    if rejected and (implemented or partial):
-        status, disposition = "unknown", "investigate"
-        rationale = (
-            "Explicit human rejection and implementation evidence coexist; "
-            "preserve both histories and investigate chronology, scope, and authority."
-        )
-    elif rejected:
-        status, disposition = "rejected", "reject_with_evidence"
-        rationale = (
-            "Explicit human rejection evidence is present; preserve the record and "
-            "do not restore automatically."
-        )
-    elif implemented:
-        status, disposition = "implemented", "preserve"
-        rationale = (
-            "Implementation evidence is present; preserve the implementation record "
-            "and verify whether a current successor remains."
-        )
-    elif partial:
-        status, disposition = "partial", "investigate"
-        rationale = (
-            "Only partial implementation evidence is present; investigate intent and "
-            "capability preservation."
-        )
-    else:
-        status = "approved" if decision else "proposed"
-        disposition = "investigate"
-        rationale = (
-            "An explicit human commitment is present without implementation or "
-            "rejection evidence; preserve for investigation."
-            if commitment
-            else "No authoritative commitment, implementation, or rejection evidence "
-            "is established; retain as an uncertain recovery candidate."
-        )
 
-    source_refs = sorted({item["span"]["source_ref"] for item in claims})
-    source_ids = sorted({item["span"]["source_id"] for item in claims})
-    claims = sorted(
+def _candidate_flags(claims: list[dict[str, Any]]) -> dict[str, bool]:
+    human_types = _human_claim_types(claims)
+    commitment_types = {
+        "approval",
+        "decision",
+        "requirement",
+        "constraint",
+        "todo",
+        "unresolved_question",
+        "proposed_patch",
+    }
+    return {
+        "rejected": "rejection" in human_types,
+        "implemented": _has_implementation_claim(claims, "implementation_evidence"),
+        "partial": _has_implementation_claim(
+            claims, "partial_implementation_evidence"
+        ),
+        "current_implemented": _has_implementation_claim(
+            claims, "implementation_evidence", "current"
+        ),
+        "current_partial": _has_implementation_claim(
+            claims, "partial_implementation_evidence", "current"
+        ),
+        "decision": bool({"approval", "decision"} & human_types),
+        "requirement": bool({"requirement", "constraint"} & human_types),
+        "unresolved": bool(
+            {"todo", "unresolved_question", "proposed_patch"} & human_types
+        ),
+        "commitment": bool(commitment_types & human_types),
+    }
+
+
+def _candidate_conflict(flags: dict[str, bool]) -> bool:
+    return flags["rejected"] and (flags["implemented"] or flags["partial"])
+
+
+def _default_candidate_state(flags: dict[str, bool]) -> tuple[str, str, str]:
+    status = "approved" if flags["decision"] else "proposed"
+    rationale = (
+        "An explicit human commitment is present without implementation or "
+        "rejection evidence; preserve for investigation."
+        if flags["commitment"]
+        else "No authoritative commitment, implementation, or rejection evidence "
+        "is established; retain as an uncertain recovery candidate."
+    )
+    return status, "investigate", rationale
+
+
+def _state_conflict(_: dict[str, bool]) -> tuple[str, str, str]:
+    return (
+        "unknown",
+        "investigate",
+        "Explicit human rejection and implementation evidence coexist; preserve both "
+        "histories and investigate chronology, scope, and authority.",
+    )
+
+
+def _state_rejected(_: dict[str, bool]) -> tuple[str, str, str]:
+    return (
+        "rejected",
+        "reject_with_evidence",
+        "Explicit human rejection evidence is present; preserve the record and do not "
+        "restore automatically.",
+    )
+
+
+def _state_implemented(_: dict[str, bool]) -> tuple[str, str, str]:
+    return (
+        "implemented",
+        "preserve",
+        "Implementation evidence is present; preserve the implementation record and "
+        "verify whether a current successor remains.",
+    )
+
+
+def _state_partial(_: dict[str, bool]) -> tuple[str, str, str]:
+    return (
+        "partial",
+        "investigate",
+        "Only partial implementation evidence is present; investigate intent and "
+        "capability preservation.",
+    )
+
+
+def _candidate_state(flags: dict[str, bool]) -> tuple[str, str, str]:
+    rules: tuple[
+        tuple[Callable[[dict[str, bool]], bool], Callable[[dict[str, bool]], tuple[str, str, str]]],
+        ...,
+    ] = (
+        (_candidate_conflict, _state_conflict),
+        (lambda state: state["rejected"], _state_rejected),
+        (lambda state: state["implemented"], _state_implemented),
+        (lambda state: state["partial"], _state_partial),
+    )
+    for predicate, result in rules:
+        if predicate(flags):
+            return result(flags)
+    return _default_candidate_state(flags)
+
+
+def _implementation_gap(flags: dict[str, bool]) -> float:
+    has_resolution = flags["implemented"] or flags["partial"] or flags["rejected"]
+    return float(flags["commitment"] and not has_resolution)
+
+
+def _candidate_components(
+    flags: dict[str, bool], source_refs: list[str], claims: list[dict[str, Any]]
+) -> dict[str, float]:
+    return {
+        "explicit_decision": float(flags["decision"]),
+        "requirement_strength": float(flags["requirement"]),
+        "unresolved_commitment": float(flags["unresolved"]),
+        "implementation_gap": _implementation_gap(flags),
+        "recurrence": min(len(source_refs) / 3.0, 1.0),
+        "evidence_confidence": sum(item["confidence"] for item in claims) / len(claims),
+    }
+
+
+def _implementation_preserved(flags: dict[str, bool]) -> bool | None:
+    if flags["current_implemented"]:
+        return True
+    if flags["current_partial"]:
+        return False
+    return None
+
+
+def _sorted_candidate_claims(claims: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
         claims,
         key=lambda item: (
             item["span"]["source_ref"],
@@ -407,15 +433,15 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
             item["claim_id"],
         ),
     )
-    gap = 1.0 if commitment and not (implemented or partial or rejected) else 0.0
-    components = {
-        "explicit_decision": 1.0 if decision else 0.0,
-        "requirement_strength": 1.0 if requirement else 0.0,
-        "unresolved_commitment": 1.0 if unresolved else 0.0,
-        "implementation_gap": gap,
-        "recurrence": min(len(source_refs) / 3.0, 1.0),
-        "evidence_confidence": sum(item["confidence"] for item in claims) / len(claims),
-    }
+
+
+def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
+    claims = _sorted_candidate_claims(claims)
+    flags = _candidate_flags(claims)
+    status, disposition, rationale = _candidate_state(flags)
+    source_refs = sorted({item["span"]["source_ref"] for item in claims})
+    source_ids = sorted({item["span"]["source_id"] for item in claims})
+    components = _candidate_components(flags, source_refs, claims)
     score = round(
         sum(components[name] * weight for name, weight in RANKING_WEIGHTS.items()),
         6,
@@ -425,7 +451,6 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
         "claim_ids": [item["claim_id"] for item in claims],
         "disposition": disposition,
     }
-
     return {
         "candidate_id": _id("candidate", material),
         "intent_key": intent,
@@ -434,16 +459,12 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
         "claim_ids": [item["claim_id"] for item in claims],
         "historical_state": {
             "status": status,
-            "explicit_rejection": rejected,
-            "implementation_evidence_present": implemented,
-            "partial_implementation_evidence_present": partial,
+            "explicit_rejection": flags["rejected"],
+            "implementation_evidence_present": flags["implemented"],
+            "partial_implementation_evidence_present": flags["partial"],
         },
         "preservation": {
-            "implementation_preserved": (
-                True
-                if current_implemented
-                else (False if current_partial else None)
-            ),
+            "implementation_preserved": _implementation_preserved(flags),
             "capability_preserved": None,
             "intent_preserved": None,
             "intent_delta": None,
@@ -463,72 +484,60 @@ def _candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _known_relationship_intents(
+    raw: dict[str, Any], known_intents: set[str], index: int
+) -> tuple[str, str]:
+    left = raw["left_intent_key"]
+    right = raw["right_intent_key"]
+    unknown = {left, right} - known_intents
+    if unknown:
+        raise CorpusArchaeologyError(
+            f"relationship_hints[{index}] references an unknown intent key"
+        )
+    return left, right
+
+
+def _known_relationship_sources(
+    raw: dict[str, Any], known_sources: set[str], index: int
+) -> list[str]:
+    refs = sorted(set(raw["evidence_source_refs"]))
+    unknown = set(refs) - known_sources
+    if unknown:
+        raise CorpusArchaeologyError(
+            f"relationship_hints[{index}] references unknown sources: "
+            f"{', '.join(sorted(unknown))}"
+        )
+    return refs
+
+
+def _relationship(
+    raw: dict[str, Any],
+    index: int,
+    known_intents: set[str],
+    known_sources: set[str],
+) -> dict[str, Any]:
+    left, right = _known_relationship_intents(raw, known_intents, index)
+    refs = _known_relationship_sources(raw, known_sources, index)
+    material = {
+        "left_intent_key": left,
+        "right_intent_key": right,
+        "relationship": raw["relationship"],
+        "rationale": raw["rationale"],
+        "evidence_source_refs": refs,
+    }
+    return {"relationship_id": _id("relationship", material), **material}
+
+
 def _relationships(
-    hints: Any,
+    hints: list[dict[str, Any]] | None,
     known_intents: set[str],
     known_sources: set[str],
 ) -> list[dict[str, Any]]:
-    if hints is None:
-        return []
-    if not isinstance(hints, list):
-        raise CorpusArchaeologyError("relationship_hints must be an array")
-
-    result = []
-    for index, raw in enumerate(hints):
-        if not isinstance(raw, dict):
-            raise CorpusArchaeologyError(
-                f"relationship_hints[{index}] must be an object"
-            )
-        left = _string(
-            raw.get("left_intent_key"),
-            f"relationship_hints[{index}].left_intent_key",
-        )
-        right = _string(
-            raw.get("right_intent_key"),
-            f"relationship_hints[{index}].right_intent_key",
-        )
-        relationship = _enum(
-            raw.get("relationship"),
-            f"relationship_hints[{index}].relationship",
-            RELATIONSHIPS,
-        )
-        rationale = _string(
-            raw.get("rationale"), f"relationship_hints[{index}].rationale"
-        )
-        if left not in known_intents or right not in known_intents:
-            raise CorpusArchaeologyError(
-                f"relationship_hints[{index}] references an unknown intent key"
-            )
-
-        refs = raw.get("evidence_source_refs", [])
-        if not isinstance(refs, list):
-            raise CorpusArchaeologyError(
-                f"relationship_hints[{index}].evidence_source_refs must be an array"
-            )
-        refs = sorted(
-            {
-                _string(
-                    item,
-                    f"relationship_hints[{index}].evidence_source_refs",
-                )
-                for item in refs
-            }
-        )
-        unknown = set(refs) - known_sources
-        if unknown:
-            raise CorpusArchaeologyError(
-                f"relationship_hints[{index}] references unknown sources: "
-                f"{', '.join(sorted(unknown))}"
-            )
-        material = {
-            "left_intent_key": left,
-            "right_intent_key": right,
-            "relationship": relationship,
-            "rationale": rationale,
-            "evidence_source_refs": refs,
-        }
-        result.append({"relationship_id": _id("relationship", material), **material})
-
+    items = hints or []
+    result = [
+        _relationship(raw, index, known_intents, known_sources)
+        for index, raw in enumerate(items)
+    ]
     return sorted(
         result,
         key=lambda item: (
@@ -540,62 +549,55 @@ def _relationships(
     )
 
 
-def analyze_corpus(
-    corpus: dict[str, Any], *, generated_at: str | None = None
-) -> dict[str, Any]:
-    """Analyze a prepared corpus without mutating source or external state."""
-    if not isinstance(corpus, dict):
-        raise CorpusArchaeologyError("corpus input must be an object")
-    _validate_input_contract(corpus)
-    if corpus.get("schema_version") != SCHEMA_VERSION:
-        raise CorpusArchaeologyError(
-            f"unsupported corpus schema_version: {corpus.get('schema_version')!r}"
-        )
-
-    corpus_id = _string(corpus.get("corpus_id"), "corpus_id")
-    source_inventory_ref = corpus.get("source_inventory_ref")
-    if source_inventory_ref is not None:
-        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
-
-    raw_sources = corpus.get("sources")
-    if not isinstance(raw_sources, list) or not raw_sources:
-        raise CorpusArchaeologyError("sources must be a non-empty array")
-
+def _normalized_sources(raw_sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
     sources = [_source(raw) for raw in raw_sources]
     refs = [item["source_ref"] for item in sources]
     if len(refs) != len(set(refs)):
         raise CorpusArchaeologyError("source_ref values must be unique")
-    sources.sort(key=lambda item: (item["source_ref"], item["source_id"]))
+    return sorted(sources, key=lambda item: (item["source_ref"], item["source_id"]))
 
+
+def _sorted_claims(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
     claims = [claim for source in sources for claim in _claims(source)]
-    claims.sort(
+    return sorted(
+        claims,
         key=lambda item: (
             item["span"]["source_ref"],
             item["span"]["line_start"],
             item["claim_id"],
-        )
+        ),
     )
 
+
+def _claims_by_intent(
+    claims: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
     by_intent: dict[str, list[dict[str, Any]]] = {}
-    unkeyed = []
+    unkeyed: list[str] = []
     for claim in claims:
-        if claim["intent_key"] is None:
-            unkeyed.append(claim["claim_id"])
-        else:
-            by_intent.setdefault(claim["intent_key"], []).append(claim)
+        intent = claim["intent_key"]
+        target = unkeyed if intent is None else by_intent.setdefault(intent, [])
+        target.append(claim["claim_id"] if intent is None else claim)
+    return by_intent, unkeyed
 
-    candidates = [
-        _candidate(intent, by_intent[intent]) for intent in sorted(by_intent)
-    ]
-    relationships = _relationships(
-        corpus.get("relationship_hints"), set(by_intent), set(refs)
-    )
-    public_sources = [
+
+def _public_sources(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
         {key: value for key, value in item.items() if key != "_content"}
         for item in sources
     ]
 
-    stable = {
+
+def _stable_report_material(
+    corpus_id: str,
+    source_inventory_ref: str | None,
+    public_sources: list[dict[str, Any]],
+    claims: list[dict[str, Any]],
+    relationships: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    unkeyed: list[str],
+) -> dict[str, Any]:
+    return {
         "corpus_id": corpus_id,
         "source_inventory_ref": source_inventory_ref,
         "sources": public_sources,
@@ -606,6 +608,27 @@ def analyze_corpus(
         "ranking_weights": RANKING_WEIGHTS,
     }
 
+
+def _report(
+    *,
+    corpus_id: str,
+    source_inventory_ref: str | None,
+    generated_at: str | None,
+    public_sources: list[dict[str, Any]],
+    claims: list[dict[str, Any]],
+    relationships: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    unkeyed: list[str],
+) -> dict[str, Any]:
+    stable = _stable_report_material(
+        corpus_id,
+        source_inventory_ref,
+        public_sources,
+        claims,
+        relationships,
+        candidates,
+        unkeyed,
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "report_id": (
@@ -630,6 +653,73 @@ def analyze_corpus(
     }
 
 
+def analyze_corpus(
+    corpus: dict[str, Any], *, generated_at: str | None = None
+) -> dict[str, Any]:
+    """Analyze a prepared corpus without mutating source or external state."""
+    if not isinstance(corpus, dict):
+        raise CorpusArchaeologyError("corpus input must be an object")
+    _validate_input_contract(corpus)
+    corpus_id = _string(corpus["corpus_id"], "corpus_id")
+    source_inventory_ref = corpus.get("source_inventory_ref")
+    if source_inventory_ref is not None:
+        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
+
+    sources = _normalized_sources(corpus["sources"])
+    claims = _sorted_claims(sources)
+    by_intent, unkeyed = _claims_by_intent(claims)
+    candidates = [
+        _candidate(intent, by_intent[intent]) for intent in sorted(by_intent)
+    ]
+    refs = {item["source_ref"] for item in sources}
+    relationships = _relationships(
+        corpus.get("relationship_hints"), set(by_intent), refs
+    )
+    return _report(
+        corpus_id=corpus_id,
+        source_inventory_ref=source_inventory_ref,
+        generated_at=generated_at,
+        public_sources=_public_sources(sources),
+        claims=claims,
+        relationships=relationships,
+        candidates=candidates,
+        unkeyed=unkeyed,
+    )
+
+
+def _candidate_markdown_lines(item: dict[str, Any]) -> list[str]:
+    return [
+        f"### `{item['intent_key']}`",
+        "",
+        f"- Disposition: `{item['recovery']['disposition']}`",
+        f"- Historical state: `{item['historical_state']['status']}`",
+        f"- Relevance: `{item['ranking']['relevance_score']:.6f}`",
+        f"- Sources: {', '.join(f'`{source}`' for source in item['source_refs'])}",
+        f"- Rationale: {item['recovery']['rationale']}",
+        "",
+    ]
+
+
+def _candidate_markdown_section(candidates: list[dict[str, Any]]) -> list[str]:
+    if not candidates:
+        return ["_No keyed recovery candidates were extracted._"]
+    return [line for item in candidates for line in _candidate_markdown_lines(item)]
+
+
+def _unkeyed_markdown_section(claim_ids: list[str]) -> list[str]:
+    if not claim_ids:
+        return []
+    return [
+        "## Unkeyed claims",
+        "",
+        "These claims retain provenance but are not promoted because no deterministic "
+        "intent key was supplied.",
+        "",
+        *[f"- `{claim_id}`" for claim_id in claim_ids],
+        "",
+    ]
+
+
 def render_markdown(report: dict[str, Any]) -> str:
     lines = [
         "# Corpus Archaeology Report",
@@ -642,37 +732,9 @@ def render_markdown(report: dict[str, Any]) -> str:
         "",
         "## Recovery candidates",
         "",
+        *_candidate_markdown_section(report["candidates"]),
+        *_unkeyed_markdown_section(report["unkeyed_claim_ids"]),
     ]
-    if not report["candidates"]:
-        lines.append("_No keyed recovery candidates were extracted._")
-    for item in report["candidates"]:
-        lines.extend(
-            [
-                f"### `{item['intent_key']}`",
-                "",
-                f"- Disposition: `{item['recovery']['disposition']}`",
-                f"- Historical state: `{item['historical_state']['status']}`",
-                f"- Relevance: `{item['ranking']['relevance_score']:.6f}`",
-                f"- Sources: {', '.join(f'`{source}`' for source in item['source_refs'])}",
-                f"- Rationale: {item['recovery']['rationale']}",
-                "",
-            ]
-        )
-    if report["unkeyed_claim_ids"]:
-        lines.extend(
-            [
-                "## Unkeyed claims",
-                "",
-                "These claims retain provenance but are not promoted because no "
-                "deterministic intent key was supplied.",
-                "",
-                *[
-                    f"- `{claim_id}`"
-                    for claim_id in report["unkeyed_claim_ids"]
-                ],
-                "",
-            ]
-        )
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -692,7 +754,7 @@ def _write_new(path: Path, payload: str) -> None:
         os.fsync(stream.fileno())
 
 
-def main() -> int:
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Analyze a custody-cleared prepared corpus without mutation"
     )
@@ -700,28 +762,45 @@ def main() -> int:
     parser.add_argument("--output", type=Path)
     parser.add_argument("--markdown-output", type=Path)
     parser.add_argument("--generated-at")
-    args = parser.parse_args()
+    return parser
 
+
+def _write_optional_output(
+    output: Path | None,
+    source: Path,
+    payload: str,
+    label: str,
+) -> None:
+    if output is None:
+        return
+    if output.resolve(strict=False) == source.resolve():
+        raise CorpusArchaeologyError(f"{label} path must not replace the source corpus")
+    _write_new(output, payload)
+
+
+def _emit_outputs(args: argparse.Namespace, report: dict[str, Any]) -> None:
+    payload = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    if args.output is None:
+        print(payload, end="")
+    _write_optional_output(args.output, args.corpus, payload, "output")
+    _write_optional_output(
+        args.markdown_output,
+        args.corpus,
+        render_markdown(report),
+        "markdown output",
+    )
+
+
+def _execute(args: argparse.Namespace) -> None:
+    corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
+    report = analyze_corpus(corpus, generated_at=args.generated_at)
+    _emit_outputs(args, report)
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
     try:
-        corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
-        report = analyze_corpus(corpus, generated_at=args.generated_at)
-        payload = json.dumps(
-            report, indent=2, sort_keys=True, ensure_ascii=False
-        ) + "\n"
-        if args.output:
-            if args.output.resolve(strict=False) == args.corpus.resolve():
-                raise CorpusArchaeologyError(
-                    "output path must not replace the source corpus"
-                )
-            _write_new(args.output, payload)
-        else:
-            print(payload, end="")
-        if args.markdown_output:
-            if args.markdown_output.resolve(strict=False) == args.corpus.resolve():
-                raise CorpusArchaeologyError(
-                    "markdown output path must not replace the source corpus"
-                )
-            _write_new(args.markdown_output, render_markdown(report))
+        _execute(args)
     except (OSError, json.JSONDecodeError, CorpusArchaeologyError) as exc:
         print(f"INVALID: {exc}")
         return 1

--- a/tools/salvage/corpus_archaeology.py
+++ b/tools/salvage/corpus_archaeology.py
@@ -11,29 +11,23 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import jsonschema
 
-try:
-    from tools.salvage.corpus_archaeology_core import (
-        RANKING_WEIGHTS,
-        SCHEMA_VERSION,
-        CorpusArchaeologyError,
-        analyze_validated_corpus,
-        render_markdown,
-    )
-except ModuleNotFoundError as exc:
-    if exc.name not in {"tools", "tools.salvage"}:
-        raise
-    from corpus_archaeology_core import (
-        RANKING_WEIGHTS,
-        SCHEMA_VERSION,
-        CorpusArchaeologyError,
-        analyze_validated_corpus,
-        render_markdown,
-    )
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from tools.salvage.corpus_archaeology_core import (  # noqa: E402
+    RANKING_WEIGHTS,
+    SCHEMA_VERSION,
+    CorpusArchaeologyError,
+    analyze_validated_corpus,
+    render_markdown,
+)
 
 INPUT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]

--- a/tools/salvage/corpus_archaeology_candidate_state.py
+++ b/tools/salvage/corpus_archaeology_candidate_state.py
@@ -1,0 +1,113 @@
+"""Candidate state resolution rules for Phase-1 corpus archaeology."""
+
+from __future__ import annotations
+
+from typing import Any
+
+IMPLEMENTATION_EVIDENCE_KINDS = {"implementation_artifact", "test_result"}
+COMMITMENT_TYPES = {
+    "approval",
+    "decision",
+    "requirement",
+    "constraint",
+    "todo",
+    "unresolved_question",
+    "proposed_patch",
+}
+
+
+def _human_claim_types(claims: list[dict[str, Any]]) -> set[str]:
+    return {
+        item["claim_type"]
+        for item in claims
+        if item["evidence_kind"] == "human_statement"
+    }
+
+
+def _is_implementation_claim(
+    item: dict[str, Any], claim_type: str, authority: str | None
+) -> bool:
+    return (
+        item["claim_type"] == claim_type
+        and item["evidence_kind"] in IMPLEMENTATION_EVIDENCE_KINDS
+        and (authority is None or item["authority_status"] == authority)
+    )
+
+
+def _has_implementation_claim(
+    claims: list[dict[str, Any]], claim_type: str, authority: str | None = None
+) -> bool:
+    return any(
+        _is_implementation_claim(item, claim_type, authority) for item in claims
+    )
+
+
+def candidate_flags(claims: list[dict[str, Any]]) -> dict[str, bool]:
+    human_types = _human_claim_types(claims)
+    return {
+        "rejected": "rejection" in human_types,
+        "implemented": _has_implementation_claim(claims, "implementation_evidence"),
+        "partial": _has_implementation_claim(
+            claims, "partial_implementation_evidence"
+        ),
+        "current_implemented": _has_implementation_claim(
+            claims, "implementation_evidence", "current"
+        ),
+        "current_partial": _has_implementation_claim(
+            claims, "partial_implementation_evidence", "current"
+        ),
+        "decision": bool({"approval", "decision"} & human_types),
+        "requirement": bool({"requirement", "constraint"} & human_types),
+        "unresolved": bool(
+            {"todo", "unresolved_question", "proposed_patch"} & human_types
+        ),
+        "commitment": bool(COMMITMENT_TYPES & human_types),
+    }
+
+
+def candidate_state(flags: dict[str, bool]) -> tuple[str, str, str]:
+    if flags["rejected"] and (flags["implemented"] or flags["partial"]):
+        return (
+            "unknown",
+            "investigate",
+            "Explicit human rejection and implementation evidence coexist; preserve both "
+            "histories and investigate chronology, scope, and authority.",
+        )
+    if flags["rejected"]:
+        return (
+            "rejected",
+            "reject_with_evidence",
+            "Explicit human rejection evidence is present; preserve the record and do not "
+            "restore automatically.",
+        )
+    if flags["implemented"]:
+        return (
+            "implemented",
+            "preserve",
+            "Implementation evidence is present; preserve the implementation record and "
+            "verify whether a current successor remains.",
+        )
+    if flags["partial"]:
+        return (
+            "partial",
+            "investigate",
+            "Only partial implementation evidence is present; investigate intent and "
+            "capability preservation.",
+        )
+    status = "approved" if flags["decision"] else "proposed"
+    rationale = (
+        "An explicit human commitment is present without implementation or rejection "
+        "evidence; preserve for investigation."
+        if flags["commitment"]
+        else "No authoritative commitment, implementation, or rejection evidence is "
+        "established; retain as an uncertain recovery candidate."
+    )
+    return status, "investigate", rationale
+
+
+def implementation_preserved(flags: dict[str, bool]) -> bool | None:
+    if flags["current_implemented"]:
+        return True
+    if flags["current_partial"]:
+        return False
+    return None

--- a/tools/salvage/corpus_archaeology_candidate_state.py
+++ b/tools/salvage/corpus_archaeology_candidate_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 IMPLEMENTATION_EVIDENCE_KINDS = {"implementation_artifact", "test_result"}
+HUMAN_AUTHORITY_STATUSES = {"current", "historical"}
 COMMITMENT_TYPES = {
     "approval",
     "decision",
@@ -21,6 +22,7 @@ def _human_claim_types(claims: list[dict[str, Any]]) -> set[str]:
         item["claim_type"]
         for item in claims
         if item["evidence_kind"] == "human_statement"
+        and item["authority_status"] in HUMAN_AUTHORITY_STATUSES
     }
 
 

--- a/tools/salvage/corpus_archaeology_candidates.py
+++ b/tools/salvage/corpus_archaeology_candidates.py
@@ -1,10 +1,26 @@
-"""Pure candidate-state and relevance logic for Phase-1 corpus archaeology."""
+"""Candidate relevance and report projection for Phase-1 corpus archaeology."""
 
 from __future__ import annotations
 
 from typing import Any
 
-IMPLEMENTATION_EVIDENCE_KINDS = {"implementation_artifact", "test_result"}
+try:
+    from tools.salvage.corpus_archaeology_candidate_state import (
+        candidate_flags,
+        candidate_state,
+        implementation_preserved,
+    )
+    from tools.salvage.corpus_archaeology_shared import make_id
+except ModuleNotFoundError as exc:
+    if exc.name not in {"tools", "tools.salvage"}:
+        raise
+    from corpus_archaeology_candidate_state import (
+        candidate_flags,
+        candidate_state,
+        implementation_preserved,
+    )
+    from corpus_archaeology_shared import make_id
+
 RANKING_WEIGHTS = {
     "explicit_decision": 0.25,
     "requirement_strength": 0.20,
@@ -26,103 +42,6 @@ def _canonical_claims(claims: list[dict[str, Any]]) -> list[dict[str, Any]]:
     )
 
 
-def _human_claim_types(claims: list[dict[str, Any]]) -> set[str]:
-    return {
-        item["claim_type"]
-        for item in claims
-        if item["evidence_kind"] == "human_statement"
-    }
-
-
-def _is_implementation_claim(
-    item: dict[str, Any], claim_type: str, authority: str | None
-) -> bool:
-    type_matches = item["claim_type"] == claim_type
-    evidence_matches = item["evidence_kind"] in IMPLEMENTATION_EVIDENCE_KINDS
-    authority_matches = authority is None or item["authority_status"] == authority
-    return type_matches and evidence_matches and authority_matches
-
-
-def _has_implementation_claim(
-    claims: list[dict[str, Any]], claim_type: str, authority: str | None = None
-) -> bool:
-    return any(
-        _is_implementation_claim(item, claim_type, authority) for item in claims
-    )
-
-
-def _candidate_flags(claims: list[dict[str, Any]]) -> dict[str, bool]:
-    human_types = _human_claim_types(claims)
-    commitment_types = {
-        "approval",
-        "decision",
-        "requirement",
-        "constraint",
-        "todo",
-        "unresolved_question",
-        "proposed_patch",
-    }
-    return {
-        "rejected": "rejection" in human_types,
-        "implemented": _has_implementation_claim(claims, "implementation_evidence"),
-        "partial": _has_implementation_claim(
-            claims, "partial_implementation_evidence"
-        ),
-        "current_implemented": _has_implementation_claim(
-            claims, "implementation_evidence", "current"
-        ),
-        "current_partial": _has_implementation_claim(
-            claims, "partial_implementation_evidence", "current"
-        ),
-        "decision": bool({"approval", "decision"} & human_types),
-        "requirement": bool({"requirement", "constraint"} & human_types),
-        "unresolved": bool(
-            {"todo", "unresolved_question", "proposed_patch"} & human_types
-        ),
-        "commitment": bool(commitment_types & human_types),
-    }
-
-
-def _candidate_state(flags: dict[str, bool]) -> tuple[str, str, str]:
-    if flags["rejected"] and (flags["implemented"] or flags["partial"]):
-        return (
-            "unknown",
-            "investigate",
-            "Explicit human rejection and implementation evidence coexist; preserve both "
-            "histories and investigate chronology, scope, and authority.",
-        )
-    if flags["rejected"]:
-        return (
-            "rejected",
-            "reject_with_evidence",
-            "Explicit human rejection evidence is present; preserve the record and do not "
-            "restore automatically.",
-        )
-    if flags["implemented"]:
-        return (
-            "implemented",
-            "preserve",
-            "Implementation evidence is present; preserve the implementation record and "
-            "verify whether a current successor remains.",
-        )
-    if flags["partial"]:
-        return (
-            "partial",
-            "investigate",
-            "Only partial implementation evidence is present; investigate intent and "
-            "capability preservation.",
-        )
-    status = "approved" if flags["decision"] else "proposed"
-    rationale = (
-        "An explicit human commitment is present without implementation or rejection "
-        "evidence; preserve for investigation."
-        if flags["commitment"]
-        else "No authoritative commitment, implementation, or rejection evidence is "
-        "established; retain as an uncertain recovery candidate."
-    )
-    return status, "investigate", rationale
-
-
 def _implementation_gap(flags: dict[str, bool]) -> float:
     has_resolution = flags["implemented"] or flags["partial"] or flags["rejected"]
     return float(flags["commitment"] and not has_resolution)
@@ -141,30 +60,21 @@ def _components(
     }
 
 
-def _implementation_preserved(flags: dict[str, bool]) -> bool | None:
-    if flags["current_implemented"]:
-        return True
-    if flags["current_partial"]:
-        return False
-    return None
+def _relevance_score(components: dict[str, float]) -> float:
+    weighted = (
+        components[name] * weight for name, weight in RANKING_WEIGHTS.items()
+    )
+    return round(sum(weighted), 6)
 
 
-def build_candidate(
-    intent: str,
-    claims: list[dict[str, Any]],
-    make_id,
-) -> dict[str, Any]:
+def build_candidate(intent: str, claims: list[dict[str, Any]]) -> dict[str, Any]:
     """Build one deterministic recovery candidate from keyed claims."""
     claims = _canonical_claims(claims)
-    flags = _candidate_flags(claims)
-    status, disposition, rationale = _candidate_state(flags)
+    flags = candidate_flags(claims)
+    status, disposition, rationale = candidate_state(flags)
     source_refs = sorted({item["span"]["source_ref"] for item in claims})
     source_ids = sorted({item["span"]["source_id"] for item in claims})
     components = _components(flags, source_refs, claims)
-    score = round(
-        sum(components[name] * weight for name, weight in RANKING_WEIGHTS.items()),
-        6,
-    )
     claim_ids = [item["claim_id"] for item in claims]
     candidate_id = make_id(
         "candidate",
@@ -187,7 +97,7 @@ def build_candidate(
             "partial_implementation_evidence_present": flags["partial"],
         },
         "preservation": {
-            "implementation_preserved": _implementation_preserved(flags),
+            "implementation_preserved": implementation_preserved(flags),
             "capability_preserved": None,
             "intent_preserved": None,
             "intent_delta": None,
@@ -199,7 +109,7 @@ def build_candidate(
             "dependencies": [],
         },
         "ranking": {
-            "relevance_score": score,
+            "relevance_score": _relevance_score(components),
             "components": {
                 name: round(value, 6) for name, value in components.items()
             },

--- a/tools/salvage/corpus_archaeology_candidates.py
+++ b/tools/salvage/corpus_archaeology_candidates.py
@@ -4,22 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-try:
-    from tools.salvage.corpus_archaeology_candidate_state import (
-        candidate_flags,
-        candidate_state,
-        implementation_preserved,
-    )
-    from tools.salvage.corpus_archaeology_shared import make_id
-except ModuleNotFoundError as exc:
-    if exc.name not in {"tools", "tools.salvage"}:
-        raise
-    from corpus_archaeology_candidate_state import (
-        candidate_flags,
-        candidate_state,
-        implementation_preserved,
-    )
-    from corpus_archaeology_shared import make_id
+from tools.salvage.corpus_archaeology_candidate_state import (
+    candidate_flags,
+    candidate_state,
+    implementation_preserved,
+)
+from tools.salvage.corpus_archaeology_shared import make_id
 
 RANKING_WEIGHTS = {
     "explicit_decision": 0.25,

--- a/tools/salvage/corpus_archaeology_candidates.py
+++ b/tools/salvage/corpus_archaeology_candidates.py
@@ -1,0 +1,207 @@
+"""Pure candidate-state and relevance logic for Phase-1 corpus archaeology."""
+
+from __future__ import annotations
+
+from typing import Any
+
+IMPLEMENTATION_EVIDENCE_KINDS = {"implementation_artifact", "test_result"}
+RANKING_WEIGHTS = {
+    "explicit_decision": 0.25,
+    "requirement_strength": 0.20,
+    "unresolved_commitment": 0.20,
+    "implementation_gap": 0.20,
+    "recurrence": 0.10,
+    "evidence_confidence": 0.05,
+}
+
+
+def _canonical_claims(claims: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        claims,
+        key=lambda item: (
+            item["span"]["source_ref"],
+            item["span"]["line_start"],
+            item["claim_id"],
+        ),
+    )
+
+
+def _human_claim_types(claims: list[dict[str, Any]]) -> set[str]:
+    return {
+        item["claim_type"]
+        for item in claims
+        if item["evidence_kind"] == "human_statement"
+    }
+
+
+def _is_implementation_claim(
+    item: dict[str, Any], claim_type: str, authority: str | None
+) -> bool:
+    type_matches = item["claim_type"] == claim_type
+    evidence_matches = item["evidence_kind"] in IMPLEMENTATION_EVIDENCE_KINDS
+    authority_matches = authority is None or item["authority_status"] == authority
+    return type_matches and evidence_matches and authority_matches
+
+
+def _has_implementation_claim(
+    claims: list[dict[str, Any]], claim_type: str, authority: str | None = None
+) -> bool:
+    return any(
+        _is_implementation_claim(item, claim_type, authority) for item in claims
+    )
+
+
+def _candidate_flags(claims: list[dict[str, Any]]) -> dict[str, bool]:
+    human_types = _human_claim_types(claims)
+    commitment_types = {
+        "approval",
+        "decision",
+        "requirement",
+        "constraint",
+        "todo",
+        "unresolved_question",
+        "proposed_patch",
+    }
+    return {
+        "rejected": "rejection" in human_types,
+        "implemented": _has_implementation_claim(claims, "implementation_evidence"),
+        "partial": _has_implementation_claim(
+            claims, "partial_implementation_evidence"
+        ),
+        "current_implemented": _has_implementation_claim(
+            claims, "implementation_evidence", "current"
+        ),
+        "current_partial": _has_implementation_claim(
+            claims, "partial_implementation_evidence", "current"
+        ),
+        "decision": bool({"approval", "decision"} & human_types),
+        "requirement": bool({"requirement", "constraint"} & human_types),
+        "unresolved": bool(
+            {"todo", "unresolved_question", "proposed_patch"} & human_types
+        ),
+        "commitment": bool(commitment_types & human_types),
+    }
+
+
+def _candidate_state(flags: dict[str, bool]) -> tuple[str, str, str]:
+    if flags["rejected"] and (flags["implemented"] or flags["partial"]):
+        return (
+            "unknown",
+            "investigate",
+            "Explicit human rejection and implementation evidence coexist; preserve both "
+            "histories and investigate chronology, scope, and authority.",
+        )
+    if flags["rejected"]:
+        return (
+            "rejected",
+            "reject_with_evidence",
+            "Explicit human rejection evidence is present; preserve the record and do not "
+            "restore automatically.",
+        )
+    if flags["implemented"]:
+        return (
+            "implemented",
+            "preserve",
+            "Implementation evidence is present; preserve the implementation record and "
+            "verify whether a current successor remains.",
+        )
+    if flags["partial"]:
+        return (
+            "partial",
+            "investigate",
+            "Only partial implementation evidence is present; investigate intent and "
+            "capability preservation.",
+        )
+    status = "approved" if flags["decision"] else "proposed"
+    rationale = (
+        "An explicit human commitment is present without implementation or rejection "
+        "evidence; preserve for investigation."
+        if flags["commitment"]
+        else "No authoritative commitment, implementation, or rejection evidence is "
+        "established; retain as an uncertain recovery candidate."
+    )
+    return status, "investigate", rationale
+
+
+def _implementation_gap(flags: dict[str, bool]) -> float:
+    has_resolution = flags["implemented"] or flags["partial"] or flags["rejected"]
+    return float(flags["commitment"] and not has_resolution)
+
+
+def _components(
+    flags: dict[str, bool], source_refs: list[str], claims: list[dict[str, Any]]
+) -> dict[str, float]:
+    return {
+        "explicit_decision": float(flags["decision"]),
+        "requirement_strength": float(flags["requirement"]),
+        "unresolved_commitment": float(flags["unresolved"]),
+        "implementation_gap": _implementation_gap(flags),
+        "recurrence": min(len(source_refs) / 3.0, 1.0),
+        "evidence_confidence": sum(item["confidence"] for item in claims) / len(claims),
+    }
+
+
+def _implementation_preserved(flags: dict[str, bool]) -> bool | None:
+    if flags["current_implemented"]:
+        return True
+    if flags["current_partial"]:
+        return False
+    return None
+
+
+def build_candidate(
+    intent: str,
+    claims: list[dict[str, Any]],
+    make_id,
+) -> dict[str, Any]:
+    """Build one deterministic recovery candidate from keyed claims."""
+    claims = _canonical_claims(claims)
+    flags = _candidate_flags(claims)
+    status, disposition, rationale = _candidate_state(flags)
+    source_refs = sorted({item["span"]["source_ref"] for item in claims})
+    source_ids = sorted({item["span"]["source_id"] for item in claims})
+    components = _components(flags, source_refs, claims)
+    score = round(
+        sum(components[name] * weight for name, weight in RANKING_WEIGHTS.items()),
+        6,
+    )
+    claim_ids = [item["claim_id"] for item in claims]
+    candidate_id = make_id(
+        "candidate",
+        {
+            "intent_key": intent,
+            "claim_ids": claim_ids,
+            "disposition": disposition,
+        },
+    )
+    return {
+        "candidate_id": candidate_id,
+        "intent_key": intent,
+        "source_refs": source_refs,
+        "source_ids": source_ids,
+        "claim_ids": claim_ids,
+        "historical_state": {
+            "status": status,
+            "explicit_rejection": flags["rejected"],
+            "implementation_evidence_present": flags["implemented"],
+            "partial_implementation_evidence_present": flags["partial"],
+        },
+        "preservation": {
+            "implementation_preserved": _implementation_preserved(flags),
+            "capability_preserved": None,
+            "intent_preserved": None,
+            "intent_delta": None,
+        },
+        "recovery": {
+            "disposition": disposition,
+            "rationale": rationale,
+            "confidence": round(components["evidence_confidence"], 6),
+            "dependencies": [],
+        },
+        "ranking": {
+            "relevance_score": score,
+            "components": {
+                name: round(value, 6) for name, value in components.items()
+            },
+        },
+    }

--- a/tools/salvage/corpus_archaeology_claims.py
+++ b/tools/salvage/corpus_archaeology_claims.py
@@ -1,0 +1,131 @@
+"""Exact-span explicit claim extraction for Phase-1 corpus archaeology."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+try:
+    from tools.salvage.corpus_archaeology_shared import make_id, sha256_text
+except ModuleNotFoundError as exc:
+    if exc.name not in {"tools", "tools.salvage"}:
+        raise
+    from corpus_archaeology_shared import make_id, sha256_text
+
+CLAIM_RE = re.compile(
+    r"^\s*(?P<label>DECISION|APPROVED|REJECTED|REQUIREMENT|CONSTRAINT|QUESTION|"
+    r"TODO|PATCH|RATIONALE|IMPLEMENTED|PARTIAL_IMPLEMENTATION)"
+    r"(?:\[(?P<intent>[A-Za-z0-9_.:/-]+)\])?\s*:\s*(?P<body>.+?)\s*$",
+    re.IGNORECASE,
+)
+CLAIM_TYPES = {
+    "DECISION": "decision",
+    "APPROVED": "approval",
+    "REJECTED": "rejection",
+    "REQUIREMENT": "requirement",
+    "CONSTRAINT": "constraint",
+    "QUESTION": "unresolved_question",
+    "TODO": "todo",
+    "PATCH": "proposed_patch",
+    "RATIONALE": "rationale",
+    "IMPLEMENTED": "implementation_evidence",
+    "PARTIAL_IMPLEMENTATION": "partial_implementation_evidence",
+}
+IMPLEMENTATION_CLAIM_TYPES = {
+    "implementation_evidence",
+    "partial_implementation_evidence",
+}
+IMPLEMENTATION_SOURCE_KINDS = {
+    "test": "test_result",
+    "code": "implementation_artifact",
+    "commit": "implementation_artifact",
+    "pull_request": "implementation_artifact",
+    "artifact": "implementation_artifact",
+}
+CREATOR_EVIDENCE_KINDS = {
+    "human": "human_statement",
+    "assistant": "model_statement",
+    "model": "model_statement",
+    "system": "system_record",
+    "mixed": "mixed_source",
+    "unknown": "unknown",
+}
+
+
+def evidence_kind(source: dict[str, Any], claim_type: str) -> str:
+    creator_kind = CREATOR_EVIDENCE_KINDS[source["creator_type"]]
+    if claim_type not in IMPLEMENTATION_CLAIM_TYPES:
+        return creator_kind
+    return IMPLEMENTATION_SOURCE_KINDS.get(source["source_type"], creator_kind)
+
+
+def claim_from_line(
+    source: dict[str, Any], line_number: int, line: str
+) -> dict[str, Any] | None:
+    match = CLAIM_RE.match(line)
+    if match is None:
+        return None
+    claim_type = CLAIM_TYPES[match.group("label").upper()]
+    intent = match.group("intent")
+    span = {
+        "source_id": source["source_id"],
+        "source_ref": source["source_ref"],
+        "line_start": line_number,
+        "line_end": line_number,
+        "text_sha256": sha256_text(line),
+        "excerpt": line,
+    }
+    material = {
+        "source_id": source["source_id"],
+        "line": line_number,
+        "claim_type": claim_type,
+        "intent_key": intent,
+        "text_sha256": span["text_sha256"],
+    }
+    return {
+        "claim_id": make_id("claim", material),
+        "claim_type": claim_type,
+        "intent_key": intent,
+        "claim": match.group("body").strip(),
+        "evidence_kind": evidence_kind(source, claim_type),
+        "authority_status": source["authority_status"],
+        "confidence": source["confidence"],
+        "span": span,
+    }
+
+
+def claims_for_source(source: dict[str, Any]) -> list[dict[str, Any]]:
+    content = source["_content"]
+    if content is None:
+        return []
+    extracted = (
+        claim_from_line(source, line_number, line)
+        for line_number, line in enumerate(content.splitlines(), start=1)
+    )
+    return [claim for claim in extracted if claim is not None]
+
+
+def sorted_claims(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    claims = [claim for source in sources for claim in claims_for_source(source)]
+    return sorted(
+        claims,
+        key=lambda item: (
+            item["span"]["source_ref"],
+            item["span"]["line_start"],
+            item["claim_id"],
+        ),
+    )
+
+
+def claims_by_intent(
+    claims: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
+    by_intent: dict[str, list[dict[str, Any]]] = {}
+    unkeyed: list[str] = []
+    for claim in claims:
+        intent = claim["intent_key"]
+        if intent is None:
+            unkeyed.append(claim["claim_id"])
+        else:
+            by_intent.setdefault(intent, []).append(claim)
+    return by_intent, unkeyed

--- a/tools/salvage/corpus_archaeology_claims.py
+++ b/tools/salvage/corpus_archaeology_claims.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-try:
-    from tools.salvage.corpus_archaeology_shared import make_id, sha256_text
-except ModuleNotFoundError as exc:
-    if exc.name not in {"tools", "tools.salvage"}:
-        raise
-    from corpus_archaeology_shared import make_id, sha256_text
+from tools.salvage.corpus_archaeology_shared import make_id, sha256_text
 
 CLAIM_RE = re.compile(
     r"^\s*(?P<label>DECISION|APPROVED|REJECTED|REQUIREMENT|CONSTRAINT|QUESTION|"

--- a/tools/salvage/corpus_archaeology_cli.py
+++ b/tools/salvage/corpus_archaeology_cli.py
@@ -1,0 +1,93 @@
+"""CLI and exclusive output policy for Phase-1 corpus archaeology."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from tools.salvage.corpus_archaeology_shared import CorpusArchaeologyError
+
+Analyzer = Callable[..., dict[str, Any]]
+Renderer = Callable[[dict[str, Any]], str]
+
+
+def _write_new(path: Path, payload: str) -> None:
+    path = path.resolve(strict=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags, 0o600)
+    except FileExistsError as exc:
+        raise CorpusArchaeologyError(
+            f"output already exists and will not be replaced: {path}"
+        ) from exc
+    with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Analyze a custody-cleared prepared corpus without mutation"
+    )
+    parser.add_argument("corpus", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--generated-at")
+    return parser
+
+
+def _write_optional_output(
+    output: Path | None,
+    source: Path,
+    payload: str,
+    label: str,
+) -> None:
+    if output is None:
+        return
+    if output.resolve(strict=False) == source.resolve():
+        raise CorpusArchaeologyError(f"{label} path must not replace the source corpus")
+    _write_new(output, payload)
+
+
+def _emit_outputs(
+    args: argparse.Namespace,
+    report: dict[str, Any],
+    render_markdown: Renderer,
+) -> None:
+    payload = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    if args.output is None:
+        print(payload, end="")
+    _write_optional_output(args.output, args.corpus, payload, "output")
+    _write_optional_output(
+        args.markdown_output,
+        args.corpus,
+        render_markdown(report),
+        "markdown output",
+    )
+
+
+def _execute(
+    args: argparse.Namespace,
+    analyze_corpus: Analyzer,
+    render_markdown: Renderer,
+) -> None:
+    corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
+    report = analyze_corpus(corpus, generated_at=args.generated_at)
+    _emit_outputs(args, report, render_markdown)
+
+
+def run_cli(analyze_corpus: Analyzer, render_markdown: Renderer) -> int:
+    """Run the public CLI while keeping analysis and rendering dependency-injected."""
+    args = _build_parser().parse_args()
+    try:
+        _execute(args, analyze_corpus, render_markdown)
+    except (OSError, json.JSONDecodeError, CorpusArchaeologyError) as exc:
+        print(f"INVALID: {exc}")
+        return 1
+    return 0

--- a/tools/salvage/corpus_archaeology_core.py
+++ b/tools/salvage/corpus_archaeology_core.py
@@ -1,11 +1,8 @@
-"""Pure semantic core for deterministic Phase-1 corpus archaeology."""
+"""Semantic orchestration and rendering for deterministic corpus archaeology."""
 
 from __future__ import annotations
 
 import hashlib
-import json
-import re
-from datetime import datetime, timezone
 from typing import Any
 
 try:
@@ -13,310 +10,36 @@ try:
         RANKING_WEIGHTS,
         build_candidate,
     )
+    from tools.salvage.corpus_archaeology_claims import claims_by_intent, sorted_claims
+    from tools.salvage.corpus_archaeology_relationships import build_relationships
+    from tools.salvage.corpus_archaeology_shared import (
+        SCHEMA_VERSION,
+        CorpusArchaeologyError,
+        canonical_bytes,
+        normalize_timestamp,
+        semantic_string,
+    )
+    from tools.salvage.corpus_archaeology_sources import normalize_sources, public_sources
 except ModuleNotFoundError as exc:
     if exc.name not in {"tools", "tools.salvage"}:
         raise
     from corpus_archaeology_candidates import RANKING_WEIGHTS, build_candidate
-
-SCHEMA_VERSION = "0.1.0"
-CLAIM_RE = re.compile(
-    r"^\s*(?P<label>DECISION|APPROVED|REJECTED|REQUIREMENT|CONSTRAINT|QUESTION|"
-    r"TODO|PATCH|RATIONALE|IMPLEMENTED|PARTIAL_IMPLEMENTATION)"
-    r"(?:\[(?P<intent>[A-Za-z0-9_.:/-]+)\])?\s*:\s*(?P<body>.+?)\s*$",
-    re.IGNORECASE,
-)
-CLAIM_TYPES = {
-    "DECISION": "decision",
-    "APPROVED": "approval",
-    "REJECTED": "rejection",
-    "REQUIREMENT": "requirement",
-    "CONSTRAINT": "constraint",
-    "QUESTION": "unresolved_question",
-    "TODO": "todo",
-    "PATCH": "proposed_patch",
-    "RATIONALE": "rationale",
-    "IMPLEMENTED": "implementation_evidence",
-    "PARTIAL_IMPLEMENTATION": "partial_implementation_evidence",
-}
-IMPLEMENTATION_CLAIM_TYPES = {
-    "implementation_evidence",
-    "partial_implementation_evidence",
-}
-IMPLEMENTATION_SOURCE_KINDS = {
-    "test": "test_result",
-    "code": "implementation_artifact",
-    "commit": "implementation_artifact",
-    "pull_request": "implementation_artifact",
-    "artifact": "implementation_artifact",
-}
-CREATOR_EVIDENCE_KINDS = {
-    "human": "human_statement",
-    "assistant": "model_statement",
-    "model": "model_statement",
-    "system": "system_record",
-    "mixed": "mixed_source",
-    "unknown": "unknown",
-}
-
-
-class CorpusArchaeologyError(ValueError):
-    """Prepared corpus is invalid or violates a Phase-1 safety boundary."""
-
-
-def _canonical_bytes(value: Any) -> bytes:
-    return json.dumps(
-        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    ).encode("utf-8")
-
-
-def _id(prefix: str, value: Any, length: int = 24) -> str:
-    return f"{prefix}:{hashlib.sha256(_canonical_bytes(value)).hexdigest()[:length]}"
-
-
-def _sha256(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def _string(value: Any, name: str) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise CorpusArchaeologyError(f"{name} must be a non-empty string")
-    return value.strip()
-
-
-def _parse_timestamp(value: str) -> str:
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except (AttributeError, ValueError) as exc:
-        raise CorpusArchaeologyError(
-            "generated_at must be timezone-aware ISO-8601"
-        ) from exc
-    if parsed.tzinfo is None or parsed.utcoffset() is None:
-        raise CorpusArchaeologyError("generated_at must include timezone information")
-    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _timestamp(value: str | None) -> str:
-    if value is None:
-        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    return _parse_timestamp(value)
-
-
-def _validate_optional_source_strings(source_ref: str, raw: dict[str, Any]) -> None:
-    for name in ("artifact_id", "inventory_report_id", "platform"):
-        value = raw.get(name)
-        if value is not None:
-            _string(value, f"{source_ref}.{name}")
-
-
-def _released_content(raw: dict[str, Any], source_ref: str) -> tuple[str, str]:
-    content = raw["content"]
-    digest = _sha256(content)
-    supplied_digest = raw.get("sha256")
-    if supplied_digest is not None and supplied_digest != digest:
-        raise CorpusArchaeologyError(
-            f"{source_ref}.sha256 does not match prepared content"
-        )
-    return content, digest
-
-
-def _prepared_content(
-    raw: dict[str, Any], source_ref: str
-) -> tuple[str | None, str | None]:
-    if raw["content_access"] == "released":
-        return _released_content(raw, source_ref)
-    return None, raw.get("sha256")
-
-
-def _source(raw: dict[str, Any]) -> dict[str, Any]:
-    source_ref = _string(raw["source_ref"], "source_ref")
-    _validate_optional_source_strings(source_ref, raw)
-    content, digest = _prepared_content(raw, source_ref)
-    artifact_id = raw.get("artifact_id")
-    inventory_ref = raw.get("inventory_report_id")
-    stable_identity = {
-        "source_ref": source_ref,
-        "sha256": digest,
-        "artifact_id": artifact_id,
-        "inventory_report_id": inventory_ref,
-    }
-    return {
-        "source_ref": source_ref,
-        "source_id": _id("source", stable_identity),
-        "title": _string(raw["title"], f"{source_ref}.title"),
-        "source_type": raw["source_type"],
-        "platform": raw.get("platform"),
-        "creator_type": raw["creator_type"],
-        "authority_status": raw["authority_status"],
-        "confidence": float(raw.get("confidence", 1.0)),
-        "artifact_id": artifact_id,
-        "inventory_report_id": inventory_ref,
-        "content_access": raw["content_access"],
-        "sha256": digest,
-        "_content": content,
-    }
-
-
-def _evidence_kind(source: dict[str, Any], claim_type: str) -> str:
-    creator_kind = CREATOR_EVIDENCE_KINDS[source["creator_type"]]
-    if claim_type not in IMPLEMENTATION_CLAIM_TYPES:
-        return creator_kind
-    return IMPLEMENTATION_SOURCE_KINDS.get(source["source_type"], creator_kind)
-
-
-def _claim_from_line(
-    source: dict[str, Any], line_number: int, line: str
-) -> dict[str, Any] | None:
-    match = CLAIM_RE.match(line)
-    if match is None:
-        return None
-    claim_type = CLAIM_TYPES[match.group("label").upper()]
-    intent = match.group("intent")
-    span = {
-        "source_id": source["source_id"],
-        "source_ref": source["source_ref"],
-        "line_start": line_number,
-        "line_end": line_number,
-        "text_sha256": _sha256(line),
-        "excerpt": line,
-    }
-    material = {
-        "source_id": source["source_id"],
-        "line": line_number,
-        "claim_type": claim_type,
-        "intent_key": intent,
-        "text_sha256": span["text_sha256"],
-    }
-    return {
-        "claim_id": _id("claim", material),
-        "claim_type": claim_type,
-        "intent_key": intent,
-        "claim": match.group("body").strip(),
-        "evidence_kind": _evidence_kind(source, claim_type),
-        "authority_status": source["authority_status"],
-        "confidence": source["confidence"],
-        "span": span,
-    }
-
-
-def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
-    content = source["_content"]
-    if content is None:
-        return []
-    extracted = (
-        _claim_from_line(source, line_number, line)
-        for line_number, line in enumerate(content.splitlines(), start=1)
+    from corpus_archaeology_claims import claims_by_intent, sorted_claims
+    from corpus_archaeology_relationships import build_relationships
+    from corpus_archaeology_shared import (
+        SCHEMA_VERSION,
+        CorpusArchaeologyError,
+        canonical_bytes,
+        normalize_timestamp,
+        semantic_string,
     )
-    return [claim for claim in extracted if claim is not None]
+    from corpus_archaeology_sources import normalize_sources, public_sources
 
 
-def _known_relationship_intents(
-    raw: dict[str, Any], known_intents: set[str], index: int
-) -> tuple[str, str]:
-    left = raw["left_intent_key"]
-    right = raw["right_intent_key"]
-    if {left, right} - known_intents:
-        raise CorpusArchaeologyError(
-            f"relationship_hints[{index}] references an unknown intent key"
-        )
-    return left, right
-
-
-def _known_relationship_sources(
-    raw: dict[str, Any], known_sources: set[str], index: int
-) -> list[str]:
-    refs = sorted(set(raw["evidence_source_refs"]))
-    unknown = set(refs) - known_sources
-    if unknown:
-        raise CorpusArchaeologyError(
-            f"relationship_hints[{index}] references unknown sources: "
-            f"{', '.join(sorted(unknown))}"
-        )
-    return refs
-
-
-def _relationship(
-    raw: dict[str, Any],
-    index: int,
-    known_intents: set[str],
-    known_sources: set[str],
-) -> dict[str, Any]:
-    left, right = _known_relationship_intents(raw, known_intents, index)
-    refs = _known_relationship_sources(raw, known_sources, index)
-    material = {
-        "left_intent_key": left,
-        "right_intent_key": right,
-        "relationship": raw["relationship"],
-        "rationale": raw["rationale"],
-        "evidence_source_refs": refs,
-    }
-    return {"relationship_id": _id("relationship", material), **material}
-
-
-def _relationships(
-    hints: list[dict[str, Any]] | None,
-    known_intents: set[str],
-    known_sources: set[str],
-) -> list[dict[str, Any]]:
-    result = [
-        _relationship(raw, index, known_intents, known_sources)
-        for index, raw in enumerate(hints or [])
-    ]
-    return sorted(
-        result,
-        key=lambda item: (
-            item["left_intent_key"],
-            item["right_intent_key"],
-            item["relationship"],
-            item["relationship_id"],
-        ),
-    )
-
-
-def _normalized_sources(raw_sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    sources = [_source(raw) for raw in raw_sources]
-    refs = [item["source_ref"] for item in sources]
-    if len(refs) != len(set(refs)):
-        raise CorpusArchaeologyError("source_ref values must be unique")
-    return sorted(sources, key=lambda item: (item["source_ref"], item["source_id"]))
-
-
-def _sorted_claims(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    claims = [claim for source in sources for claim in _claims(source)]
-    return sorted(
-        claims,
-        key=lambda item: (
-            item["span"]["source_ref"],
-            item["span"]["line_start"],
-            item["claim_id"],
-        ),
-    )
-
-
-def _claims_by_intent(
-    claims: list[dict[str, Any]],
-) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
-    by_intent: dict[str, list[dict[str, Any]]] = {}
-    unkeyed: list[str] = []
-    for claim in claims:
-        intent = claim["intent_key"]
-        if intent is None:
-            unkeyed.append(claim["claim_id"])
-        else:
-            by_intent.setdefault(intent, []).append(claim)
-    return by_intent, unkeyed
-
-
-def _public_sources(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        {key: value for key, value in item.items() if key != "_content"}
-        for item in sources
-    ]
-
-
-def _stable_report_material(
+def _stable_material(
     corpus_id: str,
     source_inventory_ref: str | None,
-    public_sources: list[dict[str, Any]],
+    sources: list[dict[str, Any]],
     claims: list[dict[str, Any]],
     relationships: list[dict[str, Any]],
     candidates: list[dict[str, Any]],
@@ -325,7 +48,7 @@ def _stable_report_material(
     return {
         "corpus_id": corpus_id,
         "source_inventory_ref": source_inventory_ref,
-        "sources": public_sources,
+        "sources": sources,
         "claims": claims,
         "relationships": relationships,
         "candidates": candidates,
@@ -334,21 +57,26 @@ def _stable_report_material(
     }
 
 
-def _report(
+def _report_id(stable: dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_bytes(stable)).hexdigest()
+    return f"corpus-report:{digest}"
+
+
+def _build_report(
     *,
     corpus_id: str,
     source_inventory_ref: str | None,
     generated_at: str | None,
-    public_sources: list[dict[str, Any]],
+    sources: list[dict[str, Any]],
     claims: list[dict[str, Any]],
     relationships: list[dict[str, Any]],
     candidates: list[dict[str, Any]],
     unkeyed: list[str],
 ) -> dict[str, Any]:
-    stable = _stable_report_material(
+    stable = _stable_material(
         corpus_id,
         source_inventory_ref,
-        public_sources,
+        sources,
         claims,
         relationships,
         candidates,
@@ -356,11 +84,8 @@ def _report(
     )
     return {
         "schema_version": SCHEMA_VERSION,
-        "report_id": (
-            "corpus-report:"
-            f"{hashlib.sha256(_canonical_bytes(stable)).hexdigest()}"
-        ),
-        "generated_at": _timestamp(generated_at),
+        "report_id": _report_id(stable),
+        "generated_at": normalize_timestamp(generated_at),
         "corpus_id": corpus_id,
         "source_inventory_ref": source_inventory_ref,
         "read_only": True,
@@ -370,7 +95,7 @@ def _report(
             "name": "explainable_relevance_v1",
             "weights": RANKING_WEIGHTS,
         },
-        "sources": public_sources,
+        "sources": sources,
         "claims": claims,
         "relationships": relationships,
         "candidates": candidates,
@@ -382,27 +107,29 @@ def analyze_validated_corpus(
     corpus: dict[str, Any], *, generated_at: str | None = None
 ) -> dict[str, Any]:
     """Analyze a structurally validated prepared corpus without external mutation."""
-    corpus_id = _string(corpus["corpus_id"], "corpus_id")
+    corpus_id = semantic_string(corpus["corpus_id"], "corpus_id")
     source_inventory_ref = corpus.get("source_inventory_ref")
     if source_inventory_ref is not None:
-        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
+        source_inventory_ref = semantic_string(
+            source_inventory_ref, "source_inventory_ref"
+        )
 
-    sources = _normalized_sources(corpus["sources"])
-    claims = _sorted_claims(sources)
-    by_intent, unkeyed = _claims_by_intent(claims)
+    normalized_sources = normalize_sources(corpus["sources"])
+    claims = sorted_claims(normalized_sources)
+    by_intent, unkeyed = claims_by_intent(claims)
     candidates = [
-        build_candidate(intent, by_intent[intent], _id) for intent in sorted(by_intent)
+        build_candidate(intent, by_intent[intent]) for intent in sorted(by_intent)
     ]
-    relationships = _relationships(
+    relationships = build_relationships(
         corpus.get("relationship_hints"),
         set(by_intent),
-        {item["source_ref"] for item in sources},
+        {item["source_ref"] for item in normalized_sources},
     )
-    return _report(
+    return _build_report(
         corpus_id=corpus_id,
         source_inventory_ref=source_inventory_ref,
         generated_at=generated_at,
-        public_sources=_public_sources(sources),
+        sources=public_sources(normalized_sources),
         claims=claims,
         relationships=relationships,
         candidates=candidates,
@@ -410,7 +137,7 @@ def analyze_validated_corpus(
     )
 
 
-def _candidate_markdown_lines(item: dict[str, Any]) -> list[str]:
+def _candidate_lines(item: dict[str, Any]) -> list[str]:
     return [
         f"### `{item['intent_key']}`",
         "",
@@ -423,13 +150,13 @@ def _candidate_markdown_lines(item: dict[str, Any]) -> list[str]:
     ]
 
 
-def _candidate_markdown_section(candidates: list[dict[str, Any]]) -> list[str]:
+def _candidate_section(candidates: list[dict[str, Any]]) -> list[str]:
     if not candidates:
         return ["_No keyed recovery candidates were extracted._"]
-    return [line for item in candidates for line in _candidate_markdown_lines(item)]
+    return [line for item in candidates for line in _candidate_lines(item)]
 
 
-def _unkeyed_markdown_section(claim_ids: list[str]) -> list[str]:
+def _unkeyed_section(claim_ids: list[str]) -> list[str]:
     if not claim_ids:
         return []
     return [
@@ -455,7 +182,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         "",
         "## Recovery candidates",
         "",
-        *_candidate_markdown_section(report["candidates"]),
-        *_unkeyed_markdown_section(report["unkeyed_claim_ids"]),
+        *_candidate_section(report["candidates"]),
+        *_unkeyed_section(report["unkeyed_claim_ids"]),
     ]
     return "\n".join(lines).rstrip() + "\n"

--- a/tools/salvage/corpus_archaeology_core.py
+++ b/tools/salvage/corpus_archaeology_core.py
@@ -1,0 +1,461 @@
+"""Pure semantic core for deterministic Phase-1 corpus archaeology."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    from tools.salvage.corpus_archaeology_candidates import (
+        RANKING_WEIGHTS,
+        build_candidate,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name not in {"tools", "tools.salvage"}:
+        raise
+    from corpus_archaeology_candidates import RANKING_WEIGHTS, build_candidate
+
+SCHEMA_VERSION = "0.1.0"
+CLAIM_RE = re.compile(
+    r"^\s*(?P<label>DECISION|APPROVED|REJECTED|REQUIREMENT|CONSTRAINT|QUESTION|"
+    r"TODO|PATCH|RATIONALE|IMPLEMENTED|PARTIAL_IMPLEMENTATION)"
+    r"(?:\[(?P<intent>[A-Za-z0-9_.:/-]+)\])?\s*:\s*(?P<body>.+?)\s*$",
+    re.IGNORECASE,
+)
+CLAIM_TYPES = {
+    "DECISION": "decision",
+    "APPROVED": "approval",
+    "REJECTED": "rejection",
+    "REQUIREMENT": "requirement",
+    "CONSTRAINT": "constraint",
+    "QUESTION": "unresolved_question",
+    "TODO": "todo",
+    "PATCH": "proposed_patch",
+    "RATIONALE": "rationale",
+    "IMPLEMENTED": "implementation_evidence",
+    "PARTIAL_IMPLEMENTATION": "partial_implementation_evidence",
+}
+IMPLEMENTATION_CLAIM_TYPES = {
+    "implementation_evidence",
+    "partial_implementation_evidence",
+}
+IMPLEMENTATION_SOURCE_KINDS = {
+    "test": "test_result",
+    "code": "implementation_artifact",
+    "commit": "implementation_artifact",
+    "pull_request": "implementation_artifact",
+    "artifact": "implementation_artifact",
+}
+CREATOR_EVIDENCE_KINDS = {
+    "human": "human_statement",
+    "assistant": "model_statement",
+    "model": "model_statement",
+    "system": "system_record",
+    "mixed": "mixed_source",
+    "unknown": "unknown",
+}
+
+
+class CorpusArchaeologyError(ValueError):
+    """Prepared corpus is invalid or violates a Phase-1 safety boundary."""
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _id(prefix: str, value: Any, length: int = 24) -> str:
+    return f"{prefix}:{hashlib.sha256(_canonical_bytes(value)).hexdigest()[:length]}"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CorpusArchaeologyError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _parse_timestamp(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise CorpusArchaeologyError(
+            "generated_at must be timezone-aware ISO-8601"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CorpusArchaeologyError("generated_at must include timezone information")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _timestamp(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return _parse_timestamp(value)
+
+
+def _validate_optional_source_strings(source_ref: str, raw: dict[str, Any]) -> None:
+    for name in ("artifact_id", "inventory_report_id", "platform"):
+        value = raw.get(name)
+        if value is not None:
+            _string(value, f"{source_ref}.{name}")
+
+
+def _released_content(raw: dict[str, Any], source_ref: str) -> tuple[str, str]:
+    content = raw["content"]
+    digest = _sha256(content)
+    supplied_digest = raw.get("sha256")
+    if supplied_digest is not None and supplied_digest != digest:
+        raise CorpusArchaeologyError(
+            f"{source_ref}.sha256 does not match prepared content"
+        )
+    return content, digest
+
+
+def _prepared_content(
+    raw: dict[str, Any], source_ref: str
+) -> tuple[str | None, str | None]:
+    if raw["content_access"] == "released":
+        return _released_content(raw, source_ref)
+    return None, raw.get("sha256")
+
+
+def _source(raw: dict[str, Any]) -> dict[str, Any]:
+    source_ref = _string(raw["source_ref"], "source_ref")
+    _validate_optional_source_strings(source_ref, raw)
+    content, digest = _prepared_content(raw, source_ref)
+    artifact_id = raw.get("artifact_id")
+    inventory_ref = raw.get("inventory_report_id")
+    stable_identity = {
+        "source_ref": source_ref,
+        "sha256": digest,
+        "artifact_id": artifact_id,
+        "inventory_report_id": inventory_ref,
+    }
+    return {
+        "source_ref": source_ref,
+        "source_id": _id("source", stable_identity),
+        "title": _string(raw["title"], f"{source_ref}.title"),
+        "source_type": raw["source_type"],
+        "platform": raw.get("platform"),
+        "creator_type": raw["creator_type"],
+        "authority_status": raw["authority_status"],
+        "confidence": float(raw.get("confidence", 1.0)),
+        "artifact_id": artifact_id,
+        "inventory_report_id": inventory_ref,
+        "content_access": raw["content_access"],
+        "sha256": digest,
+        "_content": content,
+    }
+
+
+def _evidence_kind(source: dict[str, Any], claim_type: str) -> str:
+    creator_kind = CREATOR_EVIDENCE_KINDS[source["creator_type"]]
+    if claim_type not in IMPLEMENTATION_CLAIM_TYPES:
+        return creator_kind
+    return IMPLEMENTATION_SOURCE_KINDS.get(source["source_type"], creator_kind)
+
+
+def _claim_from_line(
+    source: dict[str, Any], line_number: int, line: str
+) -> dict[str, Any] | None:
+    match = CLAIM_RE.match(line)
+    if match is None:
+        return None
+    claim_type = CLAIM_TYPES[match.group("label").upper()]
+    intent = match.group("intent")
+    span = {
+        "source_id": source["source_id"],
+        "source_ref": source["source_ref"],
+        "line_start": line_number,
+        "line_end": line_number,
+        "text_sha256": _sha256(line),
+        "excerpt": line,
+    }
+    material = {
+        "source_id": source["source_id"],
+        "line": line_number,
+        "claim_type": claim_type,
+        "intent_key": intent,
+        "text_sha256": span["text_sha256"],
+    }
+    return {
+        "claim_id": _id("claim", material),
+        "claim_type": claim_type,
+        "intent_key": intent,
+        "claim": match.group("body").strip(),
+        "evidence_kind": _evidence_kind(source, claim_type),
+        "authority_status": source["authority_status"],
+        "confidence": source["confidence"],
+        "span": span,
+    }
+
+
+def _claims(source: dict[str, Any]) -> list[dict[str, Any]]:
+    content = source["_content"]
+    if content is None:
+        return []
+    extracted = (
+        _claim_from_line(source, line_number, line)
+        for line_number, line in enumerate(content.splitlines(), start=1)
+    )
+    return [claim for claim in extracted if claim is not None]
+
+
+def _known_relationship_intents(
+    raw: dict[str, Any], known_intents: set[str], index: int
+) -> tuple[str, str]:
+    left = raw["left_intent_key"]
+    right = raw["right_intent_key"]
+    if {left, right} - known_intents:
+        raise CorpusArchaeologyError(
+            f"relationship_hints[{index}] references an unknown intent key"
+        )
+    return left, right
+
+
+def _known_relationship_sources(
+    raw: dict[str, Any], known_sources: set[str], index: int
+) -> list[str]:
+    refs = sorted(set(raw["evidence_source_refs"]))
+    unknown = set(refs) - known_sources
+    if unknown:
+        raise CorpusArchaeologyError(
+            f"relationship_hints[{index}] references unknown sources: "
+            f"{', '.join(sorted(unknown))}"
+        )
+    return refs
+
+
+def _relationship(
+    raw: dict[str, Any],
+    index: int,
+    known_intents: set[str],
+    known_sources: set[str],
+) -> dict[str, Any]:
+    left, right = _known_relationship_intents(raw, known_intents, index)
+    refs = _known_relationship_sources(raw, known_sources, index)
+    material = {
+        "left_intent_key": left,
+        "right_intent_key": right,
+        "relationship": raw["relationship"],
+        "rationale": raw["rationale"],
+        "evidence_source_refs": refs,
+    }
+    return {"relationship_id": _id("relationship", material), **material}
+
+
+def _relationships(
+    hints: list[dict[str, Any]] | None,
+    known_intents: set[str],
+    known_sources: set[str],
+) -> list[dict[str, Any]]:
+    result = [
+        _relationship(raw, index, known_intents, known_sources)
+        for index, raw in enumerate(hints or [])
+    ]
+    return sorted(
+        result,
+        key=lambda item: (
+            item["left_intent_key"],
+            item["right_intent_key"],
+            item["relationship"],
+            item["relationship_id"],
+        ),
+    )
+
+
+def _normalized_sources(raw_sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    sources = [_source(raw) for raw in raw_sources]
+    refs = [item["source_ref"] for item in sources]
+    if len(refs) != len(set(refs)):
+        raise CorpusArchaeologyError("source_ref values must be unique")
+    return sorted(sources, key=lambda item: (item["source_ref"], item["source_id"]))
+
+
+def _sorted_claims(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    claims = [claim for source in sources for claim in _claims(source)]
+    return sorted(
+        claims,
+        key=lambda item: (
+            item["span"]["source_ref"],
+            item["span"]["line_start"],
+            item["claim_id"],
+        ),
+    )
+
+
+def _claims_by_intent(
+    claims: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
+    by_intent: dict[str, list[dict[str, Any]]] = {}
+    unkeyed: list[str] = []
+    for claim in claims:
+        intent = claim["intent_key"]
+        if intent is None:
+            unkeyed.append(claim["claim_id"])
+        else:
+            by_intent.setdefault(intent, []).append(claim)
+    return by_intent, unkeyed
+
+
+def _public_sources(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: value for key, value in item.items() if key != "_content"}
+        for item in sources
+    ]
+
+
+def _stable_report_material(
+    corpus_id: str,
+    source_inventory_ref: str | None,
+    public_sources: list[dict[str, Any]],
+    claims: list[dict[str, Any]],
+    relationships: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    unkeyed: list[str],
+) -> dict[str, Any]:
+    return {
+        "corpus_id": corpus_id,
+        "source_inventory_ref": source_inventory_ref,
+        "sources": public_sources,
+        "claims": claims,
+        "relationships": relationships,
+        "candidates": candidates,
+        "unkeyed_claim_ids": sorted(unkeyed),
+        "ranking_weights": RANKING_WEIGHTS,
+    }
+
+
+def _report(
+    *,
+    corpus_id: str,
+    source_inventory_ref: str | None,
+    generated_at: str | None,
+    public_sources: list[dict[str, Any]],
+    claims: list[dict[str, Any]],
+    relationships: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    unkeyed: list[str],
+) -> dict[str, Any]:
+    stable = _stable_report_material(
+        corpus_id,
+        source_inventory_ref,
+        public_sources,
+        claims,
+        relationships,
+        candidates,
+        unkeyed,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_id": (
+            "corpus-report:"
+            f"{hashlib.sha256(_canonical_bytes(stable)).hexdigest()}"
+        ),
+        "generated_at": _timestamp(generated_at),
+        "corpus_id": corpus_id,
+        "source_inventory_ref": source_inventory_ref,
+        "read_only": True,
+        "mutation_performed": False,
+        "analysis_profile": "explicit_markers_v1",
+        "ranking_model": {
+            "name": "explainable_relevance_v1",
+            "weights": RANKING_WEIGHTS,
+        },
+        "sources": public_sources,
+        "claims": claims,
+        "relationships": relationships,
+        "candidates": candidates,
+        "unkeyed_claim_ids": sorted(unkeyed),
+    }
+
+
+def analyze_validated_corpus(
+    corpus: dict[str, Any], *, generated_at: str | None = None
+) -> dict[str, Any]:
+    """Analyze a structurally validated prepared corpus without external mutation."""
+    corpus_id = _string(corpus["corpus_id"], "corpus_id")
+    source_inventory_ref = corpus.get("source_inventory_ref")
+    if source_inventory_ref is not None:
+        source_inventory_ref = _string(source_inventory_ref, "source_inventory_ref")
+
+    sources = _normalized_sources(corpus["sources"])
+    claims = _sorted_claims(sources)
+    by_intent, unkeyed = _claims_by_intent(claims)
+    candidates = [
+        build_candidate(intent, by_intent[intent], _id) for intent in sorted(by_intent)
+    ]
+    relationships = _relationships(
+        corpus.get("relationship_hints"),
+        set(by_intent),
+        {item["source_ref"] for item in sources},
+    )
+    return _report(
+        corpus_id=corpus_id,
+        source_inventory_ref=source_inventory_ref,
+        generated_at=generated_at,
+        public_sources=_public_sources(sources),
+        claims=claims,
+        relationships=relationships,
+        candidates=candidates,
+        unkeyed=unkeyed,
+    )
+
+
+def _candidate_markdown_lines(item: dict[str, Any]) -> list[str]:
+    return [
+        f"### `{item['intent_key']}`",
+        "",
+        f"- Disposition: `{item['recovery']['disposition']}`",
+        f"- Historical state: `{item['historical_state']['status']}`",
+        f"- Relevance: `{item['ranking']['relevance_score']:.6f}`",
+        f"- Sources: {', '.join(f'`{source}`' for source in item['source_refs'])}",
+        f"- Rationale: {item['recovery']['rationale']}",
+        "",
+    ]
+
+
+def _candidate_markdown_section(candidates: list[dict[str, Any]]) -> list[str]:
+    if not candidates:
+        return ["_No keyed recovery candidates were extracted._"]
+    return [line for item in candidates for line in _candidate_markdown_lines(item)]
+
+
+def _unkeyed_markdown_section(claim_ids: list[str]) -> list[str]:
+    if not claim_ids:
+        return []
+    return [
+        "## Unkeyed claims",
+        "",
+        "These claims retain provenance but are not promoted because no deterministic "
+        "intent key was supplied.",
+        "",
+        *[f"- `{claim_id}`" for claim_id in claim_ids],
+        "",
+    ]
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Corpus Archaeology Report",
+        "",
+        f"- Report: `{report['report_id']}`",
+        f"- Corpus: `{report['corpus_id']}`",
+        f"- Sources: {len(report['sources'])}",
+        f"- Claims: {len(report['claims'])}",
+        f"- Candidates: {len(report['candidates'])}",
+        "",
+        "## Recovery candidates",
+        "",
+        *_candidate_markdown_section(report["candidates"]),
+        *_unkeyed_markdown_section(report["unkeyed_claim_ids"]),
+    ]
+    return "\n".join(lines).rstrip() + "\n"

--- a/tools/salvage/corpus_archaeology_core.py
+++ b/tools/salvage/corpus_archaeology_core.py
@@ -13,7 +13,6 @@ from tools.salvage.corpus_archaeology_claims import claims_by_intent, sorted_cla
 from tools.salvage.corpus_archaeology_relationships import build_relationships
 from tools.salvage.corpus_archaeology_shared import (
     SCHEMA_VERSION,
-    CorpusArchaeologyError,
     canonical_bytes,
     normalize_timestamp,
     semantic_string,

--- a/tools/salvage/corpus_archaeology_core.py
+++ b/tools/salvage/corpus_archaeology_core.py
@@ -5,35 +5,20 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
-try:
-    from tools.salvage.corpus_archaeology_candidates import (
-        RANKING_WEIGHTS,
-        build_candidate,
-    )
-    from tools.salvage.corpus_archaeology_claims import claims_by_intent, sorted_claims
-    from tools.salvage.corpus_archaeology_relationships import build_relationships
-    from tools.salvage.corpus_archaeology_shared import (
-        SCHEMA_VERSION,
-        CorpusArchaeologyError,
-        canonical_bytes,
-        normalize_timestamp,
-        semantic_string,
-    )
-    from tools.salvage.corpus_archaeology_sources import normalize_sources, public_sources
-except ModuleNotFoundError as exc:
-    if exc.name not in {"tools", "tools.salvage"}:
-        raise
-    from corpus_archaeology_candidates import RANKING_WEIGHTS, build_candidate
-    from corpus_archaeology_claims import claims_by_intent, sorted_claims
-    from corpus_archaeology_relationships import build_relationships
-    from corpus_archaeology_shared import (
-        SCHEMA_VERSION,
-        CorpusArchaeologyError,
-        canonical_bytes,
-        normalize_timestamp,
-        semantic_string,
-    )
-    from corpus_archaeology_sources import normalize_sources, public_sources
+from tools.salvage.corpus_archaeology_candidates import (
+    RANKING_WEIGHTS,
+    build_candidate,
+)
+from tools.salvage.corpus_archaeology_claims import claims_by_intent, sorted_claims
+from tools.salvage.corpus_archaeology_relationships import build_relationships
+from tools.salvage.corpus_archaeology_shared import (
+    SCHEMA_VERSION,
+    CorpusArchaeologyError,
+    canonical_bytes,
+    normalize_timestamp,
+    semantic_string,
+)
+from tools.salvage.corpus_archaeology_sources import normalize_sources, public_sources
 
 
 def _stable_material(

--- a/tools/salvage/corpus_archaeology_relationships.py
+++ b/tools/salvage/corpus_archaeology_relationships.py
@@ -23,6 +23,10 @@ def _known_sources(
     raw: dict[str, Any], known_sources: set[str], index: int
 ) -> list[str]:
     refs = sorted(set(raw["evidence_source_refs"]))
+    if not refs:
+        raise CorpusArchaeologyError(
+            f"relationship_hints[{index}] requires at least one evidence source"
+        )
     unknown = set(refs) - known_sources
     if unknown:
         raise CorpusArchaeologyError(

--- a/tools/salvage/corpus_archaeology_relationships.py
+++ b/tools/salvage/corpus_archaeology_relationships.py
@@ -1,0 +1,78 @@
+"""Explicit relationship validation for Phase-1 corpus archaeology."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from tools.salvage.corpus_archaeology_shared import (
+        CorpusArchaeologyError,
+        make_id,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name not in {"tools", "tools.salvage"}:
+        raise
+    from corpus_archaeology_shared import CorpusArchaeologyError, make_id
+
+
+def _known_intents(
+    raw: dict[str, Any], known_intents: set[str], index: int
+) -> tuple[str, str]:
+    left = raw["left_intent_key"]
+    right = raw["right_intent_key"]
+    if {left, right} - known_intents:
+        raise CorpusArchaeologyError(
+            f"relationship_hints[{index}] references an unknown intent key"
+        )
+    return left, right
+
+
+def _known_sources(
+    raw: dict[str, Any], known_sources: set[str], index: int
+) -> list[str]:
+    refs = sorted(set(raw["evidence_source_refs"]))
+    unknown = set(refs) - known_sources
+    if unknown:
+        raise CorpusArchaeologyError(
+            f"relationship_hints[{index}] references unknown sources: "
+            f"{', '.join(sorted(unknown))}"
+        )
+    return refs
+
+
+def build_relationship(
+    raw: dict[str, Any],
+    index: int,
+    known_intents: set[str],
+    known_sources: set[str],
+) -> dict[str, Any]:
+    left, right = _known_intents(raw, known_intents, index)
+    refs = _known_sources(raw, known_sources, index)
+    material = {
+        "left_intent_key": left,
+        "right_intent_key": right,
+        "relationship": raw["relationship"],
+        "rationale": raw["rationale"],
+        "evidence_source_refs": refs,
+    }
+    return {"relationship_id": make_id("relationship", material), **material}
+
+
+def build_relationships(
+    hints: list[dict[str, Any]] | None,
+    known_intents: set[str],
+    known_sources: set[str],
+) -> list[dict[str, Any]]:
+    result = [
+        build_relationship(raw, index, known_intents, known_sources)
+        for index, raw in enumerate(hints or [])
+    ]
+    return sorted(
+        result,
+        key=lambda item: (
+            item["left_intent_key"],
+            item["right_intent_key"],
+            item["relationship"],
+            item["relationship_id"],
+        ),
+    )

--- a/tools/salvage/corpus_archaeology_relationships.py
+++ b/tools/salvage/corpus_archaeology_relationships.py
@@ -4,15 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-try:
-    from tools.salvage.corpus_archaeology_shared import (
-        CorpusArchaeologyError,
-        make_id,
-    )
-except ModuleNotFoundError as exc:
-    if exc.name not in {"tools", "tools.salvage"}:
-        raise
-    from corpus_archaeology_shared import CorpusArchaeologyError, make_id
+from tools.salvage.corpus_archaeology_shared import CorpusArchaeologyError, make_id
 
 
 def _known_intents(

--- a/tools/salvage/corpus_archaeology_shared.py
+++ b/tools/salvage/corpus_archaeology_shared.py
@@ -1,0 +1,51 @@
+"""Shared deterministic primitives for Phase-1 corpus archaeology."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+SCHEMA_VERSION = "0.1.0"
+
+
+class CorpusArchaeologyError(ValueError):
+    """Prepared corpus is invalid or violates a Phase-1 safety boundary."""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def make_id(prefix: str, value: Any, length: int = 24) -> str:
+    digest = hashlib.sha256(canonical_bytes(value)).hexdigest()
+    return f"{prefix}:{digest[:length]}"
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def semantic_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CorpusArchaeologyError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise CorpusArchaeologyError(
+            "generated_at must be timezone-aware ISO-8601"
+        ) from exc
+
+
+def normalize_timestamp(value: str | None) -> str:
+    parsed = datetime.now(timezone.utc) if value is None else _parse_timestamp(value)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CorpusArchaeologyError("generated_at must include timezone information")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tools/salvage/corpus_archaeology_sources.py
+++ b/tools/salvage/corpus_archaeology_sources.py
@@ -1,0 +1,92 @@
+"""Prepared-source normalization for deterministic corpus archaeology."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from tools.salvage.corpus_archaeology_shared import (
+        CorpusArchaeologyError,
+        make_id,
+        semantic_string,
+        sha256_text,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name not in {"tools", "tools.salvage"}:
+        raise
+    from corpus_archaeology_shared import (
+        CorpusArchaeologyError,
+        make_id,
+        semantic_string,
+        sha256_text,
+    )
+
+
+def _validate_optional_strings(source_ref: str, raw: dict[str, Any]) -> None:
+    for name in ("artifact_id", "inventory_report_id", "platform"):
+        value = raw.get(name)
+        if value is not None:
+            semantic_string(value, f"{source_ref}.{name}")
+
+
+def _released_content(raw: dict[str, Any], source_ref: str) -> tuple[str, str]:
+    content = raw["content"]
+    digest = sha256_text(content)
+    supplied_digest = raw.get("sha256")
+    if supplied_digest is not None and supplied_digest != digest:
+        raise CorpusArchaeologyError(
+            f"{source_ref}.sha256 does not match prepared content"
+        )
+    return content, digest
+
+
+def _prepared_content(
+    raw: dict[str, Any], source_ref: str
+) -> tuple[str | None, str | None]:
+    if raw["content_access"] == "released":
+        return _released_content(raw, source_ref)
+    return None, raw.get("sha256")
+
+
+def normalize_source(raw: dict[str, Any]) -> dict[str, Any]:
+    source_ref = semantic_string(raw["source_ref"], "source_ref")
+    _validate_optional_strings(source_ref, raw)
+    content, digest = _prepared_content(raw, source_ref)
+    artifact_id = raw.get("artifact_id")
+    inventory_ref = raw.get("inventory_report_id")
+    identity = {
+        "source_ref": source_ref,
+        "sha256": digest,
+        "artifact_id": artifact_id,
+        "inventory_report_id": inventory_ref,
+    }
+    return {
+        "source_ref": source_ref,
+        "source_id": make_id("source", identity),
+        "title": semantic_string(raw["title"], f"{source_ref}.title"),
+        "source_type": raw["source_type"],
+        "platform": raw.get("platform"),
+        "creator_type": raw["creator_type"],
+        "authority_status": raw["authority_status"],
+        "confidence": float(raw.get("confidence", 1.0)),
+        "artifact_id": artifact_id,
+        "inventory_report_id": inventory_ref,
+        "content_access": raw["content_access"],
+        "sha256": digest,
+        "_content": content,
+    }
+
+
+def normalize_sources(raw_sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    sources = [normalize_source(raw) for raw in raw_sources]
+    refs = [item["source_ref"] for item in sources]
+    if len(refs) != len(set(refs)):
+        raise CorpusArchaeologyError("source_ref values must be unique")
+    return sorted(sources, key=lambda item: (item["source_ref"], item["source_id"]))
+
+
+def public_sources(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: value for key, value in item.items() if key != "_content"}
+        for item in sources
+    ]

--- a/tools/salvage/corpus_archaeology_sources.py
+++ b/tools/salvage/corpus_archaeology_sources.py
@@ -4,22 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-try:
-    from tools.salvage.corpus_archaeology_shared import (
-        CorpusArchaeologyError,
-        make_id,
-        semantic_string,
-        sha256_text,
-    )
-except ModuleNotFoundError as exc:
-    if exc.name not in {"tools", "tools.salvage"}:
-        raise
-    from corpus_archaeology_shared import (
-        CorpusArchaeologyError,
-        make_id,
-        semantic_string,
-        sha256_text,
-    )
+from tools.salvage.corpus_archaeology_shared import (
+    CorpusArchaeologyError,
+    make_id,
+    semantic_string,
+    sha256_text,
+)
 
 
 def _validate_optional_strings(source_ref: str, raw: dict[str, Any]) -> None:


### PR DESCRIPTION
## Purpose

Implements the first read-only Phase-1 vertical slice of #1526.

This PR adds a deterministic, provenance-aware corpus archaeology core that operates **above** merged custody/inventory PR #1382. It consumes only prepared, custody-cleared source records and emits exact-span claims, explicit lineage relationships, recovery candidates, and explainable relevance scores.

## Architecture boundary

The archaeology layer is not an archive reader, memory store, canon authority, or execution surface.

- #1382 owns hostile-file/archive custody, hashing, duplicate detection, quarantine, and content-access decisions.
- Insight Ledger remains the append-only audit/evidence-event authority.
- #1371 remains the durable interpretive-memory ownership lane.
- Narrative River remains a downstream/domain evidence vocabulary rather than corpus storage.

```text
custody-cleared prepared records
        ↓
strict neutral JSON Schema contract
        ↓
public schema/API façade
        ↓
source normalization + exact-span claim extraction
        ↓
explicit relationship validation + candidate-state evaluation
        ↓
explainable relevance projection
        ↓
read-only JSON + Markdown report
```

## Current module layout

### Schemas

- `schemas/salvage/corpus_archaeology_input.schema.json`
- `schemas/salvage/corpus_archaeology_report.schema.json`

### Public surface and semantic modules

- `tools/salvage/__init__.py`
- `tools/salvage/corpus_archaeology.py` — public schema/API façade
- `tools/salvage/corpus_archaeology_cli.py` — CLI + exclusive output policy
- `tools/salvage/corpus_archaeology_core.py` — semantic orchestration + report/render projection
- `tools/salvage/corpus_archaeology_shared.py` — deterministic IDs, hashing, timestamps, shared error
- `tools/salvage/corpus_archaeology_sources.py` — prepared-source normalization + hash checks
- `tools/salvage/corpus_archaeology_claims.py` — explicit-marker extraction + evidence typing
- `tools/salvage/corpus_archaeology_relationships.py` — explicit relationship validation
- `tools/salvage/corpus_archaeology_candidate_state.py` — authority-aware historical state rules
- `tools/salvage/corpus_archaeology_candidates.py` — explainable ranking + candidate projection

### Focused tests

- `tests/test_corpus_archaeology.py`
- `tests/test_corpus_archaeology_evidence_boundary.py`
- `tests/test_corpus_archaeology_input_schema.py`
- `tests/test_corpus_archaeology_lineage_conflicts.py`
- `tests/test_corpus_archaeology_runtime_schema_binding.py`

All changes remain additive. No existing runtime, registry, simulation, canon, queue, memory store, or archived source content is modified.

## Phase-1 extraction profile

`explicit_markers_v1` deliberately avoids semantic NLP inference. Prepared text may expose keyed statements such as:

```text
REQUIREMENT[threadcore.unutilized_logic]: Extract unutilized logic.
APPROVED[threadcore.unutilized_logic]: Proceed with the extractor.
TODO[threadcore.unutilized_logic]: Implement the read-only pass.
IMPLEMENTED[other.capability]: Current implementation exists.
REJECTED[retired.capability]: Explicitly rejected after review.
```

Supported markers: `DECISION`, `APPROVED`, `REJECTED`, `REQUIREMENT`, `CONSTRAINT`, `QUESTION`, `TODO`, `PATCH`, `RATIONALE`, `IMPLEMENTED`, and `PARTIAL_IMPLEMENTATION`.

Unkeyed claims retain exact provenance but are not heuristically merged into recovery candidates.

## Schema/runtime parity

`analyze_corpus()` validates input against the **committed input JSON Schema before semantic processing**. The schema is therefore the single machine structural contract rather than documentation beside a looser Python validator.

Runtime regression coverage verifies:

- unknown top-level/source fields fail;
- required source authority/type/access metadata cannot be silently defaulted;
- confidence preserves JSON numeric typing;
- malformed SHA-256 values fail;
- missing/invalid committed schema fails closed;
- valid prepared corpora continue through the read-only analyzer.

## Provenance and authority hardening

Every claim retains content-derived identity, source ref/ID, exact line/excerpt, excerpt SHA-256, evidence kind, authority status, confidence, and optional intent key.

The implementation separates **what a source says** from **what that source is allowed to prove**.

### Model self-authorization is prohibited

A model/chat/document can contain `APPROVED[...]`, `REJECTED[...]`, `REQUIREMENT[...]`, or `IMPLEMENTED[...]` text and that text remains preserved as a claim. It does not thereby become human authority or implementation proof.

- human-attributed decision/requirement markers can establish human commitment/rejection state;
- model statements remain model evidence and do not drive human-authority status;
- only `code`, `commit`, `pull_request`, `artifact`, or `test` sources can establish implementation evidence;
- test evidence is separately labeled `test_result`.

### Historical implementation is not current preservation

An implementation artifact proves that an implementation existed in the represented source context. It does not automatically prove that implementation remains preserved today.

`implementation_preserved=true` requires current-authority implementation artifact/test evidence. Historical implementation evidence leaves current preservation unknown.

### Conflicting histories remain unresolved

If explicit human rejection and concrete implementation evidence coexist, Phase 1 does not choose a winner. Historical state becomes `unknown`, both evidence flags remain visible, and recovery disposition is `investigate`.

## Custody contract

The neutral input schema formalizes `content_access`:

- `released`: prepared text may be analyzed; a supplied SHA-256 must match content;
- `metadata_only`: semantic content is absent/empty and no claims are extracted.

Top-level `source_inventory_ref` participates in deterministic report identity so otherwise identical analysis under different custody manifests cannot collapse to one report ID.

The follow-on #1382 → archaeology adapter contract is documented on #1526 and remains deliberately out of this PR. Inventory disposition is not semantic release authority; transformed/redacted/OCR/translated content requires its own custody identity.

## Preservation presumption

> Absence of implementation is not rejection evidence.

A human requirement/approval/TODO with no proven implementation and no explicit rejection remains `investigate`. Verified implementation evidence can produce `preserve`; explicit human rejection can produce `reject_with_evidence`; contradictory evidence remains `unknown/investigate`.

`capability_preserved`, `intent_preserved`, and `intent_delta` remain unknown/null in Phase 1. The tool does not manufacture semantic-equivalence judgments.

## Relationship model

Prepared relationship hints may use:

- `convergent`
- `successor`
- `parallel`
- `merged`
- `divergent`
- `superseded`
- `dormant`
- `lost_in_transition`
- `orphaned`
- `uncertain`

Referenced sources and intent keys are validated. The analyzer does not infer these relationships autonomously in Phase 1.

## Explainable ranking

`explainable_relevance_v1` exposes fixed component weights:

- explicit decision: 0.25
- requirement strength: 0.20
- unresolved commitment: 0.20
- implementation gap: 0.20
- recurrence: 0.10
- evidence confidence: 0.05

Every candidate emits all component values beside the final score.

## Review state

The PR is **ready for formal review**, not merged.

Current head: `a504407c80f20f6d276db7d59c422d26bc20ccb0`.

Current-head evidence already green:

- PR Evaluation: **passed, 0.98/1.00**;
- CodeQL: **success**;
- Code Quality: **success**;
- Constellation CI: **success**;
- Branch Protection Status Checks: **success**;
- Safety Commit Guard: **success**;
- Catastrophe Prevention: **success**;
- PR Selective Integration: **success**;
- SonarQube Cloud: **Quality Gate passed**, 0 security hotspots.

Aurora CI (Minimal) has passed its syntax, critical/smoke, and advisory lock steps; the repository-wide pytest step is still running at the time of this metadata refresh.

### Residual Codacy quality signal

Current Codacy analysis reports:

- **0 high/ErrorProne findings**;
- **1 medium Complexity finding**;
- aggregate reported complexity: **129**.

The remaining complexity result persisted after responsibility-driven decomposition of the original monolith into schema/API, CLI, semantic-core, source, claim, relationship, and candidate modules. Further blind fragmentation is intentionally stopped. The remaining Codacy item stays explicit until file/rule-level evidence is available or an evidence-backed review disposition is made.

No Codacy finding is suppressed or waived by this PR.

## Security and authority invariants

- no archive/file-tree crawling;
- no archive extraction;
- no recovered code execution;
- no network/model requirement;
- no source mutation;
- no output-path replacement;
- no canon promotion;
- no work-queue mutation;
- no issue/PR creation by the analyzer;
- no memory persistence;
- no PatchWeaver invocation;
- no L1/L2/L3 authority change;
- no autonomous semantic relationship inference.

## Non-goals

- semantic NLP extraction from arbitrary prose;
- model-assisted synthesis;
- automatic successor detection;
- automatic rejection/supersession;
- durable interpretive-memory storage;
- automatic issue/work-queue projection;
- archive ingestion;
- THREADCORE-only schema vocabulary;
- mutation or execution of recovered content.

## Branch state

At the latest comparison this branch is **40 commits ahead / 0 behind `main`**, with **17 additive files and 0 deletions**.

## Rollback

Close without merging. The branch is additive and creates no runtime state.

Refs #1526, #1382, #1371, #1373, #1380, #1477, #1534.